### PR TITLE
Allow ORB not started msg in EJB FAT

### DIFF
--- a/dev/com.ibm.ws.ejbcontainer.injection_fat/fat/src/com/ibm/ws/ejbcontainer/injection/fat/tests/InjectionMIXTest.java
+++ b/dev/com.ibm.ws.ejbcontainer.injection_fat/fat/src/com/ibm/ws/ejbcontainer/injection/fat/tests/InjectionMIXTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2006, 2023 IBM Corporation and others.
+ * Copyright (c) 2006, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -11,6 +11,8 @@
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package com.ibm.ws.ejbcontainer.injection.fat.tests;
+
+import static org.junit.Assert.assertNotNull;
 
 import java.io.File;
 import java.util.Set;
@@ -47,6 +49,7 @@ import componenttest.annotation.Server;
 import componenttest.annotation.TestServlet;
 import componenttest.annotation.TestServlets;
 import componenttest.custom.junit.runner.FATRunner;
+import componenttest.custom.junit.runner.RepeatTestFilter;
 import componenttest.rules.repeater.FeatureReplacementAction;
 import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
@@ -101,12 +104,19 @@ public class InjectionMIXTest {
         ShrinkHelper.exportToServer(server, "connectors", AdapterForEJBRar, DeployOptions.SERVER_ONLY);
 
         server.startServer();
+
+        if (RepeatTestFilter.getRepeatActionsAsString().endsWith("CDIENABLED")) {
+            // verify the appSecurity-2.0 feature is ready
+            assertNotNull("Security service did not report it was ready", server.waitForStringInLogUsingMark("CWWKS0008I"));
+            assertNotNull("LTPA configuration did not report it was ready", server.waitForStringInLogUsingMark("CWWKS4105I"));
+            assertNotNull("ORB did not report it was ready", server.waitForStringInLogUsingMark("CWWKI0001I"));
+        }
     }
 
     @AfterClass
     public static void afterClass() throws Exception {
         try {
-            server.stopServer("J2CA8501E", "CNTR0168W", "CNTR0338W", "CWNEN0013W", "CNTR0020E");
+            server.stopServer("J2CA8501E", "CNTR0168W", "CNTR0338W", "CWNEN0013W", "CNTR0020E", "CWWKS9582E");
         } finally {
             // Remove the appSecurity feature that was added by the CDI repeat actions
             if (RepeatWithCDI.isActive() || RepeatWithEE9CDI.isActive()) {

--- a/dev/com.ibm.ws.ejbcontainer.remote.client_fat/fat/src/com/ibm/ws/ejbcontainer/remote/client/fat/tests/EjbLinkTest.java
+++ b/dev/com.ibm.ws.ejbcontainer.remote.client_fat/fat/src/com/ibm/ws/ejbcontainer/remote/client/fat/tests/EjbLinkTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2023 IBM Corporation and others.
+ * Copyright (c) 2020, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -115,6 +115,7 @@ public class EjbLinkTest extends FATServletClient {
         // verify the appSecurity-2.0 feature is ready
         assertNotNull("Security service did not report it was ready", server.waitForStringInLogUsingMark("CWWKS0008I"));
         assertNotNull("LTPA configuration did not report it was ready", server.waitForStringInLogUsingMark("CWWKS4105I"));
+        assertNotNull("ORB did not report it was ready", server.waitForStringInLogUsingMark("CWWKI0001I"));
         server.setMarkToEndOfLog();
 
         //#################### InitTxRecoveryLogApp.ear (Automatically initializes transaction recovery logs)
@@ -141,7 +142,7 @@ public class EjbLinkTest extends FATServletClient {
 
     @AfterClass
     public static void afterClass() throws Exception {
-        server.stopServer("CWWKG0033W", "CNTR0019E", "CWNEN0030E", "CWWKO0221E");
+        server.stopServer("CWWKG0033W", "CNTR0019E", "CWNEN0030E", "CWWKO0221E", "CWWKS9582E");
     }
 
     private void check() throws Exception {

--- a/dev/com.ibm.ws.ejbcontainer.remote.config_fat/fat/src/com/ibm/ws/ejbcontainer/remote/config/fat/tests/RebindConfigUpdateTest.java
+++ b/dev/com.ibm.ws.ejbcontainer.remote.config_fat/fat/src/com/ibm/ws/ejbcontainer/remote/config/fat/tests/RebindConfigUpdateTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023, 2024 IBM Corporation and others.
+ * Copyright (c) 2023, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -13,6 +13,7 @@
 package com.ibm.ws.ejbcontainer.remote.config.fat.tests;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 import java.util.HashSet;
 import java.util.List;
@@ -27,6 +28,7 @@ import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestWatcher;
@@ -74,6 +76,8 @@ public class RebindConfigUpdateTest extends FATServletClient {
     private static final Class<?> c = RebindConfigUpdateTest.class;
     private static HashSet<String> apps = new HashSet<String>();
     private static String servlet = "ConfigTestsWeb/RebindConfigUpdateServlet";
+
+    private String[] expected_ssl_exceptions = null;
 
     private static int ALL_LOCAL_BINDINGS = 15;
     private static int ALL_REMOTE_BINDINGS = 12;
@@ -147,12 +151,13 @@ public class RebindConfigUpdateTest extends FATServletClient {
                 server.stopServer();
             }
             if (server_ssl != null && server_ssl.isStarted()) {
-                server_ssl.stopServer();
+                server_ssl.stopServer(expected_ssl_exceptions);
             }
         } finally {
             // Restore the original server configuration
             server.restoreServerConfiguration();
             server_ssl.restoreServerConfiguration();
+            expected_ssl_exceptions = null;
         }
     }
 
@@ -289,7 +294,8 @@ public class RebindConfigUpdateTest extends FATServletClient {
      *
      * Note: For this scenario, the application should be restarted after each configuration change.
      */
-    // @Test - issue with yoko ORB
+    @Test
+    @Ignore("ORB restart not supported on Liberty - issue with yoko ORB") //TODO
     @ExpectedFFDC("com.ibm.wsspi.injectionengine.InjectionException")
     public void testRebindWhenEjbRemoteRemovedAdded() throws Exception {
         server.startServer();
@@ -312,7 +318,8 @@ public class RebindConfigUpdateTest extends FATServletClient {
      *
      * Note: For this scenario, the application should not be restarted after the configuration update.
      */
-    // @Test
+    @Test
+    @Ignore("ORB restart not supported on Liberty") //TODO
     public void testRebindAfterEjbContainerUpdated() throws Exception {
         server.startServer();
         verifyBindings(server, ALL_LOCAL_BINDINGS, ALL_REMOTE_BINDINGS);
@@ -331,7 +338,8 @@ public class RebindConfigUpdateTest extends FATServletClient {
      *
      * Note: For this scenario, the application should not be restarted after the configuration update.
      */
-    // @Test
+    @Test
+    @Ignore("ORB restart not supported on Liberty") //TODO
     public void testRebindAfterOrbUpdated() throws Exception {
         server.startServer();
         verifyBindings(server, ALL_LOCAL_BINDINGS, ALL_REMOTE_BINDINGS);
@@ -350,11 +358,17 @@ public class RebindConfigUpdateTest extends FATServletClient {
      *
      * Note: For this scenario, the application should not be restarted after the configuration update.
      */
-    // @Test
+    @Test
+    @Ignore("ORB restart not supported on Liberty") //TODO
     @ExpectedFFDC("com.ibm.wsspi.injectionengine.InjectionException")
     public void testRebindAfterOrbLateStart() throws Exception {
         List<Element> removed = removeQuickStartConfig();
         server_ssl.startServer();
+        assertNotNull("Security service did not report it was ready", server.waitForStringInLogUsingMark("CWWKS0008I"));
+        assertNotNull("LTPA configuration did not report it was ready", server.waitForStringInLogUsingMark("CWWKS4105I"));
+        assertNotNull("ORB did not report it was ready", server.waitForStringInLogUsingMark("CWWKI0001I"));
+        expected_ssl_exceptions = new String[] { "CWWKS9582E", "CWWKS9660E" }; // No user registry
+
         verifyBindings(server_ssl, ALL_LOCAL_BINDINGS, 0);
         FATServletClient.runTest(server_ssl, servlet, "testRebindAfterOrbLateStart_Initial");
 
@@ -370,10 +384,16 @@ public class RebindConfigUpdateTest extends FATServletClient {
      *
      * Note: For this scenario, the application should not be restarted after the configuration update.
      */
-    // @Test
+    @Test
+    @Ignore("ORB restart not supported on Liberty") //TODO
     @ExpectedFFDC("com.ibm.wsspi.injectionengine.InjectionException")
     public void testRebindAfterOrbStoppedStarted() throws Exception {
         server_ssl.startServer();
+        assertNotNull("Security service did not report it was ready", server.waitForStringInLogUsingMark("CWWKS0008I"));
+        assertNotNull("LTPA configuration did not report it was ready", server.waitForStringInLogUsingMark("CWWKS4105I"));
+        assertNotNull("ORB did not report it was ready", server.waitForStringInLogUsingMark("CWWKI0001I"));
+        expected_ssl_exceptions = new String[] { "CWWKS9582E" }; // ORB did not start in 10 seconds
+
         verifyBindings(server_ssl, ALL_LOCAL_BINDINGS, ALL_REMOTE_BINDINGS);
         FATServletClient.runTest(server_ssl, servlet, "testRebindAfterOrbStoppedStarted_Initial");
 

--- a/dev/com.ibm.ws.ejbcontainer.remote.config_fat/publish/servers/com.ibm.ws.ejbcontainer.remote.config.fat.server.ssl/server.xml
+++ b/dev/com.ibm.ws.ejbcontainer.remote.config_fat/publish/servers/com.ibm.ws.ejbcontainer.remote.config.fat.server.ssl/server.xml
@@ -18,7 +18,7 @@
         <iiopsOptions iiopsPort="${bvt.prop.IIOP.secure}"  sslRef="defaultSSLConfig"/>
     </iiopEndpoint>
 
-    <orb id="defaultOrb">
+    <orb id="defaultOrb" orbSSLInitTimeout="90">
         <serverPolicy.csiv2>
             <layers>
                 <authenticationLayer establishTrustInClient="Supported" mechanisms="GSSUP"/>

--- a/dev/com.ibm.ws.ejbcontainer.remote_fat/fat/src/com/ibm/ws/ejbcontainer/remote/fat/tests/Server2ServerTests.java
+++ b/dev/com.ibm.ws.ejbcontainer.remote_fat/fat/src/com/ibm/ws/ejbcontainer/remote/fat/tests/Server2ServerTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2023 IBM Corporation and others.
+ * Copyright (c) 2019, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -11,6 +11,8 @@
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package com.ibm.ws.ejbcontainer.remote.fat.tests;
+
+import static org.junit.Assert.assertNotNull;
 
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
@@ -120,18 +122,37 @@ public class Server2ServerTests extends AbstractTest {
 
         // Finally, start servers
         remoteServer.startServer();
+        if (isSecureActive) {
+            // verify the appSecurity-2.0 feature is ready
+            assertNotNull("Security service did not report it was ready", remoteServer.waitForStringInLogUsingMark("CWWKS0008I"));
+            assertNotNull("LTPA configuration did not report it was ready", remoteServer.waitForStringInLogUsingMark("CWWKS4105I"));
+            assertNotNull("ORB did not report it was ready", remoteServer.waitForStringInLogUsingMark("CWWKI0001I"));
+        }
+
         clientServer.useSecondaryHTTPPort();
         clientServer.startServer();
+        if (isSecureActive) {
+            // verify the appSecurity-2.0 feature is ready
+            assertNotNull("Security service did not report it was ready", clientServer.waitForStringInLogUsingMark("CWWKS0008I"));
+            assertNotNull("LTPA configuration did not report it was ready", clientServer.waitForStringInLogUsingMark("CWWKS4105I"));
+            assertNotNull("ORB did not report it was ready", clientServer.waitForStringInLogUsingMark("CWWKI0001I"));
+        }
     }
 
     @AfterClass
     public static void afterClass() throws Exception {
         if (isSecureActive) {
-            secureClientServer.stopServer();
-            secureRemoteServer.stopServer("CNTR0019E");
+            try {
+                secureClientServer.stopServer("CWWKS9582E");
+            } finally {
+                secureRemoteServer.stopServer("CNTR0019E", "CWWKS9582E");
+            }
         } else {
-            unsecureClientServer.stopServer();
-            unsecureRemoteServer.stopServer("CNTR0019E");
+            try {
+                unsecureClientServer.stopServer();
+            } finally {
+                unsecureRemoteServer.stopServer("CNTR0019E");
+            }
         }
         isSecureActive = false;
     }


### PR DESCRIPTION
- Allow "CWWKS9582E" that may occur on slow hardware
- Wait for security and ORB to report started if not already doing so

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
