### PR TITLE
Extend timeout on connections and make it configurable

### DIFF
--- a/dev/com.ibm.ws.repository/src/com/ibm/ws/repository/transport/client/RestClient.java
+++ b/dev/com.ibm.ws.repository/src/com/ibm/ws/repository/transport/client/RestClient.java
@@ -67,7 +67,6 @@ public class RestClient extends AbstractRepositoryClient implements RepositoryRe
     private final ClientLoginInfo loginInfo;
 
     /**
-     * Newline string for ending lines when building an HTTP request
      */
     private static final String NEWLINE = "\r\n";
 
@@ -76,16 +75,16 @@ public class RestClient extends AbstractRepositoryClient implements RepositoryRe
      */
     private static final String ENCODED_BAR = "%7C";
 
-    private static final int REPOSITORY_SOCKET_READ_TIMEOUT = 300 * 1000;
+    private static final int REPOSITORY_SOCKET_READ_TIMEOUT = 60 * 60 * 1000;
 
     /**
      * Create a new instance of the client using the supplied userId and
      * password
      *
      * @param userId
-     *            The user id to use in Massive
+     *                     The user id to use in Massive
      * @param password
-     *            The password to use in Massive
+     *                     The password to use in Massive
      */
     public RestClient(ClientLoginInfo loginInfo) {
         super();
@@ -113,8 +112,8 @@ public class RestClient extends AbstractRepositoryClient implements RepositoryRe
      * @return This will return void if all is ok but will throw an exception if
      *         there are any problems
      * @throws RequestFailureException If the response code is not OK or the headers returned are missing
-     *             the count field (which can happen if we hit a URL that returns 200 but is not a valid repository).
-     * @throws IOException If there is a problem with the URL
+     *                                     the count field (which can happen if we hit a URL that returns 200 but is not a valid repository).
+     * @throws IOException             If there is a problem with the URL
      */
     @Override
     public void checkRepositoryStatus() throws IOException, RequestFailureException {
@@ -162,7 +161,7 @@ public class RestClient extends AbstractRepositoryClient implements RepositoryRe
      * this method.
      *
      * @param asset
-     *            The asset to add, it will not be modified by this method
+     *                  The asset to add, it will not be modified by this method
      * @return The asset with information added by Massive
      * @throws IOException
      */
@@ -187,7 +186,7 @@ public class RestClient extends AbstractRepositoryClient implements RepositoryRe
      * after calling this method.
      *
      * @param asset
-     *            The asset to add, it will not be modified by this method
+     *                  The asset to add, it will not be modified by this method
      * @return The asset with information added by Massive
      * @throws IOException
      * @throws RequestFailureException
@@ -220,7 +219,7 @@ public class RestClient extends AbstractRepositoryClient implements RepositoryRe
      *
      * @see #deleteAssetAndAttachments(String)
      * @param id
-     *            The ID to delete
+     *               The ID to delete
      * @return <code>true</code> if the delete is successful
      * @throws IOException
      * @throws RequestFailureException
@@ -240,7 +239,7 @@ public class RestClient extends AbstractRepositoryClient implements RepositoryRe
      * incorrectly).
      *
      * @param searchString The string to search for
-     * @param types The types to filter the results for
+     * @param types        The types to filter the results for
      * @return The assets that match the search string and type
      * @throws IOException
      * @throws RequestFailureException
@@ -460,9 +459,9 @@ public class RestClient extends AbstractRepositoryClient implements RepositoryRe
      * Returns the contents of an attachment
      *
      * @param assetId
-     *            The ID of the asset owning the attachment
+     *                         The ID of the asset owning the attachment
      * @param attachmentId
-     *            The ID of the attachment
+     *                         The ID of the attachment
      * @return The input stream for the attachment
      * @throws IOException
      * @throws RequestFailureException
@@ -497,9 +496,9 @@ public class RestClient extends AbstractRepositoryClient implements RepositoryRe
      * Returns the meta data about an attachment
      *
      * @param assetId
-     *            The ID of the asset owning the attachment
+     *                         The ID of the asset owning the attachment
      * @param attachmentId
-     *            The ID of the attachment
+     *                         The ID of the attachment
      * @return The attachment meta data
      * @throws IOException
      * @throws RequestFailureException
@@ -522,9 +521,9 @@ public class RestClient extends AbstractRepositoryClient implements RepositoryRe
      * Delete an attachment from an asset
      *
      * @param assetId
-     *            The ID of the asset containing the attachment
+     *                         The ID of the asset containing the attachment
      * @param attachmentId
-     *            The ID of the attachment to delete
+     *                         The ID of the attachment to delete
      * @return <code>true</code> if the delete was successful
      * @throws IOException
      * @throws RequestFailureException
@@ -541,7 +540,7 @@ public class RestClient extends AbstractRepositoryClient implements RepositoryRe
      * This will delete an asset and all its attachments
      *
      * @param assetId
-     *            The id of the asset
+     *                    The id of the asset
      * @return <code>true</code> if the asset and all its attachments are
      *         deleted. Note this is not atomic so some attachments may be
      *         deleted and <code>false</code> returned.
@@ -565,7 +564,7 @@ public class RestClient extends AbstractRepositoryClient implements RepositoryRe
      * Gets a single asset
      *
      * @param assetId
-     *            The ID of the asset to obtain
+     *                    The ID of the asset to obtain
      * @return The Asset
      * @throws IOException
      * @throws RequestFailureException
@@ -602,9 +601,9 @@ public class RestClient extends AbstractRepositoryClient implements RepositoryRe
      * action.
      *
      * @param assetId
-     *            The ID of the asset to update
+     *                    The ID of the asset to update
      * @param action
-     *            The action to take to modify the state
+     *                    The action to take to modify the state
      * @return <code>true</code> if the update was successful (currently always
      *         returns <code>true</code> from Massive)
      * @throws IOException
@@ -629,8 +628,8 @@ public class RestClient extends AbstractRepositoryClient implements RepositoryRe
      * information to connect to massive using the versioned URL as the base URL
      *
      * @param path
-     *            The path within massive to connect to (note this does not need
-     *            the API key or base path of "/ma/v1")
+     *                 The path within massive to connect to (note this does not need
+     *                 the API key or base path of "/ma/v1")
      * @return The {@link HttpURLConnection}
      * @throws IOException
      */
@@ -645,7 +644,7 @@ public class RestClient extends AbstractRepositoryClient implements RepositoryRe
      * </p>
      *
      * @param url
-     *            The complete URL to use (does not include the apiKey)
+     *                The complete URL to use (does not include the apiKey)
      * @return the {@link HttpURLConnection} with the api key and security
      *         information added
      * @throws IOException
@@ -715,7 +714,18 @@ public class RestClient extends AbstractRepositoryClient implements RepositoryRe
             connection = (HttpURLConnection) url.openConnection();
         }
 
-        connection.setReadTimeout(REPOSITORY_SOCKET_READ_TIMEOUT);
+        int timeout = REPOSITORY_SOCKET_READ_TIMEOUT;
+        String override = System.getenv("REPOSITORY_SOCKET_READ_TIMEOUT");
+        if (override != null) {
+            try {
+                int newTimeoutInSeconds = Integer.parseInt(override);
+                timeout = newTimeoutInSeconds * 1000;
+            } catch (Exception ex) {
+                // Not a number so ignore it
+            }
+        }
+        new Exception().printStackTrace();
+        connection.setReadTimeout(timeout);
 
         addAuthToConnection(connection);
 
@@ -764,13 +774,13 @@ public class RestClient extends AbstractRepositoryClient implements RepositoryRe
      * delete and an add.
      *
      * @param assetId
-     *            The ID of the asset that the attachment is attached to
+     *                    The ID of the asset that the attachment is attached to
      * @param name
-     *            The name of the attachment to update
+     *                    The name of the attachment to update
      * @param file
-     *            The file to attach
+     *                    The file to attach
      * @param attach
-     *            Attachment metadata
+     *                    Attachment metadata
      * @return
      * @throws IOException
      * @throws RequestFailureException
@@ -839,7 +849,7 @@ public class RestClient extends AbstractRepositoryClient implements RepositoryRe
      * Creates a URL filter for the <code>attribute</code> where the <code>values</code> are the valid values.
      *
      * @param attributeName The attributes to use in the filter
-     * @param values The valid values. Must not be <code>null</code> or empty
+     * @param values        The valid values. Must not be <code>null</code> or empty
      * @return The filter strings
      */
     private String createListFilter(FilterableAttribute attribute, Collection<String> values) {


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [ ] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".


This is a fix for #33697

I have increased the default timeout to one hour as well as providing the ability to override the default by creating an environment variable REPOSITORY_SOCKET_READ_TIMEOUT and giving that a timeout (in seconds)

This could be added to the installUtility documentation as an option. 
