### PR TITLE
Add com.gihub.luben.zstd as an optional import

### DIFF
--- a/dev/com.ibm.ws.filetransfer.routing.archiveExpander/bnd.bnd
+++ b/dev/com.ibm.ws.filetransfer.routing.archiveExpander/bnd.bnd
@@ -28,7 +28,8 @@ Import-Package: \
  !org.apache.commons.compress.compressors.lzw, \
  !org.apache.commons.compress, \
  !org.apache.commons.compress.parallel, \
- !org.apache.commons.io.file, *
+ !org.apache.commons.io.file, \
+ com.github.luben.zstd;resolution:=optional, *
 
 -includeresource: \
  @\${repo;com.ibm.ws.org.apache.commons.io}!/org/apache/commons/io/channels/FileChannels*, \


### PR DESCRIPTION
This change resolves getting errors like the one below:

```
[12/11/25, 6:35:36:088 UTC] 0000001f LogService-440-com.ibm.ws.jmx.connector.server.rest.jakarta  E CWWKE0702E: Could not resolve module: com.ibm.ws.jmx.connector.server.rest.jakarta [440]
  Unresolved requirement: Import-Package: com.ibm.ws.filetransfer.util; version="[1.0.0,2.0.0)"
    -> Export-Package: com.ibm.ws.filetransfer.util; bundle-symbolic-name="com.ibm.ws.filetransfer"; bundle-version="1.0.109.202512102249"; version="1.0.16"; uses:="com.ibm.websphere.ras.annotation,com.ibm.ws.ras.instrument.annotation"
       com.ibm.ws.filetransfer [443]
         Unresolved requirement: Import-Package: com.ibm.ws.filetransfer.routing.archiveExpander; version="[1.0.0,2.0.0)"
           -> Export-Package: com.ibm.ws.filetransfer.routing.archiveExpander; bundle-symbolic-name="com.ibm.ws.filetransfer.routing.archiveExpander"; bundle-version="1.0.109.202512102249"; version="1.0.0"
              com.ibm.ws.filetransfer.routing.archiveExpander [441]
                Unresolved requirement: Import-Package: com.github.luben.zstd

[12/11/25, 6:35:36:094 UTC] 0000001f gService-441-com.ibm.ws.filetransfer.routing.archiveExpander E CWWKE0702E: Could not resolve module: com.ibm.ws.filetransfer.routing.archiveExpander [441]
  Unresolved requirement: Import-Package: com.github.luben.zstd

[12/11/25, 6:35:36:097 UTC] 0000001f LogService-443-com.ibm.ws.filetransfer                       E CWWKE0702E: Could not resolve module: com.ibm.ws.filetransfer [443]
  Unresolved requirement: Import-Package: com.ibm.ws.filetransfer.routing.archiveExpander; version="[1.0.0,2.0.0)"
    -> Export-Package: com.ibm.ws.filetransfer.routing.archiveExpander; bundle-symbolic-name="com.ibm.ws.filetransfer.routing.archiveExpander"; bundle-version="1.0.109.202512102249"; version="1.0.0"
       com.ibm.ws.filetransfer.routing.archiveExpander [441]
         Unresolved requirement: Import-Package: com.github.luben.zstd
```

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
