### PR TITLE
Revert "Use buildLabel for version qualifier in all automated builds"

### DIFF
--- a/dev/wlp-gradle/propertiesSettings.gradle
+++ b/dev/wlp-gradle/propertiesSettings.gradle
@@ -95,10 +95,9 @@ def setProperties = { props ->
      */
     String timestamp = new SimpleDateFormat("yyyyMMddHHmm").format(new java.util.Date())
 
-    // For automated builds we use the buildLabel as a consistent qualifier.
+    // For release builds we use the buildLabel as a consistent qualifier.
     // buildLabel is set by the RTC build engines.
-    String buildLabel = props.getProperty('buildLabel')
-    String qualifier = (buildLabel != null && isAutomatedBuild) ? buildLabel : timestamp
+    String qualifier = (isRelease && isAutomatedBuild) ? props.getProperty('buildLabel') : timestamp
 
     props.setProperty('version.qualifier', qualifier)
     props.setProperty('buildLabel', timestamp)


### PR DESCRIPTION
Reverts OpenLiberty/open-liberty#33632