### PR TITLE
[PAUSED] Vertx HTTP request decoding

### DIFF
--- a/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
+++ b/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
@@ -1467,6 +1467,11 @@
       <version>4.1.0</version>
     </dependency>
     <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-core</artifactId>
+      <version>5.0.6</version>
+    </dependency>
+    <dependency>
       <groupId>io.zipkin.reporter2</groupId>
       <artifactId>zipkin-reporter</artifactId>
       <version>2.16.4</version>

--- a/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
+++ b/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
@@ -1469,7 +1469,7 @@
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-core</artifactId>
-      <version>5.0.6</version>
+      <version>4.5.24</version>
     </dependency>
     <dependency>
       <groupId>io.zipkin.reporter2</groupId>

--- a/dev/cnf/oss_dependencies.maven
+++ b/dev/cnf/oss_dependencies.maven
@@ -289,6 +289,7 @@ io.smallrye:smallrye-open-api-jaxrs:4.0.9
 io.smallrye:smallrye-open-api-jaxrs:4.1.0
 io.smallrye:smallrye-open-api-model:4.0.9
 io.smallrye:smallrye-open-api-model:4.1.0
+io.vertx:vertx-core:5.0.6
 io.zipkin.reporter2:zipkin-reporter:2.16.4
 io.zipkin.reporter2:zipkin-reporter:3.3.0
 io.zipkin.reporter2:zipkin-sender-okhttp3:2.16.4

--- a/dev/cnf/oss_dependencies.maven
+++ b/dev/cnf/oss_dependencies.maven
@@ -289,7 +289,7 @@ io.smallrye:smallrye-open-api-jaxrs:4.0.9
 io.smallrye:smallrye-open-api-jaxrs:4.1.0
 io.smallrye:smallrye-open-api-model:4.0.9
 io.smallrye:smallrye-open-api-model:4.1.0
-io.vertx:vertx-core:5.0.6
+io.vertx:vertx-core:4.5.24
 io.zipkin.reporter2:zipkin-reporter:2.16.4
 io.zipkin.reporter2:zipkin-reporter:3.3.0
 io.zipkin.reporter2:zipkin-sender-okhttp3:2.16.4

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/channel/internal/HttpServiceContextImpl.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/channel/internal/HttpServiceContextImpl.java
@@ -2325,6 +2325,15 @@ public abstract class HttpServiceContextImpl implements HttpServiceContext, FFDC
                 Tr.debug(tc, "sendHeaders: Adding close connection header due to keep alive disabled or exceeded number of maximum persistent requests");
             }
             getResponse().setHeader(HttpHeaderKeys.HDR_CONNECTION,  ConnectionValues.CLOSE.getName());
+            setPersistent(false);
+        }
+        // If status code is an error code, then we need to set the close value for persistence
+        else if (getResponse().getStatusCode().isErrorCode()) {
+            if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                Tr.debug(tc, "Error status code disabling persistence.");
+            }
+            getResponse().setHeader(HttpHeaderKeys.HDR_CONNECTION,  ConnectionValues.CLOSE.getName());
+            setPersistent(false);
         }
         if (HttpUtil.isContentLengthSet(response)) {
             this.nettyContext.channel().attr(NettyHttpConstants.CONTENT_LENGTH).set(HttpUtil.getContentLength(response));

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/channel/internal/HttpServiceContextImpl.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/channel/internal/HttpServiceContextImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2004, 2025 IBM Corporation and others.
+ * Copyright (c) 2004, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution,  and is available at
@@ -3085,7 +3085,14 @@ public abstract class HttpServiceContextImpl implements HttpServiceContext, FFDC
         Http2Connection connection = handler.connection();
 
         int nextPromisedStreamId = connection.local().incrementAndGetNextStreamId();
-        int currentStreamId = nettyRequest.headers().getInt(HttpConversionUtil.ExtensionHeaderNames.STREAM_ID.text(), 0);
+        int parsedStreamId = 0;
+        try {
+            parsedStreamId = Integer.parseInt(nettyRequest.headers().get(HttpConversionUtil.ExtensionHeaderNames.STREAM_ID.text()));
+        } catch (NumberFormatException e) {
+            // Ignore this exception since the currentStreamId will be left the same
+        }
+
+        final int currentStreamId = parsedStreamId;
 
         Http2Headers headers = new DefaultHttp2Headers().clear();
         String scheme = "https";

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/netty/message/NettyRequestMessage.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/netty/message/NettyRequestMessage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023, 2025 IBM Corporation and others.
+ * Copyright (c) 2023, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -811,7 +811,14 @@ public class NettyRequestMessage extends NettyBaseMessage implements HttpRequest
         Http2Connection connection = handler.connection();
 
         int nextPromisedStreamId = connection.local().incrementAndGetNextStreamId();
-        int currentStreamId = this.request.headers().getInt(HttpConversionUtil.ExtensionHeaderNames.STREAM_ID.text(), 0);
+        int parsedStreamId = 0;
+        try {
+            parsedStreamId = Integer.parseInt(this.request.headers().get(HttpConversionUtil.ExtensionHeaderNames.STREAM_ID.text()));
+        } catch (NumberFormatException e) {
+            // Ignore this exception since the currentStreamId will be left the same
+        }
+
+        final int currentStreamId = parsedStreamId;
 
         Http2Headers headers = new DefaultHttp2Headers().clear();
         String scheme = "https";

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/netty/message/NettyResponseMessage.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/netty/message/NettyResponseMessage.java
@@ -398,7 +398,20 @@ public class NettyResponseMessage extends NettyBaseMessage implements HttpRespon
 
     @Override
     public StatusCodes getStatusCode() {
-        return StatusCodes.getByOrdinal(getStatusCodeAsInt());
+        StatusCodes val = null;
+        try {
+            val = StatusCodes.getByOrdinal(getStatusCodeAsInt());
+        } catch (IndexOutOfBoundsException e) {
+            // no FFDC required
+            // nothing to do, just make the undefined value below
+        }
+
+        // this could be null because the ordinal lookup returned an empty
+        // status code, or because it was out of bounds
+        if (null == val) {
+            val = StatusCodes.makeUndefinedValue(getStatusCodeAsInt());
+        }
+        return val;
     }
 
     @Override

--- a/dev/io.openliberty.io.netty/bnd.bnd
+++ b/dev/io.openliberty.io.netty/bnd.bnd
@@ -11,6 +11,7 @@
 -include= ~../cnf/resources/bnd/bundle.props
 bVersion=1.0
 nettyVersion=4.2.10.Final
+vertxVersion=5.0.6
 
 Bundle-Name: Netty as an OSGi bundle
 Bundle-SymbolicName: io.openliberty.io.netty
@@ -40,6 +41,13 @@ Import-Package: \
   !org.slf4j*,\
   !reactor.blockhound.*,\
   !sun.*,\
+  !com.fasterxml.jackson*,\
+  !io.netty.channel.uring*,\
+  !io.netty.handler.codec.dns*,\
+  !io.netty.handler.codec.haproxy*,\
+  !io.netty.resolver.dns*,\
+  !io.vertx.codegen.annotations*,\
+  !io.vertx.core*,\
   *
 
 -includeresource: \
@@ -54,6 +62,9 @@ Bundle-NativeCode: \
   META-INF/native/libnetty_transport_native_kqueue_aarch_64.jnilib; osname=MacOSX; processor=aarch_64,\
   META-INF/native/libnetty_transport_native_kqueue_x86_64.jnilib; osname=MacOSX; processor=x86_64,\
   *
+
+Private-Package: \
+  io.vertx.core*
 
 Export-Package: \
   !io.netty.handler.ssl.*,\
@@ -80,5 +91,6 @@ instrument.disabled: true
   io.netty:netty-transport-classes-epoll;version=${nettyVersion},\
   io.netty:netty-transport-native-epoll;version=${nettyVersion},\
   io.netty:netty-transport-classes-kqueue;version=${nettyVersion},\
-  io.netty:netty-transport-native-kqueue;version=${nettyVersion}
+  io.netty:netty-transport-native-kqueue;version=${nettyVersion},\
+  io.vertx:vertx-core;version=${vertxVersion}
   

--- a/dev/io.openliberty.io.netty/bnd.bnd
+++ b/dev/io.openliberty.io.netty/bnd.bnd
@@ -11,7 +11,7 @@
 -include= ~../cnf/resources/bnd/bundle.props
 bVersion=1.0
 nettyVersion=4.2.10.Final
-vertxVersion=5.0.6
+vertxVersion=4.5.24
 
 Bundle-Name: Netty as an OSGi bundle
 Bundle-SymbolicName: io.openliberty.io.netty

--- a/dev/io.openliberty.io.netty/src/io/netty/handler/codec/http/HttpDecoderConfig.java
+++ b/dev/io.openliberty.io.netty/src/io/netty/handler/codec/http/HttpDecoderConfig.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2023 The Netty Project
+ * Copyright (c) 2024, 2025 IBM Corporation and others
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/dev/io.openliberty.io.netty/src/io/netty/handler/codec/http/HttpObjectDecoder.java
+++ b/dev/io.openliberty.io.netty/src/io/netty/handler/codec/http/HttpObjectDecoder.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2012 The Netty Project
+ * Copyright (c) 2024, 2025 IBM Corporation and others
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/dev/io.openliberty.io.netty/src/io/netty/handler/codec/http/HttpServerCodec.java
+++ b/dev/io.openliberty.io.netty/src/io/netty/handler/codec/http/HttpServerCodec.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2012 The Netty Project
+ * Copyright (c) 2024, 2025 IBM Corporation and others
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/dev/io.openliberty.io.netty/src/io/netty/handler/codec/http/HttpServerCodec.java
+++ b/dev/io.openliberty.io.netty/src/io/netty/handler/codec/http/HttpServerCodec.java
@@ -18,6 +18,7 @@ package io.netty.handler.codec.http;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.CombinedChannelDuplexHandler;
+import io.vertx.core.http.impl.VertxHttpRequestDecoder;
 
 import java.util.ArrayDeque;
 import java.util.List;
@@ -155,7 +156,9 @@ public final class HttpServerCodec extends CombinedChannelDuplexHandler<HttpRequ
      * Creates a new instance with the specified decoder configuration.
      */
     public HttpServerCodec(HttpDecoderConfig config) {
-        init(new HttpServerRequestDecoder(config), new HttpServerResponseEncoder());
+        // Liberty specific change for using Liberty httpOptions while also using
+        // Vert.x decoding logic.
+        init(new VertxHttpRequestDecoder(config), new HttpServerResponseEncoder());
     }
 
     /**

--- a/dev/io.openliberty.io.netty/src/io/netty/handler/codec/http/HttpServerCodec.java
+++ b/dev/io.openliberty.io.netty/src/io/netty/handler/codec/http/HttpServerCodec.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2012 The Netty Project
- * Copyright (c) 2024, 2025 IBM Corporation and others
+ * Copyright (c) 2024, 2026 IBM Corporation and others
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -157,9 +157,7 @@ public final class HttpServerCodec extends CombinedChannelDuplexHandler<HttpRequ
      * Creates a new instance with the specified decoder configuration.
      */
     public HttpServerCodec(HttpDecoderConfig config) {
-        // Liberty specific change for using Liberty httpOptions while also using
-        // Vert.x decoding logic.
-        init(new VertxHttpRequestDecoder(config), new HttpServerResponseEncoder());
+        init(new HttpServerRequestDecoder(config), new HttpServerResponseEncoder());
     }
 
     /**
@@ -171,7 +169,11 @@ public final class HttpServerCodec extends CombinedChannelDuplexHandler<HttpRequ
         ctx.pipeline().remove(this);
     }
 
-    private final class HttpServerRequestDecoder extends HttpRequestDecoder {
+    /**
+     * Liberty specific change for using Liberty httpOptions while also using
+     * Vert.x decoding logic for HTTP requests.
+     */
+    private final class HttpServerRequestDecoder extends VertxHttpRequestDecoder {
         HttpServerRequestDecoder(HttpDecoderConfig config) {
             super(config);
         }

--- a/dev/io.openliberty.io.netty/src/io/netty/handler/codec/http2/AbstractHttp2ConnectionHandlerBuilder.java
+++ b/dev/io.openliberty.io.netty/src/io/netty/handler/codec/http2/AbstractHttp2ConnectionHandlerBuilder.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2015 The Netty Project
+ * Copyright (c) 2024 IBM Corporation and others
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/dev/io.openliberty.io.netty/src/io/netty/handler/codec/http2/DefaultHttp2FrameReader.java
+++ b/dev/io.openliberty.io.netty/src/io/netty/handler/codec/http2/DefaultHttp2FrameReader.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2014 The Netty Project
+ * Copyright (c) 2024 IBM Corporation and others
  *
  * The Netty Project licenses this file to you under the Apache License, version 2.0 (the
  * "License"); you may not use this file except in compliance with the License. You may obtain a

--- a/dev/io.openliberty.io.netty/src/io/netty/handler/codec/http2/HpackDecoder.java
+++ b/dev/io.openliberty.io.netty/src/io/netty/handler/codec/http2/HpackDecoder.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2015 The Netty Project
+ * Copyright (c) 2024 IBM Corporation and others
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/dev/io.openliberty.io.netty/src/io/netty/handler/codec/http2/Http2ConnectionHandler.java
+++ b/dev/io.openliberty.io.netty/src/io/netty/handler/codec/http2/Http2ConnectionHandler.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2014 The Netty Project
+ * Copyright (c) 2024, 2025 IBM Corporation and others
  *
  * The Netty Project licenses this file to you under the Apache License, version 2.0 (the
  * "License"); you may not use this file except in compliance with the License. You may obtain a

--- a/dev/io.openliberty.io.netty/src/io/netty/handler/codec/http2/HttpToHttp2ConnectionHandler.java
+++ b/dev/io.openliberty.io.netty/src/io/netty/handler/codec/http2/HttpToHttp2ConnectionHandler.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2014 The Netty Project
+ * Copyright (c) 2024 IBM Corporation and others
  *
  * The Netty Project licenses this file to you under the Apache License, version 2.0 (the
  * "License"); you may not use this file except in compliance with the License. You may obtain a

--- a/dev/io.openliberty.io.netty/src/io/netty/handler/timeout/WriteTimeoutHandler.java
+++ b/dev/io.openliberty.io.netty/src/io/netty/handler/timeout/WriteTimeoutHandler.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2012 The Netty Project
+ * Copyright (c) 2025 IBM Corporation and others
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/dev/io.openliberty.io.netty/src/io/netty/util/concurrent/AutoScalingEventExecutorChooserFactory.java
+++ b/dev/io.openliberty.io.netty/src/io/netty/util/concurrent/AutoScalingEventExecutorChooserFactory.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2025 The Netty Project
+ * Copyright (c) 2025 IBM Corporation and others
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/dev/io.openliberty.io.netty/src/io/vertx/core/http/impl/VertxHttpRequestDecoder.java
+++ b/dev/io.openliberty.io.netty/src/io/vertx/core/http/impl/VertxHttpRequestDecoder.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.core.http.impl;
+
+import io.netty.handler.codec.http.*;
+import io.netty.util.AsciiString;
+import io.vertx.core.http.HttpServerOptions;
+import io.vertx.core.http.impl.headers.HeadersMultiMap;
+import io.vertx.core.impl.SysProps;
+import io.vertx.core.internal.http.HttpHeadersInternal;
+
+import java.nio.charset.StandardCharsets;
+
+/**
+ * A request decoder using {@link HeadersMultiMap} which is faster than {@code DefaultHttpHeaders} used by the super class.
+ */
+public class VertxHttpRequestDecoder extends HttpRequestDecoder {
+
+  private static final int HOST_AS_INT = 'o' << 8 | 's' << 16 | 't' << 24 ;
+
+  private static final long CONNECTION_AS_LONG_0 = 'o' << 8 | 'n' << 16 | 'n' << 24 |
+    (long) 'e' << 32 | (long) 'c' << 40 | (long) 't' << 48 | (long) 'i' << 56;
+
+  private static final short CONNECTION_AS_SHORT_1 = 'o' | 'n' << 8;
+
+  private static final long CONTENT_AS_LONG = 'o' << 8 | 'n' << 16 | 't' << 24 |
+    (long) 'e' << 32 | (long) 'n' << 40 | (long) 't' << 48 | (long) '-' << 56;
+
+  private static final int TYPE_AS_INT = 'y' << 8 | 'p' << 16 | 'e' << 24;
+
+  private static final long LENGTH_AS_LONG = 'e' << 8 | 'n' << 16 | 'g' << 24 |
+    (long) 't' << 32 | (long) 'h' << 40;
+
+  private static final long ACCEPT_AS_LONG = 'c' << 8 | 'c' << 16 | 'e' << 24 |
+    (long) 'p' << 32 | (long) 't' << 40;
+
+  private final AsciiString _Host;
+  private final AsciiString _Connection;
+  private final AsciiString _Content_Type;
+  private final AsciiString _Content_Length;
+  private final AsciiString _Accept;
+
+  public VertxHttpRequestDecoder(HttpServerOptions options) {
+    super(
+      options.getMaxInitialLineLength(),
+      options.getMaxHeaderSize(),
+      options.getMaxChunkSize(),
+      !HttpHeadersInternal.DISABLE_HTTP_HEADERS_VALIDATION,
+      options.getDecoderInitialBufferSize());
+
+    boolean internToLowerCase = SysProps.INTERN_COMMON_HTTP_REQUEST_HEADERS_TO_LOWER_CASE.getBoolean();
+
+    // Get headers from super class
+    _Host = internToLowerCase ? HttpHeaderNames.HOST : intern("Host");
+    _Connection = internToLowerCase ? HttpHeaderNames.CONNECTION : intern("Connection");
+    _Content_Type = internToLowerCase ? HttpHeaderNames.CONTENT_TYPE : intern("Content-Type");
+    _Content_Length = internToLowerCase ? HttpHeaderNames.CONTENT_LENGTH : intern("Content-Length");
+    _Accept = internToLowerCase ? HttpHeaderNames.ACCEPT : intern("Accept");
+  }
+
+  private AsciiString intern(String name) {
+    byte[] bytes = name.getBytes(StandardCharsets.UTF_8);
+    return super.splitHeaderName(bytes, 0, bytes.length);
+  }
+
+  @Override
+  protected AsciiString splitHeaderName(byte[] sb, int start, int length) {
+    final byte firstChar = sb[start];
+    if (firstChar == 'H' || firstChar == 'h') {
+      if (length == 4 && isHost(sb, start)) {
+        return firstChar == 'H' ? _Host : HttpHeaderNames.HOST;
+      }
+    } else if (firstChar == 'A' || firstChar == 'a') {
+      if (length == 6 && isAccept(sb, start)) {
+        return firstChar == 'A' ? _Accept : HttpHeaderNames.ACCEPT;
+      }
+    } else if (firstChar == 'C' || firstChar == 'c') {
+      if (length == 10) {
+        if (isConnection(sb, start)) {
+          return firstChar == 'C' ? _Connection : HttpHeaderNames.CONNECTION;
+        }
+      } else if (length == 12) {
+        if (isContentType(sb, start)) {
+          return firstChar == 'C' ? _Content_Type : HttpHeaderNames.CONTENT_TYPE;
+        }
+      } else if (length == 14) {
+        if (isContentLength(sb, start)) {
+          return firstChar == 'C' ? _Content_Length : HttpHeaderNames.CONTENT_LENGTH;
+        }
+      }
+    }
+    return new AsciiString(sb, start, length, true);
+  }
+
+  private static boolean isAccept(byte[] sb, int start) {
+    final long maybeAccept = sb[start + 1] << 8 |
+      sb[start + 2] << 16 |
+      sb[start + 3] << 24 |
+      (long) sb[start + 4] << 32 |
+      (long) sb[start + 5] << 40;
+    return maybeAccept == ACCEPT_AS_LONG;
+  }
+
+  private static boolean isHost(byte[] sb, int start) {
+    final int maybeHost = sb[start + 1] << 8 |
+      sb[start + 2] << 16 |
+      sb[start + 3] << 24;
+    int a = HOST_AS_INT;
+    return maybeHost == HOST_AS_INT;
+  }
+
+  private static boolean isConnection(byte[] sb, int start) {
+    final long maybeConnecti = sb[start + 1] << 8 |
+      sb[start + 2] << 16 |
+      sb[start + 3] << 24 |
+      (long) sb[start + 4] << 32 |
+      (long) sb[start + 5] << 40 |
+      (long) sb[start + 6] << 48 |
+      (long) sb[start + 7] << 56;
+    if (maybeConnecti != CONNECTION_AS_LONG_0) {
+      return false;
+    }
+    final short maybeOn = (short) (sb[start + 8] | sb[start + 9] << 8);
+    return maybeOn == CONNECTION_AS_SHORT_1;
+  }
+
+  private static boolean isContentType(byte[] sb, int start) {
+    final long maybeContent = sb[start + 1] << 8 |
+      sb[start + 2] << 16 |
+      sb[start + 3] << 24 |
+      (long) sb[start + 4] << 32 |
+      (long) sb[start + 5] << 40 |
+      (long) sb[start + 6] << 48 |
+      (long) sb[start + 7] << 56;
+    if (maybeContent != CONTENT_AS_LONG) {
+      return false;
+    }
+    final int maybeType = sb[start + 9] << 8 |
+      sb[start + 10] << 16 |
+      sb[start + 11] << 24;
+    return maybeType == TYPE_AS_INT;
+  }
+
+  private static boolean isContentLength(byte[] sb, int start) {
+    final long maybeContent = sb[start + 1] << 8 |
+      sb[start + 2] << 16 |
+      sb[start + 3] << 24 |
+      (long) sb[start + 4] << 32 |
+      (long) sb[start + 5] << 40 |
+      (long) sb[start + 6] << 48 |
+      (long) sb[start + 7] << 56;
+    if (maybeContent != CONTENT_AS_LONG) {
+      return false;
+    }
+    final long maybeLength = sb[start + 9] << 8 |
+      sb[start + 10] << 16 |
+      sb[start + 11] << 24 |
+      (long) sb[start + 12] << 32 |
+      (long) sb[start + 13] << 40;
+    return maybeLength == LENGTH_AS_LONG;
+  }
+
+  @Override
+  protected HttpMessage createMessage(String[] initialLine) {
+    return new DefaultHttpRequest(
+      HttpVersion.valueOf(initialLine[2]),
+      HttpMethod.valueOf(initialLine[0]),
+      initialLine[1],
+      HeadersMultiMap.httpHeaders());
+  }
+
+  @Override
+  protected boolean isContentAlwaysEmpty(HttpMessage msg) {
+    if (msg == null) {
+      return false;
+    }
+    // we are forced to perform exact type check here because
+    // users can override createMessage with a DefaultHttpRequest implements HttpResponse
+    // and we have to enforce
+    // if (msg instance HttpResponse) return super.isContentAlwaysEmpty(msg)
+    if (msg.getClass() == DefaultHttpRequest.class) {
+      return false;
+    }
+    return super.isContentAlwaysEmpty(msg);
+  }
+}

--- a/dev/io.openliberty.io.netty/src/io/vertx/core/http/impl/VertxHttpRequestDecoder.java
+++ b/dev/io.openliberty.io.netty/src/io/vertx/core/http/impl/VertxHttpRequestDecoder.java
@@ -15,8 +15,6 @@ import io.netty.handler.codec.http.*;
 import io.netty.util.AsciiString;
 import io.vertx.core.http.HttpServerOptions;
 import io.vertx.core.http.impl.headers.HeadersMultiMap;
-import io.vertx.core.impl.SysProps;
-import io.vertx.core.internal.http.HttpHeadersInternal;
 
 import java.nio.charset.StandardCharsets;
 
@@ -52,7 +50,7 @@ public class VertxHttpRequestDecoder extends HttpRequestDecoder {
   public VertxHttpRequestDecoder(HttpDecoderConfig config) {
     super(config);
 
-    boolean internToLowerCase = SysProps.INTERN_COMMON_HTTP_REQUEST_HEADERS_TO_LOWER_CASE.getBoolean();
+    boolean internToLowerCase = true;
 
     // Get headers from super class
     _Host = internToLowerCase ? HttpHeaderNames.HOST : intern("Host");

--- a/dev/io.openliberty.io.netty/src/io/vertx/core/http/impl/VertxHttpRequestDecoder.java
+++ b/dev/io.openliberty.io.netty/src/io/vertx/core/http/impl/VertxHttpRequestDecoder.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2011-2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2026 IBM Corporation and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at

--- a/dev/io.openliberty.io.netty/src/io/vertx/core/http/impl/VertxHttpRequestDecoder.java
+++ b/dev/io.openliberty.io.netty/src/io/vertx/core/http/impl/VertxHttpRequestDecoder.java
@@ -48,13 +48,8 @@ public class VertxHttpRequestDecoder extends HttpRequestDecoder {
   private final AsciiString _Content_Length;
   private final AsciiString _Accept;
 
-  public VertxHttpRequestDecoder(HttpServerOptions options) {
-    super(
-      options.getMaxInitialLineLength(),
-      options.getMaxHeaderSize(),
-      options.getMaxChunkSize(),
-      !HttpHeadersInternal.DISABLE_HTTP_HEADERS_VALIDATION,
-      options.getDecoderInitialBufferSize());
+  public VertxHttpRequestDecoder(HttpDecoderConfig config) {
+    super(config);
 
     boolean internToLowerCase = SysProps.INTERN_COMMON_HTTP_REQUEST_HEADERS_TO_LOWER_CASE.getBoolean();
 


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [ ] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

Adds Vert.x HTTP request decoding to Netty logic in Open Liberty for increased HTTP throughput performance.