### PR TITLE
missing data tests

### DIFF
--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022, 2025 IBM Corporation and others.
+ * Copyright (c) 2022, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -2222,6 +2222,34 @@ public class DataTestServlet extends FATServlet {
         idAndName = all.get(8);
         assertEquals(23L, idAndName[0]);
         assertEquals("twenty-three", idAndName[1]);
+    }
+
+    /**
+     * Repository method with a float literal in a query.
+     */
+    @Test
+    public void testFloatLiteral() {
+        products.clear();
+
+        Product prod1 = new Product();
+        prod1.pk = UUID.nameUUIDFromBytes("TestFloatLiteral-1".getBytes());
+        prod1.name = "TestFloatLiteral-Product-1";
+        prod1.price = 18.49f;
+        products.save(prod1);
+
+        Product prod2 = new Product();
+        prod2.pk = UUID.nameUUIDFromBytes("TestFloatLiteral-2".getBytes());
+        prod2.name = "TestFloatLiteral-Product-2";
+        prod2.price = 18.52f;
+        products.save(prod2);
+
+        assertEquals(List.of("TestFloatLiteral-Product-1"),
+                     products.pricedBelowWithTax(20.0f)
+                                     .stream()
+                                     .map(p -> p.name)
+                                     .collect(Collectors.toList()));
+
+        products.clear();
     }
 
     /**

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Products.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Products.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022,2025 IBM Corporation and others.
+ * Copyright (c) 2022,2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -56,6 +56,12 @@ public interface Products {
 
     Optional<Product> findByPK(UUID id);
 
+    @Query("SELECT name")
+    String[] names();
+
+    @Query("WHERE price * 1.08125f < ?1")
+    List<Product> pricedBelowWithTax(float priceLimitIncludingTax);
+
     @Query("DELETE FROM Product p WHERE p.name LIKE ?1")
     int purge(String namePattern);
 
@@ -66,9 +72,6 @@ public interface Products {
                      WHERE name LIKE CONCAT('%', ?1, '%')
                     """)
     long putOnSale(String nameContains, float discount);
-
-    @Query("SELECT name")
-    String[] names();
 
     // Custom repository method that combines multiple operations into a single transaction
     @Transactional

--- a/dev/io.openliberty.data.internal_fat_errorpaths/fat/src/test/jakarta/data/errpaths/DataErrPathsTest.java
+++ b/dev/io.openliberty.data.internal_fat_errorpaths/fat/src/test/jakarta/data/errpaths/DataErrPathsTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024,2025 IBM Corporation and others.
+ * Copyright (c) 2024,2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -48,6 +48,9 @@ public class DataErrPathsTest extends FATServletClient {
     private static final String[] EXPECTED_ERROR_MESSAGES = //
                     new String[] {
                                    "CWWJP9991W.*4002", // 2 persistence units attempt to autocreate same table
+                                   "CWWKD1002E.*addAndRetrieve", // Insert and Find on same method
+                                   "CWWKD1002E.*saveAndRemove", // Save and Delete on same method
+                                   "CWWKD1002E.*updateAndRetrieve", // Update and Query on same method
                                    "CWWKD1003E.*existsByAddress", // exists method returning int
                                    "CWWKD1003E.*existsByBirthday", // exists method returning Page<Boolean>
                                    "CWWKD1003E.*existsByName", // exists method returning CompletableFuture<Long>

--- a/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/DataErrPathsTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/DataErrPathsTestServlet.java
@@ -40,6 +40,12 @@ import jakarta.data.page.Page;
 import jakarta.data.page.PageRequest;
 import jakarta.data.page.PageRequest.Cursor;
 import jakarta.data.page.PageRequest.Mode;
+import jakarta.data.repository.Delete;
+import jakarta.data.repository.Find;
+import jakarta.data.repository.Insert;
+import jakarta.data.repository.Query;
+import jakarta.data.repository.Save;
+import jakarta.data.repository.Update;
 import jakarta.inject.Inject;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.EntityManagerFactory;
@@ -1533,6 +1539,73 @@ public class DataErrPathsTestServlet extends FATServlet {
             if (x.getMessage() == null ||
                 !x.getMessage().startsWith("CWWKD1084E:") ||
                 !x.getMessage().contains("bornIn"))
+                throw x;
+        }
+    }
+
+    /**
+     * Verify an appropriate error is raised when Insert and Find annotate
+     * the same repository method.
+     */
+    @Test
+    public void testMixInsertAndFind() {
+        Voter v = new Voter(22446688, "Vera", //
+                        LocalDate.of(1972, Month.JANUARY, 7), //
+                        "244 Soldiers Field Dr SW, Rochester, MN 55902");
+
+        try {
+            v = voters.addAndRetrieve(v);
+            fail("Repository method annotated both Insert and Find" +
+                 " should be invalid. Instead found: " + v);
+        } catch (UnsupportedOperationException x) {
+            if (x.getMessage() == null ||
+                !x.getMessage().startsWith("CWWKD1002E:") ||
+                !x.getMessage().contains(Find.class.getName()) ||
+                !x.getMessage().contains(Insert.class.getName()))
+                throw x;
+        }
+    }
+
+    /**
+     * Verify an appropriate error is raised when Save and Delete annotate
+     * the same repository method.
+     */
+    @Test
+    public void testMixSaveAndDelete() {
+        Voter v = voters.findById(987665432).orElseThrow();
+        v.birthday = LocalDate.of(1988, Month.JANUARY, 8);
+
+        try {
+            voters.saveAndRemove(v);
+            fail("Repository method annotated both Save and Remove" +
+                 " should be invalid.");
+        } catch (UnsupportedOperationException x) {
+            if (x.getMessage() == null ||
+                !x.getMessage().startsWith("CWWKD1002E:") ||
+                !x.getMessage().contains(Save.class.getName()) ||
+                !x.getMessage().contains(Delete.class.getName()))
+                throw x;
+        }
+    }
+
+    /**
+     * Verify an appropriate error is raised when Update and Query annotate
+     * the same repository method.
+     */
+    @Test
+    public void testMixUpdateAndQuery() {
+        Voter v = voters.findById(987665432).orElseThrow();
+        v.birthday = LocalDate.of(1981, Month.JANUARY, 5);
+
+        try {
+            Optional<Voter> found = voters.updateAndRetrieve(v.ssn, v);
+            fail("Repository method annotated both Update and Query" +
+                 " should be invalid. Instead found: " + found);
+        } catch (UnsupportedOperationException x) {
+            if (x.getMessage() == null ||
+                !x.getMessage().startsWith("CWWKD1002E:") ||
+                !x.getMessage().contains(Query.class.getName()) ||
+                !x.getMessage().contains(Update.class.getName()))
                 throw x;
         }
     }

--- a/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/DataErrPathsTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/DataErrPathsTestServlet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024,2025 IBM Corporation and others.
+ * Copyright (c) 2024,2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -2318,6 +2318,42 @@ public class DataErrPathsTestServlet extends FATServlet {
             if (x.getMessage() == null ||
                 !x.getMessage().startsWith("CWWKD1015E") ||
                 !x.getMessage().contains("addOrUpdate"))
+                throw x;
+        }
+    }
+
+    /**
+     * Verify an appropriate error is raised upon attempt to access totals from
+     * a Page that was requested without totals.
+     */
+    @Test
+    public void testTotalsWhenRequestedWithoutTotals() {
+        Order<Voter> order = Order.by(_Voter.birthday.asc(),
+                                      _Voter.name.asc());
+        PageRequest pageReq = PageRequest.ofSize(12).withoutTotal();
+        String address = "4051 E River Rd NE, Rochester, MN 55906";
+
+        Page<Voter> page = voters.atAddress(address, pageReq, order);
+
+        try {
+            long total = page.totalElements();
+            fail("Should not be able to retrieve totalElements when the page is" +
+                 " requested without totals. Found: " + total);
+        } catch (IllegalStateException x) {
+            if (x.getMessage() == null ||
+                !x.getMessage().startsWith("CWWKD1042E:") ||
+                !x.getMessage().contains("requestTotal"))
+                throw x;
+        }
+
+        try {
+            long total = page.totalPages();
+            fail("Should not be able to retrieve totalPages when the page is" +
+                 " requested without totals. Found: " + total);
+        } catch (IllegalStateException x) {
+            if (x.getMessage() == null ||
+                !x.getMessage().startsWith("CWWKD1042E:") ||
+                !x.getMessage().contains("requestTotal"))
                 throw x;
         }
     }

--- a/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/Voters.java
+++ b/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/Voters.java
@@ -49,6 +49,14 @@ public interface Voters extends BasicRepository<Voter, Integer> {
     }
 
     /**
+     * Invalid method. Insert and Find cannot annotate the same repository
+     * method.
+     */
+    @Insert
+    @Find
+    Voter addAndRetrieve(Voter v);
+
+    /**
      * Invalid method. A method with a life cycle annotation must have exactly
      * 1 parameter.
      */
@@ -505,6 +513,14 @@ public interface Voters extends BasicRepository<Voter, Integer> {
                            String city, // extra, unused parameter
                            String stateCode); // extra, unused parameter
 
+    /**
+     * Invalid method. Save and Delete cannot annotate the same repository
+     * method.
+     */
+    @Save
+    @Delete
+    void saveAndRemove(Voter v);
+
     @Find
     Page<Voter> selectAll(PageRequest req,
                           Sort<?>... sorts);
@@ -593,6 +609,10 @@ public interface Voters extends BasicRepository<Voter, Integer> {
     CursoredPage<Voter> unionOfAddresses(String address1,
                                          String address2,
                                          PageRequest pageReq);
+
+    @Update
+    @Query("FROM Voter WHERE ssn = ?1")
+    Optional<Voter> updateAndRetrieve(int ssn, Voter v);
 
     /**
      * This invalid method has a query that requires a single positional parameter,


### PR DESCRIPTION
Resolves #29104 by adding remaining tests that were identified to be missing:
- totalElements and totalPages must not be available when requested withoutTotals
- query with literal float value
- invalid combinations of annotations on repository methods

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
