### PR TITLE
Always use TypedQuery for queries that fetch results

### DIFF
--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/CursoredPageImpl.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/CursoredPageImpl.java
@@ -118,7 +118,9 @@ public class CursoredPageImpl<T> implements CursoredPage<T> {
                         isForward ? queryInfo.jpqlAfterCursor : //
                                         queryInfo.jpqlBeforeCursor;
 
-        jakarta.persistence.Query query = em.createQuery(jpql);
+        @SuppressWarnings("unchecked")
+        TypedQuery<T> query = (TypedQuery<T>) em.createQuery(jpql,
+                                                             Object.class);
         queryInfo.setParameters(query, args);
 
         if (cursor.isPresent())
@@ -127,7 +129,6 @@ public class CursoredPageImpl<T> implements CursoredPage<T> {
         query.setFirstResult(firstResult);
         query.setMaxResults(maxPageSize + (maxPageSize == Integer.MAX_VALUE ? 0 : 1)); // extra position is for knowing whether to expect another page
 
-        @SuppressWarnings("unchecked")
         List<T> resultList = query.getResultList();
         results = resultList;
 

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/PageImpl.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/PageImpl.java
@@ -100,14 +100,15 @@ public class PageImpl<T> implements Page<T> {
         this.pageRequest = pageRequest;
         this.args = args;
 
-        jakarta.persistence.Query query = em.createQuery(queryInfo.jpql);
+        @SuppressWarnings("unchecked")
+        TypedQuery<T> query = (TypedQuery<T>) em.createQuery(queryInfo.jpql,
+                                                             Object.class);
         queryInfo.setParameters(query, args);
 
         int maxPageSize = pageRequest.size();
         query.setFirstResult(queryInfo.computeOffset(pageRequest));
         query.setMaxResults(maxPageSize + (maxPageSize == Integer.MAX_VALUE ? 0 : 1));
 
-        @SuppressWarnings("unchecked")
         List<T> resultList = query.getResultList();
         results = resultList;
 

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
@@ -1690,7 +1690,7 @@ public class QueryInfo {
         if (trace && tc.isEntryEnabled())
             Tr.entry(this, tc, "exists");
 
-        jakarta.persistence.Query query = em.createQuery(jpql);
+        TypedQuery<?> query = em.createQuery(jpql, Object.class);
         query.setMaxResults(1);
         setParameters(query, args);
 
@@ -1903,7 +1903,7 @@ public class QueryInfo {
                          jpql,
                          entityInfo.entityClass.getName());
 
-            jakarta.persistence.Query query = em.createQuery(jpql);
+            TypedQuery<?> query = em.createQuery(jpql, Object.class);
             setParameters(query, args);
 
             if (type == FIND_AND_DELETE)
@@ -2244,7 +2244,7 @@ public class QueryInfo {
         if (TraceComponent.isAnyTracingEnabled() && jpql != this.jpql)
             Tr.debug(this, tc, "JPQL adjusted for NULL id or version", jpql);
 
-        jakarta.persistence.Query query = em.createQuery(jpql);
+        TypedQuery<?> query = em.createQuery(jpql, Object.class);
         query.setLockMode(LockModeType.PESSIMISTIC_WRITE);
 
         if (entityInfo.idClassAttributeAccessors == null) {


### PR DESCRIPTION
Align with direction of Jakarta Persistence, which is deprecating the use of `jakarta.persistence.Query` for queries that fetch results (SELECT/FROM queries).

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
