### PR TITLE
Revert "Add trace WC31 CDITestHttpUpgradeHandler"

### DIFF
--- a/dev/com.ibm.ws.webcontainer.servlet.3.1_fat/test-applications/CDI12TestV2Upgrade.war/src/com/ibm/ws/webcontainer/servlet_31_fat/cdi12testv2upgrade/war/cdi/upgrade/handlers/CDITestHttpUpgradeHandler.java
+++ b/dev/com.ibm.ws.webcontainer.servlet.3.1_fat/test-applications/CDI12TestV2Upgrade.war/src/com/ibm/ws/webcontainer/servlet_31_fat/cdi12testv2upgrade/war/cdi/upgrade/handlers/CDITestHttpUpgradeHandler.java
@@ -261,7 +261,6 @@ public class CDITestHttpUpgradeHandler implements HttpUpgradeHandler {
 
         logBeanActivity(methodName, "Exit");
 
-        writeListener.setCloseWriteListener(); //tell WL, which is running on different thread, that this WL is closed/nulled out
         logInfo(methodName, "null out readListener [" + readListener + "] , writeListener [" + writeListener + "]");
         readListener = null;
         writeListener = null;

--- a/dev/com.ibm.ws.webcontainer.servlet.3.1_fat/test-applications/CDI12TestV2Upgrade.war/src/com/ibm/ws/webcontainer/servlet_31_fat/cdi12testv2upgrade/war/cdi/upgrade/handlers/CDITestReadListener.java
+++ b/dev/com.ibm.ws.webcontainer.servlet.3.1_fat/test-applications/CDI12TestV2Upgrade.war/src/com/ibm/ws/webcontainer/servlet_31_fat/cdi12testv2upgrade/war/cdi/upgrade/handlers/CDITestReadListener.java
@@ -93,7 +93,6 @@ public class CDITestReadListener implements ReadListener {
         logInfo(methodName, "this [" + this + "]");
 
         logBeanActivity(methodName, "Entry");
-        logInfo(methodName, "appendBeanData [RV]");
         appendBeanData("RV"); // 'R' for "ReadListener"; 'V' for "Available"
 
         byte[] buffer = new byte[1024];
@@ -133,8 +132,6 @@ public class CDITestReadListener implements ReadListener {
 
     private int doRead(byte[] buffer) throws IOException {
         String methodName = "doRead";
-        logInfo(methodName, "this [ " + this + "]");
-
         if (!servletInput.isReady()) {
             logInfo(methodName, "Servlet input is not ready; read [ -1 ]");
             return -1;
@@ -151,7 +148,6 @@ public class CDITestReadListener implements ReadListener {
         logEntry(methodName);
 
         logBeanActivity(methodName, "Entry");
-        logInfo(methodName, "appendBeanData [RA], this [" + this + "]");
 
         appendBeanData("RA"); // 'R' for "ReadListener"; 'A' for "AllData"
         logBeanState(methodName);
@@ -169,8 +165,6 @@ public class CDITestReadListener implements ReadListener {
         logEntry(methodName);
 
         logBeanActivity(methodName, "Entry");
-        logInfo(methodName, "appendBeanData [RE] , this [" + this + "]");
-
         appendBeanData("RE"); // 'R' for "ReadListener"; 'E' for "Error"
 
         try {

--- a/dev/com.ibm.ws.webcontainer.servlet.3.1_fat/test-applications/CDI12TestV2Upgrade.war/src/com/ibm/ws/webcontainer/servlet_31_fat/cdi12testv2upgrade/war/cdi/upgrade/handlers/CDITestWriteListener.java
+++ b/dev/com.ibm.ws.webcontainer.servlet.3.1_fat/test-applications/CDI12TestV2Upgrade.war/src/com/ibm/ws/webcontainer/servlet_31_fat/cdi12testv2upgrade/war/cdi/upgrade/handlers/CDITestWriteListener.java
@@ -22,11 +22,6 @@ import javax.servlet.http.WebConnection;
 public class CDITestWriteListener implements WriteListener {
     public static final String LOG_CLASS_NAME = "CDITestWriteListener";
 
-    //This flag control whether the test bean should be logged if the WL already closed
-    //There is an intermittent issue that can cause the "java.io.IOException: Broken pipe!".
-    //When pipe is broken AFTER the WL is closed/null out, the test bean should NOT be logged with the "WE"
-    private boolean closedWriteListener = true;
-
     private void logEntry(String methodName) {
         // System.out.println(LOG_CLASS_NAME + " " + methodName + " " + "ENTRY");
         CDITestHttpUpgradeHandler.logEntry(LOG_CLASS_NAME, methodName);
@@ -60,7 +55,6 @@ public class CDITestWriteListener implements WriteListener {
 
         this.webConnection = webConnection;
         this.requestOutput = this.webConnection.getOutputStream(); // throws IOException
-        this.closedWriteListener = false;
 
         // Assigning the write listener spawns a new thread,
         // which may run before or after this method exits.
@@ -102,7 +96,6 @@ public class CDITestWriteListener implements WriteListener {
         logInfo(methodName, "this [" + this + "]");
 
         logBeanActivity(methodName, "Entry");
-        logInfo(methodName, "appendBeanData [WP]");
         appendBeanData("WP"); // 'W' for "WriteListener"; 'P' for "Possible"
 
         boolean nextIsNumbers = false;
@@ -169,12 +162,7 @@ public class CDITestWriteListener implements WriteListener {
         logEntry(methodName);
 
         logBeanActivity(methodName, "Entry");
-
-        //Only log WE to the test BeanData if this writeListener is still active.  Do not log if WL already nulled out or closed
-        if (!closedWriteListener) {
-            logInfo(methodName, "appendBeanData [WE]");
-            appendBeanData("WE"); // 'W' for "WriteListener"; 'E' for "Error"
-        }
+        appendBeanData("WE"); // 'W' for "WriteListener"; 'E' for "Error"
 
         try {
             webConnection.close(); // throws Exception
@@ -186,10 +174,5 @@ public class CDITestWriteListener implements WriteListener {
         logBeanState(methodName);
 
         logExit(methodName);
-    }
-
-    public void setCloseWriteListener() {
-        logInfo("setCloseWriteListener", "close this WL [" + this + "]");
-        this.closedWriteListener = true;
     }
 }


### PR DESCRIPTION
Reverts OpenLiberty/open-liberty#33695

It causes some hard breaks.  The test passed in the PB beta server and locally so I don't know what is happening.
Also the break seems to be more on EE11

`testCDIUpgradeHandlerUpgrade_EE11_FEATURES:junit.framework.AssertionFailedError: Timeout occurred. Please note the time in the report does not reflect the time until the timeout.`