### PR TITLE
Allow TCK tests to run on PostgreSQL and SQL Server now that workaround is in place

### DIFF
--- a/dev/io.openliberty.jakarta.data.1.0_fat_tck/fat/src/io/openliberty/jakarta/data/tck/FATSuite.java
+++ b/dev/io.openliberty.jakarta.data.1.0_fat_tck/fat/src/io/openliberty/jakarta/data/tck/FATSuite.java
@@ -110,13 +110,9 @@ public class FATSuite extends TestContainerSuite {
             case Oracle:
                 return ""; // All tests passing on Oracle
             case Postgres:
-                //TODO testInsertEntityThatAlreadyExists PostgreSQL throws org.postgresql.util.PSQLException which is not a subclass of SQLIntegrityConstraintViolationException
-                exclude.add("ee.jakarta.tck.data.standalone.persistence.PersistenceEntityTests");
-                break;
+                return ""; // All tests passing on PostgreSQL
             case SQLServer:
-                //TODO testInsertEntityThatAlreadyExists SQLServer throws com.microsoft.sqlserver.jdbc.SQLServerException which is not a subclass of SQLIntegrityConstraintViolationException
-                exclude.add("ee.jakarta.tck.data.standalone.persistence.PersistenceEntityTests");
-                break;
+                return ""; // All tests passing on Microsoft SQL Server
             default:
                 break;
         }

--- a/dev/io.openliberty.jakarta.data.1.1_fat_tck/fat/src/io/openliberty/jakarta/data/tck/FATSuite.java
+++ b/dev/io.openliberty.jakarta.data.1.1_fat_tck/fat/src/io/openliberty/jakarta/data/tck/FATSuite.java
@@ -113,13 +113,9 @@ public class FATSuite extends TestContainerSuite {
             case Oracle:
                 return ""; // All tests passing on Oracle
             case Postgres:
-                //TODO testInsertEntityThatAlreadyExists PostgreSQL throws org.postgresql.util.PSQLException which is not a subclass of SQLIntegrityConstraintViolationException
-                exclude.add("ee.jakarta.tck.data.standalone.persistence.PersistenceEntityTests");
-                break;
+                return "";
             case SQLServer:
-                //TODO testInsertEntityThatAlreadyExists SQLServer throws com.microsoft.sqlserver.jdbc.SQLServerException which is not a subclass of SQLIntegrityConstraintViolationException
-                exclude.add("ee.jakarta.tck.data.standalone.persistence.PersistenceEntityTests");
-                break;
+                return "";
             default:
                 break;
         }


### PR DESCRIPTION
2 additional places in the TCK buckets noted by Kyle's review comment where we need to enable tests with PostgreSQL and Microsoft SQL Server, with the workaround now in place.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
