### PR TITLE
Ensure listener quiesce starts before thread quiesce

### DIFF
--- a/dev/com.ibm.ws.runtime.update/src/com/ibm/ws/runtime/update/internal/RuntimeUpdateManagerImpl.java
+++ b/dev/com.ibm.ws.runtime.update/src/com/ibm/ws/runtime/update/internal/RuntimeUpdateManagerImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2023 IBM Corporation and others.
+ * Copyright (c) 2013, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -395,13 +395,35 @@ public class RuntimeUpdateManagerImpl implements RuntimeUpdateManager, Synchrono
             }
         }
 
-        if (tc.isDebugEnabled())
-            Tr.debug(tc, "About to begin quiesce of executor service threads.");
+        // Listener quiesce started above. Give it up to 2 seconds to complete, before thread pool quiesce.
+        // Listener quiesce should normally complete quickly (less than 1 second.)
+        // Thread pool quiesce immediately sets the state to STOPPING.  If new work comes in (via listeners),
+        // that new work is accepted but is not tracked, not quiesced, and might will likely be abruptly terminated.
+        // So we need to give listeners a chance to complete before we quiesce the thread pool.
+        long startTimeNanos = System.nanoTime();
+        int listenersTimeoutSeconds = 2;
+        boolean listenersComplete = quiesceListenerFutures.isComplete(startTimeNanos, listenersTimeoutSeconds);
+        if (tc.isDebugEnabled()) {
+            Tr.debug(tc, "Quiesce listeners " + (listenersComplete ? "completed" : "did not complete") +
+                     " within  " + listenersTimeoutSeconds + " seconds");
+        }
 
         // Notify the executor service that we are quiescing
-
-        long startTime = System.currentTimeMillis();
-        if (tq.quiesceThreads() && quiesceListenerFutures.isComplete(startTime, quiesceTimeout)) {
+        // Thread pool quiesce gets all remaining time (28 seconds if listeners timed out at 2s)
+        long listenersElapsedSeconds = (System.nanoTime() - startTimeNanos) / 1_000_000_000L;
+        int remainingTimeSeconds = (int) Math.max(0, quiesceTimeout - listenersElapsedSeconds);
+        boolean threadPoolComplete = tq.quiesceThreads(remainingTimeSeconds);
+        
+        // If listeners didn't complete earlier, give listener quiesce the rest of the timeout
+        if (!listenersComplete) {
+            listenersComplete = quiesceListenerFutures.isComplete(startTimeNanos, quiesceTimeout);
+            if (tc.isDebugEnabled()) {
+                Tr.debug(tc, "After thread pool quiesce, listeners are " +
+                         (listenersComplete ? "complete" : "still running"));
+            }
+        }
+        
+        if (threadPoolComplete && listenersComplete) {
             if (isServer())
                 Tr.info(tc, "quiesce.end");
             else
@@ -474,17 +496,16 @@ public class RuntimeUpdateManagerImpl implements RuntimeUpdateManager, Synchrono
          * @return
          */
         @FFDCIgnore(TimeoutException.class)
-        boolean isComplete(long startTime, int quiesceTimeout) {
-            // We will wait quiesceTimeout seconds past the start time for tasks to complete
-            // Configured in the <executor> element of server.xml.  Default 30 seconds.
-            long endTime = startTime + quiesceTimeout * 1000;
+        boolean isComplete(long startTimeNanos, int quiesceTimeoutSeconds) {
+            // We will wait quiesceTimeoutSeconds past the start time for tasks to complete
+            long endTimeNanos = startTimeNanos + quiesceTimeoutSeconds * 1_000_000_000L;
 
             for (Future<?> f : quiesceListenerFutures) {
-                long waitTime = endTime - System.currentTimeMillis();
-                if (waitTime < 0)
+                long waitTimeNanos = endTimeNanos - System.nanoTime();
+                if (waitTimeNanos <= 0)
                     return false;
                 try {
-                    f.get(waitTime, TimeUnit.MILLISECONDS);
+                    f.get(waitTimeNanos, TimeUnit.NANOSECONDS);
                 } catch (TimeoutException e) {
                     return false;
                 } catch (Exception e) {

--- a/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/ThreadQuiesce.java
+++ b/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/ThreadQuiesce.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 IBM Corporation and others.
+ * Copyright (c) 2018, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -18,6 +18,14 @@ package com.ibm.ws.threading;
 public interface ThreadQuiesce {
 
     boolean quiesceThreads();
+
+    /**
+     * Quiesce threads with a specific timeout.
+     *
+     * @param timeoutSeconds Maximum time to wait for threads to complete, in seconds
+     * @return true if all threads completed within the timeout, false otherwise
+     */
+    boolean quiesceThreads(int timeoutSeconds);
 
     int getActiveThreads();
 

--- a/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/internal/ExecutorServiceImpl.java
+++ b/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/internal/ExecutorServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010, 2025 IBM Corporation and others.
+ * Copyright (c) 2010, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -619,14 +619,24 @@ public final class ExecutorServiceImpl implements WSExecutorService, ThreadQuies
      * @see com.ibm.ws.threading.ThreadQuiesce#quiesceThreads()
      */
     @Override
-    @FFDCIgnore(TimeoutException.class)
     public boolean quiesceThreads() {
+        return quiesceThreads(quiesceTimeout);
+    }
+
+    /*
+     * (non-Javadoc)
+     *
+     * @see com.ibm.ws.threading.ThreadQuiesce#quiesceThreads(long)
+     */
+    @Override
+    @FFDCIgnore(TimeoutException.class)
+    public boolean quiesceThreads(int timeoutSeconds) {
         this.serverStopping = true;
 
         try {
             // Wait for all pre-quiesce work to complete.
             phaser.arriveAndDeregister();
-            phaser.awaitAdvanceInterruptibly(0, quiesceTimeout, TimeUnit.SECONDS);
+            phaser.awaitAdvanceInterruptibly(0, timeoutSeconds, TimeUnit.SECONDS);
         } catch (InterruptedException e) {
             //FFDC and fail quiesce notification
             return false;


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] Fixes #33731  (verify `release bug` label)
- [x]  Fixes #33731

################################################################################################


Currently the RuntimeUpdateManager kicks off the quiesce for Listeners and then immediately begins quiescing threads.  It all happens in parallel. This race condition potentially allows new work to come in while the threads are quiescing.
- quiesceThreads() method immediately sets STOPPING state.
- New work during quiesce is accepted but is not tracked, not quiesced, and if thread quiesce completes before new work, the new work will likely be terminated abruptly as the JVM comes down.
   
This proposed change causes the RuntimeUpdateManager to wait **up to** 2 seconds before quiescing the threads.  Listener quiesce should normally complete in < 1 second.  It's not a perfect solution, but it gives the listeners a better chance of winning the race without adding to the total quiesceTimeout time.

**Solution:**

I modified the shutdown sequence to be more sequential instead of in parallel:

1. Added new API to ThreadQuiesce interface.   Timeout originates in ExecutorServiceImpl, but now RuntimeUpdateManagerImpl will consume **up to** 2 seconds for listener quiesce before quiescing threads.  It passes remaining time back to ExecutorServiceImpl.
`
public boolean quiesceThreads(int timeoutSeconds) `

2. Updated RuntimeUpdateManagerImpl.quiesceListeners():

- Wait for ServerQuiesceListener to complete (2 seconds max)
- Calculate remaining time from total 30-second timeout
- Pass remaining time to thread pool quiesce
- Better chance for JCA endpoints to deactivate BEFORE thread pool quiesce
