### PR TITLE
Update openliberty-MavenArtifact published version to be a timestamp

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/build.gradle
+++ b/dev/com.ibm.websphere.appserver.features/build.gradle
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018,2025 IBM Corporation and others.
+ * Copyright (c) 2018,2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -426,7 +426,10 @@ if (isAutomatedBuild) {
         publications {
             newMavenArtifact(MavenPublication) {
                 artifactId = 'openliberty-MavenArtifact'
-                version = project.version
+                // Not using project.version since some code expects it to be
+                // a timestamp instead of the build label
+                // version = project.version
+                version = bnd.get('libertyRelease') + '-' + rootProject.userProps.getProperty('build.timestamp')
                 artifact zipOpenLibertyMavenRepo
             }
         }

--- a/dev/wlp-gradle/propertiesSettings.gradle
+++ b/dev/wlp-gradle/propertiesSettings.gradle
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2022 IBM Corporation and others.
+ * Copyright (c) 2019, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -101,6 +101,7 @@ def setProperties = { props ->
 
     props.setProperty('version.qualifier', qualifier)
     props.setProperty('buildLabel', qualifier)
+    props.setProperty('build.timestamp', timestamp)
 
     /**
 	 * Properties used for making test outputs available in a commmon location.


### PR DESCRIPTION
- Before #33681 was merged in the openliberty-MavenArtifact zip file that was published from the build had a version of the liberty release followed by a timestamp.  After that PR was merged it was changed to be the build label instead of a timestamp to match all of the other files that are published from a build.  If it is determined that we want / need to go back to this one file having a timestamp instead of the build label, this PR allows for that change.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
