### PR TITLE
Remove obsolete outputServer and rename outputPath to libertyfsOutputPath

### DIFF
--- a/.ci-orchestrator/steps/fats/fatCommon.properties
+++ b/.ci-orchestrator/steps/fats/fatCommon.properties
@@ -4,8 +4,7 @@ command=ant -f build-test.xml localrun ${extra.fat.ant.options} -propertyfile ..
 ebcPlan=See Shortlist
 # The branch of CRIU installed in CRIU-supported environments for Checkpoint testing; only used in standard FAT steps (i.e. it is ignored for z/OS). 
 ebcExtraProps=criu_branch=0.50.1-release
-outputPath=/liberty/personal/2/ciorchestrator
-outputServer=libertyfs.hursley.ibm.com
+libertyfsOutputPath=/liberty/personal/2/ciorchestrator
 reportingOS=ubuntu22_x86
 retry_failing_fats=true
 runner_minimum_total=10


### PR DESCRIPTION

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).

For https://github.ibm.com/WAS-CD-Area/WAS-CD-Area/issues/2238