### PR TITLE
Use buildLabel for version qualifier in all automated builds

### DIFF
--- a/dev/wlp-gradle/propertiesSettings.gradle
+++ b/dev/wlp-gradle/propertiesSettings.gradle
@@ -97,8 +97,7 @@ def setProperties = { props ->
 
     // For automated builds we use the buildLabel as a consistent qualifier.
     // buildLabel is set by the RTC build engines.
-    String buildLabel = props.getProperty('buildLabel')
-    String qualifier = isAutomatedBuild ? buildLabel : timestamp
+    String qualifier = isAutomatedBuild ? props.getProperty('buildLabel') : timestamp
 
     props.setProperty('version.qualifier', qualifier)
     props.setProperty('buildLabel', qualifier)

--- a/dev/wlp-gradle/propertiesSettings.gradle
+++ b/dev/wlp-gradle/propertiesSettings.gradle
@@ -98,10 +98,10 @@ def setProperties = { props ->
     // For automated builds we use the buildLabel as a consistent qualifier.
     // buildLabel is set by the RTC build engines.
     String buildLabel = props.getProperty('buildLabel')
-    String qualifier = (buildLabel != null && isAutomatedBuild) ? buildLabel : timestamp
+    String qualifier = isAutomatedBuild ? buildLabel : timestamp
 
     props.setProperty('version.qualifier', qualifier)
-    props.setProperty('buildLabel', timestamp)
+    props.setProperty('buildLabel', qualifier)
 
     /**
 	 * Properties used for making test outputs available in a commmon location.

--- a/dev/wlp-gradle/propertiesSettings.gradle
+++ b/dev/wlp-gradle/propertiesSettings.gradle
@@ -95,9 +95,10 @@ def setProperties = { props ->
      */
     String timestamp = new SimpleDateFormat("yyyyMMddHHmm").format(new java.util.Date())
 
-    // For release builds we use the buildLabel as a consistent qualifier.
+    // For automated builds we use the buildLabel as a consistent qualifier.
     // buildLabel is set by the RTC build engines.
-    String qualifier = (isRelease && isAutomatedBuild) ? props.getProperty('buildLabel') : timestamp
+    String buildLabel = props.getProperty('buildLabel')
+    String qualifier = (buildLabel != null && isAutomatedBuild) ? buildLabel : timestamp
 
     props.setProperty('version.qualifier', qualifier)
     props.setProperty('buildLabel', timestamp)


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".