### PR TITLE
Address JMS Netty Connection Properties TODOs

### DIFF
--- a/dev/com.ibm.ws.messaging.comms.client/src/com/ibm/ws/sib/jfapchannel/netty/NettyNetworkConnection.java
+++ b/dev/com.ibm.ws.messaging.comms.client/src/com/ibm/ws/sib/jfapchannel/netty/NettyNetworkConnection.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022, 2025 IBM Corporation and others.
+ * Copyright (c) 2022, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -136,11 +136,10 @@ public class NettyNetworkConnection implements NetworkConnection{
 	 *
 	 * @see com.ibm.ws.sib.jfapchannel.framework.NetworkConnection#requestPermissionToClose(long)
 	 */
-	public boolean requestPermissionToClose(long timeout)
-	{
-		// TODO Figure out the netty equivalent for this. Only used in connection see https://github.com/OpenLiberty/open-liberty/issues/24812
-		if (TraceComponent.isAnyTracingEnabled() && tc.isEntryEnabled()) SibTr.entry(this, tc, "requestPermissionToClose", Long.valueOf(timeout));
-		//	      boolean canProcess = vc.requestPermissionToClose(timeout);
+	public boolean requestPermissionToClose(long timeout) {
+	
+		// Netty does not need a requestPermissionToClose because Netty handles shutdowns gracefully via Channel.close().
+		// Relying on a timeout here would be unnecessary as CHFW & Netty's architectures differ 
 		if (TraceComponent.isAnyTracingEnabled() && tc.isEntryEnabled()) SibTr.exit(this, tc, "requestPermissionToClose", Boolean.valueOf(true));
 		return true;
 	}

--- a/dev/com.ibm.ws.messaging.comms.client/src/com/ibm/ws/sib/jfapchannel/netty/NettyNetworkConnection.java
+++ b/dev/com.ibm.ws.messaging.comms.client/src/com/ibm/ws/sib/jfapchannel/netty/NettyNetworkConnection.java
@@ -89,12 +89,10 @@ public class NettyNetworkConnection implements NetworkConnection{
 		if (TraceComponent.isAnyTracingEnabled() && tc.isEntryEnabled()) SibTr.entry(this, tc, "<init>" ,new Object[] {bootstrap, chainName});
 
 		this.chainName = chainName;
-		// TODO: Check if this is the best way to do this for SSL options https://github.com/OpenLiberty/open-liberty/issues/24813
 		this.sslOptions = sslOptions == null ? null : new HashMap<String, Object>((Map)sslOptions);
 		this.isInbound = isInbound;
 		this.tlsProvider = tlsProvider;
 		this.nettyBundle = nettyBundle;
-		// TODO Check if we need to clone this https://github.com/OpenLiberty/open-liberty/issues/24813
 		this.bootstrap = bootstrap;
 
 		if (TraceComponent.isAnyTracingEnabled() && tc.isEntryEnabled()) SibTr.exit(tc, "<init>", new Object[] {bootstrap, chainName});


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

fixes #24813

Bob's analysis of why cloning wasn't necessary: 
```
The cloning approach is problematic because:

Bootstrap cloning doesn't deep-clone all internal state
- The handler still references the original bootstrap's initializer
- Netty Bootstrap objects are designed to be reused directly, not cloned
- The parent.init(ch) call (line 345) creates shared state issues
Recommendation
- Remove the cloning entirely. Use the original bootstrap directly and ensure each connection gets its own handler instance (which you're already doing). The issue is likely that the base initializer isn't setting up the pipeline correctly for the heartbeat handler replacement to work.
```