### PR TITLE
security: automatically get MongoDB updates

### DIFF
--- a/dev/io.openliberty.data.internal_fat_nosql/bnd.bnd
+++ b/dev/io.openliberty.data.internal_fat_nosql/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2022, 2025 IBM Corporation and others.
+# Copyright (c) 2022, 2026 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at

--- a/dev/io.openliberty.data.internal_fat_nosql/bnd.bnd
+++ b/dev/io.openliberty.data.internal_fat_nosql/bnd.bnd
@@ -23,7 +23,7 @@ javac.target: 17
 fat.minimum.java.level: 17
 fat.project: true
 
-fat.test.container.images: public.ecr.aws/docker/library/mongo:6.0.6
+fat.test.container.images: public.ecr.aws/docker/library/mongo:6.0
 
 -buildpath: \
 	com.ibm.ws.componenttest.2.0,\

--- a/dev/io.openliberty.data.internal_fat_nosql/fat/src/test/jakarta/data/nosql/FATSuite.java
+++ b/dev/io.openliberty.data.internal_fat_nosql/fat/src/test/jakarta/data/nosql/FATSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022, 2025 IBM Corporation and others.
+ * Copyright (c) 2022, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/dev/io.openliberty.data.internal_fat_nosql/fat/src/test/jakarta/data/nosql/FATSuite.java
+++ b/dev/io.openliberty.data.internal_fat_nosql/fat/src/test/jakarta/data/nosql/FATSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022,2024 IBM Corporation and others.
+ * Copyright (c) 2022, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -32,8 +32,9 @@ import componenttest.custom.junit.runner.AlwaysPassesTest;
 })
 public class FATSuite extends TestContainerSuite {
 
-    private static final DockerImageName mongoDBImage = DockerImageName.parse("public.ecr.aws/docker/library/mongo:6.0.6")
-                    .asCompatibleSubstituteFor("mongo:6.0.6");
+    private static final DockerImageName mongoDBImage = DockerImageName//
+                    .parse("public.ecr.aws/docker/library/mongo:6.0")
+                    .asCompatibleSubstituteFor("mongo:6.0");
 
     @ClassRule
     public static MongoDBContainer mongoDBContainer = new MongoDBContainer(mongoDBImage);

--- a/dev/io.openliberty.jakarta.data.1.0_fat_tck/bnd.bnd
+++ b/dev/io.openliberty.jakarta.data.1.0_fat_tck/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2022, 2025 IBM Corporation and others.
+# Copyright (c) 2022, 2026 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at

--- a/dev/io.openliberty.jakarta.data.1.0_fat_tck/bnd.bnd
+++ b/dev/io.openliberty.jakarta.data.1.0_fat_tck/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2022, 2024 IBM Corporation and others.
+# Copyright (c) 2022, 2025 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -34,7 +34,7 @@ fat.project: true
 # Options: Derby, Postgre, DB2, Oracle, SQLServer
 #fat.bucket.db.type: Postgre
 
-fat.test.container.images: public.ecr.aws/docker/library/mongo:6.0.6
+fat.test.container.images: public.ecr.aws/docker/library/mongo:6.0
 
 tested.features: databaseRotation, data-1.0
 

--- a/dev/io.openliberty.jakarta.data.1.0_fat_tck/fat/src/io/openliberty/jakarta/data/tck/FATSuite.java
+++ b/dev/io.openliberty.jakarta.data.1.0_fat_tck/fat/src/io/openliberty/jakarta/data/tck/FATSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022, 2025 IBM Corporation and others.
+ * Copyright (c) 2022, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/dev/io.openliberty.jakarta.data.1.0_fat_tck/fat/src/io/openliberty/jakarta/data/tck/FATSuite.java
+++ b/dev/io.openliberty.jakarta.data.1.0_fat_tck/fat/src/io/openliberty/jakarta/data/tck/FATSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022, 2024 IBM Corporation and others.
+ * Copyright (c) 2022, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -45,8 +45,9 @@ import componenttest.topology.impl.JavaInfo;
 })
 public class FATSuite extends TestContainerSuite {
 
-    private static final DockerImageName mongoDBImage = DockerImageName.parse("public.ecr.aws/docker/library/mongo:6.0.6")
-                    .asCompatibleSubstituteFor("mongo:6.0.6");
+    private static final DockerImageName mongoDBImage = DockerImageName //
+                    .parse("public.ecr.aws/docker/library/mongo:6.0")
+                    .asCompatibleSubstituteFor("mongo:6.0");
 
     @ClassRule
     public static JdbcDatabaseContainer<?> relationalDatabase = DatabaseContainerFactory.create();

--- a/dev/io.openliberty.jakarta.data.1.1_fat_tck/bnd.bnd
+++ b/dev/io.openliberty.jakarta.data.1.1_fat_tck/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2022, 2025 IBM Corporation and others.
+# Copyright (c) 2022, 2026 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at

--- a/dev/io.openliberty.jakarta.data.1.1_fat_tck/bnd.bnd
+++ b/dev/io.openliberty.jakarta.data.1.1_fat_tck/bnd.bnd
@@ -34,7 +34,7 @@ fat.project: true
 # Options: Derby, Postgre, DB2, Oracle, SQLServer
 #fat.bucket.db.type: Postgre
 
-fat.test.container.images: public.ecr.aws/docker/library/mongo:6.0.6
+fat.test.container.images: public.ecr.aws/docker/library/mongo:6.0
 
 tested.features:\
     data-1.1,\

--- a/dev/io.openliberty.jakarta.data.1.1_fat_tck/fat/src/io/openliberty/jakarta/data/tck/FATSuite.java
+++ b/dev/io.openliberty.jakarta.data.1.1_fat_tck/fat/src/io/openliberty/jakarta/data/tck/FATSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022, 2025 IBM Corporation and others.
+ * Copyright (c) 2022, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/dev/io.openliberty.jakarta.data.1.1_fat_tck/fat/src/io/openliberty/jakarta/data/tck/FATSuite.java
+++ b/dev/io.openliberty.jakarta.data.1.1_fat_tck/fat/src/io/openliberty/jakarta/data/tck/FATSuite.java
@@ -48,8 +48,9 @@ import componenttest.topology.impl.JavaInfo;
 })
 public class FATSuite extends TestContainerSuite {
 
-    private static final DockerImageName mongoDBImage = DockerImageName.parse("public.ecr.aws/docker/library/mongo:6.0.6")
-                    .asCompatibleSubstituteFor("mongo:6.0.6");
+    private static final DockerImageName mongoDBImage = DockerImageName //
+                    .parse("public.ecr.aws/docker/library/mongo:6.0")
+                    .asCompatibleSubstituteFor("mongo:6.0");
 
     @ClassRule
     public static JdbcDatabaseContainer<?> relationalDatabase = DatabaseContainerFactory.create();

--- a/dev/io.openliberty.org.testcontainers/cache/externals
+++ b/dev/io.openliberty.org.testcontainers/cache/externals
@@ -45,7 +45,7 @@ otel/opentelemetry-collector:0.74.0
 public.ecr.aws/docker/library/alpine:3
 public.ecr.aws/docker/library/alpine:3.17
 public.ecr.aws/docker/library/couchdb:3
-public.ecr.aws/docker/library/mongo:6.0.6
+public.ecr.aws/docker/library/mongo:6.0
 public.ecr.aws/docker/library/postgres:17
 public.ecr.aws/docker/library/postgres:17-alpine
 public.ecr.aws/docker/library/python:3.11.6

--- a/dev/io.openliberty.org.testcontainers/cache/images
+++ b/dev/io.openliberty.org.testcontainers/cache/images
@@ -3,7 +3,7 @@
 wasliberty-aws-docker-remote/docker/library/alpine:3
 wasliberty-aws-docker-remote/docker/library/alpine:3.17
 wasliberty-aws-docker-remote/docker/library/couchdb:3
-wasliberty-aws-docker-remote/docker/library/mongo:6.0.6
+wasliberty-aws-docker-remote/docker/library/mongo:6.0
 wasliberty-aws-docker-remote/docker/library/postgres:17
 wasliberty-aws-docker-remote/docker/library/postgres:17-alpine
 wasliberty-aws-docker-remote/docker/library/python:3.11.6


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

Switch to use a major version for MongoDB which will automatically get security updates but should not have breaking behavior.
