### PR TITLE
Add portOpenRetries  to com.ibm.ws.grpc_fat where it is missing

### DIFF
--- a/dev/com.ibm.ws.grpc_fat/publish/files/grpc.both.metrics.server.xml
+++ b/dev/com.ibm.ws.grpc_fat/publish/files/grpc.both.metrics.server.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2021 IBM Corporation and others.
+    Copyright (c) 2021, 2025 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -20,7 +20,9 @@
                   host="*"
                   httpPort="${bvt.prop.HTTP_secondary}"
                   httpsPort="${bvt.prop.HTTP_secondary.secure}"/>
-                  
+
+    <tcpOptions id="defaultTCPOptions" portOpenRetries="60"/>
+
     <include location="../fatTestCommon.xml" />
 
     <javaPermission className="java.security.AllPermission"  name="*" actions="*" />

--- a/dev/com.ibm.ws.grpc_fat/publish/files/grpc.client.disabled.server.xml
+++ b/dev/com.ibm.ws.grpc_fat/publish/files/grpc.client.disabled.server.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2021 IBM Corporation and others.
+    Copyright (c) 2021, 2025 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -16,6 +16,8 @@
                   host="*"
                   httpPort="${bvt.prop.HTTP_secondary}"
                   httpsPort="${bvt.prop.HTTP_secondary.secure}"/>
+
+    <tcpOptions id="defaultTCPOptions" portOpenRetries="60"/>
 
     <include location="../fatTestCommon.xml" />
 

--- a/dev/com.ibm.ws.grpc_fat/publish/files/grpc.client.interceptor.xml
+++ b/dev/com.ibm.ws.grpc_fat/publish/files/grpc.client.interceptor.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2020 IBM Corporation and others.
+    Copyright (c) 2020, 2025 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -18,6 +18,8 @@
                   host="*"
                   httpPort="${bvt.prop.HTTP_secondary}"
                   httpsPort="${bvt.prop.HTTP_secondary.secure}"/>
+
+    <tcpOptions id="defaultTCPOptions" portOpenRetries="60"/>
 
     <include location="../fatTestCommon.xml" />
 

--- a/dev/com.ibm.ws.grpc_fat/publish/files/grpc.client.invalid.interceptor.xml
+++ b/dev/com.ibm.ws.grpc_fat/publish/files/grpc.client.invalid.interceptor.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2020 IBM Corporation and others.
+    Copyright (c) 2020, 2025 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -18,6 +18,8 @@
                   host="*"
                   httpPort="${bvt.prop.HTTP_secondary}"
                   httpsPort="${bvt.prop.HTTP_secondary.secure}"/>
+
+    <tcpOptions id="defaultTCPOptions" portOpenRetries="60"/>
 
     <include location="../fatTestCommon.xml" />
 

--- a/dev/com.ibm.ws.grpc_fat/publish/files/grpc.client.invalidkeepalivew.server.xml
+++ b/dev/com.ibm.ws.grpc_fat/publish/files/grpc.client.invalidkeepalivew.server.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2020 IBM Corporation and others.
+    Copyright (c) 2020, 2025 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -16,7 +16,9 @@
                   host="*"
                   httpPort="${bvt.prop.HTTP_secondary}"
                   httpsPort="${bvt.prop.HTTP_secondary.secure}"/>
-                  
+
+    <tcpOptions id="defaultTCPOptions" portOpenRetries="60"/>
+
     <include location="../fatTestCommon.xml"/>
 
     <grpcClient host="*" keepAliveWithoutCalls="morejunk" keepAliveTime="120" keepAliveTimeout="360" />

--- a/dev/com.ibm.ws.grpc_fat/publish/files/grpc.client.invalidmsgsize.server.xml
+++ b/dev/com.ibm.ws.grpc_fat/publish/files/grpc.client.invalidmsgsize.server.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2020 IBM Corporation and others.
+    Copyright (c) 2020, 2025 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -16,6 +16,8 @@
                   host="*"
                   httpPort="${bvt.prop.HTTP_secondary}"
                   httpsPort="${bvt.prop.HTTP_secondary.secure}"/>
+
+    <tcpOptions id="defaultTCPOptions" portOpenRetries="60"/>
 
     <include location="../fatTestCommon.xml"/>
 

--- a/dev/com.ibm.ws.grpc_fat/publish/files/grpc.client.invaliduseplaintext.server.xml
+++ b/dev/com.ibm.ws.grpc_fat/publish/files/grpc.client.invaliduseplaintext.server.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2020 IBM Corporation and others.
+    Copyright (c) 2020, 2025 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -16,6 +16,8 @@
                   host="*"
                   httpPort="${bvt.prop.HTTP_secondary}"
                   httpsPort="${bvt.prop.HTTP_secondary.secure}"/>
+
+    <tcpOptions id="defaultTCPOptions" portOpenRetries="60"/>
 
     <include location="../fatTestCommon.xml"/>
 

--- a/dev/com.ibm.ws.grpc_fat/publish/files/grpc.client.keepalivew.false.server.xml
+++ b/dev/com.ibm.ws.grpc_fat/publish/files/grpc.client.keepalivew.false.server.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2020 IBM Corporation and others.
+    Copyright (c) 2020, 2025 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -16,7 +16,9 @@
                   host="*"
                   httpPort="${bvt.prop.HTTP_secondary}"
                   httpsPort="${bvt.prop.HTTP_secondary.secure}"/>
-                  
+
+    <tcpOptions id="defaultTCPOptions" portOpenRetries="60"/>
+
     <include location="../fatTestCommon.xml"/>
 
     <grpcClient host="*" keepAliveWithoutCalls="false" keepAliveTime="120" keepAliveTimeout="360" />

--- a/dev/com.ibm.ws.grpc_fat/publish/files/grpc.client.keepalivew.true.server.xml
+++ b/dev/com.ibm.ws.grpc_fat/publish/files/grpc.client.keepalivew.true.server.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2020 IBM Corporation and others.
+    Copyright (c) 2020, 2025 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -16,6 +16,8 @@
                   host="*"
                   httpPort="${bvt.prop.HTTP_secondary}"
                   httpsPort="${bvt.prop.HTTP_secondary.secure}"/>
+
+    <tcpOptions id="defaultTCPOptions" portOpenRetries="60"/>
 
     <include location="../fatTestCommon.xml"/>
 

--- a/dev/com.ibm.ws.grpc_fat/publish/files/grpc.client.maxmetasize.server.xml
+++ b/dev/com.ibm.ws.grpc_fat/publish/files/grpc.client.maxmetasize.server.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2020 IBM Corporation and others.
+    Copyright (c) 2020, 2025 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -16,6 +16,8 @@
                   host="*"
                   httpPort="${bvt.prop.HTTP_secondary}"
                   httpsPort="${bvt.prop.HTTP_secondary.secure}"/>
+
+    <tcpOptions id="defaultTCPOptions" portOpenRetries="60"/>
 
     <include location="../fatTestCommon.xml"/>
 

--- a/dev/com.ibm.ws.grpc_fat/publish/files/grpc.client.metrics.server.xml
+++ b/dev/com.ibm.ws.grpc_fat/publish/files/grpc.client.metrics.server.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2021 IBM Corporation and others.
+    Copyright (c) 2021, 2025 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -19,6 +19,8 @@
                   host="*"
                   httpPort="${bvt.prop.HTTP_secondary}"
                   httpsPort="${bvt.prop.HTTP_secondary.secure}"/>
+
+    <tcpOptions id="defaultTCPOptions" portOpenRetries="60"/>
 
     <include location="../fatTestCommon.xml" />
 

--- a/dev/com.ibm.ws.grpc_fat/publish/files/grpc.client.multiple.interceptor.xml
+++ b/dev/com.ibm.ws.grpc_fat/publish/files/grpc.client.multiple.interceptor.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2020 IBM Corporation and others.
+    Copyright (c) 2020, 2025 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -19,7 +19,9 @@
                   httpPort="${bvt.prop.HTTP_secondary}"
                   httpsPort="${bvt.prop.HTTP_secondary.secure}"/>
 
-     <include location="../fatTestCommon.xml" />            
+    <tcpOptions id="defaultTCPOptions" portOpenRetries="60"/>
+
+     <include location="../fatTestCommon.xml" />
 
     <javaPermission className="java.security.AllPermission"  name="*" actions="*" />
 </server>

--- a/dev/com.ibm.ws.grpc_fat/publish/files/grpc.client.nomatch.server.xml
+++ b/dev/com.ibm.ws.grpc_fat/publish/files/grpc.client.nomatch.server.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2020 IBM Corporation and others.
+    Copyright (c) 2020, 2025 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -16,6 +16,8 @@
                   host="*"
                   httpPort="${bvt.prop.HTTP_secondary}"
                   httpsPort="${bvt.prop.HTTP_secondary.secure}"/>
+
+    <tcpOptions id="defaultTCPOptions" portOpenRetries="60"/>
 
     <include location="../fatTestCommon.xml"/>
 

--- a/dev/com.ibm.ws.grpc_fat/publish/files/grpc.client.notarget.server.xml
+++ b/dev/com.ibm.ws.grpc_fat/publish/files/grpc.client.notarget.server.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2020 IBM Corporation and others.
+    Copyright (c) 2020, 2025 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -16,6 +16,8 @@
                   host="*"
                   httpPort="${bvt.prop.HTTP_secondary}"
                   httpsPort="${bvt.prop.HTTP_secondary.secure}"/>
+
+    <tcpOptions id="defaultTCPOptions" portOpenRetries="60"/>
 
     <include location="../fatTestCommon.xml"/>
 

--- a/dev/com.ibm.ws.grpc_fat/publish/files/grpc.client.param.server.xml
+++ b/dev/com.ibm.ws.grpc_fat/publish/files/grpc.client.param.server.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2020 IBM Corporation and others.
+    Copyright (c) 2020, 2025 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -16,6 +16,8 @@
                   host="*"
                   httpPort="${bvt.prop.HTTP_secondary}"
                   httpsPort="${bvt.prop.HTTP_secondary.secure}"/>
+
+    <tcpOptions id="defaultTCPOptions" portOpenRetries="60"/>
 
     <include location="../fatTestCommon.xml"/>
 

--- a/dev/com.ibm.ws.grpc_fat/publish/files/grpc.client.smallmsgsize.server.xml
+++ b/dev/com.ibm.ws.grpc_fat/publish/files/grpc.client.smallmsgsize.server.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2020 IBM Corporation and others.
+    Copyright (c) 2020, 2025 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -16,6 +16,8 @@
                   host="*"
                   httpPort="${bvt.prop.HTTP_secondary}"
                   httpsPort="${bvt.prop.HTTP_secondary.secure}"/>
+
+    <tcpOptions id="defaultTCPOptions" portOpenRetries="60"/>
 
     <include location="../fatTestCommon.xml"/>
 

--- a/dev/com.ibm.ws.grpc_fat/publish/files/grpc.client.spec.server.xml
+++ b/dev/com.ibm.ws.grpc_fat/publish/files/grpc.client.spec.server.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2020 IBM Corporation and others.
+    Copyright (c) 2020, 2025 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -16,7 +16,9 @@
                   host="*"
                   httpPort="${bvt.prop.HTTP_secondary}"
                   httpsPort="${bvt.prop.HTTP_secondary.secure}"/>
-    
+
+    <tcpOptions id="defaultTCPOptions" portOpenRetries="60"/>
+
     <include location="../fatTestCommon.xml"/>
 
     <grpcClient host="localhost" clientInterceptors="com.ibm.ws.grpc.fat.helloworld.client.HelloWorldClientInterceptor"/>

--- a/dev/com.ibm.ws.grpc_fat/publish/files/grpc.client.target.server.xml
+++ b/dev/com.ibm.ws.grpc_fat/publish/files/grpc.client.target.server.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2020 IBM Corporation and others.
+    Copyright (c) 2020, 2025 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -16,6 +16,8 @@
                   host="*"
                   httpPort="${bvt.prop.HTTP_secondary}"
                   httpsPort="${bvt.prop.HTTP_secondary.secure}"/>
+
+    <tcpOptions id="defaultTCPOptions" portOpenRetries="60"/>
 
     <include location="../fatTestCommon.xml"/>
 

--- a/dev/com.ibm.ws.grpc_fat/publish/files/grpc.client.useplaintext.false.server.xml
+++ b/dev/com.ibm.ws.grpc_fat/publish/files/grpc.client.useplaintext.false.server.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2020 IBM Corporation and others.
+    Copyright (c) 2020, 2025 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -16,7 +16,9 @@
                   host="*"
                   httpPort="${bvt.prop.HTTP_secondary}"
                   httpsPort="${bvt.prop.HTTP_secondary.secure}"/>
-                  
+
+    <tcpOptions id="defaultTCPOptions" portOpenRetries="60"/>
+
     <include location="../fatTestCommon.xml"/>
 
     <grpcClient host="*" usePlaintext="false" />

--- a/dev/com.ibm.ws.grpc_fat/publish/files/grpc.client.useplaintext.true.server.xml
+++ b/dev/com.ibm.ws.grpc_fat/publish/files/grpc.client.useplaintext.true.server.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2020 IBM Corporation and others.
+    Copyright (c) 2020, 2025 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -16,6 +16,8 @@
                   host="*"
                   httpPort="${bvt.prop.HTTP_secondary}"
                   httpsPort="${bvt.prop.HTTP_secondary.secure}"/>
+
+    <tcpOptions id="defaultTCPOptions" portOpenRetries="60"/>
 
     <include location="../fatTestCommon.xml"/>
 

--- a/dev/com.ibm.ws.grpc_fat/publish/files/grpc.client.wildcard.server.xml
+++ b/dev/com.ibm.ws.grpc_fat/publish/files/grpc.client.wildcard.server.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2020 IBM Corporation and others.
+    Copyright (c) 2020, 2025 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -16,6 +16,8 @@
                   host="*"
                   httpPort="${bvt.prop.HTTP_secondary}"
                   httpsPort="${bvt.prop.HTTP_secondary.secure}"/>
+
+    <tcpOptions id="defaultTCPOptions" portOpenRetries="60"/>
 
     <include location="../fatTestCommon.xml"/>
 

--- a/dev/com.ibm.ws.grpc_fat/publish/files/grpc.client.xml
+++ b/dev/com.ibm.ws.grpc_fat/publish/files/grpc.client.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2020 IBM Corporation and others.
+    Copyright (c) 2020, 2025 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -16,6 +16,8 @@
                   host="*"
                   httpPort="${bvt.prop.HTTP_secondary}"
                   httpsPort="${bvt.prop.HTTP_secondary.secure}"/>
+
+    <tcpOptions id="defaultTCPOptions" portOpenRetries="60"/>
 
     <include location="../fatTestCommon.xml" />
 

--- a/dev/com.ibm.ws.grpc_fat/publish/servers/ConsumerServer/server.xml
+++ b/dev/com.ibm.ws.grpc_fat/publish/servers/ConsumerServer/server.xml
@@ -27,6 +27,8 @@
                   httpPort="${bvt.prop.member_1.http}"
                   httpsPort="${bvt.prop.member_1.https}"/>
 
+    <tcpOptions id="defaultTCPOptions" portOpenRetries="60"/>
+
     <!-- <keyStore id="defaultKeyStore" password="passw0rd" /> -->
 
     <javaPermission className="java.security.AllPermission"

--- a/dev/com.ibm.ws.grpc_fat/publish/servers/GrpcClientOnly/server.xml
+++ b/dev/com.ibm.ws.grpc_fat/publish/servers/GrpcClientOnly/server.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2020 IBM Corporation and others.
+    Copyright (c) 2020, 2025 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -16,6 +16,8 @@
                   host="*"
                   httpPort="${bvt.prop.HTTP_secondary}"
                   httpsPort="${bvt.prop.HTTP_secondary.secure}"/>
+
+    <tcpOptions id="defaultTCPOptions" portOpenRetries="60"/>
 
     <include location="../fatTestCommon.xml" />
 

--- a/dev/com.ibm.ws.grpc_fat/publish/servers/ProducerServer/server.xml
+++ b/dev/com.ibm.ws.grpc_fat/publish/servers/ProducerServer/server.xml
@@ -27,6 +27,9 @@
                   host="*"
                   httpPort="${bvt.prop.HTTP_secondary}"
                   httpsPort="${bvt.prop.HTTP_secondary.secure}"/>
+
+    <tcpOptions id="defaultTCPOptions" portOpenRetries="60"/>
+
     <keyStore id="defaultKeyStore" password="passw0rd" />
 
     <javaPermission className="java.security.AllPermission"


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

Fixes #33672