### PR TITLE
Updated H2 tests for hard break with Java 2 security with Netty

### DIFF
--- a/dev/com.ibm.ws.http2.client/src/com/ibm/ws/http2/test/frames/FrameSettingsClient.java
+++ b/dev/com.ibm.ws.http2.client/src/com/ibm/ws/http2/test/frames/FrameSettingsClient.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2023 IBM Corporation and others.
+ * Copyright (c) 2018, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -9,6 +9,8 @@
  *******************************************************************************/
 package com.ibm.ws.http2.test.frames;
 
+import java.security.AccessController;
+import java.security.PrivilegedAction;
 import java.util.Base64;
 
 import com.ibm.wsspi.bytebuffer.WsByteBuffer;
@@ -27,6 +29,25 @@ public class FrameSettingsClient extends com.ibm.ws.http.channel.h2internal.fram
     private final WsByteBuffer frameBuilt;
 
     private final ByteBuf frame;
+
+    static {
+        // We discovered an issue with the adaptive allocator using Unsafe being unavailable
+        // and throwing exceptions which do not allow the tests to proceed due to Java 2 Security.
+        // Because of this, while this is fixed we will use the pooled allocator as before to
+        // ensure proper testing
+        if (System.getSecurityManager() == null) {
+            System.setProperty("io.netty.allocator.type", "pooled");
+        }
+        else {
+            AccessController.doPrivileged(new PrivilegedAction<Void>() {
+                @Override
+                public Void run() {
+                    System.setProperty("io.netty.allocator.type", "pooled");
+                    return null;
+                }
+            });
+        }
+    }
 
     /**
      *

--- a/dev/com.ibm.ws.transport.http2_fat/publish/servers/http2ClientRuntime.tracing/server.xml
+++ b/dev/com.ibm.ws.transport.http2_fat/publish/servers/http2ClientRuntime.tracing/server.xml
@@ -12,6 +12,10 @@
     <keyStore id="defaultKeyStore" password="Liberty" type="PKCS12" location="${shared.resource.dir}/security/key.p12" />
 
     <javaPermission className="java.net.SocketPermission" actions="accept,connect,listen,resolve" name="*"/>
+    <!-- Java 2 Security issue using Netty's Unpooled to create proper settings frames for the H2 client
+    Access denied ("java.io.FilePermission "/open-liberty/dev/com.ibm.ws.transport.http2_fat/build/libs/autoFVT/build/tmp" "read")
+    No idea of the actual base path to the tmp directory that is attempted to be created -->
+    <javaPermission className="java.io.FilePermission" name="/-" actions="read"/>
     
     <!-- FAT framework expects to start with the usual port  -->
     <httpEndpoint id="defaultHttpEndpoint"

--- a/dev/com.ibm.ws.transport.http2_fat/publish/servers/http2ClientRuntime/server.xml
+++ b/dev/com.ibm.ws.transport.http2_fat/publish/servers/http2ClientRuntime/server.xml
@@ -12,6 +12,10 @@
     <keyStore id="defaultKeyStore" password="Liberty" type="PKCS12" location="${shared.resource.dir}/security/key.p12"/>
     
     <javaPermission className="java.net.SocketPermission" actions="accept,connect,listen,resolve" name="*"/>
+    <!-- Java 2 Security issue using Netty's Unpooled to create proper settings frames for the H2 client
+    Access denied ("java.io.FilePermission "/open-liberty/dev/com.ibm.ws.transport.http2_fat/build/libs/autoFVT/build/tmp" "read")
+    No idea of the actual base path to the tmp directory that is attempted to be created -->
+    <javaPermission className="java.io.FilePermission" name="/-" actions="read"/>
     
     <!-- FAT framework expects to start with the usual port  -->
     <httpEndpoint id="defaultHttpEndpoint"
@@ -19,5 +23,5 @@
                   httpPort="${bvt.prop.HTTP_default}"
                   httpsPort="${bvt.prop.HTTP_default.secure}">
         <tcpOptions soReuseAddr="true" />
-    </httpEndpoint>   
+    </httpEndpoint>
 </server>


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [ ] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

Switch Netty allocator for HTTP 2.0 client and added missing Java2 security permission issues for defect 307420