### PR TITLE
Wait for LTPA configuration to complete

### DIFF
--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config.commonTest/fat/src/io/openliberty/security/jakartasec/fat/config/tests/ConfigurationDisplayTests.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config.commonTest/fat/src/io/openliberty/security/jakartasec/fat/config/tests/ConfigurationDisplayTests.java
@@ -92,7 +92,7 @@ public class ConfigurationDisplayTests extends CommonAnnotatedSecurityTests {
         rpHttpsBase = "https://localhost:" + rpServer.getBvtSecurePort();
 
         deployMyApps(); // run this after starting the RP so we have the rp port to update the openIdConfig.properties file within the apps
-
+        rpServer.waitForStringInLog("CWWKS4105I.*",60000);
     }
 
     /**


### PR DESCRIPTION
LTPA configuration may complete after the apps have been installed and the apps have started. as such wait a resonable period for LTPA to complete configuring.

Fixes [#307938](https://wasrtc.hursley.ibm.com:9443/jazz/web/projects/WS-CD#action=com.ibm.team.workitem.viewWorkItem&id=307938)

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".