### PR TITLE
Fix for RTC 305871

### DIFF
--- a/dev/com.ibm.ws.security.javaeesec_fat.4/fat/src/com/ibm/ws/security/javaeesec/fat/SSOTest.java
+++ b/dev/com.ibm.ws.security.javaeesec_fat.4/fat/src/com/ibm/ws/security/javaeesec/fat/SSOTest.java
@@ -91,6 +91,11 @@ public class SSOTest extends JavaEESecTestBase {
         basicUrl = urlHttps + "/JavaEESec/MultipleISBasicAuthServlet";
         formContextRoot = urlHttps + "/FormPostRedirect";
         formUrl = formContextRoot + "/FormPostServlet";
+
+        /*
+         * Wait for the SSL endpoint to start.
+         */
+        myServer.waitForStringInLog("CWWKO0219I.*defaultHttpEndpoint-ssl");
     }
 
     @AfterClass

--- a/dev/com.ibm.ws.security.javaeesec_fat.4/fat/src/com/ibm/ws/security/javaeesec/fat/SSOTest.java
+++ b/dev/com.ibm.ws.security.javaeesec_fat.4/fat/src/com/ibm/ws/security/javaeesec/fat/SSOTest.java
@@ -95,7 +95,7 @@ public class SSOTest extends JavaEESecTestBase {
         /*
          * Wait for the SSL endpoint to start.
          */
-        myServer.waitForStringInLog("CWWKO0219I.*defaultHttpEndpoint-ssl");
+        myServer.waitForSSLStart();
     }
 
     @AfterClass

--- a/dev/com.ibm.ws.security.javaeesec_fat.4/fat/src/com/ibm/ws/security/javaeesec/fat/ScopedTest.java
+++ b/dev/com.ibm.ws.security.javaeesec_fat.4/fat/src/com/ibm/ws/security/javaeesec/fat/ScopedTest.java
@@ -74,6 +74,11 @@ public class ScopedTest extends JavaEESecTestBase {
         myServer.addInstalledAppForValidation("RequestScopedMechanismWithApplicationScopedStore");
 
         urlHttps = "https://" + myServer.getHostname() + ":" + myServer.getHttpDefaultSecurePort();
+
+        /*
+         * Wait for the SSL endpoint to start.
+         */
+        myServer.waitForStringInLog("CWWKO0219I.*defaultHttpEndpoint-ssl");
     }
 
     @AfterClass

--- a/dev/com.ibm.ws.security.javaeesec_fat.4/fat/src/com/ibm/ws/security/javaeesec/fat/ScopedTest.java
+++ b/dev/com.ibm.ws.security.javaeesec_fat.4/fat/src/com/ibm/ws/security/javaeesec/fat/ScopedTest.java
@@ -78,7 +78,7 @@ public class ScopedTest extends JavaEESecTestBase {
         /*
          * Wait for the SSL endpoint to start.
          */
-        myServer.waitForStringInLog("CWWKO0219I.*defaultHttpEndpoint-ssl");
+        myServer.waitForSSLStart();
     }
 
     @AfterClass

--- a/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/AutoApplySessionTest.java
+++ b/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/AutoApplySessionTest.java
@@ -78,7 +78,7 @@ public class AutoApplySessionTest extends JavaEESecTestBase {
         /*
          * Wait for the SSL endpoint to start.
          */
-        myServer.waitForStringInLog("CWWKO0219I");
+        myServer.waitForStringInLog("CWWKO0219I.*defaultHttpEndpoint-ssl");
     }
 
     @AfterClass

--- a/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/AutoApplySessionTest.java
+++ b/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/AutoApplySessionTest.java
@@ -78,7 +78,7 @@ public class AutoApplySessionTest extends JavaEESecTestBase {
         /*
          * Wait for the SSL endpoint to start.
          */
-        myServer.waitForStringInLog("CWWKO0219I.*defaultHttpEndpoint-ssl");
+        myServer.waitForSSLStart();
     }
 
     @AfterClass

--- a/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/BasicAuthenticationMechanismTest.java
+++ b/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/BasicAuthenticationMechanismTest.java
@@ -80,6 +80,11 @@ public class BasicAuthenticationMechanismTest extends JavaEESecTestBase {
         myServer.startServer(true);
         urlHttp = "http://" + myServer.getHostname() + ":" + myServer.getHttpDefaultPort();
         urlHttps = "https://" + myServer.getHostname() + ":" + myServer.getHttpDefaultSecurePort();
+
+        /*
+         * Wait for the SSL endpoint to start.
+         */
+        myServer.waitForStringInLog("CWWKO0219I.*defaultHttpEndpoint-ssl");
     }
 
     @AfterClass

--- a/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/BasicAuthenticationMechanismTest.java
+++ b/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/BasicAuthenticationMechanismTest.java
@@ -84,7 +84,7 @@ public class BasicAuthenticationMechanismTest extends JavaEESecTestBase {
         /*
          * Wait for the SSL endpoint to start.
          */
-        myServer.waitForStringInLog("CWWKO0219I.*defaultHttpEndpoint-ssl");
+        myServer.waitForSSLStart();
     }
 
     @AfterClass

--- a/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/FormHttpAuthenticationMechanismTest.java
+++ b/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/FormHttpAuthenticationMechanismTest.java
@@ -84,6 +84,11 @@ public class FormHttpAuthenticationMechanismTest extends JavaEESecTestBase {
         myServer.startServer(true);
         urlHttp = "http://" + myServer.getHostname() + ":" + myServer.getHttpDefaultPort();
         urlHttps = "https://" + myServer.getHostname() + ":" + myServer.getHttpDefaultSecurePort();
+
+        /*
+         * Wait for the SSL endpoint to start.
+         */
+        myServer.waitForStringInLog("CWWKO0219I.*defaultHttpEndpoint-ssl");
     }
 
     @AfterClass

--- a/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/FormHttpAuthenticationMechanismTest.java
+++ b/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/FormHttpAuthenticationMechanismTest.java
@@ -88,7 +88,7 @@ public class FormHttpAuthenticationMechanismTest extends JavaEESecTestBase {
         /*
          * Wait for the SSL endpoint to start.
          */
-        myServer.waitForStringInLog("CWWKO0219I.*defaultHttpEndpoint-ssl");
+        myServer.waitForSSLStart();
     }
 
     @AfterClass

--- a/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/ProgrammaticTest.java
+++ b/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/ProgrammaticTest.java
@@ -65,6 +65,11 @@ public class ProgrammaticTest extends JavaEESecTestBase {
 
         urlBase = "http://" + myServer.getHostname() + ":" + myServer.getHttpDefaultPort();
         urlHttps = "https://" + myServer.getHostname() + ":" + myServer.getHttpDefaultSecurePort();
+
+        /*
+         * Wait for the SSL endpoint to start.
+         */
+        myServer.waitForStringInLog("CWWKO0219I.*defaultHttpEndpoint-ssl");
     }
 
     @AfterClass

--- a/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/ProgrammaticTest.java
+++ b/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/ProgrammaticTest.java
@@ -69,7 +69,7 @@ public class ProgrammaticTest extends JavaEESecTestBase {
         /*
          * Wait for the SSL endpoint to start.
          */
-        myServer.waitForStringInLog("CWWKO0219I.*defaultHttpEndpoint-ssl");
+        myServer.waitForSSLStart();
     }
 
     @AfterClass

--- a/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/RememberMeTest.java
+++ b/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/RememberMeTest.java
@@ -97,6 +97,11 @@ public class RememberMeTest extends JavaEESecTestBase {
 
         urlHttp = "http://" + myServer.getHostname() + ":" + myServer.getHttpDefaultPort();
         urlHttps = "https://" + myServer.getHostname() + ":" + myServer.getHttpDefaultSecurePort();
+
+        /*
+         * Wait for the SSL endpoint to start.
+         */
+        myServer.waitForStringInLog("CWWKO0219I.*defaultHttpEndpoint-ssl");
     }
 
     @AfterClass

--- a/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/RememberMeTest.java
+++ b/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/RememberMeTest.java
@@ -101,7 +101,7 @@ public class RememberMeTest extends JavaEESecTestBase {
         /*
          * Wait for the SSL endpoint to start.
          */
-        myServer.waitForStringInLog("CWWKO0219I.*defaultHttpEndpoint-ssl");
+        myServer.waitForSSLStart();
     }
 
     @AfterClass


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [ ] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

----

- Tests run into a `Connection to https://localhost:8020/ refused` due to SSL port not being initialized before proceeding with test
- Add wait to allow for initialization of SSL port