### PR TITLE
Initialize buffer only for CHFW

### DIFF
--- a/dev/com.ibm.ws.messaging.comms.client/src/com/ibm/ws/sib/jfapchannel/impl/Connection.java
+++ b/dev/com.ibm.ws.messaging.comms.client/src/com/ibm/ws/sib/jfapchannel/impl/Connection.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2023 IBM Corporation and others.
+ * Copyright (c) 2012, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -373,8 +373,8 @@ public abstract class Connection implements ConnectionInterface
             }
 
             // MS:4 take advantage of being able to leave this null for read (cf integration)
-            // TODO: Verify adding Netty check for performance?
-            if (tcpReadCtx.getBuffer() == null)
+            // Only needed for CHFW
+            if (!isUsingNetty() && tcpReadCtx.getBuffer() == null)
             {
                 if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) SibTr.debug(this, tc, "needs new buffer");
                 WsByteBuffer buffer = WsByteBufferPool.getInstance().wrap(new byte[1024]); // F196678.10


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

################################################################################################

`tcpReadCtx.getBuffer()` doesn't look to be used in netty, for example: 
https://github.com/OpenLiberty/open-liberty/blob/d091431a6cc980bb4ab9f5a0bf82201b78454a75/dev/com.ibm.ws.messaging.comms.client/src/com/ibm/ws/sib/jfapchannel/impl/Connection.java#L405C1-L407C18

`NettyConnectionReadCompletedCallback.readCompleted()` uses buffers from the netty pipeline. 

Fixes https://github.com/OpenLiberty/open-liberty/issues/31349