### PR TITLE
Move hasSubBuckets.txt file to build directory

### DIFF
--- a/dev/wlp-gradle/subprojects/fat.gradle
+++ b/dev/wlp-gradle/subprojects/fat.gradle
@@ -614,7 +614,7 @@ task zipProjectFVT {
             fileset(dir: "${distributionsDir}", includes: "${autoFVTFileName}")
             globmapper(from: 'autoFVT*.zip', to: "${bucketName}/build/lib/autoFVT.zip")
           }
-          zipfileset(dir: "${distributionsDir}", prefix: "${bucketName}/", includes: 'hasSubBuckets.txt')
+          zipfileset(dir: "${distributionsDir}", prefix: "${bucketName}/build/", includes: 'hasSubBuckets.txt')
         }
         file("${distributionsDir}/hasSubBuckets.txt").delete()
       }


### PR DESCRIPTION
- Moving the file to the build directory makes it be seen as a built resource and not a potential source file that need to be checked in.  

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
