### PR TITLE
Disable java security by default and only run with it for the Java 2 security pipeline

### DIFF
--- a/dev/com.ibm.ws.security.utility_fat/publish/clients/mySSLCmdClient/bootstrap.properties
+++ b/dev/com.ibm.ws.security.utility_fat/publish/clients/mySSLCmdClient/bootstrap.properties
@@ -25,6 +25,3 @@ ds.loglevel=debug
 ServerPort=8010
 ServerSecurePort=8020
 ServerIIOPPort=2809
-
-websphere.java.security
-websphere.java.security.norethrow=false


### PR DESCRIPTION
- By having the test run with Java 2 security always, it will always fail on Java 24 and later where Java 2 security isn't allowed any longer.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
