### PR TITLE
Remove requireService comments

### DIFF
--- a/dev/com.ibm.ws.messaging.comms.client/src/com/ibm/ws/sib/jfapchannel/impl/CommsOutboundChain.java
+++ b/dev/com.ibm.ws.messaging.comms.client/src/com/ibm/ws/sib/jfapchannel/impl/CommsOutboundChain.java
@@ -6,9 +6,6 @@
  * http://www.eclipse.org/legal/epl-2.0/
  * 
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package com.ibm.ws.sib.jfapchannel.impl;
 
@@ -85,8 +82,6 @@ public class CommsOutboundChain implements ApplicationPrereq {
     
     private static Map<String, CommsOutboundChain> chainList = new HashMap<String,CommsOutboundChain>();
 
-
-    // TODO: Check if this can be removed in favor of using requireService
     public static CommsOutboundChain getChainDetails(String chainName) {
         if (TraceComponent.isAnyTracingEnabled() && tc.isEntryEnabled())
             Tr.entry(tc, "getChainDetails");

--- a/dev/com.ibm.ws.messaging.comms.client/src/com/ibm/ws/sib/jfapchannel/impl/OutboundConnection.java
+++ b/dev/com.ibm.ws.messaging.comms.client/src/com/ibm/ws/sib/jfapchannel/impl/OutboundConnection.java
@@ -1,14 +1,11 @@
 /*******************************************************************************
- * Copyright (c) 2003, 2023 IBM Corporation and others.
+ * Copyright (c) 2003, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
  * 
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package com.ibm.ws.sib.jfapchannel.impl;
 
@@ -79,9 +76,8 @@ public class OutboundConnection extends Connection
                               int heartbeatInterval, // F175658
                               int heartbeatTimeout, // F175658
                               ConnectionData connectionData) throws FrameworkException
-    {//TODO: Check about using requireService for this see https://github.com/OpenLiberty/open-liberty/issues/24830
-        super(connLink, vc, heartbeatInterval, heartbeatTimeout, 
-        		CommsOutboundChain.getChainDetails(connLink.getMetaData().getChainName()) == null ? false : CommsOutboundChain.getChainDetails(connLink.getMetaData().getChainName()).useNetty()); // F174772, F175658
+    {
+        super(connLink, vc, heartbeatInterval, heartbeatTimeout, isNettyUsed(connLink)); // F174772, F175658
 
         if (TraceComponent.isAnyTracingEnabled() && tc.isEntryEnabled())
             SibTr.entry(this, tc, "<init>",
@@ -463,4 +459,10 @@ public class OutboundConnection extends Connection
     {
         return eyeCatcher;
     }
+
+    // Helper method for constructor
+    private static boolean isNettyUsed(NetworkConnectionContext connLink) {
+       CommsOutboundChain chain = CommsOutboundChain.getChainDetails(connLink.getMetaData().getChainName());
+       return (chain != null) && chain.useNetty();
+    }   
 }


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

################################################################################################

fixes #24830

The `requireService` is a OSGi service component method that is best for singleton services.  While chains are singletons, the look ups are much faster via the hashmap.  Refactoring the code would introduce complexity and hurt performance.  

The chainList is a private static method and it's only used within that class.  

The chainList also don't match the exisiting requireService lookups, such as nettyBundle, actualPoolManager, ...etc, so I've decided to remove the comments and leave things be.

