### PR TITLE
336514 failstart

### DIFF
--- a/dev/com.ibm.ws.microprofile.health/src/com/ibm/ws/microprofile/health/internal/AppTrackerImpl.java
+++ b/dev/com.ibm.ws.microprofile.health/src/com/ibm/ws/microprofile/health/internal/AppTrackerImpl.java
@@ -415,7 +415,12 @@ public class AppTrackerImpl implements AppTracker, ApplicationStateListener {
         lock.writeLock().lock();
         try {
             String state = getApplicationMBean(appName);
-            if (state.equals("STARTING")) {
+            /*
+             * Application can be stopped due to failure whilst starting. This would result in a "STARTING" state.
+             * Or it could already be started (thanks to deferServletLoad defaulting to true), but when the module is trying
+             * to complete it's initialization, it still fails.
+             */
+            if (state != null && (state.equals("STARTING") || state.equals("INSTALLED"))) {
                 appStateMap.replace(appName, ApplicationState.INSTALLED);
             } else {
                 appStateMap.remove(appName);

--- a/dev/io.openliberty.microprofile.health.3.1.internal_fat/.classpath
+++ b/dev/io.openliberty.microprofile.health.3.1.internal_fat/.classpath
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" path="fat/src"/>
+	<classpathentry kind="src" path="test-applications/StartedThenFailsApp/src"/>
 	<classpathentry kind="src" path="test-applications/DelayedHealthCheckAppFast/src"/>
 	<classpathentry kind="src" path="test-applications/ConfigAdminXmlCheckApp/src"/>
 	<classpathentry kind="src" path="test-applications/ConfigAdminDropinsCheckApp/src"/>

--- a/dev/io.openliberty.microprofile.health.3.1.internal_fat/bnd.bnd
+++ b/dev/io.openliberty.microprofile.health.3.1.internal_fat/bnd.bnd
@@ -16,7 +16,8 @@ src: \
 	test-applications/DelayedHealthCheckAppFast/src, \
 	test-applications/ConfigAdminDropinsCheckApp/src, \
 	test-applications/FailsToStartHealthCheckApp/src, \
-	test-applications/ConfigAdminXmlCheckApp/src
+	test-applications/ConfigAdminXmlCheckApp/src, \
+	test-applications/StartedThenFailsApp/src
 
 fat.project: true
 

--- a/dev/io.openliberty.microprofile.health.3.1.internal_fat/fat/src/io/openliberty/microprofile/health31/fat/FailedApplicationStartTest.java
+++ b/dev/io.openliberty.microprofile.health.3.1.internal_fat/fat/src/io/openliberty/microprofile/health31/fat/FailedApplicationStartTest.java
@@ -56,6 +56,12 @@ public class FailedApplicationStartTest {
 
     private final String HEALTH_ENDPOINT = "/health";
 
+    private final String READY_ENDPOINT = "/health/ready";
+
+    private final String LIVE_ENDPOINT = "/health/live";
+
+    private final String STARTED_ENDPOINT = "/health/started";
+
     @Server(SERVER_NAME_DROPINS)
     public static LibertyServer serverDropins;
 
@@ -109,6 +115,33 @@ public class FailedApplicationStartTest {
         assertTrue("The JSON response was not empty.", checks.isEmpty());
         assertEquals("The status of the (overall) health check was epected to be DOWN, but we received UP.", jsonResponse.getString("status"), "DOWN");
 
+        // Check /health/started -> expect that we report DOWN.
+        // Must skip for mpHealth-2.0 and mpHealth-3.1, does not contain start health check
+        if (!server.getServerConfiguration().getFeatureManager().getFeatures().contains("mpHealth-2.0") &&
+            !server.getServerConfiguration().getFeatureManager().getFeatures().contains("mpHealth-3.0")) {
+            connhealth = HttpUtils.getHttpConnectionWithAnyResponseCode(server, STARTED_ENDPOINT);
+            jsonResponse = getJSONPayload(connhealth);
+            checks = (JsonArray) jsonResponse.get("checks");
+            assertTrue("The JSON response was not empty.", checks.isEmpty());
+            assertEquals("The status of the started health check was epected to be DOWN, but we received UP.", jsonResponse.getString("status"), "DOWN");
+        } else {
+            log("webModuleStartsandFailsTest_dropins", "mpHealth-2.0 detected, skipping on checking the /health/started endpoint");
+        }
+
+        // Check /health/ready -> expect that we report DOWN.
+        connhealth = HttpUtils.getHttpConnectionWithAnyResponseCode(server, READY_ENDPOINT);
+        jsonResponse = getJSONPayload(connhealth);
+        checks = (JsonArray) jsonResponse.get("checks");
+        assertTrue("The JSON response was not empty.", checks.isEmpty());
+        assertEquals("The status of the ready health check was epected to be DOWN, but we received UP.", jsonResponse.getString("status"), "DOWN");
+
+        // Check /health/live -> expect that we report UP.
+        connhealth = HttpUtils.getHttpConnectionWithAnyResponseCode(server, LIVE_ENDPOINT);
+        jsonResponse = getJSONPayload(connhealth);
+        checks = (JsonArray) jsonResponse.get("checks");
+        assertTrue("The JSON response was not empty.", checks.isEmpty());
+        assertEquals("The status of the live health check was epected to be UP, but we received DOWN.", jsonResponse.getString("status"), "UP");
+
     }
 
     /**
@@ -144,6 +177,33 @@ public class FailedApplicationStartTest {
         assertTrue("The JSON response was not empty.", checks.isEmpty());
         assertEquals("The status of the (overall) health check was epected to be DOWN, but we received UP.", jsonResponse.getString("status"), "DOWN");
 
+        // Check /health/started -> expect that we report DOWN.
+        // Must skip for mpHealth-2.0, does not contain start health check
+        if (!server.getServerConfiguration().getFeatureManager().getFeatures().contains("mpHealth-2.0") &&
+            !server.getServerConfiguration().getFeatureManager().getFeatures().contains("mpHealth-3.0")) {
+            connhealth = HttpUtils.getHttpConnectionWithAnyResponseCode(server, STARTED_ENDPOINT);
+            jsonResponse = getJSONPayload(connhealth);
+            checks = (JsonArray) jsonResponse.get("checks");
+            assertTrue("The JSON response was not empty.", checks.isEmpty());
+            assertEquals("The status of the started health check was epected to be DOWN, but we received UP.", jsonResponse.getString("status"), "DOWN");
+        } else {
+            log("webModuleStartsandFailsTest_dropins", "mpHealth-2.0 detected, skipping on checking the /health/started endpoint");
+        }
+
+        // Check /health/ready -> expect that we report DOWN.
+        connhealth = HttpUtils.getHttpConnectionWithAnyResponseCode(server, READY_ENDPOINT);
+        jsonResponse = getJSONPayload(connhealth);
+        checks = (JsonArray) jsonResponse.get("checks");
+        assertTrue("The JSON response was not empty.", checks.isEmpty());
+        assertEquals("The status of the ready health check was epected to be DOWN, but we received UP.", jsonResponse.getString("status"), "DOWN");
+
+        // Check /health/live -> expect that we report UP.
+        connhealth = HttpUtils.getHttpConnectionWithAnyResponseCode(server, LIVE_ENDPOINT);
+        jsonResponse = getJSONPayload(connhealth);
+        checks = (JsonArray) jsonResponse.get("checks");
+        assertTrue("The JSON response was not empty.", checks.isEmpty());
+        assertEquals("The status of the live health check was epected to be UP, but we received DOWN.", jsonResponse.getString("status"), "UP");
+
     }
 
     @After
@@ -153,8 +213,9 @@ public class FailedApplicationStartTest {
          * CWWKZ0012I -> These tests are meant to fail so that the app does not start, we expect this Warning/Error.
          * CWMMH0053W -> MpHealth-3.x can throw CWMMH0053W (double M) if ready is DOWN for ANY endpoint (not just only when checking /ready)
          * CWMMH0053W -> MpHealth-2.x can throw CWMH0053W (single M) if ready is DOWN for ANY endpoint (not just only when checking /ready)
+         * CWMMH0054W -> When querying /started, we expect this to be thrown since app did not start.
          */
-        server.stopServer("CWWKZ0012I", "CWMMH0053W", "CWMH0053W");
+        server.stopServer("CWWKZ0012I", "CWMMH0053W", "CWMH0053W", "CWMMH0054W");
     }
 
     public JsonObject getJSONPayload(HttpURLConnection con) throws Exception {

--- a/dev/io.openliberty.microprofile.health.3.1.internal_fat/fat/src/io/openliberty/microprofile/health31/fat/FailedApplicationStartTest.java
+++ b/dev/io.openliberty.microprofile.health.3.1.internal_fat/fat/src/io/openliberty/microprofile/health31/fat/FailedApplicationStartTest.java
@@ -1,0 +1,180 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.microprofile.health31.fat;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.BufferedReader;
+import java.net.HttpURLConnection;
+
+import javax.json.Json;
+import javax.json.JsonArray;
+import javax.json.JsonObject;
+import javax.servlet.ServletContainerInitializer;
+
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions;
+import com.ibm.websphere.simplicity.log.Log;
+
+import componenttest.annotation.ExpectedFFDC;
+import componenttest.annotation.Server;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.rules.repeater.FeatureReplacementAction;
+import componenttest.rules.repeater.MicroProfileActions;
+import componenttest.rules.repeater.RepeatTests;
+import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.utils.HttpUtils;
+import io.openliberty.microprofile.health.internal_fat.shared.HealthActions;
+
+/**
+ *
+ */
+@RunWith(FATRunner.class)
+public class FailedApplicationStartTest {
+
+    final static String SERVER_NAME_DROPINS = "ServletContainerInitializerFailsServerDropins";
+
+    final static String SERVER_NAME_APP_DIR = "ServletContainerInitializerFailsServerAppDir";
+
+    final static String APP_NAME = "StartedThenFailsApp";
+
+    private final String HEALTH_ENDPOINT = "/health";
+
+    @Server(SERVER_NAME_DROPINS)
+    public static LibertyServer serverDropins;
+
+    @Server(SERVER_NAME_APP_DIR)
+    public static LibertyServer serverAppDir;
+
+    public static LibertyServer server;
+
+    @ClassRule
+    public static RepeatTests r = MicroProfileActions.repeat(FeatureReplacementAction.ALL_SERVERS,
+                                                             MicroProfileActions.MP70_EE10, // mpHealth-4.0 LITE
+                                                             MicroProfileActions.MP70_EE11, // mpHealth-4.0 FULL
+                                                             HealthActions.MP41_MPHEALTH40, //  mpHealth-4.0 FULL w/ MP41 EE8
+                                                             HealthActions.MP14_MPHEALTH40, // mpHealth-4.0 FULL w/ MP14 EE7
+                                                             MicroProfileActions.MP41, // mpHealth-3.1 FULL
+                                                             MicroProfileActions.MP40, // mpHealth-3.0 FULL
+                                                             MicroProfileActions.MP30); //mpHealth-2.0 FULL
+
+    /**
+     * Test that loads an app that throws a java.lang.Error in the servlet container intializer.
+     * We expect to see a CWWKZ0012I because of it and that the health check (overall health check) reports DOWN.
+     *
+     * This test tests the app in dropins folder.
+     *
+     * @throws Exception
+     */
+    @ExpectedFFDC("java.lang.Error")
+    @Test
+    public void webModuleStartsandFailsTest_dropins() throws Exception {
+
+        server = serverDropins;
+
+        Assert.assertTrue(String.format("Server [%s] should not have been started", server), !server.isStarted());
+
+        WebArchive app = ShrinkHelper.buildDefaultApp(APP_NAME, "io.openliberty.microprofile.health31.start.and.fails.app")
+                        .addAsServiceProvider(ServletContainerInitializer.class.getName(),
+                                              "io.openliberty.microprofile.health31.start.and.fails.app.AppServletContainerInitializer");
+
+        ShrinkHelper.exportDropinAppToServer(server, app, DeployOptions.DISABLE_VALIDATION, DeployOptions.SERVER_ONLY);
+
+        server.startServer();
+
+        log("webModuleStartsandFailsTest", "Checking (and waiting) for CWWKZ0012I");
+        String ret = server.waitForStringInLog("CWWKZ0012I");
+        assertNotNull("We expected to find CWWKZ0012I, but was not found", ret);
+
+        // Check /health -> expect that we report DOWN.
+        HttpURLConnection connhealth = HttpUtils.getHttpConnectionWithAnyResponseCode(server, HEALTH_ENDPOINT);
+        JsonObject jsonResponse = getJSONPayload(connhealth);
+        JsonArray checks = (JsonArray) jsonResponse.get("checks");
+        assertTrue("The JSON response was not empty.", checks.isEmpty());
+        assertEquals("The status of the (overall) health check was epected to be DOWN, but we recieved UP.", jsonResponse.getString("status"), "DOWN");
+
+    }
+
+    /**
+     * Test that loads an app that throws a java.lang.Error in the servlet container intializer.
+     * We expect to see a CWWKZ0012I because of it and that the health check (overall health check) reports DOWN.
+     *
+     * This test tests the app in apps folder.
+     *
+     * @throws Exception
+     */
+    @ExpectedFFDC("java.lang.Error")
+    @Test
+    public void webModuleStartsandFailsTest_apps() throws Exception {
+
+        server = serverAppDir;
+
+        WebArchive app = ShrinkHelper.buildDefaultApp(APP_NAME, "io.openliberty.microprofile.health31.start.and.fails.app")
+                        .addAsServiceProvider(ServletContainerInitializer.class.getName(),
+                                              "io.openliberty.microprofile.health31.start.and.fails.app.AppServletContainerInitializer");
+
+        ShrinkHelper.exportAppToServer(server, app, DeployOptions.DISABLE_VALIDATION, DeployOptions.SERVER_ONLY);
+
+        server.startServer();
+
+        log("webModuleStartsandFailsTest", "Checking (and waiting) for CWWKZ0012I");
+        String ret = server.waitForStringInLog("CWWKZ0012I");
+        assertNotNull("We expected to find CWWKZ0012I, but was not found", ret);
+
+        // Check /health -> expect that we report DOWN.
+        HttpURLConnection connhealth = HttpUtils.getHttpConnectionWithAnyResponseCode(server, HEALTH_ENDPOINT);
+        JsonObject jsonResponse = getJSONPayload(connhealth);
+        JsonArray checks = (JsonArray) jsonResponse.get("checks");
+        assertTrue("The JSON response was not empty.", checks.isEmpty());
+        assertEquals("The status of the (overall) health check was epected to be DOWN, but we recieved UP.", jsonResponse.getString("status"), "DOWN");
+
+    }
+
+    @After
+    public void after() throws Exception {
+        /*
+         * We expect:
+         * CWWKZ0012I -> These tests are meant to fail so that the app does not start, we expect this Warning/Error.
+         * CWMMH0053W -> MpHealth-3.x can throw CWMMH0053W (double M) if ready is DOWN for ANY endpoint (not just only when checking /ready)
+         * CWMMH0053W -> MpHealth-2.x can throw CWMH0053W (single M) if ready is DOWN for ANY endpoint (not just only when checking /ready)
+         */
+        server.stopServer("CWWKZ0012I", "CWMMH0053W", "CWMH0053W");
+    }
+
+    public JsonObject getJSONPayload(HttpURLConnection con) throws Exception {
+        assertEquals("application/json; charset=UTF-8", con.getHeaderField("Content-Type"));
+
+        BufferedReader br = HttpUtils.getResponseBody(con, "UTF-8");
+        Json.createReader(br);
+        JsonObject jsonResponse = Json.createReader(br).readObject();
+        br.close();
+
+        log("getJSONPayload", "Response: jsonResponse= " + jsonResponse.toString());
+        assertNotNull("The contents of the health endpoint must not be null.", jsonResponse.getString("status"));
+
+        return jsonResponse;
+    }
+
+    /**
+     * Helper for simple logging.
+     */
+    private static void log(String method, String msg) {
+        Log.info(ConfigAdminHealthCheckTest.class, method, msg);
+    }
+}

--- a/dev/io.openliberty.microprofile.health.3.1.internal_fat/fat/src/io/openliberty/microprofile/health31/fat/FailedApplicationStartTest.java
+++ b/dev/io.openliberty.microprofile.health.3.1.internal_fat/fat/src/io/openliberty/microprofile/health31/fat/FailedApplicationStartTest.java
@@ -107,7 +107,7 @@ public class FailedApplicationStartTest {
         JsonObject jsonResponse = getJSONPayload(connhealth);
         JsonArray checks = (JsonArray) jsonResponse.get("checks");
         assertTrue("The JSON response was not empty.", checks.isEmpty());
-        assertEquals("The status of the (overall) health check was epected to be DOWN, but we recieved UP.", jsonResponse.getString("status"), "DOWN");
+        assertEquals("The status of the (overall) health check was epected to be DOWN, but we received UP.", jsonResponse.getString("status"), "DOWN");
 
     }
 
@@ -142,7 +142,7 @@ public class FailedApplicationStartTest {
         JsonObject jsonResponse = getJSONPayload(connhealth);
         JsonArray checks = (JsonArray) jsonResponse.get("checks");
         assertTrue("The JSON response was not empty.", checks.isEmpty());
-        assertEquals("The status of the (overall) health check was epected to be DOWN, but we recieved UP.", jsonResponse.getString("status"), "DOWN");
+        assertEquals("The status of the (overall) health check was epected to be DOWN, but we received UP.", jsonResponse.getString("status"), "DOWN");
 
     }
 

--- a/dev/io.openliberty.microprofile.health.3.1.internal_fat/fat/src/io/openliberty/microprofile/health31/fat/FailedApplicationStartTest.java
+++ b/dev/io.openliberty.microprofile.health.3.1.internal_fat/fat/src/io/openliberty/microprofile/health31/fat/FailedApplicationStartTest.java
@@ -116,7 +116,7 @@ public class FailedApplicationStartTest {
         assertEquals("The status of the (overall) health check was epected to be DOWN, but we received UP.", jsonResponse.getString("status"), "DOWN");
 
         // Check /health/started -> expect that we report DOWN.
-        // Must skip for mpHealth-2.0 and mpHealth-3.1, does not contain start health check
+        // Must skip for mpHealth-2.0 and mpHealth-3.0, does not contain start health check
         if (!server.getServerConfiguration().getFeatureManager().getFeatures().contains("mpHealth-2.0") &&
             !server.getServerConfiguration().getFeatureManager().getFeatures().contains("mpHealth-3.0")) {
             connhealth = HttpUtils.getHttpConnectionWithAnyResponseCode(server, STARTED_ENDPOINT);
@@ -178,7 +178,7 @@ public class FailedApplicationStartTest {
         assertEquals("The status of the (overall) health check was epected to be DOWN, but we received UP.", jsonResponse.getString("status"), "DOWN");
 
         // Check /health/started -> expect that we report DOWN.
-        // Must skip for mpHealth-2.0, does not contain start health check
+        // Must skip for mpHealth-2.0 and mpHealth-3.0, does not contain start health check
         if (!server.getServerConfiguration().getFeatureManager().getFeatures().contains("mpHealth-2.0") &&
             !server.getServerConfiguration().getFeatureManager().getFeatures().contains("mpHealth-3.0")) {
             connhealth = HttpUtils.getHttpConnectionWithAnyResponseCode(server, STARTED_ENDPOINT);

--- a/dev/io.openliberty.microprofile.health.3.1.internal_fat/fat/src/io/openliberty/microprofile/health31/fat/suite/FATSuite.java
+++ b/dev/io.openliberty.microprofile.health.3.1.internal_fat/fat/src/io/openliberty/microprofile/health31/fat/suite/FATSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2024 IBM Corporation and others.
+ * Copyright (c) 2021, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -19,6 +19,7 @@ import org.junit.runners.Suite.SuiteClasses;
 import io.openliberty.microprofile.health31.fat.ConfigAdminHealthCheckTest;
 import io.openliberty.microprofile.health31.fat.DefaultOverallStartupStatusUpAppStartupFastTest;
 import io.openliberty.microprofile.health31.fat.DefaultOverallStartupStatusUpAppStartupTest;
+import io.openliberty.microprofile.health31.fat.FailedApplicationStartTest;
 import io.openliberty.microprofile.health31.fat.SlowAppStartupHealthCheckFastTest;
 import io.openliberty.microprofile.health31.fat.SlowAppStartupHealthCheckTest;
 
@@ -28,7 +29,8 @@ import io.openliberty.microprofile.health31.fat.SlowAppStartupHealthCheckTest;
                 DefaultOverallStartupStatusUpAppStartupFastTest.class,
                 SlowAppStartupHealthCheckTest.class,
                 SlowAppStartupHealthCheckFastTest.class,
-                ConfigAdminHealthCheckTest.class
+                ConfigAdminHealthCheckTest.class,
+                FailedApplicationStartTest.class
 })
 
 public class FATSuite {

--- a/dev/io.openliberty.microprofile.health.3.1.internal_fat/publish/servers/ServletContainerInitializerFailsServerAppDir/bootstrap.properties
+++ b/dev/io.openliberty.microprofile.health.3.1.internal_fat/publish/servers/ServletContainerInitializerFailsServerAppDir/bootstrap.properties
@@ -1,0 +1,3 @@
+bootstrap.include=../testports.properties
+osgi.console=7771
+com.ibm.ws.logging.trace.specification=*=info:HEALTH=all

--- a/dev/io.openliberty.microprofile.health.3.1.internal_fat/publish/servers/ServletContainerInitializerFailsServerAppDir/bootstrap.properties
+++ b/dev/io.openliberty.microprofile.health.3.1.internal_fat/publish/servers/ServletContainerInitializerFailsServerAppDir/bootstrap.properties
@@ -1,3 +1,2 @@
 bootstrap.include=../testports.properties
-osgi.console=7771
 com.ibm.ws.logging.trace.specification=*=info:HEALTH=all

--- a/dev/io.openliberty.microprofile.health.3.1.internal_fat/publish/servers/ServletContainerInitializerFailsServerAppDir/server.xml
+++ b/dev/io.openliberty.microprofile.health.3.1.internal_fat/publish/servers/ServletContainerInitializerFailsServerAppDir/server.xml
@@ -1,0 +1,23 @@
+<server description="Server for testing Config Admin with a server.xml configuration">
+
+    <include location="../fatTestPorts.xml"/>
+
+    <featureManager>
+        <feature>osgiconsole-1.0</feature>
+        <feature>localConnector-1.0</feature>
+        <feature>appSecurity-2.0</feature>
+        <feature>mpHealth-3.1</feature>
+        <feature>mpConfig-2.0</feature>
+        <feature>jsonp-1.1</feature>
+    </featureManager>
+	
+	
+	<application location="StartedThenFailsApp.war"/>
+	
+	<logging traceSpecification="*=info:HEALTH=all:com.ibm.websphere.org.eclipse.microprofile.health.*=all=enabled"/>
+	
+	<httpEndpoint id="defaultHttpEndpoint" host="*" httpPort="${bvt.prop.HTTP_default}" httpsPort="${bvt.prop.HTTP_default.secure}">
+		<tcpOptions portOpenRetries="60" />                   
+	</httpEndpoint>
+	
+</server>

--- a/dev/io.openliberty.microprofile.health.3.1.internal_fat/publish/servers/ServletContainerInitializerFailsServerAppDir/server.xml
+++ b/dev/io.openliberty.microprofile.health.3.1.internal_fat/publish/servers/ServletContainerInitializerFailsServerAppDir/server.xml
@@ -3,7 +3,6 @@
     <include location="../fatTestPorts.xml"/>
 
     <featureManager>
-        <feature>osgiconsole-1.0</feature>
         <feature>localConnector-1.0</feature>
         <feature>appSecurity-2.0</feature>
         <feature>mpHealth-3.1</feature>

--- a/dev/io.openliberty.microprofile.health.3.1.internal_fat/publish/servers/ServletContainerInitializerFailsServerDropins/bootstrap.properties
+++ b/dev/io.openliberty.microprofile.health.3.1.internal_fat/publish/servers/ServletContainerInitializerFailsServerDropins/bootstrap.properties
@@ -1,0 +1,3 @@
+bootstrap.include=../testports.properties
+osgi.console=7771
+com.ibm.ws.logging.trace.specification=*=info:HEALTH=all

--- a/dev/io.openliberty.microprofile.health.3.1.internal_fat/publish/servers/ServletContainerInitializerFailsServerDropins/bootstrap.properties
+++ b/dev/io.openliberty.microprofile.health.3.1.internal_fat/publish/servers/ServletContainerInitializerFailsServerDropins/bootstrap.properties
@@ -1,3 +1,2 @@
 bootstrap.include=../testports.properties
-osgi.console=7771
 com.ibm.ws.logging.trace.specification=*=info:HEALTH=all

--- a/dev/io.openliberty.microprofile.health.3.1.internal_fat/publish/servers/ServletContainerInitializerFailsServerDropins/server.xml
+++ b/dev/io.openliberty.microprofile.health.3.1.internal_fat/publish/servers/ServletContainerInitializerFailsServerDropins/server.xml
@@ -1,0 +1,20 @@
+<server description="Server for testing Config Admin with a server.xml configuration">
+
+    <include location="../fatTestPorts.xml"/>
+
+    <featureManager>
+        <feature>osgiconsole-1.0</feature>
+        <feature>localConnector-1.0</feature>
+        <feature>appSecurity-2.0</feature>
+        <feature>mpHealth-3.1</feature>
+        <feature>mpConfig-2.0</feature>
+        <feature>jsonp-1.1</feature>
+    </featureManager>
+	
+	<logging traceSpecification="*=info:HEALTH=all:com.ibm.websphere.org.eclipse.microprofile.health.*=all=enabled"/>
+	
+	<httpEndpoint id="defaultHttpEndpoint" host="*" httpPort="${bvt.prop.HTTP_default}" httpsPort="${bvt.prop.HTTP_default.secure}">
+		<tcpOptions portOpenRetries="60" />                   
+	</httpEndpoint>
+	
+</server>

--- a/dev/io.openliberty.microprofile.health.3.1.internal_fat/publish/servers/ServletContainerInitializerFailsServerDropins/server.xml
+++ b/dev/io.openliberty.microprofile.health.3.1.internal_fat/publish/servers/ServletContainerInitializerFailsServerDropins/server.xml
@@ -3,7 +3,6 @@
     <include location="../fatTestPorts.xml"/>
 
     <featureManager>
-        <feature>osgiconsole-1.0</feature>
         <feature>localConnector-1.0</feature>
         <feature>appSecurity-2.0</feature>
         <feature>mpHealth-3.1</feature>

--- a/dev/io.openliberty.microprofile.health.3.1.internal_fat/test-applications/StartedThenFailsApp/resources/META-INF/MANIFEST.MF
+++ b/dev/io.openliberty.microprofile.health.3.1.internal_fat/test-applications/StartedThenFailsApp/resources/META-INF/MANIFEST.MF
@@ -1,0 +1,2 @@
+Manifest-Version: 1.0
+Class-Path: 

--- a/dev/io.openliberty.microprofile.health.3.1.internal_fat/test-applications/StartedThenFailsApp/src/io/openliberty/microprofile/health31/start/and/fails/app/AppServletContainerInitializer.java
+++ b/dev/io.openliberty.microprofile.health.3.1.internal_fat/test-applications/StartedThenFailsApp/src/io/openliberty/microprofile/health31/start/and/fails/app/AppServletContainerInitializer.java
@@ -1,0 +1,32 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.microprofile.health31.start.and.fails.app;
+
+import java.util.Set;
+
+import javax.servlet.ServletContainerInitializer;
+import javax.servlet.ServletContext;
+import javax.servlet.ServletException;
+
+/**
+ *
+ */
+public class AppServletContainerInitializer implements ServletContainerInitializer {
+
+    /** {@inheritDoc} */
+    @Override
+    public void onStartup(Set<Class<?>> arg0, ServletContext arg1) throws ServletException {
+        /*
+         * When this error is thrown, we will see a CWWKZ0012I thrown in the logs.
+         */
+        System.out.println("AppServletContainerInitializer: onStartup()");
+        throw new Error("Stop! An error!");
+    }
+}

--- a/dev/io.openliberty.microprofile.health.3.1.internal_fat/test-applications/StartedThenFailsApp/src/io/openliberty/microprofile/health31/start/and/fails/app/FailsToStartServlet.java
+++ b/dev/io.openliberty.microprofile.health.3.1.internal_fat/test-applications/StartedThenFailsApp/src/io/openliberty/microprofile/health31/start/and/fails/app/FailsToStartServlet.java
@@ -1,0 +1,48 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.microprofile.health31.start.and.fails.app;
+
+import java.io.IOException;
+
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * A sample HTTP servlet used to simulate a start failure
+ */
+@WebServlet("/FailsToStartServlet")
+public class FailsToStartServlet extends HttpServlet {
+
+    private static final long serialVersionUID = 1L;
+
+    public FailsToStartServlet() {
+        super();
+    }
+
+    @Override
+    protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        response.setContentType("text/plain");
+        response.setCharacterEncoding("UTF-8");
+        response.getWriter().append("Served at: ").append(request.getContextPath()).append("\n");
+        response.getWriter().println("You won't see this message, because I'm not going to start!");
+    }
+
+    @Override
+    protected void doPost(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        doGet(request, response);
+    }
+
+}


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

################################################################################################

Fixes #33651 

When application is stopped (either fail to start or shutdown), the application is removed from the AppTracker's config map if the previous state is NOT set at "STARTING". This is the typical state seen if an app fails to start.

However for instances where the app has "started" already but subsequently "fails to start" then state is already set to "INSTALLED" when we enter the application stopped phase. This results in the app being removed from the config map (thinking the application was shutdown/removed). This results in the health runtime evaluating it as having no apps deployed when there is a failed app.