### PR TITLE
Make MCP metadata classes implement APIs

### DIFF
--- a/dev/io.openliberty.mcp.internal/src/io/openliberty/mcp/internal/McpCdiExtension.java
+++ b/dev/io.openliberty.mcp.internal/src/io/openliberty/mcp/internal/McpCdiExtension.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2025 IBM Corporation and others.
+ * Copyright (c) 2025, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -12,9 +12,11 @@ package io.openliberty.mcp.internal;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -23,7 +25,6 @@ import com.ibm.websphere.ras.TraceComponent;
 
 import io.openliberty.mcp.annotations.Tool;
 import io.openliberty.mcp.content.ContentEncoder;
-import io.openliberty.mcp.internal.ToolMetadata.ArgumentMetadata;
 import io.openliberty.mcp.internal.ToolMetadata.SpecialArgumentMetadata;
 import io.openliberty.mcp.internal.encoders.EncoderRegistry;
 import io.openliberty.mcp.internal.exceptions.GenericArgumentException;
@@ -34,6 +35,7 @@ import io.openliberty.mcp.internal.requests.McpRequestIdSerializer;
 import io.openliberty.mcp.internal.schemas.SchemaRegistry;
 import io.openliberty.mcp.internal.schemas.TypeUtility;
 import io.openliberty.mcp.internal.tools.BeanMethodHandler.MethodMetadata;
+import io.openliberty.mcp.internal.tools.ToolManager.ToolArgument;
 import io.openliberty.mcp.messaging.Encoder;
 import io.openliberty.mcp.tools.ToolResponseEncoder;
 import jakarta.enterprise.context.spi.CreationalContext;
@@ -147,19 +149,23 @@ public class McpCdiExtension implements Extension {
 
         for (ToolMetadata tool : tools.getAllTools()) {
 
-            for (var argEntry : tool.arguments().entrySet()) {
-                String argName = argEntry.getKey();
-                ArgumentMetadata argMetadata = argEntry.getValue();
-                if (argName.isBlank()) {
+            Set<String> names = new HashSet<>();
+            for (ToolArgument argMetadata : tool.arguments()) {
+
+                // Check name
+                if (argMetadata.name().isBlank()) {
                     Tr.error(tc, "CWMCM0001E.blank.arguments", tool.getToolQualifiedName());
                     blankArgumentsFound = true;
-                } else if (argMetadata.isDuplicate()) {
-                    Tr.error(tc, "CWMCM0002E.duplicate.arguments", tool.getToolQualifiedName(), argName);
-                    duplicateArgumentsFound = true;
-                } else if (argName.equals(ToolMetadata.MISSING_TOOL_ARG_NAME)) {
+                } else if (argMetadata.name().equals(ToolMetadata.MISSING_TOOL_ARG_NAME)) {
                     Tr.error(tc, "CWMCM0003E.missing.tool.argument.name", tool.getToolQualifiedName());
                     missingArgumentName = true;
-                } else if (!argMetadata.defaultValue().isEmpty()) {
+                } else if (!names.add(argMetadata.name())) {
+                    Tr.error(tc, "CWMCM0002E.duplicate.arguments", tool.getToolQualifiedName(), argMetadata.name());
+                    duplicateArgumentsFound = true;
+                }
+
+                // Check default value
+                if (!argMetadata.defaultValue().isEmpty()) {
                     Type typeWrapperClass = TypeUtility.box(argMetadata.type());
                     DefaultValueConverter<?> converter = BuiltinDefaultValueConverters.CONVERTERS.get(typeWrapperClass);
                     if (converter != null) {
@@ -171,10 +177,9 @@ public class McpCdiExtension implements Extension {
                             invalidDefaultValueForType = true;
                         }
                     } else {
-                        Tr.error(tc, "CWMCM0017E.missing.toolarg.defaultvalue.converter", tool.getToolQualifiedName(), argName, argMetadata.type());
+                        Tr.error(tc, "CWMCM0017E.missing.toolarg.defaultvalue.converter", tool.getToolQualifiedName(), argMetadata.name(), argMetadata.type());
                         unsupportedDefaultValueType = true;
                     }
-
                 }
             }
         }

--- a/dev/io.openliberty.mcp.internal/src/io/openliberty/mcp/internal/ToolDescription.java
+++ b/dev/io.openliberty.mcp.internal/src/io/openliberty/mcp/internal/ToolDescription.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2025 IBM Corporation and others.
+ * Copyright (c) 2025, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -8,6 +8,8 @@
  * SPDX-License-Identifier: EPL-2.0
  *******************************************************************************/
 package io.openliberty.mcp.internal;
+
+import java.util.Optional;
 
 import io.openliberty.mcp.internal.tools.ToolManager.ToolAnnotations;
 import jakarta.json.JsonObject;
@@ -50,32 +52,16 @@ public class ToolDescription {
         this.title = toolMetadata.title();
         this.description = toolMetadata.description();
 
-        ToolAnnotations ann = toolMetadata.annotations();
-        if (isDefaultAnnotation(ann)) {
-            this.annotations = null;
-        } else {
-            this.annotations = new AnnotationsDescription(
-                                                          ann.readOnlyHint() == false ? null : ann.readOnlyHint(),
-                                                          ann.destructiveHint() == true ? null : ann.destructiveHint(),
-                                                          ann.idempotentHint() == false ? null : ann.idempotentHint(),
-                                                          ann.openWorldHint() == true ? null : ann.openWorldHint(),
-                                                          ann.title().isEmpty() ? null : ann.title());
-        }
+        Optional<ToolAnnotations> annotations = toolMetadata.annotations();
+        this.annotations = annotations.map(ann -> new AnnotationsDescription(ann.readOnlyHint() == false ? null : ann.readOnlyHint(),
+                                                                             ann.destructiveHint() == true ? null : ann.destructiveHint(),
+                                                                             ann.idempotentHint() == false ? null : ann.idempotentHint(),
+                                                                             ann.openWorldHint() == true ? null : ann.openWorldHint(),
+                                                                             ann.title().isEmpty() ? null : ann.title()))
+                                      .orElse(null);
+
         this.inputSchema = toolMetadata.inputSchema();
         this.outputSchema = toolMetadata.outputSchema();
-    }
-
-    /*
-     * Helper Method for default Annotation
-     */
-
-    private boolean isDefaultAnnotation(ToolAnnotations ann) {
-        return ann.readOnlyHint() == false
-               && ann.destructiveHint() == true
-               && ann.idempotentHint() == false
-               && ann.openWorldHint() == true
-               && ann.title().isEmpty();
-
     }
 
     public record AnnotationsDescription(

--- a/dev/io.openliberty.mcp.internal/src/io/openliberty/mcp/internal/ToolMetadata.java
+++ b/dev/io.openliberty.mcp.internal/src/io/openliberty/mcp/internal/ToolMetadata.java
@@ -9,13 +9,15 @@
  *******************************************************************************/
 package io.openliberty.mcp.internal;
 
+import static java.util.stream.Collectors.toUnmodifiableList;
+
 import java.lang.reflect.GenericArrayType;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.lang.reflect.TypeVariable;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -35,7 +37,9 @@ import io.openliberty.mcp.internal.security.SecurityRequirement;
 import io.openliberty.mcp.internal.tools.AsyncBeanMethodHandler;
 import io.openliberty.mcp.internal.tools.BeanMethodHandler.MethodMetadata;
 import io.openliberty.mcp.internal.tools.SyncBeanMethodHandler;
+import io.openliberty.mcp.internal.tools.ToolManager;
 import io.openliberty.mcp.internal.tools.ToolManager.ToolAnnotations;
+import io.openliberty.mcp.internal.tools.ToolManager.ToolArgument;
 import io.openliberty.mcp.internal.tools.ToolManager.ToolArguments;
 import io.openliberty.mcp.tools.ToolResponse;
 import jakarta.enterprise.inject.spi.AnnotatedMethod;
@@ -51,8 +55,8 @@ import jakarta.json.bind.Jsonb;
  * @param name the tool name
  * @param title the tool title, may be {@code null}
  * @param description the tool description, may be {@code null}
- * @param arguments a map of argument name to argument metadata
- * @param annotations the MCP annotations applied to the tool
+ * @param arguments the list of tool argument metadata
+ * @param annotations the MCP annotations applied to the tool, if supplied
  * @param returnsCompletionStage whether the tool is asynchronous
  * @param inputSchema the input schema for the tool, usually an object containing all of the named parameters
  * @param outputSchema the output schema, {@code null} if the tool does not return structured content
@@ -60,28 +64,30 @@ import jakarta.json.bind.Jsonb;
  * @param asyncHandler the async handler, {@code null} if this is not an async tool
  * @param methodMetadata data about the method if this tool was discovered by annotating a method with {@link Tool}. Should not be used in most circumstances.
  * @param securityRequirement stores authorization requirements needed to authorize access to a MCP tool
+ * @param createdAt when the tool was created
  */
 public record ToolMetadata(String name,
                            String title,
                            String description,
-                           Map<String, ArgumentMetadata> arguments,
-                           ToolAnnotations annotations,
+                           List<ToolArgument> arguments,
+                           Optional<ToolAnnotations> annotations,
                            boolean returnsCompletionStage,
                            JsonObject inputSchema,
                            JsonObject outputSchema,
                            Function<ToolArguments, ToolResponse> handler,
                            Function<ToolArguments, CompletionStage<ToolResponse>> asyncHandler,
                            Optional<MethodMetadata> methodMetadata,
-                           SecurityRequirement securityRequirement) {
+                           SecurityRequirement securityRequirement,
+                           Instant createdAt) implements ToolManager.ToolInfo {
 
     public static final String MISSING_TOOL_ARG_NAME = "<<<MISSING TOOL_ARG NAME>>>";
 
-    public record ArgumentMetadata(String name, Type type, int index, String description, boolean required, String defaultValue, boolean isDuplicate) {}
+    public record ToolMethodArgument(AnnotatedParameter<?> parameter, ToolArgument argument) {}
 
     public record SpecialArgumentMetadata(SpecialArgumentType.Resolution typeResolution, int index) {}
 
     public ToolMetadata {
-        arguments = ((arguments == null) ? Collections.emptyMap() : arguments);
+        arguments = ((arguments == null) ? Collections.emptyList() : arguments);
 
         if (handler == null && asyncHandler == null) {
             throw new IllegalArgumentException("Either handler or asyncHandler must be set");
@@ -116,14 +122,14 @@ public record ToolMetadata(String name,
             Type javaType = bean.getBeanClass();
             genericMap = TypeUtility.generateGenericMap(javaType);
         }
-        Map<String, ArgumentMetadata> argumentMap = getArgumentMap(method, genericMap);
+        List<ToolMethodArgument> methodArguments = getArguments(method, genericMap);
 
         WrapBusinessError wrapAnnotation = method.getAnnotation(WrapBusinessError.class);
         List<Class<? extends Throwable>> businessExceptions = (wrapAnnotation != null) ? List.of(wrapAnnotation.value()) : Collections.emptyList();
         boolean returnsCompletionStage = CompletionStage.class.isAssignableFrom(returnTypeClass);
         SchemaRegistry sr = SchemaRegistry.get();
 
-        JsonObject inputSchema = sr.getToolInputSchema(method, argumentMap);
+        JsonObject inputSchema = sr.getToolInputSchema(methodArguments);
 
         boolean hasContentListReturn = unwrappedOutputType instanceof ParameterizedType pt
                                        && (List.class.isAssignableFrom((Class<?>) pt.getRawType())
@@ -149,7 +155,7 @@ public record ToolMetadata(String name,
 
         outputSchema = (outputSchema == null || outputSchema.isEmpty()) ? null : outputSchema;
 
-        ToolAnnotations annotations = readAnnotations(annotation.annotations());
+        Optional<ToolAnnotations> annotations = readAnnotations(annotation.annotations());
 
         MethodMetadata methodMetadata = new MethodMetadata(name,
                                                            bean,
@@ -157,7 +163,7 @@ public record ToolMetadata(String name,
                                                            hasOutputSchema,
                                                            businessExceptions,
                                                            getSpecialArgumentList(method),
-                                                           getArgNameArray(method, argumentMap),
+                                                           getArgNameArray(method, methodArguments),
                                                            genericMap);
 
         SyncBeanMethodHandler handler = null;
@@ -171,7 +177,7 @@ public record ToolMetadata(String name,
         return new ToolMetadata(name,
                                 title,
                                 description,
-                                argumentMap,
+                                methodArguments.stream().map(ToolMethodArgument::argument).collect(toUnmodifiableList()),
                                 annotations,
                                 returnsCompletionStage,
                                 inputSchema,
@@ -179,19 +185,20 @@ public record ToolMetadata(String name,
                                 handler,
                                 asyncHandler,
                                 Optional.of(methodMetadata),
-                                SecurityRequirement.createFrom(method));
+                                SecurityRequirement.createFrom(method),
+                                Instant.now());
     }
 
-    private static String[] getArgNameArray(AnnotatedMethod<?> method, Map<String, ArgumentMetadata> argumentMap) {
+    private static String[] getArgNameArray(AnnotatedMethod<?> method, List<ToolMethodArgument> toolMethodArgs) {
         String[] nameArray = new String[method.getJavaMember().getParameterCount()];
-        for (var entry : argumentMap.entrySet()) {
-            nameArray[entry.getValue().index] = entry.getKey();
+        for (ToolMethodArgument arg : toolMethodArgs) {
+            nameArray[arg.parameter().getPosition()] = arg.argument().name();
         }
         return nameArray;
     }
 
-    public static Map<String, ArgumentMetadata> getArgumentMap(AnnotatedMethod<?> method, Map<TypeVariable<?>, Type> genericMap) {
-        Map<String, ArgumentMetadata> result = new HashMap<>();
+    public static List<ToolMethodArgument> getArguments(AnnotatedMethod<?> method, Map<TypeVariable<?>, Type> genericMap) {
+        List<ToolMethodArgument> result = new ArrayList<>();
         ArrayList<String> genericParams = new ArrayList<>();
         for (AnnotatedParameter<?> param : method.getParameters()) {
             if (TypeUtility.hasGenericParams(param.getBaseType())) {
@@ -210,7 +217,7 @@ public record ToolMetadata(String name,
         if (!genericParams.isEmpty()) {
             throw new GenericArgumentException(genericParams);
         }
-        return result.isEmpty() ? Collections.emptyMap() : result;
+        return result.isEmpty() ? Collections.emptyList() : result;
     }
 
     /**
@@ -231,21 +238,18 @@ public record ToolMetadata(String name,
 
     }
 
-    private static void addArgumentMetadata(AnnotatedParameter<?> param, Type argumentType, Map<String, ArgumentMetadata> result) {
+    private static void addArgumentMetadata(AnnotatedParameter<?> param, Type argumentType, List<ToolMethodArgument> result) {
         ToolArg argAnnotation = param.getAnnotation(ToolArg.class);
 
         if (argAnnotation != null) {
             String argName = resolveArgumentName(param, argAnnotation);
-            boolean isDuplicateArg = result.containsKey(argName);
-
             boolean required = isArgumentRequired(argAnnotation.required(), argAnnotation.defaultValue(), param.getBaseType());
-
-            result.put(argName, new ArgumentMetadata(argName, argumentType,
-                                                     param.getPosition(),
-                                                     argAnnotation.description(),
-                                                     required,
-                                                     argAnnotation.defaultValue(),
-                                                     isDuplicateArg));
+            result.add(new ToolMethodArgument(param,
+                                              new ToolArgument(argName,
+                                                               argAnnotation.description(),
+                                                               required,
+                                                               argumentType,
+                                                               argAnnotation.defaultValue())));
         }
 
     }
@@ -312,12 +316,25 @@ public record ToolMetadata(String name,
         return Collections.unmodifiableList(result);
     }
 
-    public static ToolAnnotations readAnnotations(Tool.Annotations annotations) {
-        return new ToolAnnotations(annotations.title(),
-                                   annotations.readOnlyHint(),
-                                   annotations.destructiveHint(),
-                                   annotations.idempotentHint(),
-                                   annotations.openWorldHint());
+    public static Optional<ToolAnnotations> readAnnotations(Tool.Annotations annotations) {
+
+        if (isDefaultAnnotation(annotations)) {
+            return Optional.empty();
+        } else {
+            return Optional.of(new ToolAnnotations(annotations.title(),
+                                                   annotations.readOnlyHint(),
+                                                   annotations.destructiveHint(),
+                                                   annotations.idempotentHint(),
+                                                   annotations.openWorldHint()));
+        }
+    }
+
+    private static boolean isDefaultAnnotation(Tool.Annotations ann) {
+        return ann.readOnlyHint() == false
+               && ann.destructiveHint() == true
+               && ann.idempotentHint() == false
+               && ann.openWorldHint() == true
+               && ann.title().isEmpty();
     }
 
     /**
@@ -370,6 +387,12 @@ public record ToolMetadata(String name,
         } else {
             return Object.class;
         }
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public boolean isMethod() {
+        return methodMetadata.isPresent();
     }
 
 }

--- a/dev/io.openliberty.mcp.internal/src/io/openliberty/mcp/internal/features/FeatureManager.java
+++ b/dev/io.openliberty.mcp.internal/src/io/openliberty/mcp/internal/features/FeatureManager.java
@@ -29,7 +29,6 @@ import io.openliberty.mcp.internal.features.FeatureManager.FeatureInfo;
 import io.openliberty.mcp.messaging.Cancellation;
 import io.openliberty.mcp.meta.Meta;
 import io.openliberty.mcp.request.RequestId;
-import jakarta.json.JsonObject;
 
 /**
  *
@@ -75,7 +74,8 @@ public interface FeatureManager<INFO extends FeatureInfo> extends Iterable<INFO>
             return result == 0 ? name().compareTo(o.name()) : result;
         }
 
-        JsonObject asJson();
+//        Unsure if we want this here, leaving off moving our implementation for now
+//        JsonObject asJson();
 
     }
 

--- a/dev/io.openliberty.mcp.internal/src/io/openliberty/mcp/internal/requests/DefaultValueResolver.java
+++ b/dev/io.openliberty.mcp.internal/src/io/openliberty/mcp/internal/requests/DefaultValueResolver.java
@@ -17,8 +17,8 @@ import java.util.Optional;
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 
-import io.openliberty.mcp.internal.ToolMetadata.ArgumentMetadata;
 import io.openliberty.mcp.internal.schemas.TypeUtility;
+import io.openliberty.mcp.internal.tools.ToolManager.ToolArgument;
 
 /**
  * Resolves an argument default value for a tool method parameter
@@ -44,9 +44,11 @@ public class DefaultValueResolver {
      * If type is primitive, return primitive default
      * Otherwise return null
      *
+     * @param argMetadata the tool argument metadata
+     * @return the default value, converted to the argument type
      * @throws IllegalArgumentException if default value conversion fails
      */
-    public static Object resolveDefaultValue(ArgumentMetadata argMetadata) {
+    public static Object resolveDefaultValue(ToolArgument argMetadata) {
         if (!argMetadata.defaultValue().isEmpty()) {
             try {
                 return convertDefaultValue(argMetadata.defaultValue(), argMetadata.name(), argMetadata.type());

--- a/dev/io.openliberty.mcp.internal/src/io/openliberty/mcp/internal/requests/McpToolCallParams.java
+++ b/dev/io.openliberty.mcp.internal/src/io/openliberty/mcp/internal/requests/McpToolCallParams.java
@@ -23,11 +23,11 @@ import com.ibm.websphere.ras.TraceComponent;
 
 import io.openliberty.mcp.annotations.ToolArg;
 import io.openliberty.mcp.internal.ToolMetadata;
-import io.openliberty.mcp.internal.ToolMetadata.ArgumentMetadata;
 import io.openliberty.mcp.internal.ToolRegistry;
 import io.openliberty.mcp.internal.exceptions.jsonrpc.JSONRPCErrorCode;
 import io.openliberty.mcp.internal.exceptions.jsonrpc.JSONRPCException;
 import io.openliberty.mcp.internal.schemas.TypeUtility;
+import io.openliberty.mcp.internal.tools.ToolManager.ToolArgument;
 import jakarta.json.JsonObject;
 import jakarta.json.JsonValue;
 import jakarta.json.bind.Jsonb;
@@ -92,15 +92,14 @@ public class McpToolCallParams {
     }
 
     private Map<String, Object> parseArguments(JsonObject requestArguments, Jsonb jsonb) {
-        Map<String, ArgumentMetadata> metadatas = metadata.arguments();
+        List<ToolArgument> metadatas = metadata.arguments();
         Map<String, Object> result = new HashMap<>();
 
         boolean hasMissingArgs = false;
         int requestArgumentsProcessed = 0;
 
-        for (var argEntry : metadatas.entrySet()) {
-            String argName = argEntry.getKey();
-            ArgumentMetadata argMetadata = argEntry.getValue();
+        for (ToolArgument argMetadata : metadatas) {
+            String argName = argMetadata.name();
             JsonValue argValue = requestArguments.get(argName);
             if (argValue != null) {
                 String argValueJson = jsonb.toJson(argValue);
@@ -117,11 +116,14 @@ public class McpToolCallParams {
         }
 
         if (hasMissingArgs || requestArgumentsProcessed != requestArguments.size()) {
-            Set<String> requiredArgs = metadatas.values().stream()
+            Set<String> requiredArgs = metadatas.stream()
                                                 .filter(arg -> arg.required())
                                                 .map(arg -> arg.name())
                                                 .collect(Collectors.toSet());
-            List<String> data = generateArgumentMismatchData(requestArguments.keySet(), metadatas.keySet(), requiredArgs);
+            Set<String> allowedArgs = metadatas.stream()
+                                               .map(arg -> arg.name())
+                                               .collect(Collectors.toSet());
+            List<String> data = generateArgumentMismatchData(requestArguments.keySet(), allowedArgs, requiredArgs);
             throw new JSONRPCException(JSONRPCErrorCode.INVALID_PARAMS, data);
         }
         return result;
@@ -136,7 +138,7 @@ public class McpToolCallParams {
      * @throws IllegalArgumentException if the default value cannot be converted to the target type or there is no converter for the target type.
      */
     @SuppressWarnings("unchecked")
-    public static Object convertDefaultValueToArgType(ToolMetadata toolMetadata, ArgumentMetadata argMetadata) {
+    public static Object convertDefaultValueToArgType(ToolMetadata toolMetadata, ToolArgument argMetadata) {
         String defaultValue = argMetadata.defaultValue();
         Type type = TypeUtility.box(argMetadata.type());
         DefaultValueConverter<?> converter = BuiltinDefaultValueConverters.CONVERTERS.get(type);

--- a/dev/io.openliberty.mcp.internal/src/io/openliberty/mcp/internal/schemas/SchemaGenerator.java
+++ b/dev/io.openliberty.mcp.internal/src/io/openliberty/mcp/internal/schemas/SchemaGenerator.java
@@ -34,7 +34,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 
-import io.openliberty.mcp.internal.ToolMetadata.ArgumentMetadata;
+import io.openliberty.mcp.internal.ToolMetadata.ToolMethodArgument;
 import io.openliberty.mcp.internal.schemas.SchemaCreationBlueprintGenerator.FieldInfo;
 import io.openliberty.mcp.internal.schemas.blueprints.ClassSchemaCreationBlueprint;
 import io.openliberty.mcp.internal.schemas.blueprints.ListSchemaCreationBlueprint;
@@ -84,37 +84,35 @@ public class SchemaGenerator {
     /**
      * Generate the input schema for a tool
      *
-     * @param tool the tool to generate the schema for
-     * @param argumentMap resolved arguments for tool
+     * @param arguments the tool method arguments
      * @param blueprintRegistry the blueprint registry to use
      * @return the schema as a json object
      */
-    public static JsonObject generateToolInputSchema(AnnotatedMethod<?> toolMethod, SchemaCreationBlueprintRegistry blueprintRegistry, Map<String, ArgumentMetadata> argumentMap) {
+    public static JsonObject generateToolInputSchema(List<ToolMethodArgument> arguments, SchemaCreationBlueprintRegistry blueprintRegistry) {
         // create base schema components
         JsonObjectBuilder properties = Json.createObjectBuilder();
         JsonArrayBuilder required = Json.createArrayBuilder();
-        Parameter[] parameters = toolMethod.getJavaMember().getParameters();
         SchemaGenerationContext ctx = new SchemaGenerationContext(blueprintRegistry, INPUT);
         // for each parameter
-        for (ArgumentMetadata argument : argumentMap.values()) {
-            calculateClassFrequency(argument.type(), SchemaDirection.INPUT, ctx);
+        for (ToolMethodArgument argument : arguments) {
+            calculateClassFrequency(argument.argument().type(), SchemaDirection.INPUT, ctx);
         }
 
-        for (var entry : argumentMap.entrySet()) {
-            String argumentName = entry.getKey();
-            ArgumentMetadata argument = entry.getValue();
-            Parameter parameter = parameters[argument.index()];
+        for (ToolMethodArgument argument : arguments) {
+            String argumentName = argument.argument().name();
+            Parameter parameter = argument.parameter().getJavaParameter();
             SchemaAnnotation annotation = SchemaAnnotation.read(parameter);
 
-            JsonObjectBuilder parameterSchemaBuilder = generateSubSchema(argument.type(), ctx, annotation);
+            JsonObjectBuilder parameterSchemaBuilder = generateSubSchema(argument.argument().type(), ctx, annotation);
 
-            if (argument.description() != null && !argument.description().equals("")) {
-                parameterSchemaBuilder.add(DESCRIPTION, argument.description());
+            String description = argument.argument().description();
+            if (description != null && !description.isEmpty()) {
+                parameterSchemaBuilder.add(DESCRIPTION, description);
             }
             // - add it as a property
             properties.add(argumentName, parameterSchemaBuilder.build());
             // - add it as required (if it is)
-            if (argument.required()) {
+            if (argument.argument().required()) {
                 required.add(argumentName);
             }
         }

--- a/dev/io.openliberty.mcp.internal/src/io/openliberty/mcp/internal/schemas/SchemaRegistry.java
+++ b/dev/io.openliberty.mcp.internal/src/io/openliberty/mcp/internal/schemas/SchemaRegistry.java
@@ -11,10 +11,10 @@ package io.openliberty.mcp.internal.schemas;
 
 import java.lang.reflect.Type;
 import java.util.HashMap;
-import java.util.Map;
+import java.util.List;
 
 import io.openliberty.mcp.internal.McpCdiExtension;
-import io.openliberty.mcp.internal.ToolMetadata.ArgumentMetadata;
+import io.openliberty.mcp.internal.ToolMetadata.ToolMethodArgument;
 import jakarta.enterprise.inject.spi.AnnotatedMethod;
 import jakarta.enterprise.inject.spi.CDI;
 import jakarta.json.JsonObject;
@@ -67,12 +67,12 @@ public class SchemaRegistry {
     /**
      * Gets the input JSON schema for a tool
      *
-     * @param toolMethod the tool to get the schema for
+     * @param arguments the tool method arguments
      * @return the json schema
      */
-    public JsonObject getToolInputSchema(AnnotatedMethod<?> toolMethod, Map<String, ArgumentMetadata> argumentMap) {
-        SchemaKey key = new ToolInputKey(toolMethod, argumentMap, SchemaDirection.INPUT);
-        return schemaCache.computeIfAbsent(key, k -> SchemaGenerator.generateToolInputSchema(toolMethod, blueprintRegistry, argumentMap));
+    public JsonObject getToolInputSchema(List<ToolMethodArgument> arguments) {
+        SchemaKey key = new ToolInputKey(arguments);
+        return schemaCache.computeIfAbsent(key, k -> SchemaGenerator.generateToolInputSchema(arguments, blueprintRegistry));
     }
 
     /**
@@ -83,7 +83,7 @@ public class SchemaRegistry {
      * @return the json schema
      */
     public JsonObject getToolOutputSchema(AnnotatedMethod<?> toolMethod, Type toolOutputType) {
-        SchemaKey key = new ToolOutputKey(toolMethod, toolOutputType, SchemaDirection.OUTPUT);
+        SchemaKey key = new ToolOutputKey(toolMethod, toolOutputType);
         return schemaCache.computeIfAbsent(key, k -> SchemaGenerator.generateToolOutputSchema(toolMethod, toolOutputType, blueprintRegistry));
     }
 
@@ -94,8 +94,8 @@ public class SchemaRegistry {
 
     public record ClassKey(Class<?> cls, SchemaDirection direction) implements SchemaKey {};
 
-    public record ToolInputKey(AnnotatedMethod<?> tool, Map<String, ArgumentMetadata> argumentMap, SchemaDirection direction) implements SchemaKey {};
+    public record ToolInputKey(List<ToolMethodArgument> arguments) implements SchemaKey {};
 
-    public record ToolOutputKey(AnnotatedMethod<?> tool, Type toolOutputType, SchemaDirection direction) implements SchemaKey {};
+    public record ToolOutputKey(AnnotatedMethod<?> tool, Type toolOutputType) implements SchemaKey {};
 
 }

--- a/dev/io.openliberty.mcp.internal/test/io/openliberty/mcp/internal/test/MessageParsingTest.java
+++ b/dev/io.openliberty.mcp.internal/test/io/openliberty/mcp/internal/test/MessageParsingTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2025 IBM Corporation and others.
+ * Copyright (c) 2025, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -16,6 +16,7 @@ import static org.junit.Assert.assertEquals;
 import java.io.StringReader;
 import java.math.BigDecimal;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
 import org.junit.BeforeClass;
@@ -28,7 +29,6 @@ import io.openliberty.mcp.internal.Capabilities.Roots;
 import io.openliberty.mcp.internal.Capabilities.Sampling;
 import io.openliberty.mcp.internal.Literals;
 import io.openliberty.mcp.internal.RequestMethod;
-import io.openliberty.mcp.internal.ToolMetadata.ArgumentMetadata;
 import io.openliberty.mcp.internal.ToolRegistry;
 import io.openliberty.mcp.internal.exceptions.jsonrpc.JSONRPCException;
 import io.openliberty.mcp.internal.requests.McpInitializeParams;
@@ -38,6 +38,7 @@ import io.openliberty.mcp.internal.requests.McpRequest;
 import io.openliberty.mcp.internal.requests.McpRequestIdDeserializer;
 import io.openliberty.mcp.internal.requests.McpRequestIdSerializer;
 import io.openliberty.mcp.internal.requests.McpToolCallParams;
+import io.openliberty.mcp.internal.tools.ToolManager.ToolArgument;
 import jakarta.json.JsonException;
 import jakarta.json.bind.Jsonb;
 import jakarta.json.bind.JsonbBuilder;
@@ -59,16 +60,16 @@ public class MessageParsingTest {
         ToolRegistry.set(registry);
 
         Tool testTool = Literals.tool("echo", "Echo", "Echos the input");
-        Map<String, ArgumentMetadata> arguments = Map.of("input", new ArgumentMetadata("input", String.class, 0, "", true, "", false));
+        List<ToolArgument> arguments = List.of(new ToolArgument("input", "", true, String.class, ""));
         registry.addTool(ToolMetadataTestUtility.createFrom(testTool, arguments, Collections.emptyList()));
 
         Tool addTestTool = Literals.tool("add", "Add", "Addition calculator");
-        Map<String, ArgumentMetadata> additionArgs = Map.of("num1", new ArgumentMetadata("num1", Integer.class, 0, "", true, "", false),
-                                                            "num2", new ArgumentMetadata("num2", Integer.class, 1, "", true, "", false));
+        List<ToolArgument> additionArgs = List.of(new ToolArgument("num1", "", true, Integer.class, ""),
+                                                  new ToolArgument("num2", "", true, Integer.class, ""));
         registry.addTool(ToolMetadataTestUtility.createFrom(addTestTool, additionArgs, Collections.emptyList()));
 
         Tool toogleTestTool = Literals.tool("toggle", "Toggle", "Toggle a boolean");
-        Map<String, ArgumentMetadata> booleanArgs = Map.of("input", new ArgumentMetadata("input", Boolean.class, 0, "boolean value", true, "", false));
+        List<ToolArgument> booleanArgs = List.of(new ToolArgument("input", "boolean value", true, Boolean.class, ""));
         registry.addTool(ToolMetadataTestUtility.createFrom(toogleTestTool, booleanArgs, Collections.emptyList()));
     }
 

--- a/dev/io.openliberty.mcp.internal/test/io/openliberty/mcp/internal/test/ToolArgDefaultValueConverterTest.java
+++ b/dev/io.openliberty.mcp.internal/test/io/openliberty/mcp/internal/test/ToolArgDefaultValueConverterTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2025 IBM Corporation and others.
+ * Copyright (c) 2025, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -16,19 +16,20 @@ import static org.hamcrest.Matchers.equalTo;
 
 import java.io.StringReader;
 import java.util.Collections;
-import java.util.Map;
+import java.util.List;
 
 import org.junit.BeforeClass;
 import org.junit.Test;
 
 import io.openliberty.mcp.annotations.Tool;
 import io.openliberty.mcp.internal.Literals;
-import io.openliberty.mcp.internal.ToolMetadata.ArgumentMetadata;
 import io.openliberty.mcp.internal.ToolRegistry;
 import io.openliberty.mcp.internal.requests.McpRequest;
 import io.openliberty.mcp.internal.requests.McpRequestIdDeserializer;
 import io.openliberty.mcp.internal.requests.McpRequestIdSerializer;
 import io.openliberty.mcp.internal.requests.McpToolCallParams;
+import io.openliberty.mcp.internal.tools.ToolManager.ToolArgument;
+import io.openliberty.mcp.internal.tools.ToolManager.ToolInfo;
 import jakarta.json.bind.Jsonb;
 import jakarta.json.bind.JsonbBuilder;
 import jakarta.json.bind.JsonbConfig;
@@ -47,31 +48,31 @@ public class ToolArgDefaultValueConverterTest {
         ToolRegistry.set(registry);
 
         Tool defaultValueIntArgTestTool = Literals.tool("defaultValueInt", "Default Value Int", "ToolArg with a default value of a integer type");
-        Map<String, ArgumentMetadata> defaultValIntToolArgs = Map.of("year", new ArgumentMetadata("year", Integer.class, 0, "Integer value", false, "2025", false));
+        List<ToolArgument> defaultValIntToolArgs = List.of(new ToolArgument("year", "Integer value", false, Integer.class, "2025"));
         registry.addTool(ToolMetadataTestUtility.createFrom(defaultValueIntArgTestTool, defaultValIntToolArgs, Collections.emptyList()));
 
         Tool defaultValueStringArgTestTool = Literals.tool("defaultValueString", "Default Value String", "ToolArg with a default value of a String type");
-        Map<String, ArgumentMetadata> defaultValStringToolArgs = Map.of("planet", new ArgumentMetadata("planet", String.class, 0, "String value", false, "Jupiter", false));
+        List<ToolArgument> defaultValStringToolArgs = List.of(new ToolArgument("planet", "String value", false, String.class, "Jupiter"));
         registry.addTool(ToolMetadataTestUtility.createFrom(defaultValueStringArgTestTool, defaultValStringToolArgs, Collections.emptyList()));
 
         Tool defaultValueCharArgTestTool = Literals.tool("defaultValueChar", "Default Value Char", "ToolArg with a default value of a Char type");
-        Map<String, ArgumentMetadata> defaultValCharToolArgs = Map.of("initial", new ArgumentMetadata("initial", Character.class, 0, "Char value", false, "H", false));
+        List<ToolArgument> defaultValCharToolArgs = List.of(new ToolArgument("initial", "Char value", false, Character.class, "H"));
         registry.addTool(ToolMetadataTestUtility.createFrom(defaultValueCharArgTestTool, defaultValCharToolArgs, Collections.emptyList()));
 
         Tool defaultValueInvalidArgTestTool = Literals.tool("defaultValueInvalidChar", "Default Value Invalid Char", "ToolArg with an invalid default value of a Char type");
-        Map<String, ArgumentMetadata> defaultValInvalidToolArgs = Map.of("initial", new ArgumentMetadata("initial", Character.class, 0, "Char value", false, "HH", false));
+        List<ToolArgument> defaultValInvalidToolArgs = List.of(new ToolArgument("initial", "Char value", false, Character.class, "HH"));
         registry.addTool(ToolMetadataTestUtility.createFrom(defaultValueInvalidArgTestTool, defaultValInvalidToolArgs, Collections.emptyList()));
 
         Tool defaultValueInvalidLongArgTestTool = Literals.tool("defaultValueInvalidLong", "Default Value Invalid Long", "ToolArg with an invalid default value of a Long type");
-        Map<String, ArgumentMetadata> defaultValInvalidLongToolArgs = Map.of("count", new ArgumentMetadata("count", Long.class, 0, "Long value", false, "notANumber", false));
+        List<ToolArgument> defaultValInvalidLongToolArgs = List.of(new ToolArgument("count", "Long value", false, Long.class, "notANumber"));
         registry.addTool(ToolMetadataTestUtility.createFrom(defaultValueInvalidLongArgTestTool, defaultValInvalidLongToolArgs, Collections.emptyList()));
 
         Tool defaultValueBoolArgTestTool = Literals.tool("defaultValueBool", "Default Value Bool", "ToolArg with a default value of a Bool type");
-        Map<String, ArgumentMetadata> defaultValBoolToolArgs = Map.of("bool", new ArgumentMetadata("bool", Boolean.class, 0, "Bool value", false, "true", false));
+        List<ToolArgument> defaultValBoolToolArgs = List.of(new ToolArgument("bool", "Bool value", false, Boolean.class, "true"));
         registry.addTool(ToolMetadataTestUtility.createFrom(defaultValueBoolArgTestTool, defaultValBoolToolArgs, Collections.emptyList()));
 
         Tool defaultValueObjArgTestTool = Literals.tool("defaultValueObj", "Default Value Obj", "ToolArg with a default value of a Obj type");
-        Map<String, ArgumentMetadata> defaultValObjToolArgs = Map.of("city", new ArgumentMetadata("city", City.class, 0, "City value", false, "true", false));
+        List<ToolArgument> defaultValObjToolArgs = List.of(new ToolArgument("city", "City value", false, City.class, "true"));
         registry.addTool(ToolMetadataTestUtility.createFrom(defaultValueObjArgTestTool, defaultValObjToolArgs, Collections.emptyList()));
     }
 
@@ -91,7 +92,7 @@ public class ToolArgDefaultValueConverterTest {
                         """);
         McpRequest request = jsonb.fromJson(reader, McpRequest.class);
         McpToolCallParams toolCallRequest = request.getParams(McpToolCallParams.class, jsonb);
-        ArgumentMetadata argMetadata = toolCallRequest.getMetadata().arguments().get("year");
+        ToolArgument argMetadata = getArgument(toolCallRequest.getMetadata(), "year");
         assertThat(McpToolCallParams.convertDefaultValueToArgType(toolCallRequest.getMetadata(), argMetadata), equalTo(2025));
     }
 
@@ -110,7 +111,7 @@ public class ToolArgDefaultValueConverterTest {
                         """);
         McpRequest request = jsonb.fromJson(reader, McpRequest.class);
         McpToolCallParams toolCallRequest = request.getParams(McpToolCallParams.class, jsonb);
-        ArgumentMetadata argMetadata = toolCallRequest.getMetadata().arguments().get("planet");
+        ToolArgument argMetadata = getArgument(toolCallRequest.getMetadata(), "planet");
         assertThat(McpToolCallParams.convertDefaultValueToArgType(toolCallRequest.getMetadata(), argMetadata), equalTo("Jupiter"));
     }
 
@@ -129,7 +130,7 @@ public class ToolArgDefaultValueConverterTest {
                         """);
         McpRequest request = jsonb.fromJson(reader, McpRequest.class);
         McpToolCallParams toolCallRequest = request.getParams(McpToolCallParams.class, jsonb);
-        ArgumentMetadata argMetadata = toolCallRequest.getMetadata().arguments().get("initial");
+        ToolArgument argMetadata = getArgument(toolCallRequest.getMetadata(), "initial");
         assertThat(McpToolCallParams.convertDefaultValueToArgType(toolCallRequest.getMetadata(), argMetadata), equalTo('H'));
     }
 
@@ -148,7 +149,7 @@ public class ToolArgDefaultValueConverterTest {
                         """);
         McpRequest request = jsonb.fromJson(reader, McpRequest.class);
         McpToolCallParams toolCallRequest = request.getParams(McpToolCallParams.class, jsonb);
-        ArgumentMetadata argMetadata = toolCallRequest.getMetadata().arguments().get("initial");
+        ToolArgument argMetadata = getArgument(toolCallRequest.getMetadata(), "initial");
         assertThrows(() -> McpToolCallParams.convertDefaultValueToArgType(toolCallRequest.getMetadata(), argMetadata),
                      exception()
                                 .ofType(IllegalArgumentException.class)
@@ -170,7 +171,7 @@ public class ToolArgDefaultValueConverterTest {
                         """);
         McpRequest request = jsonb.fromJson(reader, McpRequest.class);
         McpToolCallParams toolCallRequest = request.getParams(McpToolCallParams.class, jsonb);
-        ArgumentMetadata argMetadata = toolCallRequest.getMetadata().arguments().get("count");
+        ToolArgument argMetadata = getArgument(toolCallRequest.getMetadata(), "count");
         assertThrows(() -> McpToolCallParams.convertDefaultValueToArgType(toolCallRequest.getMetadata(), argMetadata),
                      exception()
                                 .ofType(IllegalArgumentException.class)
@@ -192,7 +193,7 @@ public class ToolArgDefaultValueConverterTest {
                         """);
         McpRequest request = jsonb.fromJson(reader, McpRequest.class);
         McpToolCallParams toolCallRequest = request.getParams(McpToolCallParams.class, jsonb);
-        ArgumentMetadata argMetadata = toolCallRequest.getMetadata().arguments().get("bool");
+        ToolArgument argMetadata = getArgument(toolCallRequest.getMetadata(), "bool");
         assertThat(McpToolCallParams.convertDefaultValueToArgType(toolCallRequest.getMetadata(), argMetadata), equalTo(true));
     }
 
@@ -211,10 +212,18 @@ public class ToolArgDefaultValueConverterTest {
                         """);
         McpRequest request = jsonb.fromJson(reader, McpRequest.class);
         McpToolCallParams toolCallRequest = request.getParams(McpToolCallParams.class, jsonb);
-        ArgumentMetadata argMetadata = toolCallRequest.getMetadata().arguments().get("city");
+        ToolArgument argMetadata = getArgument(toolCallRequest.getMetadata(), "city");
         assertThrows(() -> McpToolCallParams.convertDefaultValueToArgType(toolCallRequest.getMetadata(), argMetadata),
                      exception()
                                 .ofType(IllegalArgumentException.class));
+    }
+
+    private static ToolArgument getArgument(ToolInfo toolInfo, String argName) {
+        return toolInfo.arguments()
+                       .stream()
+                       .filter(arg -> arg.name().equals(argName))
+                       .findAny()
+                       .orElseThrow(() -> new IllegalArgumentException("No argument named " + argName));
     }
 
 }

--- a/dev/io.openliberty.mcp.internal/test/io/openliberty/mcp/internal/test/ToolMetadataTestUtility.java
+++ b/dev/io.openliberty.mcp.internal/test/io/openliberty/mcp/internal/test/ToolMetadataTestUtility.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2025 IBM Corporation and others.
+ * Copyright (c) 2025, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -9,19 +9,20 @@
  *******************************************************************************/
 package io.openliberty.mcp.internal.test;
 
+import java.time.Instant;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 
 import io.openliberty.mcp.annotations.Tool;
 import io.openliberty.mcp.internal.ToolMetadata;
+import io.openliberty.mcp.internal.tools.ToolManager;
 
 /**
  * Used for testing where the ArgumentMetadata is already created and not derived from an application
  */
 public class ToolMetadataTestUtility {
 
-    public static ToolMetadata createFrom(Tool annotation, Map<String, ToolMetadata.ArgumentMetadata> arguments, List<ToolMetadata.SpecialArgumentMetadata> specialArguments) {
+    public static ToolMetadata createFrom(Tool annotation, List<ToolManager.ToolArgument> arguments, List<ToolMetadata.SpecialArgumentMetadata> specialArguments) {
         // used for unit Tests that pre-populate argumentData and create Tools within the tests
         String title = annotation.title().isEmpty() ? null : annotation.title();
         return new ToolMetadata(annotation.name(),
@@ -35,6 +36,7 @@ public class ToolMetadataTestUtility {
                                 t -> null,
                                 null,
                                 Optional.empty(),
-                                null);
+                                null,
+                                Instant.now());
     }
 }

--- a/dev/io.openliberty.mcp.internal/test/io/openliberty/mcp/internal/test/schema/SchemaTest.java
+++ b/dev/io.openliberty.mcp.internal/test/io/openliberty/mcp/internal/test/schema/SchemaTest.java
@@ -26,7 +26,7 @@ import io.openliberty.mcp.annotations.Schema;
 import io.openliberty.mcp.annotations.Tool;
 import io.openliberty.mcp.annotations.ToolArg;
 import io.openliberty.mcp.internal.ToolMetadata;
-import io.openliberty.mcp.internal.ToolMetadata.ArgumentMetadata;
+import io.openliberty.mcp.internal.ToolMetadata.ToolMethodArgument;
 import io.openliberty.mcp.internal.exceptions.GenericArgumentException;
 import io.openliberty.mcp.internal.schemas.SchemaDirection;
 import io.openliberty.mcp.internal.schemas.SchemaRegistry;
@@ -285,7 +285,7 @@ public class SchemaTest {
                             "$ref": "#/$defs/Person"
                         }
                             """;
-        JSONAssert.assertEquals(expectedResponseString, response, true);
+        JSONAssert.assertEquals(expectedResponseString, response, JSONCompareMode.NON_EXTENSIBLE);
     }
 
     public record Widget(String name, int flangeCount) {};
@@ -299,8 +299,8 @@ public class SchemaTest {
     @Test
     public void testToolInputSchema() throws NoSuchMethodException, SecurityException {
         MockAnnotatedMethod<Object> toolMethod = TestUtils.findMethod(SchemaTest.class, "updateWidget");
-        Map<String, ArgumentMetadata> argumentMap = ToolMetadata.getArgumentMap(toolMethod, Collections.emptyMap());
-        String toolInputSchema = registry.getToolInputSchema(toolMethod, argumentMap).toString();
+        List<ToolMethodArgument> arguments = ToolMetadata.getArguments(toolMethod, Collections.emptyMap());
+        String toolInputSchema = registry.getToolInputSchema(arguments).toString();
         String expectedSchema = """
                         {
                         "type" : "object",
@@ -332,7 +332,7 @@ public class SchemaTest {
                         ]
                         }
                         """;
-        JSONAssert.assertEquals(expectedSchema, toolInputSchema, true);
+        JSONAssert.assertEquals(expectedSchema, toolInputSchema, JSONCompareMode.NON_EXTENSIBLE);
     }
 
     @Test
@@ -358,7 +358,7 @@ public class SchemaTest {
                             ]
                         }
                         """;
-        JSONAssert.assertEquals(expectedSchema, response, true);
+        JSONAssert.assertEquals(expectedSchema, response, JSONCompareMode.NON_EXTENSIBLE);
     }
 
     public record CompositeWidget(String name, int flangeCount, List<CompositeWidget> subwidgets) {}
@@ -372,8 +372,8 @@ public class SchemaTest {
     @Test
     public void testToolInputRecursive() {
         MockAnnotatedMethod<Object> toolMethod = TestUtils.findMethod(SchemaTest.class, "combineWidgets");
-        Map<String, ArgumentMetadata> argumentMap = ToolMetadata.getArgumentMap(toolMethod, Collections.emptyMap());
-        String toolInputSchema = registry.getToolInputSchema(toolMethod, argumentMap).toString();
+        List<ToolMethodArgument> arguments = ToolMetadata.getArguments(toolMethod, Collections.emptyMap());
+        String toolInputSchema = registry.getToolInputSchema(arguments).toString();
 
         String expectedSchema = """
                         {
@@ -418,7 +418,7 @@ public class SchemaTest {
                             ]
                         }
                         """;
-        JSONAssert.assertEquals(expectedSchema, toolInputSchema, true);
+        JSONAssert.assertEquals(expectedSchema, toolInputSchema, JSONCompareMode.NON_EXTENSIBLE);
     }
 
     @Test
@@ -456,15 +456,15 @@ public class SchemaTest {
                             "$ref": "#/$defs/CompositeWidget",
                         }
                         """;
-        JSONAssert.assertEquals(expectedSchema, response, true);
+        JSONAssert.assertEquals(expectedSchema, response, JSONCompareMode.NON_EXTENSIBLE);
 
     }
 
     @Test
     public void testPersonCheckToolSchema() throws NoSuchMethodException, SecurityException {
         MockAnnotatedMethod<Object> toolMethod = TestUtils.findMethod(SchemaTest.class, "checkPerson");
-        Map<String, ArgumentMetadata> argumentMap = ToolMetadata.getArgumentMap(toolMethod, Collections.emptyMap());
-        String toolInputSchema = registry.getToolInputSchema(toolMethod, argumentMap).toString();
+        List<ToolMethodArgument> arguments = ToolMetadata.getArguments(toolMethod, Collections.emptyMap());
+        String toolInputSchema = registry.getToolInputSchema(arguments).toString();
         String expectedResponseString = """
                         {
                             "$defs": {
@@ -573,7 +573,7 @@ public class SchemaTest {
                             "type": "object"
                         }
                                                     """;
-        JSONAssert.assertEquals(expectedResponseString, toolInputSchema, true);
+        JSONAssert.assertEquals(expectedResponseString, toolInputSchema, JSONCompareMode.NON_EXTENSIBLE);
     }
 
     @Test
@@ -612,7 +612,7 @@ public class SchemaTest {
                             "type": "object"
                         }
                             """;
-        JSONAssert.assertEquals(expectedResponseString, response, true);
+        JSONAssert.assertEquals(expectedResponseString, response, JSONCompareMode.NON_EXTENSIBLE);
     }
 
     @Test
@@ -634,7 +634,7 @@ public class SchemaTest {
                           "type": "object"
                         }
                         """;
-        JSONAssert.assertEquals(expectedResponseString, response, true);
+        JSONAssert.assertEquals(expectedResponseString, response, JSONCompareMode.NON_EXTENSIBLE);
     }
 
     @Test
@@ -734,7 +734,7 @@ public class SchemaTest {
                             "$ref": "#/$defs/Company"
                         }
                                 """;
-        JSONAssert.assertEquals(expectedResponseString, response, true);
+        JSONAssert.assertEquals(expectedResponseString, response, JSONCompareMode.NON_EXTENSIBLE);
     }
 
     @Test
@@ -897,8 +897,8 @@ public class SchemaTest {
     @Test
     public void testPersonAddtoListToolInputSchema() throws NoSuchMethodException, SecurityException {
         MockAnnotatedMethod<Object> toolMethod = TestUtils.findMethod(SchemaTest.class, "addPersonToList");
-        Map<String, ArgumentMetadata> argumentMap = ToolMetadata.getArgumentMap(toolMethod, Collections.emptyMap());
-        String toolInputSchema = registry.getToolInputSchema(toolMethod, argumentMap).toString();
+        List<ToolMethodArgument> arguments = ToolMetadata.getArguments(toolMethod, Collections.emptyMap());
+        String toolInputSchema = registry.getToolInputSchema(arguments).toString();
         String expectedResponseString = """
                                                 {
                                                 "$defs": {
@@ -1007,7 +1007,7 @@ public class SchemaTest {
                                                 "type": "object"
                                             }
                         """;
-        JSONAssert.assertEquals(expectedResponseString, toolInputSchema, true);
+        JSONAssert.assertEquals(expectedResponseString, toolInputSchema, JSONCompareMode.NON_EXTENSIBLE);
     }
 
     @Test
@@ -1111,7 +1111,7 @@ public class SchemaTest {
                             "type": "array"
                         }
                                                     """;
-        JSONAssert.assertEquals(expectedResponseString, response, true);
+        JSONAssert.assertEquals(expectedResponseString, response, JSONCompareMode.NON_EXTENSIBLE);
     }
 
     public enum TestEnum {
@@ -1141,7 +1141,7 @@ public class SchemaTest {
                             "required": ["testEnum"]
                         }""";
 
-        JSONAssert.assertEquals(expectedSchema, schema, true);
+        JSONAssert.assertEquals(expectedSchema, schema, JSONCompareMode.NON_EXTENSIBLE);
     }
 
     public record EnumMapHolder(Map<TestEnum, String> map) {};
@@ -1170,7 +1170,7 @@ public class SchemaTest {
                             },
                             "required": ["map"]
                         }""";
-        JSONAssert.assertEquals(expectedSchema, schema, true);
+        JSONAssert.assertEquals(expectedSchema, schema, JSONCompareMode.NON_EXTENSIBLE);
     }
 
     @Test
@@ -1242,7 +1242,7 @@ public class SchemaTest {
                             "$ref": "#/$defs/PartialPerson"
                         }
                             """;
-        JSONAssert.assertEquals(expectedResponseString, response, true);
+        JSONAssert.assertEquals(expectedResponseString, response, JSONCompareMode.NON_EXTENSIBLE);
     }
 
     public static class BoxMap<K, V, T> {
@@ -1345,7 +1345,7 @@ public class SchemaTest {
                             ]
                         }
                             """;
-        JSONAssert.assertEquals(expectedResponseString, response, true);
+        JSONAssert.assertEquals(expectedResponseString, response, JSONCompareMode.NON_EXTENSIBLE);
     }
 
     public static class BoxMapTwo<K, V, T> {
@@ -1577,7 +1577,7 @@ public class SchemaTest {
                                             }
                                         }
                         """;
-        JSONAssert.assertEquals(expectedResponseString, response, true);
+        JSONAssert.assertEquals(expectedResponseString, response, JSONCompareMode.NON_EXTENSIBLE);
     }
 
     public static class MyClass<U> {
@@ -1639,7 +1639,7 @@ public class SchemaTest {
                                 }
                             }
                         """;
-        JSONAssert.assertEquals(expectedResponseString, response, true);
+        JSONAssert.assertEquals(expectedResponseString, response, JSONCompareMode.NON_EXTENSIBLE);
     }
 
     static class TestGenericReuse {
@@ -1751,7 +1751,7 @@ public class SchemaTest {
                                 }
                             }
                         """;
-        JSONAssert.assertEquals(expectedResponseString, response, true);
+        JSONAssert.assertEquals(expectedResponseString, response, JSONCompareMode.NON_EXTENSIBLE);
 
     }
 
@@ -1866,7 +1866,7 @@ public class SchemaTest {
                                 }
                             }
                         """;
-        JSONAssert.assertEquals(expectedResponseString, response, true);
+        JSONAssert.assertEquals(expectedResponseString, response, JSONCompareMode.NON_EXTENSIBLE);
 
     }
 
@@ -1922,7 +1922,7 @@ public class SchemaTest {
                             ]
                         }
                             """;
-        JSONAssert.assertEquals(expectedResponseString, response, true);
+        JSONAssert.assertEquals(expectedResponseString, response, JSONCompareMode.NON_EXTENSIBLE);
     }
 
     @Tool(name = "addGenericToList", title = "adds generic to generic list", description = "adds person to employee list, returns nothing")
@@ -1934,12 +1934,12 @@ public class SchemaTest {
         //comment
     }
 
+    @SuppressWarnings("unused")
     @Test(expected = GenericArgumentException.class)
     public void testGenericToolArg() {
         MockAnnotatedMethod<Object> toolMethod = TestUtils.findMethod(SchemaTest.class, "addGenericToList");
-        Map<String, ArgumentMetadata> argumentMap = ToolMetadata.getArgumentMap(toolMethod, Collections.emptyMap());
-        String toolInputSchema = registry.getToolInputSchema(toolMethod, argumentMap).toString();
-
+        List<ToolMethodArgument> arguments = ToolMetadata.getArguments(toolMethod, Collections.emptyMap());
+        String toolInputSchema = registry.getToolInputSchema(arguments).toString();
     }
 
     @Tool(name = "addGenericSingleBoundToList", title = "adds generic to generic list", description = "adds person to employee list, returns nothing")
@@ -1952,11 +1952,12 @@ public class SchemaTest {
         //comment
     }
 
+    @SuppressWarnings("unused")
     @Test(expected = GenericArgumentException.class)
     public void testGenericSingleBoundToolArg() {
         MockAnnotatedMethod<Object> toolMethod = TestUtils.findMethod(SchemaTest.class, "addGenericSingleBoundToList");
-        Map<String, ArgumentMetadata> argumentMap = ToolMetadata.getArgumentMap(toolMethod, Collections.emptyMap());
-        String toolInputSchema = registry.getToolInputSchema(toolMethod, argumentMap).toString();
+        List<ToolMethodArgument> arguments = ToolMetadata.getArguments(toolMethod, Collections.emptyMap());
+        String toolInputSchema = registry.getToolInputSchema(arguments).toString();
     }
 
     public static interface NumberRestrictor {
@@ -2021,7 +2022,7 @@ public class SchemaTest {
                             }
                         }
                             """;
-        JSONAssert.assertEquals(expectedResponseString, response, true);
+        JSONAssert.assertEquals(expectedResponseString, response, JSONCompareMode.NON_EXTENSIBLE);
     }
 
     @Tool(name = "addWildcardToList", title = "adds wildcard to wildcard list", description = "adds person to employee list, returns nothing")
@@ -2035,8 +2036,8 @@ public class SchemaTest {
     @Test
     public void testWildcardToolArg() {
         MockAnnotatedMethod<Object> toolMethod = TestUtils.findMethod(SchemaTest.class, "addWildcardToList");
-        Map<String, ArgumentMetadata> argumentMap = ToolMetadata.getArgumentMap(toolMethod, Collections.emptyMap());
-        String toolInputSchema = registry.getToolInputSchema(toolMethod, argumentMap).toString();
+        List<ToolMethodArgument> arguments = ToolMetadata.getArguments(toolMethod, Collections.emptyMap());
+        String toolInputSchema = registry.getToolInputSchema(arguments).toString();
         String expectedResponseString = """
                         {
                             "type": "object",
@@ -2059,7 +2060,7 @@ public class SchemaTest {
                             ]
                         }
                         """;
-        JSONAssert.assertEquals(expectedResponseString, toolInputSchema, true);
+        JSONAssert.assertEquals(expectedResponseString, toolInputSchema, JSONCompareMode.NON_EXTENSIBLE);
     }
 
     @Tool(name = "addWildcardExtendBoundToList", title = "adds wildcard to wildcard list", description = "adds person to employee list, returns nothing")
@@ -2074,8 +2075,8 @@ public class SchemaTest {
     @Test
     public void testGenericExtendBoundToolArg() {
         MockAnnotatedMethod<Object> toolMethod = TestUtils.findMethod(SchemaTest.class, "addWildcardExtendBoundToList");
-        Map<String, ArgumentMetadata> argumentMap = ToolMetadata.getArgumentMap(toolMethod, Collections.emptyMap());
-        String toolInputSchema = registry.getToolInputSchema(toolMethod, argumentMap).toString();
+        List<ToolMethodArgument> arguments = ToolMetadata.getArguments(toolMethod, Collections.emptyMap());
+        String toolInputSchema = registry.getToolInputSchema(arguments).toString();
         String expectedResponseString = """
                                     {
                                         "type": "object",
@@ -2110,7 +2111,7 @@ public class SchemaTest {
                                         ]
                                     }
                         """;
-        JSONAssert.assertEquals(expectedResponseString, toolInputSchema, true);
+        JSONAssert.assertEquals(expectedResponseString, toolInputSchema, JSONCompareMode.NON_EXTENSIBLE);
     }
 
     @Tool(name = "addWildcardSuperBoundsToList", title = "adds wildcard to wildcard list", description = "adds person to employee list, returns nothing")
@@ -2125,8 +2126,8 @@ public class SchemaTest {
     @Test
     public void testWildcardSuperBoundsToolArg() {
         MockAnnotatedMethod<Object> toolMethod = TestUtils.findMethod(SchemaTest.class, "addWildcardSuperBoundsToList");
-        Map<String, ArgumentMetadata> argumentMap = ToolMetadata.getArgumentMap(toolMethod, Collections.emptyMap());
-        String toolInputSchema = registry.getToolInputSchema(toolMethod, argumentMap).toString();
+        List<ToolMethodArgument> arguments = ToolMetadata.getArguments(toolMethod, Collections.emptyMap());
+        String toolInputSchema = registry.getToolInputSchema(arguments).toString();
         String expectedResponseString = """
                                     {
                                         "type": "object",
@@ -2149,7 +2150,7 @@ public class SchemaTest {
                                         ]
                                     }
                         """;
-        JSONAssert.assertEquals(expectedResponseString, toolInputSchema, true);
+        JSONAssert.assertEquals(expectedResponseString, toolInputSchema, JSONCompareMode.NON_EXTENSIBLE);
     }
 
     @Tool(name = "primitiveArrayTest", title = "Test Content Response", description = "tests Content Response")
@@ -2168,7 +2169,7 @@ public class SchemaTest {
         String expectedResponseString = """
                             {"type":"array","items":{"type":"integer"}}
                         """;
-        JSONAssert.assertEquals(expectedResponseString, response, true);
+        JSONAssert.assertEquals(expectedResponseString, response, JSONCompareMode.NON_EXTENSIBLE);
     }
 
     @Tool(name = "addGenericToGenericArrayGenericConcrete", title = "adds generic to generic Array", description = "adds person to Generic Array, returns nothing")
@@ -2186,8 +2187,8 @@ public class SchemaTest {
         MockAnnotatedMethod<Object> toolMethod = TestUtils.findMethod(SchemaTest.class, "addGenericToGenericArrayGenericConcrete");
         Map<TypeVariable<?>, Type> genericMap = new HashMap<>();
         genericMap.put((TypeVariable<?>) toolMethod.getJavaMember().getParameters()[2].getParameterizedType(), String.class);
-        Map<String, ArgumentMetadata> argumentMap = ToolMetadata.getArgumentMap(toolMethod, genericMap);
-        String toolInputSchema = registry.getToolInputSchema(toolMethod, argumentMap).toString();
+        List<ToolMethodArgument> arguments = ToolMetadata.getArguments(toolMethod, genericMap);
+        String toolInputSchema = registry.getToolInputSchema(arguments).toString();
         String expectedResponseString = """
                                             {
                                                 "type": "object",
@@ -2221,7 +2222,7 @@ public class SchemaTest {
                                                 ]
                                             }
                         """;
-        JSONAssert.assertEquals(expectedResponseString, toolInputSchema, true);
+        JSONAssert.assertEquals(expectedResponseString, toolInputSchema, JSONCompareMode.NON_EXTENSIBLE);
     }
 
     @Test
@@ -2247,7 +2248,7 @@ public class SchemaTest {
                                         }
 
                         """;
-        JSONAssert.assertEquals(expectedResponseString, response, true);
+        JSONAssert.assertEquals(expectedResponseString, response, JSONCompareMode.NON_EXTENSIBLE);
     }
 
 }

--- a/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/tool/GenericToolTest.java
+++ b/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/tool/GenericToolTest.java
@@ -21,6 +21,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.skyscreamer.jsonassert.JSONAssert;
+import org.skyscreamer.jsonassert.JSONCompareMode;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
 
@@ -133,7 +134,7 @@ public class GenericToolTest extends FATServletClient {
                             }
                         }
                             """;
-        JSONAssert.assertEquals(expectedString, response, true);
+        JSONAssert.assertEquals(expectedString, response, JSONCompareMode.NON_EXTENSIBLE);
 
     }
 


### PR DESCRIPTION
- Make `ToolMetadata` implement `ToolManager.ToolInfo`
  - replace the argument map with a list of arguments
  - make annotations an `Optional`
  - add `createdAt` field
  - implement additional required methods (`isMethod`)
- Replace `ArgumentMetadata` with `ToolManager.ToolArgument`
  - Add `ToolMethodArgument` to hold the parameter information for a `ToolArgument` when the tool has an associated method
  - refactor how duplicate arguments are detected

Part of #33351 

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
