### PR TITLE
Fix intermittent telemetry metrics test failures for RTC 303368

### DIFF
--- a/dev/io.openliberty.microprofile.telemetry.internal.monitor_fat/fat/src/io/openliberty/microprofile/telemetry/internal/monitor_fat/BaseTestClass.java
+++ b/dev/io.openliberty.microprofile.telemetry.internal.monitor_fat/fat/src/io/openliberty/microprofile/telemetry/internal/monitor_fat/BaseTestClass.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024, 2025 IBM Corporation and others.
+ * Copyright (c) 2024, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -99,13 +99,14 @@ public abstract class BaseTestClass {
   }
     
     /**
-     * Waits one second before checking the condition. Will wait 1 second for every retry amount. Uses the default of 5 seconds.
+     * Waits one second before checking the condition. Will wait 1 second for every retry amount. Uses the default of 40 seconds.
+     * Increased from 20 to 40 to accommodate slower platforms (especially z/OS) where OpenTelemetry exporter may be busy.
      *
      * @param metricsText The /metrics output
      * @param expectedString String array of expected strings
      */
     protected void matchStringsWithRetries(Supplier<String> metricsOutput, String[] expectedString) throws InterruptedException {
-	matchStringsWithRetries(metricsOutput, expectedString, 20);
+ matchStringsWithRetries(metricsOutput, expectedString, 40);
     }
 
     /**

--- a/dev/io.openliberty.microprofile.telemetry.internal.monitor_fat/fat/src/io/openliberty/microprofile/telemetry/internal/monitor_fat/ConnectionPoolMetricsTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.internal.monitor_fat/fat/src/io/openliberty/microprofile/telemetry/internal/monitor_fat/ConnectionPoolMetricsTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024, 2025 IBM Corporation and others.
+ * Copyright (c) 2024, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -112,26 +112,27 @@ public class ConnectionPoolMetricsTest extends BaseTestClass {
 		matchStringsWithRetries(() -> getContainerCollectorMetrics(container), new String[] {".*"});
 
 		// Allow time for the collector to receive and expose metrics
+		// Made patterns more flexible - removed strict job="unknown_service" and instance patterns
 		matchStringsWithRetries(() -> getContainerCollectorMetrics(container),
-                new String[] { "io_openliberty_connection_pool_handle_count\\{instance=\"[a-zA-Z0-9-]*\",io_openliberty_datasource_name=\"jdbc/exampleDS1\",job=\"unknown_service\"\\}.*",
-                        "io_openliberty_connection_pool_connection_free\\{instance=\"[a-zA-Z0-9-]*\",io_openliberty_datasource_name=\"jdbc/exampleDS1\",job=\"unknown_service\"\\}.*",
-                        "io_openliberty_connection_pool_connection_destroyed_total\\{instance=\"[a-zA-Z0-9-]*\",io_openliberty_datasource_name=\"jdbc/exampleDS1\",job=\"unknown_service\"\\}.*",
-                        "io_openliberty_connection_pool_connection_created_total\\{instance=\"[a-zA-Z0-9-]*\",io_openliberty_datasource_name=\"jdbc/exampleDS1\",job=\"unknown_service\"\\}.*",
-                        "io_openliberty_connection_pool_connection_count\\{instance=\"[a-zA-Z0-9-]*\",io_openliberty_datasource_name=\"jdbc/exampleDS1\",job=\"unknown_service\"\\}.*",
-                        
-                        "io_openliberty_connection_pool_connection_use_time_seconds_bucket\\{instance=\"[a-zA-Z0-9-]*\",io_openliberty_datasource_name=\"jdbc/exampleDS1\",job=\"unknown_service\",le=\"\\+Inf\"\\}.*",
-                        "io_openliberty_connection_pool_connection_use_time_seconds_sum\\{instance=\"[a-zA-Z0-9-]*\",io_openliberty_datasource_name=\"jdbc/exampleDS1\",job=\"unknown_service\"\\}.*",
-                        "io_openliberty_connection_pool_connection_use_time_seconds_count\\{instance=\"[a-zA-Z0-9-]*\",io_openliberty_datasource_name=\"jdbc/exampleDS1\",job=\"unknown_service\"\\}.*",
-                        
-                        "io_openliberty_connection_pool_handle_count\\{instance=\"[a-zA-Z0-9-]*\",io_openliberty_datasource_name=\"jdbc/exampleDS2\",job=\"unknown_service\"\\}.*",
-                        "io_openliberty_connection_pool_connection_free\\{instance=\"[a-zA-Z0-9-]*\",io_openliberty_datasource_name=\"jdbc/exampleDS2\",job=\"unknown_service\"\\}.*",
-                        "io_openliberty_connection_pool_connection_destroyed_total\\{instance=\"[a-zA-Z0-9-]*\",io_openliberty_datasource_name=\"jdbc/exampleDS2\",job=\"unknown_service\"\\}.*",
-                        "io_openliberty_connection_pool_connection_created_total\\{instance=\"[a-zA-Z0-9-]*\",io_openliberty_datasource_name=\"jdbc/exampleDS2\",job=\"unknown_service\"\\}.*",
-                        "io_openliberty_connection_pool_connection_count\\{instance=\"[a-zA-Z0-9-]*\",io_openliberty_datasource_name=\"jdbc/exampleDS2\",job=\"unknown_service\"\\}.*",
-                        
-                        "io_openliberty_connection_pool_connection_use_time_seconds_bucket\\{instance=\"[a-zA-Z0-9-]*\",io_openliberty_datasource_name=\"jdbc/exampleDS2\",job=\"unknown_service\",le=\"\\+Inf\"\\}.*",
-                        "io_openliberty_connection_pool_connection_use_time_seconds_sum\\{instance=\"[a-zA-Z0-9-]*\",io_openliberty_datasource_name=\"jdbc/exampleDS2\",job=\"unknown_service\"\\}.*",
-                        "io_openliberty_connection_pool_connection_use_time_seconds_count\\{instance=\"[a-zA-Z0-9-]*\",io_openliberty_datasource_name=\"jdbc/exampleDS2\",job=\"unknown_service\"\\}.*"});
+		              new String[] { "io_openliberty_connection_pool_handle_count\\{.*io_openliberty_datasource_name=\"jdbc/exampleDS1\".*\\}.*",
+		                      "io_openliberty_connection_pool_connection_free\\{.*io_openliberty_datasource_name=\"jdbc/exampleDS1\".*\\}.*",
+		                      "io_openliberty_connection_pool_connection_destroyed_total\\{.*io_openliberty_datasource_name=\"jdbc/exampleDS1\".*\\}.*",
+		                      "io_openliberty_connection_pool_connection_created_total\\{.*io_openliberty_datasource_name=\"jdbc/exampleDS1\".*\\}.*",
+		                      "io_openliberty_connection_pool_connection_count\\{.*io_openliberty_datasource_name=\"jdbc/exampleDS1\".*\\}.*",
+		                      
+		                      "io_openliberty_connection_pool_connection_use_time_seconds_bucket\\{.*io_openliberty_datasource_name=\"jdbc/exampleDS1\".*le=\"\\+Inf\".*\\}.*",
+		                      "io_openliberty_connection_pool_connection_use_time_seconds_sum\\{.*io_openliberty_datasource_name=\"jdbc/exampleDS1\".*\\}.*",
+		                      "io_openliberty_connection_pool_connection_use_time_seconds_count\\{.*io_openliberty_datasource_name=\"jdbc/exampleDS1\".*\\}.*",
+		                      
+		                      "io_openliberty_connection_pool_handle_count\\{.*io_openliberty_datasource_name=\"jdbc/exampleDS2\".*\\}.*",
+		                      "io_openliberty_connection_pool_connection_free\\{.*io_openliberty_datasource_name=\"jdbc/exampleDS2\".*\\}.*",
+		                      "io_openliberty_connection_pool_connection_destroyed_total\\{.*io_openliberty_datasource_name=\"jdbc/exampleDS2\".*\\}.*",
+		                      "io_openliberty_connection_pool_connection_created_total\\{.*io_openliberty_datasource_name=\"jdbc/exampleDS2\".*\\}.*",
+		                      "io_openliberty_connection_pool_connection_count\\{.*io_openliberty_datasource_name=\"jdbc/exampleDS2\".*\\}.*",
+		                      
+		                      "io_openliberty_connection_pool_connection_use_time_seconds_bucket\\{.*io_openliberty_datasource_name=\"jdbc/exampleDS2\".*le=\"\\+Inf\".*\\}.*",
+		                      "io_openliberty_connection_pool_connection_use_time_seconds_sum\\{.*io_openliberty_datasource_name=\"jdbc/exampleDS2\".*\\}.*",
+		                      "io_openliberty_connection_pool_connection_use_time_seconds_count\\{.*io_openliberty_datasource_name=\"jdbc/exampleDS2\".*\\}.*"});
 	}
 
 }


### PR DESCRIPTION
fixes #32067

This PR addresses the recurring intermittent test failures in the telemetry metrics tests that were still occurring after PR #32152.

### Changes Made:
1. **Increased retry timeout from 20 to 40 seconds** in `BaseTestClass.matchStringsWithRetries()` to accommodate slower z/OS platforms where the OpenTelemetry exporter may be busy and drop metrics (as noted by @dchan in RTC 303368)

2. **Fixed `ConnectionPoolMetricsTest` regex patterns** - removed strict `job="unknown_service"` and `instance` pattern requirements that were missed in the previous fix. Made patterns flexible like `LibertyMetricsTest`.

3. **Updated copyright** to 2026 in all modified files

### Root Causes Addressed:
- **Timing issue**: OpenTelemetry exporter being busy on z/OS platforms (35% failure rate)
- **Pattern matching**: ConnectionPoolMetricsTest still had strict patterns from before PR #32152

### Testing:
The changes follow the same pattern that was applied to LibertyMetricsTest in PR #32152, but now comprehensively applied across all affected tests with increased timeout for reliability.

Related: RTC 303368
