### PR TITLE
Update LTPA and SSL readiness checks

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -31448,7 +31448,7 @@
         "hashed_secret": "24f7d8c6c21b17f112c58ef315d303df07272d9b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 572,
+        "line_number": 568,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -31476,7 +31476,7 @@
         "hashed_secret": "a7e2474250e27feed983bb4b04413c3c6922d932",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 176,
+        "line_number": 174,
         "type": "Base64 High Entropy String",
         "verified_result": null
       },
@@ -31484,7 +31484,7 @@
         "hashed_secret": "757b9071d0a7d0eff9917ee8a5cf377584d78429",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 209,
+        "line_number": 207,
         "type": "Base64 High Entropy String",
         "verified_result": null
       }

--- a/dev/com.ibm.ws.cdi.2.0_fat/fat/src/com/ibm/ws/cdi20/fat/tests/SecureAsyncEventsTest.java
+++ b/dev/com.ibm.ws.cdi.2.0_fat/fat/src/com/ibm/ws/cdi20/fat/tests/SecureAsyncEventsTest.java
@@ -65,7 +65,7 @@ public class SecureAsyncEventsTest extends FATServletClient {
 
         assertNotNull("CWWKF0011I.* not received on server", server.waitForStringInLog("CWWKF0011I.*")); // wait for server is ready to run a smarter planet
         assertNotNull("Security service did not report it was ready", server.waitForStringInLog("CWWKS0008I"));
-        assertNotNull("CWWKS4105I.* not received on server", server.waitForStringInLog("CWWKS4105I.*")); // wait for LTPA key to be available
+        server.waitForLTPAConfigReady(); // wait for LTPA key to be available
     }
 
     @AfterClass

--- a/dev/com.ibm.ws.concurrent_fat_jakarta/fat/src/test/jakarta/concurrency/ConcurrencyJSPTest.java
+++ b/dev/com.ibm.ws.concurrent_fat_jakarta/fat/src/test/jakarta/concurrency/ConcurrencyJSPTest.java
@@ -59,8 +59,7 @@ public class ConcurrencyJSPTest extends FATServletClient {
         server.startServer();
 
         // wait for LTPA key to be available to avoid CWWKS4000E
-        assertNotNull("CWWKS4105I.* not received on server",
-                      server.waitForStringInLog("CWWKS4105I.*"));
+         server.waitForLTPAConfigReady();
     }
 
     /**

--- a/dev/com.ibm.ws.concurrent_fat_zcontext/fat/src/test/concurrent/sim/zos/context/SimZOSContextProviderTest.java
+++ b/dev/com.ibm.ws.concurrent_fat_zcontext/fat/src/test/concurrent/sim/zos/context/SimZOSContextProviderTest.java
@@ -50,8 +50,7 @@ public class SimZOSContextProviderTest extends FATServletClient {
 
         server.startServer();
         // wait for LTPA key to be available to avoid CWWKS4000E
-        assertNotNull("CWWKS4105I.* not received on server",
-                      server.waitForStringInLog("CWWKS4105I.*"));
+        server.waitForLTPAConfigReady();
     }
 
     @AfterClass

--- a/dev/com.ibm.ws.config_fat/fat/src/test/server/config/FeaturelistGeneratorMBeanTest.java
+++ b/dev/com.ibm.ws.config_fat/fat/src/test/server/config/FeaturelistGeneratorMBeanTest.java
@@ -87,8 +87,7 @@ public class FeaturelistGeneratorMBeanTest {
                       server.waitForStringInLog("CWWKT0016I.*IBMJMXConnectorREST"));
 
         Log.info(logClass, methodName, "Waiting for 'CWWKO0219I.*ssl'");
-        assertNotNull("'CWWKO0219I.*ssl' was not received on server",
-                      server.waitForStringInLog("CWWKO0219I.*ssl"));
+         server.waitForDefaultHTTPEndpointSSLStart();
 
         Log.info(logClass, methodName, "Waiting for 'CWPKI0803A.*ssl'");
         assertNotNull("'CWPKI0803A.*ssl' was not generated on server",
@@ -99,8 +98,7 @@ public class FeaturelistGeneratorMBeanTest {
                       server.waitForStringInLog("CWWKS0008I"));
 
         Log.info(logClass, methodName, "Waiting for 'CWWKS4105I: LTPA configuration is ready'");
-        assertNotNull("'CWWKS4105I: LTPA configuration is ready' was not generated on server",
-                      server.waitForStringInLog("CWWKS4105I"));
+        server.waitForLTPAConfigReady();
 
         Log.info(logClass, methodName, "Waiting for 'CWWKX0103I: The JMX REST connector is running and is available at the following service URL");
         assertNotNull("'CWWKX0103I' was not found", server.waitForStringInLog("CWWKX0103I"));

--- a/dev/com.ibm.ws.config_fat/fat/src/test/server/config/SchemaGeneratorMBeanTest.java
+++ b/dev/com.ibm.ws.config_fat/fat/src/test/server/config/SchemaGeneratorMBeanTest.java
@@ -92,8 +92,7 @@ public class SchemaGeneratorMBeanTest {
                       server.waitForStringInLog("CWWKT0016I.*IBMJMXConnectorREST"));
 
         Log.info(logClass, methodName, "Waiting for 'CWWKO0219I.*ssl'");
-        assertNotNull("'CWWKO0219I.*ssl' was not received on server",
-                      server.waitForStringInLog("CWWKO0219I.*ssl"));
+        server.waitForDefaultHTTPEndpointSSLStart();
 
         // Set up the trust store
         System.setProperty("javax.net.ssl.trustStore", outputDir + "/resources/security/key.p12");
@@ -245,7 +244,7 @@ public class SchemaGeneratorMBeanTest {
 
         Log.info(logClass, methodName, "Waiting for 'CWWKO0219I.*ssl'");
         assertNotNull("'CWWKO0219I.*ssl' was not received on server",
-                      server.waitForStringInLog("CWWKO0219I.*ssl"));
+                      server.waitForDefaultHTTPEndpointSSLStart(true));
 
         // Verify that the file was cleaned up after server restart
         assertFalse("Generated schema file was not deleted after server restart. File=" + sourcePath, new File(sourcePath).exists());

--- a/dev/com.ibm.ws.config_fat/fat/src/test/server/config/ServerXMLConfigurationMBeanTest.java
+++ b/dev/com.ibm.ws.config_fat/fat/src/test/server/config/ServerXMLConfigurationMBeanTest.java
@@ -82,8 +82,7 @@ public class ServerXMLConfigurationMBeanTest {
                       server.waitForStringInLog("CWWKT0016I.*IBMJMXConnectorREST"));
 
         Log.info(logClass, methodName, "Waiting for 'CWWKO0219I.*ssl'");
-        assertNotNull("'CWWKO0219I.*ssl' was not received on server",
-                      server.waitForStringInLog("CWWKO0219I.*ssl"));
+server.waitForDefaultHTTPEndpointSSLStart();
 
         Log.info(logClass, methodName, "Waiting for 'CWPKI0803A.*ssl'");
         assertNotNull("'CWPKI0803A.*ssl' was not generated on server",
@@ -94,8 +93,7 @@ public class ServerXMLConfigurationMBeanTest {
                       server.waitForStringInLog("CWWKS0008I"));
 
         Log.info(logClass, methodName, "Waiting for 'CWWKS4105I: LTPA configuration is ready'");
-        assertNotNull("'CWWKS4105I: LTPA configuration is ready' was not generated on server",
-                      server.waitForStringInLog("CWWKS4105I"));
+        server.waitForLTPAConfigReady();
 
         // Set up the trust store
         TrustManager[] trustAllCerts = new TrustManager[] { new X509TrustManager() {

--- a/dev/com.ibm.ws.ejbcontainer.async_fat/fat/src/com/ibm/ws/ejbcontainer/async/fat/tests/AsyncConfigTests.java
+++ b/dev/com.ibm.ws.ejbcontainer.async_fat/fat/src/com/ibm/ws/ejbcontainer/async/fat/tests/AsyncConfigTests.java
@@ -84,7 +84,7 @@ public class AsyncConfigTests extends AbstractTest {
 
         // verify the appSecurity-2.0 feature is ready
         assertNotNull("Security service did not report it was ready", server.waitForStringInLogUsingMark("CWWKS0008I"));
-        assertNotNull("LTPA configuration did not report it was ready", server.waitForStringInLogUsingMark("CWWKS4105I"));
+        server.waitForLTPAConfigReady();
         server.setMarkToEndOfLog();
 
         //#################### InitTxRecoveryLogApp.ear (Automatically initializes transaction recovery logs)

--- a/dev/com.ibm.ws.ejbcontainer.async_fat/fat/src/com/ibm/ws/ejbcontainer/async/fat/tests/AsyncSecureTests.java
+++ b/dev/com.ibm.ws.ejbcontainer.async_fat/fat/src/com/ibm/ws/ejbcontainer/async/fat/tests/AsyncSecureTests.java
@@ -72,7 +72,7 @@ public class AsyncSecureTests extends AbstractTest {
 
         // verify the appSecurity-2.0 feature is ready
         assertNotNull("Security service did not report it was ready", server.waitForStringInLogUsingMark("CWWKS0008I"));
-        assertNotNull("LTPA configuration did not report it was ready", server.waitForStringInLogUsingMark("CWWKS4105I"));
+        server.waitForLTPAConfigReady();
         server.setMarkToEndOfLog();
 
         // Allow apps in this test to start slower than the default

--- a/dev/com.ibm.ws.ejbcontainer.injection_fat/fat/src/com/ibm/ws/ejbcontainer/injection/fat/tests/InjectionMIXTest.java
+++ b/dev/com.ibm.ws.ejbcontainer.injection_fat/fat/src/com/ibm/ws/ejbcontainer/injection/fat/tests/InjectionMIXTest.java
@@ -131,7 +131,7 @@ public class InjectionMIXTest {
         if (RepeatTestFilter.getRepeatActionsAsString().endsWith("CDIENABLED")) {
             // verify the appSecurity-2.0 feature is ready
             assertNotNull("Security service did not report it was ready", server.waitForStringInLogUsingMark("CWWKS0008I"));
-            assertNotNull("LTPA configuration did not report it was ready", server.waitForStringInLogUsingMark("CWWKS4105I"));
+            server.waitForLTPAConfigReady();
             assertNotNull("ORB did not report it was ready", server.waitForStringInLogUsingMark("CWWKI0001I"));
         }
     }

--- a/dev/com.ibm.ws.ejbcontainer.remote.client_fat/fat/src/com/ibm/ws/ejbcontainer/remote/client/fat/tests/EjbLinkTest.java
+++ b/dev/com.ibm.ws.ejbcontainer.remote.client_fat/fat/src/com/ibm/ws/ejbcontainer/remote/client/fat/tests/EjbLinkTest.java
@@ -123,7 +123,7 @@ public class EjbLinkTest extends FATServletClient {
 
         // verify the appSecurity-2.0 feature is ready
         assertNotNull("Security service did not report it was ready", server.waitForStringInLogUsingMark("CWWKS0008I"));
-        assertNotNull("LTPA configuration did not report it was ready", server.waitForStringInLogUsingMark("CWWKS4105I"));
+        server.waitForLTPAConfigReady();
         assertNotNull("ORB did not report it was ready", server.waitForStringInLogUsingMark("CWWKI0001I"));
         server.setMarkToEndOfLog();
 

--- a/dev/com.ibm.ws.ejbcontainer.remote.config_fat/fat/src/com/ibm/ws/ejbcontainer/remote/config/fat/tests/RebindConfigUpdateTest.java
+++ b/dev/com.ibm.ws.ejbcontainer.remote.config_fat/fat/src/com/ibm/ws/ejbcontainer/remote/config/fat/tests/RebindConfigUpdateTest.java
@@ -366,7 +366,7 @@ public class RebindConfigUpdateTest extends FATServletClient {
         server_ssl.startServer();
         // Security service and ORB will not start without QuickStartSecurity
         assertTrue("Security service reported it was ready", server_ssl.findStringsInLogsUsingMark("CWWKS0008I", server_ssl.getDefaultLogFile()).isEmpty());
-        assertNotNull("LTPA configuration did not report it was ready", server_ssl.waitForStringInLogUsingMark("CWWKS4105I"));
+        server.waitForLTPAConfigReady();
         assertTrue("ORB reported it was ready", server_ssl.findStringsInLogsUsingMark("CWWKI0001I", server_ssl.getDefaultLogFile()).isEmpty());
         expected_ssl_exceptions = new String[] { "CWWKS9582E", "CWWKS9660E" }; // No user registry
 
@@ -391,7 +391,7 @@ public class RebindConfigUpdateTest extends FATServletClient {
     public void testRebindAfterOrbStoppedStarted() throws Exception {
         server_ssl.startServer();
         assertNotNull("Security service did not report it was ready", server_ssl.waitForStringInLogUsingMark("CWWKS0008I"));
-        assertNotNull("LTPA configuration did not report it was ready", server_ssl.waitForStringInLogUsingMark("CWWKS4105I"));
+        server.waitForLTPAConfigReady();
         assertNotNull("ORB did not report it was ready", server_ssl.waitForStringInLogUsingMark("CWWKI0001I"));
         expected_ssl_exceptions = new String[] { "CWWKS9582E" }; // ORB did not start in 10 seconds
 

--- a/dev/com.ibm.ws.ejbcontainer.remote_fat/fat/src/com/ibm/ws/ejbcontainer/remote/fat/tests/Server2ServerTests.java
+++ b/dev/com.ibm.ws.ejbcontainer.remote_fat/fat/src/com/ibm/ws/ejbcontainer/remote/fat/tests/Server2ServerTests.java
@@ -147,7 +147,7 @@ public class Server2ServerTests extends AbstractTest {
         if (isSecureActive) {
             // verify the appSecurity-2.0 feature is ready
             assertNotNull("Security service did not report it was ready", remoteServer.waitForStringInLogUsingMark("CWWKS0008I"));
-            assertNotNull("LTPA configuration did not report it was ready", remoteServer.waitForStringInLogUsingMark("CWWKS4105I"));
+            remoteServer.waitForLTPAConfigReady();
             assertNotNull("ORB did not report it was ready", remoteServer.waitForStringInLogUsingMark("CWWKI0001I"));
         }
 
@@ -156,7 +156,7 @@ public class Server2ServerTests extends AbstractTest {
         if (isSecureActive) {
             // verify the appSecurity-2.0 feature is ready
             assertNotNull("Security service did not report it was ready", clientServer.waitForStringInLogUsingMark("CWWKS0008I"));
-            assertNotNull("LTPA configuration did not report it was ready", clientServer.waitForStringInLogUsingMark("CWWKS4105I"));
+            clientServer.waitForLTPAConfigReady();
             assertNotNull("ORB did not report it was ready", clientServer.waitForStringInLogUsingMark("CWWKI0001I"));
         }
     }

--- a/dev/com.ibm.ws.ejbcontainer.security.jacc_fat.common/fat/src/com/ibm/ws/ejbcontainer/security/jacc_fat/EJBAnnTestBase.java
+++ b/dev/com.ibm.ws.ejbcontainer.security.jacc_fat.common/fat/src/com/ibm/ws/ejbcontainer/security/jacc_fat/EJBAnnTestBase.java
@@ -130,7 +130,7 @@ public class EJBAnnTestBase {
         // Wait for feature update to complete
         assertNotNull("FeatureManager did not report update was complete", server.waitForStringInLog("CWWKF0008I"));
         assertEquals("Application/s did not start", expectedStartedApps, server.waitForMultipleStringsInLog(expectedStartedApps, "CWWKZ0001I"));
-        assertNotNull("LTPA configuration did not report it was ready", server.waitForStringInLog("CWWKS4105I"));
+        server.waitForLTPAConfigReady();
         if (server.getValidateApps()) { // If this build is Java 7 or above
             verifyServerStartedWithJaccFeature(server);
         }

--- a/dev/com.ibm.ws.ejbcontainer.timer.auto_fat/fat/src/com/ibm/ws/ejbcontainer/timer/auto/fat/tests/AutomaticNPTimerContextPropTest.java
+++ b/dev/com.ibm.ws.ejbcontainer.timer.auto_fat/fat/src/com/ibm/ws/ejbcontainer/timer/auto/fat/tests/AutomaticNPTimerContextPropTest.java
@@ -92,7 +92,7 @@ public class AutomaticNPTimerContextPropTest extends FATServletClient {
 
         // verify the appSecurity-2.0 feature is ready
         assertNotNull("Security service did not report it was ready", server.waitForStringInLogUsingMark("CWWKS0008I"));
-        assertNotNull("LTPA configuration did not report it was ready", server.waitForStringInLogUsingMark("CWWKS4105I"));
+        server.waitForLTPAConfigReady();
     }
 
     @After

--- a/dev/com.ibm.ws.grpc_fat/fat/src/com/ibm/ws/fat/grpc/HelloWorldTlsTest.java
+++ b/dev/com.ibm.ws.grpc_fat/fat/src/com/ibm/ws/fat/grpc/HelloWorldTlsTest.java
@@ -76,7 +76,7 @@ public class HelloWorldTlsTest extends HelloWorldBasicTest {
                                       "io.grpc.examples.helloworld");
 
         helloWorldTlsServer.startServer(HelloWorldTlsTest.class.getSimpleName() + ".log");
-        assertNotNull("CWWKO0219I.*ssl not received", helloWorldTlsServer.waitForStringInLog("CWWKO0219I.*ssl"));
+        helloWorldTlsServer.waitForDefaultHTTPEndpointSSLStart();
     }
 
     @AfterClass
@@ -142,7 +142,7 @@ public class HelloWorldTlsTest extends HelloWorldBasicTest {
     public void testHelloWorldWithTlsInvalidClientTrustStore() throws Exception {
         serverConfigurationFile = GrpcTestUtils.setServerConfiguration(helloWorldTlsServer, serverConfigurationFile, TLS_INVALID_CLIENT_TRUST_STORE, clientAppName, LOG);
         // grpc.server.tls.invalid.trust.xml will cause the ssl channel to get restarted; we need to wait for it to come back up
-        assertNotNull("CWWKO0219I.*ssl not received", helloWorldTlsServer.waitForStringInLog("CWWKO0219I.*ssl"));
+        helloWorldTlsServer.waitForDefaultHTTPEndpointSSLStart();
         Exception clientException = null;
 
         try {
@@ -151,11 +151,11 @@ public class HelloWorldTlsTest extends HelloWorldBasicTest {
             clientException = e;
             Log.info(c, name.getMethodName(), "exception caught: " + e);
         }
-        assertTrue("An error is expected for this case", clientException != null);
+        assertNotNull("An error is expected for this case", clientException);
 
         // test cleanup: restore a "good" server.xml so that we don't need to wait for the ssl channel restart in another test case
         serverConfigurationFile = GrpcTestUtils.setServerConfiguration(helloWorldTlsServer, serverConfigurationFile, TLS_OUTBOUND_FILTER, clientAppName, LOG);
-        assertNotNull("CWWKO0219I.*ssl not received", helloWorldTlsServer.waitForStringInLog("CWWKO0219I.*ssl"));
+        helloWorldTlsServer.waitForDefaultHTTPEndpointSSLStart();
     }
 
     /**

--- a/dev/com.ibm.ws.grpc_fat/fat/src/com/ibm/ws/fat/grpc/SecureHelloWorldTest.java
+++ b/dev/com.ibm.ws.grpc_fat/fat/src/com/ibm/ws/fat/grpc/SecureHelloWorldTest.java
@@ -71,7 +71,7 @@ public class SecureHelloWorldTest extends HelloWorldBasicTest {
                                       "io.grpc.examples.helloworld");
 
         secureHelloWorldServer.startServer(SecureHelloWorldTest.class.getSimpleName() + ".log");
-        assertNotNull("CWWKO0219I.*ssl not received", secureHelloWorldServer.waitForStringInLog("CWWKO0219I.*ssl"));
+        secureHelloWorldServer.waitForDefaultHTTPEndpointSSLStart();
     }
 
     @AfterClass

--- a/dev/com.ibm.ws.grpc_fat/fat/src/com/ibm/ws/fat/grpc/StoreConsumerServletClientTests.java
+++ b/dev/com.ibm.ws.grpc_fat/fat/src/com/ibm/ws/fat/grpc/StoreConsumerServletClientTests.java
@@ -80,11 +80,11 @@ public class StoreConsumerServletClientTests extends FATServletClient {
         StoreClientTestsUtils.addConsumerApp(consumerServer, isArchive);
 
         storeServer.startServer(c.getSimpleName() + ".log");
-        assertNotNull("CWWKO0219I.*ssl not received", storeServer.waitForStringInLog("CWWKO0219I.*ssl"));
+        storeServer.waitForDefaultHTTPEndpointSSLStart();
 
         producerServer.useSecondaryHTTPPort(); // sets httpSecondaryPort and httpSecondarySecurePort
         producerServer.startServer(c.getSimpleName() + ".log");
-        assertNotNull("CWWKO0219I.*ssl not received", producerServer.waitForStringInLog("CWWKO0219I.*ssl"));
+        producerServer.waitForDefaultHTTPEndpointSSLStart();
 
         // set bvt.prop.member_1.http=8080 and bvt.prop.member_1.https=8081
         consumerServer.setHttpDefaultPort(Integer.parseInt(getSysProp("member_1.http")));
@@ -94,12 +94,10 @@ public class StoreConsumerServletClientTests extends FATServletClient {
 
         consumerServer.setHttpDefaultSecurePort(securePort);
         consumerServer.startServer(c.getSimpleName() + ".log");
-        assertNotNull("CWWKO0219I.*ssl not received", consumerServer.waitForStringInLog("CWWKO0219I.*ssl"));
+        consumerServer.waitForDefaultHTTPEndpointSSLStart();
 
         // Error CWWKS4000E shows up intermittently due to LTPA slowness
-        // Add CWWKS4105I: LTPA configuration is ready check to avoid this
-        assertNotNull("CWWKS4105I LTPA configuration message not found.",
-                      consumerServer.waitForStringInLogUsingMark("CWWKS4105I.*"));
+        consumerServer.waitForLTPAConfigReady();
 
         Log.info(c, "setUp", "Check if Store.war started");
         assertNotNull(storeServer.waitForStringInLog("CWWKZ0001I: Application StoreApp started"));

--- a/dev/com.ibm.ws.grpc_fat/fat/src/com/ibm/ws/fat/grpc/StoreProducerServletClientTests.java
+++ b/dev/com.ibm.ws.grpc_fat/fat/src/com/ibm/ws/fat/grpc/StoreProducerServletClientTests.java
@@ -69,11 +69,11 @@ public class StoreProducerServletClientTests extends FATServletClient {
 
         storeServer.startServer(c.getSimpleName() + ".log");
         Log.info(c, "setUp", "Check if in store server ssl started");
-        assertNotNull("CWWKO0219I.*ssl not received", storeServer.waitForStringInLog("CWWKO0219I.*ssl"));
+        storeServer.waitForDefaultHTTPEndpointSSLStart();
 
         producerServer.useSecondaryHTTPPort(); // sets httpSecondaryPort and httpSecondarySecurePort
         producerServer.startServer(c.getSimpleName() + ".log");
-        assertNotNull("CWWKO0219I.*ssl not received", producerServer.waitForStringInLog("CWWKO0219I.*ssl"));
+        producerServer.waitForDefaultHTTPEndpointSSLStart();
 
         Log.info(c, "setUp", "Check if Store.war started");
         assertNotNull(storeServer.waitForStringInLog("CWWKZ0001I: Application StoreApp started"));

--- a/dev/com.ibm.ws.grpc_fat/fat/src/com/ibm/ws/fat/grpc/StoreServicesRESTClientTests.java
+++ b/dev/com.ibm.ws.grpc_fat/fat/src/com/ibm/ws/fat/grpc/StoreServicesRESTClientTests.java
@@ -77,11 +77,11 @@ public class StoreServicesRESTClientTests extends FATServletClient {
         StoreClientTestsUtils.addConsumerApp_RestClient(consumerServer, isArchive);
 
         storeServer.startServer(c.getSimpleName() + ".log");
-        assertNotNull("CWWKO0219I.*ssl not received", storeServer.waitForStringInLog("CWWKO0219I.*ssl"));
+        storeServer.waitForDefaultHTTPEndpointSSLStart();
 
         producerServer.useSecondaryHTTPPort(); // sets httpSecondaryPort and httpSecondarySecurePort
         producerServer.startServer(c.getSimpleName() + ".log");
-        assertNotNull("CWWKO0219I.*ssl not received", producerServer.waitForStringInLog("CWWKO0219I.*ssl"));
+        producerServer.waitForDefaultHTTPEndpointSSLStart();
 
         // set bvt.prop.member_1.http=8080 and bvt.prop.member_1.https=8081
         consumerServer.setHttpDefaultPort(Integer.parseInt(getSysProp("member_1.http")));
@@ -91,12 +91,10 @@ public class StoreServicesRESTClientTests extends FATServletClient {
 
         consumerServer.setHttpDefaultSecurePort(securePort);
         consumerServer.startServer(c.getSimpleName() + ".log");
-        assertNotNull("CWWKO0219I.*ssl not received", consumerServer.waitForStringInLog("CWWKO0219I.*ssl"));
+        consumerServer.waitForDefaultHTTPEndpointSSLStart();
 
         // Error CWWKS4000E shows up intermittently due to LTPA slowness
-        // Add CWWKS4105I: LTPA configuration is ready check to avoid this
-        assertNotNull("CWWKS4105I LTPA configuration message not found.",
-                      consumerServer.waitForStringInLogUsingMark("CWWKS4105I.*"));
+        consumerServer.waitForLTPAConfigReady();
 
         //once this war file is installed on external Server
         // send the request e.g.

--- a/dev/com.ibm.ws.grpc_fat/fat/src/com/ibm/ws/fat/grpc/StoreServicesSecurityTests.java
+++ b/dev/com.ibm.ws.grpc_fat/fat/src/com/ibm/ws/fat/grpc/StoreServicesSecurityTests.java
@@ -67,12 +67,10 @@ public class StoreServicesSecurityTests extends FATServletClient {
         StoreClientTestsUtils.addConsumerApp_RestClient(consumerServer, isArchive);
 
         storeJWTSSoServer.startServer(c.getSimpleName() + ".log");
-        assertNotNull("CWWKO0219I.*ssl not received", storeJWTSSoServer.waitForStringInLog("CWWKO0219I.*ssl"));
+        storeJWTSSoServer.waitForDefaultHTTPEndpointSSLStart();
 
         // Error CWWKS4000E shows up intermittently due to LTPA slowness
-        // Add CWWKS4105I: LTPA configuration is ready check to avoid this
-        assertNotNull("CWWKS4105I LTPA configuration message not found.",
-                      storeJWTSSoServer.waitForStringInLogUsingMark("CWWKS4105I.*"));
+        storeJWTSSoServer.waitForLTPAConfigReady();
 
         // set bvt.prop.member_1.http=8080 and bvt.prop.member_1.https=8081
         consumerServer.setHttpDefaultPort(Integer.parseInt(getSysProp("member_1.http")));
@@ -82,12 +80,10 @@ public class StoreServicesSecurityTests extends FATServletClient {
 
         consumerServer.setHttpDefaultSecurePort(securePort);
         consumerServer.startServer(c.getSimpleName() + ".log");
-        assertNotNull("CWWKO0219I.*ssl not received", consumerServer.waitForStringInLog("CWWKO0219I.*ssl"));
+        consumerServer.waitForDefaultHTTPEndpointSSLStart();
 
         // Error CWWKS4000E shows up intermittently due to LTPA slowness
-        // Add CWWKS4105I: LTPA configuration is ready check to avoid this
-        assertNotNull("CWWKS4105I LTPA configuration message not found.",
-                      consumerServer.waitForStringInLogUsingMark("CWWKS4105I.*"));
+        consumerServer.waitForLTPAConfigReady();
 
     }
 

--- a/dev/com.ibm.ws.gvt.rest_fat/fat/src/com/ibm/ws/gvt/rest/fat/BaseTestCase.java
+++ b/dev/com.ibm.ws.gvt.rest_fat/fat/src/com/ibm/ws/gvt/rest/fat/BaseTestCase.java
@@ -74,8 +74,7 @@ public abstract class BaseTestCase {
      *
      * @param server The server to check the logs for the message.
      */
-    protected static void waitForDefaultHttpsEndpoint(LibertyServer server) {
-        assertNotNull("The SSL TCP Channel for default HTTPS endpoint did not start in time.",
-                      server.waitForStringInLog("CWWKO0219I.*defaultHttpEndpoint-ssl.*" + server.getHttpDefaultSecurePort()));
+    protected static void waitForDefaultHttpsEndpoint(LibertyServer server) throws Exception {
+        server.waitForDefaultHTTPEndpointSSLStart();
     }
 }

--- a/dev/com.ibm.ws.javamail.1.6_fat/fat/src/com/ibm/ws/javamail/fat/JavaMailResourceMBeanTest.java
+++ b/dev/com.ibm.ws.javamail.1.6_fat/fat/src/com/ibm/ws/javamail/fat/JavaMailResourceMBeanTest.java
@@ -94,8 +94,7 @@ public class JavaMailResourceMBeanTest {
                       server.waitForStringInLog("CWWKT0016I.*IBMJMXConnectorREST"));
 
         Log.info(logClass, methodName, "Waiting for 'CWWKO0219I.*ssl'");
-        assertNotNull("'CWWKO0219I.*ssl' was not received on server",
-                      server.waitForStringInLog("CWWKO0219I.*ssl"));
+        server.waitForDefaultHTTPEndpointSSLStart();
 
         Log.info(logClass, methodName, "Waiting for 'CWWKS0008I'");
         assertNotNull("Security service did not report it was ready",

--- a/dev/com.ibm.ws.jaxrs.2.0.client_fat/fat/src/com/ibm/ws/jaxrs20/client/fat/test/JAXRSClientLtpaTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.client_fat/fat/src/com/ibm/ws/jaxrs20/client/fat/test/JAXRSClientLtpaTest.java
@@ -78,16 +78,14 @@ public class JAXRSClientLtpaTest extends AbstractTest {
                       serverServer.waitForStringInLog("CWWKF0011I"));
 
         // wait for LTPA key to be available to avoid CWWKS4000E
-        assertNotNull("CWWKS4105I.* not received on serverServer",
-                      serverServer.waitForStringInLog("CWWKS4105I.*"));
+        serverServer.waitForLTPAConfigReady();
         
         // Pause for the smarter planet message
         assertNotNull("The smarter planet message did not get printed on clientServer",
                       clientServer.waitForStringInLog("CWWKF0011I"));
 
         // wait for LTPA key to be available to avoid CWWKS4000E
-        assertNotNull("CWWKS4105I.* not received on clientServer",
-                      clientServer.waitForStringInLog("CWWKS4105I.*"));        
+        clientServer.waitForLTPAConfigReady();
     }
 
     @AfterClass

--- a/dev/com.ibm.ws.jaxrs.2.0.client_fat/fat/src/com/ibm/ws/jaxrs20/client/fat/test/JAXRSClientSSLDefaultTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.client_fat/fat/src/com/ibm/ws/jaxrs20/client/fat/test/JAXRSClientSSLDefaultTest.java
@@ -59,8 +59,7 @@ public class JAXRSClientSSLDefaultTest extends AbstractTest {
                       server.waitForStringInLog("CWWKF0011I"));
 
         // wait for LTPA key to be available to avoid CWWKS4000E
-        assertNotNull("CWWKS4105I.* not received on server",
-                      server.waitForStringInLog("CWWKS4105I.*"));
+        server.waitForLTPAConfigReady();
     }
 
     @AfterClass

--- a/dev/com.ibm.ws.jaxrs.2.0.client_fat/fat/src/com/ibm/ws/jaxrs20/client/fat/test/JAXRSClientSSLFiltersTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.client_fat/fat/src/com/ibm/ws/jaxrs20/client/fat/test/JAXRSClientSSLFiltersTest.java
@@ -61,8 +61,7 @@ public class JAXRSClientSSLFiltersTest extends AbstractTest {
                       server.waitForStringInLog("CWWKF0011I"));
 
         // wait for LTPA key to be available to avoid CWWKS4000E
-        assertNotNull("CWWKS4105I.* not received on server",
-                      server.waitForStringInLog("CWWKS4105I.*"));
+        server.waitForLTPAConfigReady();
     }
 
     @AfterClass

--- a/dev/com.ibm.ws.jaxrs.2.0.client_fat/fat/src/com/ibm/ws/jaxrs20/client/fat/test/JAXRSClientSSLTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.client_fat/fat/src/com/ibm/ws/jaxrs20/client/fat/test/JAXRSClientSSLTest.java
@@ -58,8 +58,7 @@ public class JAXRSClientSSLTest extends AbstractTest {
                       server.waitForStringInLog("CWWKF0011I"));
 
         // wait for LTPA key to be available to avoid CWWKS4000E
-        assertNotNull("CWWKS4105I.* not received on server",
-                      server.waitForStringInLog("CWWKS4105I.*"));
+        server.waitForLTPAConfigReady();
     }
 
     @AfterClass

--- a/dev/com.ibm.ws.jaxrs.2.0.client_fat/fat/src/com/ibm/ws/jaxrs20/client/fat/test/JAXRSClientSSLTestNoLibertySSLCfg.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.client_fat/fat/src/com/ibm/ws/jaxrs20/client/fat/test/JAXRSClientSSLTestNoLibertySSLCfg.java
@@ -84,8 +84,7 @@ public class JAXRSClientSSLTestNoLibertySSLCfg extends AbstractTest {
                       server.waitForStringInLog("CWWKF0011I"));
 
         // wait for LTPA key to be available to avoid CWWKS4000E
-        assertNotNull("CWWKS4105I.* not received on server",
-                      server.waitForStringInLog("CWWKS4105I.*"));
+        server.waitForLTPAConfigReady();
     }
 
     @AfterClass

--- a/dev/com.ibm.ws.jaxrs.2.0.client_fat/fat/src/com/ibm/ws/jaxrs20/client/fat/test/JAXRSClientSSLTestNoLibertySSLFeature.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.client_fat/fat/src/com/ibm/ws/jaxrs20/client/fat/test/JAXRSClientSSLTestNoLibertySSLFeature.java
@@ -63,8 +63,7 @@ public class JAXRSClientSSLTestNoLibertySSLFeature extends JAXRSClientSSLTestNoL
                       server.waitForStringInLog("CWWKF0011I"));
 
         // wait for LTPA key to be available to avoid CWWKS4000E
-        assertNotNull("CWWKS4105I.* not received on server",
-                      server.waitForStringInLog("CWWKS4105I.*"));
+        server.waitForLTPAConfigReady();
     }
 
     @AfterClass

--- a/dev/com.ibm.ws.jaxrs.2.0.client_fat/fat/src/com/ibm/ws/jaxrs20/client/fat/test/SimpleSSLMultipleServersDefaultLibertySSLConfigTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.client_fat/fat/src/com/ibm/ws/jaxrs20/client/fat/test/SimpleSSLMultipleServersDefaultLibertySSLConfigTest.java
@@ -27,7 +27,6 @@ import componenttest.annotation.TestServlet;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
-import io.openliberty.jaxrs.client.fat.simpleSSL.multi.servlet.SimpleSSLMultipleServersClientTestServlet;
 import io.openliberty.jaxrs.client.fat.simpleSSL.multi.servlet.defaultconfig.SimpleSSLDefaultConfigMultipleServersClientTestServlet;
 
 @RunWith(FATRunner.class)
@@ -52,7 +51,7 @@ public class SimpleSSLMultipleServersDefaultLibertySSLConfigTest extends FATServ
         // already started server
         try {
             server.startServer("server.log", true);
-            server.waitForSSLStart();
+            server.waitForDefaultHTTPEndpointSSLStart();
             assertNotNull("The server did not start", server.waitForStringInLog("CWWKF0011I"));
             assertNotNull("FeatureManager did not report update was complete", server.waitForStringInLog("CWWKF0008I"));
 
@@ -66,7 +65,7 @@ public class SimpleSSLMultipleServersDefaultLibertySSLConfigTest extends FATServ
              */
             server2.useSecondaryHTTPPort();
             server2.startServer("server.log", true);
-            server2.waitForSSLStart();
+            server2.waitForDefaultHTTPEndpointSSLStart();
             assertNotNull("The server did not start", server2.waitForStringInLog("CWWKF0011I"));
             assertNotNull("FeatureManager did not report update was complete", server2.waitForStringInLog("CWWKF0008I"));
         } catch (Exception e) {

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/CustomSecurityContextTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/CustomSecurityContextTest.java
@@ -46,7 +46,7 @@ public class CustomSecurityContextTest {
         try {
             server.startServer();
             assertNotNull("FeatureManager did not report update was complete", server.waitForStringInLog("CWWKF0008I"));
-            assertNotNull("LTPA configuration should report it is ready", server.waitForStringInLog("CWWKS4105I"));
+            server.waitForLTPAConfigReady();
         } catch (Exception e) {
             System.out.println(e.toString());
         }

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/ExceptionMappingWithOTTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/ExceptionMappingWithOTTest.java
@@ -69,8 +69,7 @@ public class ExceptionMappingWithOTTest {
                       server.waitForStringInLog("CWWKF0011I"));
 
         // wait for LTPA key to be available to avoid CWWKS4000E
-        assertNotNull("CWWKS4105I.* not received on server",
-                      server.waitForStringInLog("CWWKS4105I.*"));
+        server.waitForLTPAConfigReady();
     }
 
     @AfterClass

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/RestMetricsTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/RestMetricsTest.java
@@ -116,8 +116,7 @@ public class RestMetricsTest {
                       server.waitForStringInLog("CWWKF0011I"));
 
         // wait for LTPA key to be available to avoid CWWKS4000E
-        assertNotNull("CWWKS4105I.* not received on server",
-                  server.waitForStringInLog("CWWKS4105I.*"));
+        server.waitForLTPAConfigReady();
     }
 
     @AfterClass

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/SecurityAnnotationsTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/SecurityAnnotationsTest.java
@@ -61,7 +61,7 @@ public class SecurityAnnotationsTest {
             assertNotNull("The server did not start", server.waitForStringInLog("CWWKF0011I"));
             assertNotNull("The Security Service should be ready", server.waitForStringInLog("CWWKS0008I"));
             assertNotNull("FeatureManager did not report update was complete", server.waitForStringInLog("CWWKF0008I"));
-            assertNotNull("LTPA configuration should report it is ready", server.waitForStringInLog("CWWKS4105I"));
+            assertNotNull("LTPA configuration should report it is ready", server.waitForLTPAConfigReady(true));
         } catch (Exception e) {
             System.out.println(e.toString());
         }

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/SecurityContextTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/SecurityContextTest.java
@@ -61,7 +61,7 @@ public class SecurityContextTest {
             assertNotNull("The server did not start", server.waitForStringInLog("CWWKF0011I"));
             assertNotNull("The Security Service should be ready", server.waitForStringInLog("CWWKS0008I"));
             assertNotNull("FeatureManager did not report update was complete", server.waitForStringInLog("CWWKF0008I"));
-            assertNotNull("LTPA configuration should report it is ready", server.waitForStringInLog("CWWKS4105I"));
+            assertNotNull("LTPA configuration should report it is ready", server.waitForLTPAConfigReady(true));
         } catch (Exception e) {
             System.out.println(e.toString());
         }

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/SecuritySSLTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/SecuritySSLTest.java
@@ -59,8 +59,8 @@ public class SecuritySSLTest {
             assertNotNull("The server did not start", server.waitForStringInLog("CWWKF0011I"));
             assertNotNull("The Security Service should be ready", server.waitForStringInLog("CWWKS0008I"));
             assertNotNull("FeatureManager did not report update was complete", server.waitForStringInLog("CWWKF0008I"));
-            assertNotNull("LTPA configuration should report it is ready", server.waitForStringInLog("CWWKS4105I"));
-            assertNotNull("The defaultHttpEndpoint-ssl endpoint should report it is ready", server.waitForStringInLog("CWWKO0219I.*defaultHttpEndpoint-ssl"));
+            assertNotNull("LTPA configuration should report it is ready", server.waitForLTPAConfigReady(true));
+            assertNotNull("The defaultHttpEndpoint-ssl endpoint should report it is ready", server.waitForDefaultHTTPEndpointSSLStart(true));
             // Wait for /security endpoints to be initialized
             assertNotNull("/security com.ibm.ws.jaxrs.fat.security.ssl.SSLApplication was not initialized (SRVE0242I not found)",
                           server.waitForStringInLog("SRVE0242I.*/security.*com.ibm.ws.jaxrs.fat.security.ssl.SSLApplication"));

--- a/dev/com.ibm.ws.jaxrs.2.1.client_fat/fat/src/com/ibm/ws/jaxrs21/client/fat/test/JAXRS21ClientLTPATest.java
+++ b/dev/com.ibm.ws.jaxrs.2.1.client_fat/fat/src/com/ibm/ws/jaxrs21/client/fat/test/JAXRS21ClientLTPATest.java
@@ -51,7 +51,7 @@ public class JAXRS21ClientLTPATest extends JAXRS21AbstractTest {
         // already started server
         try {
             server.startServer(true);
-            server.waitForSSLStart();
+            server.waitForDefaultHTTPEndpointSSLStart();
         } catch (Exception e) {
             System.out.println(e.toString());
         }

--- a/dev/com.ibm.ws.jaxrs.2.1.client_fat/fat/src/com/ibm/ws/jaxrs21/client/fat/test/JAXRS21ClientSSLProxyAuthTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.1.client_fat/fat/src/com/ibm/ws/jaxrs21/client/fat/test/JAXRS21ClientSSLProxyAuthTest.java
@@ -98,7 +98,7 @@ public class JAXRS21ClientSSLProxyAuthTest extends JAXRS21AbstractTest {
         try {
             Log.info(c, "setup", "Starting Liberty server");
             server.startServer(true);
-            server.waitForSSLStart();
+            server.waitForDefaultHTTPEndpointSSLStart();
         } catch (Exception e) {
             Log.error(c, "setup", e, "Exception while starting server");
         }

--- a/dev/com.ibm.ws.jaxrs.2.1.client_fat/fat/src/com/ibm/ws/jaxrs21/client/fat/test/JAXRS21ClientSSLTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.1.client_fat/fat/src/com/ibm/ws/jaxrs21/client/fat/test/JAXRS21ClientSSLTest.java
@@ -58,7 +58,6 @@ public class JAXRS21ClientSSLTest extends JAXRS21AbstractTest {
         // already started server
         try {
             server.startServer(true);
-            server.waitForSSLStart();
         } catch (Exception e) {
             System.out.println(e.toString());
         }
@@ -66,10 +65,7 @@ public class JAXRS21ClientSSLTest extends JAXRS21AbstractTest {
         // Pause for the smarter planet message
         assertNotNull("The smarter planet message did not get printed on server",
                       server.waitForStringInLog("CWWKF0011I"));
-
-        // wait for the tcp channel to start
-        assertNotNull("TCP Channel not started",
-                      server.waitForStringInLog("CWWKO0219I"));
+        server.waitForDefaultHTTPEndpointSSLStart();
     }
 
     @AfterClass

--- a/dev/com.ibm.ws.jaxrs.2.1_fat/fat/src/com/ibm/ws/jaxrs21/fat/JAXRS21SecurityAnnotationsTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.1_fat/fat/src/com/ibm/ws/jaxrs21/fat/JAXRS21SecurityAnnotationsTest.java
@@ -61,7 +61,7 @@ public class JAXRS21SecurityAnnotationsTest {
             assertNotNull("The server did not start", server.waitForStringInLog("CWWKF0011I"));
             assertNotNull("The Security Service should be ready", server.waitForStringInLog("CWWKS0008I"));
             assertNotNull("FeatureManager did not report update was complete", server.waitForStringInLog("CWWKF0008I"));
-            assertNotNull("LTPA configuration should report it is ready", server.waitForStringInLog("CWWKS4105I"));
+            assertNotNull("LTPA configuration should report it is ready", server.waitForLTPAConfigReady(true));
         } catch (Exception e) {
             System.out.println(e.toString());
         }

--- a/dev/com.ibm.ws.jaxrs.2.1_fat/fat/src/com/ibm/ws/jaxrs21/fat/JAXRS21SecurityContextTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.1_fat/fat/src/com/ibm/ws/jaxrs21/fat/JAXRS21SecurityContextTest.java
@@ -65,7 +65,7 @@ public class JAXRS21SecurityContextTest {
             assertNotNull("The server did not start", server.waitForStringInLog("CWWKF0011I"));
             assertNotNull("The Security Service should be ready", server.waitForStringInLog("CWWKS0008I"));
             assertNotNull("FeatureManager did not report update was complete", server.waitForStringInLog("CWWKF0008I"));
-            assertNotNull("LTPA configuration should report it is ready", server.waitForStringInLog("CWWKS4105I"));
+            assertNotNull("LTPA configuration should report it is ready", server.waitForLTPAConfigReady(true));
         } catch (Exception e) {
             System.out.println(e.toString());
         }

--- a/dev/com.ibm.ws.jaxrs.2.1_fat/fat/src/com/ibm/ws/jaxrs21/fat/JAXRS21SecuritySSLTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.1_fat/fat/src/com/ibm/ws/jaxrs21/fat/JAXRS21SecuritySSLTest.java
@@ -69,8 +69,7 @@ public class JAXRS21SecuritySSLTest {
                       server.waitForStringInLog("CWWKF0011I"));
 
         // wait for LTPA key to be available to avoid CWWKS4000E
-        assertNotNull("CWWKS4105I.* not received on server",
-                      server.waitForStringInLog("CWWKS4105I.*"));
+        server.waitForLTPAConfigReady();
 
         // Wait for /jaxrs21security endpoints to be initialized
         assertNotNull("/jaxrs21security com.ibm.ws.jaxrs21.fat.security.ssl.SSLApplication was not initialized (SRVE0242I not found)",

--- a/dev/com.ibm.ws.jaxrs.2.1_fat/fat/src/com/ibm/ws/jaxrs21/fat/RolesAllowedTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.1_fat/fat/src/com/ibm/ws/jaxrs21/fat/RolesAllowedTest.java
@@ -45,7 +45,7 @@ public class RolesAllowedTest {
         try {
             server.startServer();
             assertNotNull("FeatureManager did not report update was complete", server.waitForStringInLog("CWWKF0008I"));
-            assertNotNull("LTPA configuration should report it is ready", server.waitForStringInLog("CWWKS4105I"));
+            assertNotNull("LTPA configuration should report it is ready", server.waitForLTPAConfigReady(true));
         } catch (Exception e) {
             System.out.println(e.toString());
         }

--- a/dev/com.ibm.ws.jaxrs.2.1_fat_extended/fat/src/com/ibm/ws/jaxrs21/fat/extended/PatchTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.1_fat_extended/fat/src/com/ibm/ws/jaxrs21/fat/extended/PatchTest.java
@@ -38,7 +38,7 @@ public class PatchTest extends FATServletClient {
     public static void setUp() throws Exception {
         ShrinkHelper.defaultDropinApp(server, appName, "jaxrs21.fat.patch");
         server.startServer();
-        server.waitForSSLStart();
+        server.waitForDefaultHTTPEndpointSSLStart();
     }
 
     @AfterClass

--- a/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat/fat/src/com/ibm/ws/jaxws/fat/LibertyCXFNegativePropertiesTest.java
+++ b/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat/fat/src/com/ibm/ws/jaxws/fat/LibertyCXFNegativePropertiesTest.java
@@ -62,7 +62,7 @@ public class LibertyCXFNegativePropertiesTest {
 
         server.waitForStringInLog("CWWKF0011I");
 
-        assertNotNull("SSL service needs to be started for tests, but the HTTPS was never started", server.waitForStringInLog("CWWKO0219I.*ssl"));
+        server.waitForDefaultHTTPEndpointSSLStart();
     }
 
     @AfterClass

--- a/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat/fat/src/com/ibm/ws/jaxws/fat/LibertyCXFPositivePropertiesTest.java
+++ b/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat/fat/src/com/ibm/ws/jaxws/fat/LibertyCXFPositivePropertiesTest.java
@@ -93,7 +93,7 @@ public class LibertyCXFPositivePropertiesTest {
 
         server.waitForStringInLog("CWWKF0011I");
 
-        assertNotNull("SSL service needs to be started for tests, but the HTTPS was never started", server.waitForStringInLog("CWWKO0219I.*ssl"));
+        server.waitForDefaultHTTPEndpointSSLStart();
     }
 
     @AfterClass

--- a/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat/fat/src/com/ibm/ws/jaxws/fat/WebServiceMonitorTest.java
+++ b/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat/fat/src/com/ibm/ws/jaxws/fat/WebServiceMonitorTest.java
@@ -122,7 +122,7 @@ public class WebServiceMonitorTest {
         //Check to see if Rest service is up
         server.waitForStringInLog("CWWKX0103I.*");
         //Wait till LTPA configuration is ready
-        server.waitForStringInLog("CWWKS4105I.*");
+        server.waitForLTPAConfigReady();
 
         ClientConnector cc = new ClientConnector(server.getServerRoot(), server.getHostname(), server.getHttpDefaultSecurePort());
         mbsc = cc.getMBeanServer();

--- a/dev/com.ibm.ws.jaxws.ejb_fat/fat/src/com/ibm/ws/jaxws/ejb/fat/EJBHandlerTest.java
+++ b/dev/com.ibm.ws.jaxws.ejb_fat/fat/src/com/ibm/ws/jaxws/ejb/fat/EJBHandlerTest.java
@@ -90,7 +90,7 @@ public class EJBHandlerTest {
         //EJBHandler does not require app security things, the feature is just added there to make sure, our functions could work
         //with secuirty enabled.
         Assert.assertNotNull("LTPA keys in not created",
-                             server.waitForStringInLog("CWWKS4104A.*LTPA"));
+                             server.waitForLTPAKeysCreated());
 
         CLIENT_HANDLER_ENDPOINT_URL = "http://" + server.getHostname() + ":" + server.getHttpDefaultPort() + "/EJBHandler/EJBHandlerClientBeanService";
 

--- a/dev/com.ibm.ws.jbatch.fat.common/src/com/ibm/ws/jbatch/test/FatUtils.java
+++ b/dev/com.ibm.ws.jbatch.fat.common/src/com/ibm/ws/jbatch/test/FatUtils.java
@@ -5,7 +5,6 @@ import static org.junit.Assert.assertNotNull;
 import com.ibm.websphere.simplicity.config.DataSource;
 import com.ibm.websphere.simplicity.config.JdbcDriver;
 import com.ibm.websphere.simplicity.config.ServerConfiguration;
-import componenttest.custom.junit.runner.JavaLevelFilter;
 import componenttest.topology.impl.LibertyServer;
 
 /**
@@ -37,7 +36,7 @@ public class FatUtils {
     /**
      * Wait for the "smarter planet" and "ssl endpoint started" messages.
      */
-    public static void waitForStartupAndSsl(LibertyServer server) {
+    public static void waitForStartupAndSsl(LibertyServer server) throws Exception {
         waitForSmarterPlanet(server);
         waitForSslEndpoint(server);
     }
@@ -61,12 +60,10 @@ public class FatUtils {
      * 
      * @param server
      */
-    public static void waitForSslEndpoint(LibertyServer server) {
+    public static void waitForSslEndpoint(LibertyServer server) throws Exception {
         // Wait for SSL endpoint
         server.resetLogMarks();
-        assertNotNull("defaultHttpEndpoint-ssl was not started",
-                      //server.waitForStringInLog("CWWKO0219I: TCP Channel defaultHttpEndpoint-ssl has been started"));
-                      server.waitForStringInLog("CWWKO0219I:(.*)defaultHttpEndpoint-ssl"));
+        server.waitForDefaultHTTPEndpointSSLStart();
 
     }
     
@@ -77,13 +74,9 @@ public class FatUtils {
      * 
      * @param server
      */
-    public static void waitForLTPA(LibertyServer server) {
+    public static void waitForLTPA(LibertyServer server) throws Exception {
         server.resetLogMarks();
-        // Previously it looked like we were trying to match CWWKS4105A
-        // in addition to a CWWKS4104A.  As it turns out, there is only CWWKS4105I
-        // so we will remove that.
-        assertNotNull("Waited for the LTPA keys to be generated, but did not receive the CWWKS4104A message ",
-                       server.waitForStringInLog("CWWKS4104A"));
+        server.waitForLTPAConfigReady();
 
     }
     
@@ -107,7 +100,7 @@ public class FatUtils {
      * 
      * @param server
      */
-    public static void waitForStartupSslAndLTPA(LibertyServer server) {
+    public static void waitForStartupSslAndLTPA(LibertyServer server) throws Exception {
         waitForSmarterPlanet(server);
         waitForSslEndpoint(server);
         waitForLTPA (server);
@@ -118,7 +111,7 @@ public class FatUtils {
      * 
      * @param server
      */
-    public static void waitForSSLKeyAndLTPAKey(LibertyServer server) {
+    public static void waitForSSLKeyAndLTPAKey(LibertyServer server) throws Exception {
     	waitForSSLKeyFile(server);
     	waitForLTPA(server);
     }

--- a/dev/com.ibm.ws.jca_fat/fat/src/com/ibm/ws/jca/fat/regr/InboundSecurityTest.java
+++ b/dev/com.ibm.ws.jca_fat/fat/src/com/ibm/ws/jca/fat/regr/InboundSecurityTest.java
@@ -64,7 +64,7 @@ public class InboundSecurityTest extends JCAFATTest implements RarTests {
         server.waitForStringInLog("CWWKE0002I");
         server.waitForStringInLog("CWWKZ0001I:.*fvtapp"); // Wait for application start.
         server.waitForStringInLog("CWWKF0011I");
-        server.waitForStringInLog("CWWKS4104A"); // Wait for Ltpa keys to be generated
+        server.waitForLTPAKeysCreated(); // Wait for Ltpa keys to be generated
     }
 
     public static void serverTearDown(ServerMode mode, LibertyServer server) throws Exception {

--- a/dev/com.ibm.ws.jca_fat/fat/src/com/ibm/ws/jca/fat/regr/InboundSecurityTestRapid.java
+++ b/dev/com.ibm.ws.jca_fat/fat/src/com/ibm/ws/jca/fat/regr/InboundSecurityTestRapid.java
@@ -67,7 +67,7 @@ public class InboundSecurityTestRapid extends JCAFATTest implements RarTests {
         server.waitForStringInLog("CWWKE0002I");
         server.waitForStringInLog("CWWKZ0001I:.*fvtapp"); // Wait for application start.
         server.waitForStringInLog("CWWKF0011I");
-        server.waitForStringInLog("CWWKS4104A"); // Wait for Ltpa keys to be generated
+        server.waitForLTPAKeysCreated(); // Wait for Ltpa keys to be generated
     }
 
     public static void serverTearDown(ServerMode mode, LibertyServer server) throws Exception {

--- a/dev/com.ibm.ws.jpa.tests.container.client_fat/fat/src/com/ibm/ws/jpa/clientcontainer/fat/CommonTest.java
+++ b/dev/com.ibm.ws.jpa.tests.container.client_fat/fat/src/com/ibm/ws/jpa/clientcontainer/fat/CommonTest.java
@@ -187,8 +187,7 @@ public class CommonTest {
                       testServer.waitForStringInLog("CWWKF0008I"));
         // assertNotNull("Application did not start",
         // testServer.waitForStringInLog("CWWKZ0001I"));
-        assertNotNull("LTPA configuration did not report it was ready",
-                      testServer.waitForStringInLog("CWWKS4105I"));
+        testServer.waitForLTPAConfigReady();
 
     }
 

--- a/dev/com.ibm.ws.kernel.feature.resolver_fat/fat/src/com/ibm/ws/feature/tests/VersionlessTest.java
+++ b/dev/com.ibm.ws.kernel.feature.resolver_fat/fat/src/com/ibm/ws/feature/tests/VersionlessTest.java
@@ -115,7 +115,7 @@ public class VersionlessTest {
         server.startServer();
         try {
             if (waitForSSL()) {
-                server.waitForSSLStart();
+                server.waitForDefaultHTTPEndpointSSLStart();
             }
             action.accept(server);
         } finally {

--- a/dev/com.ibm.ws.kernel.filemonitor_fat/fat/src/com/ibm/ws/kernel/filemonitor/fat/FileNotificationMBeanTest.java
+++ b/dev/com.ibm.ws.kernel.filemonitor_fat/fat/src/com/ibm/ws/kernel/filemonitor/fat/FileNotificationMBeanTest.java
@@ -77,8 +77,7 @@ public class FileNotificationMBeanTest extends AbstractNotificationTest {
         assertNotNull("The application 'IBMJMXConnectorREST' did not report it was started",
                       server.waitForStringInLog("CWWKT0016I.*IBMJMXConnectorREST"));
         // Wait for secure port to be ready
-        assertNotNull("SSL port is not ready",
-                      server.waitForStringInLog("CWWKO0219I.*ssl"));
+        server.waitForDefaultHTTPEndpointSSLStart();
         assertNotNull("The server is not ready to run a smarter planet",
                       server.waitForStringInLog("CWWKF0011I"));
         assertNotNull("The security service is not ready",

--- a/dev/com.ibm.ws.logging_fat/fat/src/com/ibm/ws/logging/fat/CustomAccessLogFieldsTest.java
+++ b/dev/com.ibm.ws.logging_fat/fat/src/com/ibm/ws/logging/fat/CustomAccessLogFieldsTest.java
@@ -71,8 +71,8 @@ public class CustomAccessLogFieldsTest {
     private static Class<?> c = CustomAccessLogFieldsTest.class;
 
     private static final String MESSAGE_LOG = "logs/messages.log";
-    private static final long LOG_TIMEOUT = 30 * 1000;
-    private static final long WAIT_TIMEOUT = 30 * 1000;
+    private static final int LOG_TIMEOUT = 30 * 1000;
+    private static final int WAIT_TIMEOUT = 30 * 1000;
 
     @Server("CustomAccessLogFieldsEnv")
     public static LibertyServer envServer;
@@ -179,8 +179,8 @@ public class CustomAccessLogFieldsTest {
     @Test
     public void testAccessLogFieldNamesEnv() throws Exception {
         setUp(envServer);
-        waitForSecurityPrerequisites(envServer, WAIT_TIMEOUT);
-        waitForMetricsToStart(envServer, WAIT_TIMEOUT);
+        waitForSecurityPrerequisites(envServer);
+        waitForMetricsToStart(envServer);
         hitHttpsEndpointSecure("/metrics", envServer);
         String line = envServer.waitForStringInLog("liberty_accesslog.*/metrics");
         assertNotNull("No liberty_accesslog found in the output JSON log.", line);
@@ -195,8 +195,8 @@ public class CustomAccessLogFieldsTest {
     @Test
     public void testAccessLogFieldNamesBootstrap() throws Exception {
         setUp(bootstrapServer);
-        waitForSecurityPrerequisites(bootstrapServer, WAIT_TIMEOUT);
-        waitForMetricsToStart(bootstrapServer, WAIT_TIMEOUT);
+        waitForSecurityPrerequisites(bootstrapServer);
+        waitForMetricsToStart(bootstrapServer);
         hitHttpsEndpointSecure("/metrics", bootstrapServer);
         String line = bootstrapServer.waitForStringInLog("liberty_accesslog.*/metrics");
         assertNotNull("No liberty_accesslog found in the output JSON log.", line);
@@ -212,9 +212,9 @@ public class CustomAccessLogFieldsTest {
     public void testAccessLogFieldNamesXml() throws Exception {
         setUp(xmlServerWithMetrics);
         if (isFirstTimeUsingXmlServerWithMetrics) {
-            waitForSecurityPrerequisites(xmlServerWithMetrics, WAIT_TIMEOUT);
+            waitForSecurityPrerequisites(xmlServerWithMetrics);
         }
-        waitForMetricsToStart(xmlServerWithMetrics, WAIT_TIMEOUT);
+        waitForMetricsToStart(xmlServerWithMetrics);
 
         isFirstTimeUsingXmlServerWithMetrics = false;
         hitHttpsEndpointSecure("/metrics", xmlServer);
@@ -285,9 +285,9 @@ public class CustomAccessLogFieldsTest {
         xmlServerWithMetrics.setServerConfigurationFile("accessLogging/server-all-fields.xml");
         waitForConfigUpdate(xmlServerWithMetrics);
         if (isFirstTimeUsingXmlServerWithMetrics) {
-            waitForSecurityPrerequisites(xmlServerWithMetrics, WAIT_TIMEOUT);
+            waitForSecurityPrerequisites(xmlServerWithMetrics);
         }
-        waitForMetricsToStart(xmlServerWithMetrics, WAIT_TIMEOUT);
+        waitForMetricsToStart(xmlServerWithMetrics);
 
         isFirstTimeUsingXmlServerWithMetrics = false;
 
@@ -340,9 +340,9 @@ public class CustomAccessLogFieldsTest {
     public void testFieldsInAccessLogAreSameInJSON() throws Exception {
         setUp(xmlServerWithMetrics);
         if (isFirstTimeUsingXmlServerWithMetrics) {
-            waitForSecurityPrerequisites(xmlServerWithMetrics, WAIT_TIMEOUT);
+            waitForSecurityPrerequisites(xmlServerWithMetrics);
         }
-        waitForMetricsToStart(xmlServerWithMetrics, WAIT_TIMEOUT);
+        waitForMetricsToStart(xmlServerWithMetrics);
 
         isFirstTimeUsingXmlServerWithMetrics = false;
 
@@ -398,8 +398,8 @@ public class CustomAccessLogFieldsTest {
     @Test
     public void testChangeJsonAccessLogFieldsConfigValue() throws Exception {
         setUp(changeConfigServer);
-        waitForSecurityPrerequisites(changeConfigServer, WAIT_TIMEOUT);
-        waitForMetricsToStart(changeConfigServer, WAIT_TIMEOUT);
+        waitForSecurityPrerequisites(changeConfigServer);
+        waitForMetricsToStart(changeConfigServer);
 
         hitHttpsEndpointSecure("/metrics", changeConfigServer);
         String line = changeConfigServer.waitForStringInLogUsingMark("liberty_accesslog.*/metrics");
@@ -808,18 +808,18 @@ public class CustomAccessLogFieldsTest {
         assertNotNull("Wrong number of updates have occurred", result);
     }
 
-    private void waitForSecurityPrerequisites(LibertyServer server, long logTimeout) {
+    private void waitForSecurityPrerequisites(LibertyServer server) throws Exception {
         // Need to ensure LTPA keys and configuration are created before hitting a secure endpoint
-        assertNotNull("LTPA keys are not created within timeout period of " + logTimeout + "ms.", server.waitForStringInLog("CWWKS4104A", logTimeout));
-        assertNotNull("LTPA configuration is not ready within timeout period of " + logTimeout + "ms.", server.waitForStringInLog("CWWKS4105I", logTimeout));
+        server.waitForLTPAKeysCreatedAndConfigComplete(CustomAccessLogFieldsTest.WAIT_TIMEOUT);
+        // Wait for port 8020 to be ready
+        server.waitForDefaultHTTPEndpointSSLStart(CustomAccessLogFieldsTest.WAIT_TIMEOUT);
     }
 
-    private void waitForMetricsToStart(LibertyServer server, long logTimeout) {
-        // Wait for port 8020 to be ready
-        assertNotNull("TCP Channel defaultHttpEndpoint-ssl has not started (CWWKO0219I not found)",
-                      server.waitForStringInLog("CWWKO0219I.*defaultHttpEndpoint-ssl", logTimeout));
+    private void waitForMetricsToStart(LibertyServer server) {
+
+
         // Wait for /metrics to be initialized
         assertNotNull("/metrics was not initialized (SRVE0242I not found)",
-                      server.waitForStringInLog("SRVE0242I.*/metrics", logTimeout));
+                      server.waitForStringInLog("SRVE0242I.*/metrics", CustomAccessLogFieldsTest.WAIT_TIMEOUT));
     }
 }

--- a/dev/com.ibm.ws.logging_fat/fat/src/com/ibm/ws/logging/fat/CustomAccessLogFieldsTest.java
+++ b/dev/com.ibm.ws.logging_fat/fat/src/com/ibm/ws/logging/fat/CustomAccessLogFieldsTest.java
@@ -71,8 +71,8 @@ public class CustomAccessLogFieldsTest {
     private static Class<?> c = CustomAccessLogFieldsTest.class;
 
     private static final String MESSAGE_LOG = "logs/messages.log";
-    private static final int LOG_TIMEOUT = 30 * 1000;
-    private static final int WAIT_TIMEOUT = 30 * 1000;
+    private static final int LOG_TIMEOUT = 60 * 1000;
+    private static final int WAIT_TIMEOUT = 60 * 1000;
 
     @Server("CustomAccessLogFieldsEnv")
     public static LibertyServer envServer;
@@ -809,15 +809,13 @@ public class CustomAccessLogFieldsTest {
     }
 
     private void waitForSecurityPrerequisites(LibertyServer server) throws Exception {
-        // Need to ensure LTPA keys and configuration are created before hitting a secure endpoint
-        server.waitForLTPAKeysCreatedAndConfigComplete(CustomAccessLogFieldsTest.WAIT_TIMEOUT);
+        // Need to ensure LTPA configuration is ready before hitting a secure endpoint
+        server.waitForLTPAConfigReady(CustomAccessLogFieldsTest.WAIT_TIMEOUT);
         // Wait for port 8020 to be ready
         server.waitForDefaultHTTPEndpointSSLStart(CustomAccessLogFieldsTest.WAIT_TIMEOUT);
     }
 
     private void waitForMetricsToStart(LibertyServer server) {
-
-
         // Wait for /metrics to be initialized
         assertNotNull("/metrics was not initialized (SRVE0242I not found)",
                       server.waitForStringInLog("SRVE0242I.*/metrics", CustomAccessLogFieldsTest.WAIT_TIMEOUT));

--- a/dev/com.ibm.ws.microprofile.graphql.1.0_fat/fat/src/com/ibm/ws/microprofile/graphql/fat/RolesAuthTest.java
+++ b/dev/com.ibm.ws.microprofile.graphql.1.0_fat/fat/src/com/ibm/ws/microprofile/graphql/fat/RolesAuthTest.java
@@ -49,8 +49,7 @@ public class RolesAuthTest extends FATServletClient {
         server.startServer();
 
         // wait for LTPA key to be available to avoid CWWKS4000E
-        assertNotNull("CWWKS4105I.* not received on server",
-                      server.waitForStringInLog("CWWKS4105I.*"));
+        server.waitForLTPAConfigReady();
     }
 
     @AfterClass

--- a/dev/com.ibm.ws.microprofile.metrics.2.x.monitor_fat/fat/src/com/ibm/ws/microprofile/metrics/monitor_fat/MetricsMonitorTest.java
+++ b/dev/com.ibm.ws.microprofile.metrics.2.x.monitor_fat/fat/src/com/ibm/ws/microprofile/metrics/monitor_fat/MetricsMonitorTest.java
@@ -35,7 +35,6 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import com.ibm.websphere.simplicity.ShrinkHelper;
 import com.ibm.websphere.simplicity.log.Log;
 
 import componenttest.annotation.Server;
@@ -51,6 +50,8 @@ public class MetricsMonitorTest {
 
     @Server("MetricsMonitorServer")
     public static LibertyServer server;
+
+    private static int timeout = 60000;
     
     @BeforeClass
     public static void setUp() throws Exception {
@@ -99,10 +100,10 @@ public class MetricsMonitorTest {
     	Log.info(c, testName, "------- Enable mpMetrics-1.1 and monitor-1.0: vendor metrics should be available ------");
     	server.setServerConfigurationFile("server_monitor.xml");
     	server.startServer();
-        Assert.assertNotNull("LTPA keys are not created/ready within timeout period of " + 60000 + "ms.", server.waitForStringInLog("CWWKS4104A.*|CWWKS4105I.*",60000));
-    	Assert.assertNotNull("CWWKO0219I NOT FOUND",server.waitForStringInLog("defaultHttpEndpoint-ssl",60000));
+        server.waitForLTPAConfigReady(timeout);
+    	server.waitForDefaultHTTPEndpointSSLStart(timeout);
     	Log.info(c, testName, "------- server started -----");
-    	Assert.assertNotNull("CWWKT0016I NOT FOUND",server.waitForStringInLogUsingMark("CWWKT0016I"));
+    	Assert.assertNotNull("CWWKT0016I NOT FOUND", server.waitForStringInLogUsingMark("CWWKT0016I"));
       	checkStrings(getHttpsServlet("/metrics"), 
           	new String[] { "base:", "vendor:" }, 
           	new String[] {});
@@ -122,8 +123,8 @@ public class MetricsMonitorTest {
     	Log.info(c, testName, "------- Enable mpMetrics-2.0 and monitor-1.0: vendor metrics should be available ------");
     	server.setServerConfigurationFile("server_monitor2.xml");
     	server.startServer();
-        Assert.assertNotNull("LTPA keys are not created/ready within timeout period of " + 60000 + "ms.", server.waitForStringInLog("CWWKS4104A.*|CWWKS4105I.*",60000));
-    	Assert.assertNotNull("CWWKO0219I NOT FOUND", server.waitForStringInLog("defaultHttpEndpoint-ssl",60000));
+        server.waitForLTPAConfigReady(timeout);
+    	server.waitForDefaultHTTPEndpointSSLStart(timeout);
     	Log.info(c, testName, "------- server started -----");
     	Assert.assertNotNull("CWWKT0016I NOT FOUND",server.waitForStringInLogUsingMark("CWWKT0016I"));
       	checkStrings(getHttpsServlet("/metrics"), 
@@ -146,8 +147,8 @@ public class MetricsMonitorTest {
     	Log.info(c, testName, "------- Enable mpMetrics-2.3 and monitor-1.0: vendor metrics should be available ------");
     	server.setServerConfigurationFile("server_monitor2.xml");
     	server.startServer();
-        Assert.assertNotNull("LTPA keys are not created/ready within timeout period of " + 60000 + "ms.", server.waitForStringInLog("CWWKS4104A.*|CWWKS4105I.*",60000));
-    	Assert.assertNotNull("CWWKO0219I NOT FOUND", server.waitForStringInLog("defaultHttpEndpoint-ssl",60000));
+        server.waitForLTPAConfigReady(timeout);
+    	server.waitForDefaultHTTPEndpointSSLStart(timeout);
     	Log.info(c, testName, "------- server started -----");
     	Assert.assertNotNull("CWWKT0016I NOT FOUND",server.waitForStringInLogUsingMark("CWWKT0016I"));
       	checkStrings(getHttpsServlet("/metrics"), 
@@ -170,12 +171,12 @@ public class MetricsMonitorTest {
     	Log.info(c, testName, "------- Enable mpMetrics-1.0 and monitor-1.0: vendor metrics should not be available ------");
     	server.setServerConfigurationFile("server_mpMetric10Monitor10.xml");
     	server.startServer();
-        Assert.assertNotNull("LTPA keys are not created/ready within timeout period of " + 60000 + "ms.", server.waitForStringInLog("CWWKS4104A.*|CWWKS4105I.*",60000));
-    	Assert.assertNotNull("CWWKO0219I NOT FOUND", server.waitForStringInLog("defaultHttpEndpoint-ssl",60000));
-        String logMsg = server.waitForStringInLog("SRVE9103I",60000);   
+        server.waitForLTPAConfigReady(timeout);
+    	server.waitForDefaultHTTPEndpointSSLStart(timeout);
+        String logMsg = server.waitForDefaultHTTPEndpointSSLStart(true);
         Log.info(c, testName, logMsg);
         Assert.assertNotNull("No SRVE9103I message", logMsg);    
-        Assert.assertNotNull("CWWKT0016I NOT FOUND",server.waitForStringInLog(".*CWWKT0016I.*metrics.*",60000));
+        Assert.assertNotNull("CWWKT0016I NOT FOUND",server.waitForStringInLog(".*CWWKT0016I.*metrics.*",timeout));
         Log.info(c, testName, "------- server started -----");
       	checkStrings(getHttpsServlet("/metrics"), 
           	new String[] { "base:" }, 
@@ -190,10 +191,10 @@ public class MetricsMonitorTest {
     	Log.info(c, testName, "------- Enable microProfile-1.3 and monitor-1.0: vendor metrics should be available ------");
     	server.setServerConfigurationFile("server_microProfile13Monitor10.xml");
     	server.startServer();
-        Assert.assertNotNull("LTPA keys are not created/ready within timeout period of " + 60000 + "ms.", server.waitForStringInLog("CWWKS4104A.*|CWWKS4105I.*",60000));
-    	Log.info(c, testName, server.waitForStringInLog("CWWKS5500I",60000));
-    	Assert.assertNotNull("CWWKT0016I NOT FOUND",server.waitForStringInLog(".*CWWKT0016I.*metrics.*",60000));
-    	Assert.assertNotNull("CWWKO0219I NOT FOUND",server.waitForStringInLog(".*CWWKO0219I.*defaultHttpEndpoint-ssl.*",60000));
+        server.waitForLTPAConfigReady(timeout);
+    	Log.info(c, testName, server.waitForStringInLog("CWWKS5500I",timeout));
+    	Assert.assertNotNull("CWWKT0016I NOT FOUND",server.waitForStringInLog(".*CWWKT0016I.*metrics.*",timeout));
+    	server.waitForDefaultHTTPEndpointSSLStart(timeout);
     	Log.info(c, testName, "------- server started -----");
       	checkStrings(getHttpsServlet("/metrics"),
           	new String[] { "vendor:" }, 

--- a/dev/com.ibm.ws.microprofile.metrics.2.x.monitor_fat/fat/src/com/ibm/ws/microprofile/metrics/monitor_fat/TestEnableDisableFeaturesTest.java
+++ b/dev/com.ibm.ws.microprofile.metrics.2.x.monitor_fat/fat/src/com/ibm/ws/microprofile/metrics/monitor_fat/TestEnableDisableFeaturesTest.java
@@ -543,8 +543,8 @@ public class TestEnableDisableFeaturesTest {
     }
     
     private void waitForSecurityPrerequisites(LibertyServer server, int timeout) throws Exception {
-    	// Need to ensure LTPA keys and configuration are created before hitting a secure endpoint
-            server.waitForLTPAKeysCreatedAndConfigComplete(timeout);
+    	// Need to ensure LTPA configuration is ready before hitting a secure endpoint
+            server.waitForLTPAConfigReady(timeout);
             // Ensure defaultHttpEndpoint-ssl TCP Channel is started
             server.waitForDefaultHTTPEndpointSSLStart(timeout);
     }

--- a/dev/com.ibm.ws.microprofile.metrics.2.x.monitor_fat/fat/src/com/ibm/ws/microprofile/metrics/monitor_fat/TestEnableDisableFeaturesTest.java
+++ b/dev/com.ibm.ws.microprofile.metrics.2.x.monitor_fat/fat/src/com/ibm/ws/microprofile/metrics/monitor_fat/TestEnableDisableFeaturesTest.java
@@ -87,7 +87,9 @@ public class TestEnableDisableFeaturesTest {
     private static LibertyServer currentServ;
     
     private static boolean serverEDF6FirstUse = true;
-    
+
+    private static final int timeout = 60000;
+
     @BeforeClass
     public static void setUp() throws Exception {
     	trustAll();
@@ -177,7 +179,7 @@ public class TestEnableDisableFeaturesTest {
         Log.info(c, testName, "------- No monitor-1.0: no vendor metrics should be available ------");
         serverEDF1.setServerConfigurationFile("server_mpMetric20.xml");
         serverEDF1.startServer();
-        waitForSecurityPrerequisites(serverEDF1, 60000);
+        waitForSecurityPrerequisites(serverEDF1, timeout);
         Assert.assertNotNull("Web application /metrics not loaded", serverEDF1.waitForStringInLog("CWWKT0016I.*http:\\/\\/.*:.*\\/metrics\\/"));
         Assert.assertNotNull("SRVE9103I NOT FOUND",serverEDF1.waitForStringInLogUsingMark("SRVE9103I"));
         Log.info(c, testName, "------- server started -----");
@@ -193,7 +195,7 @@ public class TestEnableDisableFeaturesTest {
     	String testName = "testEDF2";
     	Log.info(c, testName, "------- Enable " + metricFeature + " and monitor-1.0: threadpool metrics should be available ------");
     	serverEDF2.startServer();
-    	waitForSecurityPrerequisites(serverEDF2, 60000);
+    	waitForSecurityPrerequisites(serverEDF2, timeout);
     	
     	String logMsg;
     	/*
@@ -255,7 +257,7 @@ public class TestEnableDisableFeaturesTest {
     	currentServ = serverEDF3;
     	String testName = "testEDF3";
     	serverEDF3.startServer();
-    	waitForSecurityPrerequisites(serverEDF3, 60000);
+    	waitForSecurityPrerequisites(serverEDF3, timeout);
     	Log.info(c, testName, "------- Add session application and run session servlet ------");
        	ShrinkHelper.defaultDropinApp(serverEDF3, "testSessionApp", "com.ibm.ws.microprofile.metrics.monitor_fat.session.servlet");
        	Log.info(c, testName, "------- added testSessionApp to dropins -----");
@@ -276,7 +278,7 @@ public class TestEnableDisableFeaturesTest {
     	currentServ = serverEDF4;
     	String testName = "testEDF4";
     	serverEDF4.startServer();
-    	waitForSecurityPrerequisites(serverEDF4, 60000);
+    	waitForSecurityPrerequisites(serverEDF4, timeout);
     	Log.info(c, testName, "------- Add session application ------");
        	ShrinkHelper.defaultDropinApp(serverEDF4, "testSessionApp", "com.ibm.ws.microprofile.metrics.monitor_fat.session.servlet");
        	Log.info(c, testName, "------- added testSessionApp to dropins -----");
@@ -343,7 +345,7 @@ public class TestEnableDisableFeaturesTest {
     	currentServ = serverEDF5;
     	String testName = "testEDF5";
     	serverEDF5.startServer();
-    	waitForSecurityPrerequisites(serverEDF5, 60000);
+    	waitForSecurityPrerequisites(serverEDF5, timeout);
     	Log.info(c, testName, "------- Add jax-ws endpoint application and run jax-ws client servlet ------");
        	ShrinkHelper.defaultDropinApp(serverEDF5, "testJaxWsApp", "com.ibm.ws.microprofile.metrics.monitor_fat.jaxws","com.ibm.ws.microprofile.metrics.monitor_fat.jaxws.client");
        	Log.info(c, testName, "------- added testJaxWsApp to dropins -----");
@@ -375,9 +377,9 @@ public class TestEnableDisableFeaturesTest {
     	
     	if (serverEDF6FirstUse) {
     		// We only need to wait for LTPA keys if this is the first time using this server
-    		waitForSecurityPrerequisites(serverEDF6, 60000);
+    		waitForSecurityPrerequisites(serverEDF6, timeout);
     	} else {
-    		Assert.assertNotNull("TCP Channel defaultHttpEndpoint-ssl has not started (CWWKO0219I not found)",serverEDF6.waitForStringInLog("CWWKO0219I.*defaultHttpEndpoint-ssl",60000));
+    		serverEDF6.waitForDefaultHTTPEndpointSSLStart(timeout);
     	}
     	serverEDF6FirstUse = false;
     	
@@ -400,9 +402,9 @@ public class TestEnableDisableFeaturesTest {
     	
     	if (serverEDF6FirstUse) {
     		// We only need to wait for LTPA keys if this is the first time using this server
-    		waitForSecurityPrerequisites(serverEDF6, 60000);
+    		waitForSecurityPrerequisites(serverEDF6, timeout);
     	} else {
-    		Assert.assertNotNull("TCP Channel defaultHttpEndpoint-ssl has not started (CWWKO0219I not found)",serverEDF6.waitForStringInLog("CWWKO0219I.*defaultHttpEndpoint-ssl",60000));
+    		serverEDF6.waitForDefaultHTTPEndpointSSLStart(timeout);
     	}
     	serverEDF6FirstUse = false;
     	
@@ -423,7 +425,7 @@ public class TestEnableDisableFeaturesTest {
     	currentServ = serverEDF8;
     	String testName = "testEDF8";
     	serverEDF8.startServer();
-    	waitForSecurityPrerequisites(serverEDF8, 60000);
+    	waitForSecurityPrerequisites(serverEDF8, timeout);
     	checkStrings(getHttpServlet("/testJDBCApp/testJDBCServlet?operation=create", serverEDF8), 
           		new String[] { "sql: create table cities" }, new String[] {});
     	Log.info(c, testName, "------- Monitor filter Session and ConnectionPool ------");
@@ -444,7 +446,7 @@ public class TestEnableDisableFeaturesTest {
         String testName = "testEDF9";
 
         serverEDF9.startServer();
-        waitForSecurityPrerequisites(serverEDF9, 60000);
+        waitForSecurityPrerequisites(serverEDF9, timeout);
 
         // Prime the DB app so the table exists
         checkStrings(getHttpServlet("/testJDBCApp/testJDBCServlet?operation=create", serverEDF9),
@@ -486,7 +488,7 @@ public class TestEnableDisableFeaturesTest {
     	currentServ = serverEDF10;
     	String testName = "testEDF10";
     	serverEDF10.startServer();
-    	waitForSecurityPrerequisites(serverEDF10, 60000);
+    	waitForSecurityPrerequisites(serverEDF10, timeout);
     	Log.info(c, testName, "------- Remove JAX-WS application ------");
     	boolean rc1 = serverEDF10.removeAndStopDropinsApplications("testJaxWsApp.war");
     	Log.info(c, testName, "------- " + (rc1 ? "successfully removed" : "failed to remove") + " JAX-WS application ------");
@@ -507,7 +509,7 @@ public class TestEnableDisableFeaturesTest {
     	currentServ = serverEDF11;
     	String testName = "testEDF11";
     	serverEDF11.startServer();
-    	waitForSecurityPrerequisites(serverEDF11, 60000);
+    	waitForSecurityPrerequisites(serverEDF11, timeout);
     	Log.info(c, testName, "------- Remove JDBC application ------");
     	boolean rc2 = serverEDF11.removeAndStopDropinsApplications("testJDBCApp.war");
     	Log.info(c, testName, "------- " + (rc2 ? "successfully removed" : "failed to remove") + " JDBC application ------");
@@ -528,7 +530,7 @@ public class TestEnableDisableFeaturesTest {
     	currentServ = serverEDF12;
     	String testName = "testEDF12";
     	serverEDF12.startServer();
-    	waitForSecurityPrerequisites(serverEDF12, 60000);
+    	waitForSecurityPrerequisites(serverEDF12, timeout);
     	Assert.assertNotNull("CWWKF0011I NOT FOUND",serverEDF12.waitForStringInLogUsingMark("CWWKF0011I"));
     	Log.info(c, testName, "------- Remove monitor-1.0 ------");
     	serverEDF12.setMarkToEndOfLog();
@@ -540,13 +542,11 @@ public class TestEnableDisableFeaturesTest {
     		new String[] { "vendor_" });
     }
     
-    private void waitForSecurityPrerequisites(LibertyServer server, int timeout) {
+    private void waitForSecurityPrerequisites(LibertyServer server, int timeout) throws Exception {
     	// Need to ensure LTPA keys and configuration are created before hitting a secure endpoint
-        Assert.assertNotNull("LTPA keys are not created within timeout period of " + timeout + "ms.", server.waitForStringInLog("CWWKS4104A",timeout));
-        Assert.assertNotNull("LTPA configuration is not ready within timeout period of " + timeout + "ms.", server.waitForStringInLog("CWWKS4105I",timeout));
-
-        // Ensure defaultHttpEndpoint-ssl TCP Channel is started
-        Assert.assertNotNull("TCP Channel defaultHttpEndpoint-ssl has not started (CWWKO0219I not found)",server.waitForStringInLog("CWWKO0219I.*defaultHttpEndpoint-ssl",timeout));
+            server.waitForLTPAKeysCreatedAndConfigComplete(timeout);
+            // Ensure defaultHttpEndpoint-ssl TCP Channel is started
+            server.waitForDefaultHTTPEndpointSSLStart(timeout);
     }
     
     private String getHttpServlet(String servletPath, LibertyServer server) throws Exception {

--- a/dev/com.ibm.ws.microprofile.metrics.monitor_fat/fat/src/com/ibm/ws/microprofile/metrics/monitor_fat/MetricsMonitorTest.java
+++ b/dev/com.ibm.ws.microprofile.metrics.monitor_fat/fat/src/com/ibm/ws/microprofile/metrics/monitor_fat/MetricsMonitorTest.java
@@ -35,7 +35,6 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import com.ibm.websphere.simplicity.ShrinkHelper;
 import com.ibm.websphere.simplicity.log.Log;
 
 import componenttest.annotation.Server;
@@ -46,6 +45,8 @@ import componenttest.topology.impl.LibertyServer;
 public class MetricsMonitorTest {
 	
     private static Class<?> c = MetricsMonitorTest.class;
+
+    private static final int timeout = 60000;
 
     @Server("MetricsMonitorServer")
     public static LibertyServer server;
@@ -97,9 +98,8 @@ public class MetricsMonitorTest {
     	Log.info(c, testName, "------- Enable mpMetrics-1.1 and monitor-1.0: vendor metrics should be available ------");
     	server.setServerConfigurationFile("server_monitor.xml");
     	server.startServer();
-        Assert.assertNotNull("LTPA keys are not created/ready within timeout period of " + 60000 + "ms.", server.waitForStringInLog("CWWKS4104A.*|CWWKS4105I.*",60000));
-    	Assert.assertNotNull("CWWKO0219I NOT FOUND",server.waitForStringInLog("defaultHttpEndpoint-ssl",60000));
-    	Log.info(c, testName, server.waitForStringInLog("defaultHttpEndpoint-ssl",60000));
+        server.waitForLTPAConfigReady(timeout);
+    	server.waitForDefaultHTTPEndpointSSLStart(timeout);
     	Log.info(c, testName, "------- server started -----");
     	Assert.assertNotNull("CWWKT0016I NOT FOUND",server.waitForStringInLogUsingMark("CWWKT0016I"));
       	checkStrings(getHttpsServlet("/metrics"), 
@@ -121,12 +121,12 @@ public class MetricsMonitorTest {
     	Log.info(c, testName, "------- Enable mpMetrics-1.0 and monitor-1.0: vendor metrics should not be available ------");
     	server.setServerConfigurationFile("server_mpMetric10Monitor10.xml");
     	server.startServer();
-        Assert.assertNotNull("LTPA keys are not created/ready within timeout period of " + 60000 + "ms.", server.waitForStringInLog("CWWKS4104A.*|CWWKS4105I.*",60000));
-    	Assert.assertNotNull("CWWKO0219I NOT FOUND",server.waitForStringInLog("defaultHttpEndpoint-ssl",60000));
-        String logMsg = server.waitForStringInLog("SRVE9103I",60000);   
+        server.waitForLTPAConfigReady(timeout);
+    	server.waitForDefaultHTTPEndpointSSLStart(timeout);
+        String logMsg = server.waitForStringInLog("SRVE9103I",timeout);
         Log.info(c, testName, logMsg);
         Assert.assertNotNull("No SRVE9103I message", logMsg);    
-        Assert.assertNotNull("CWWKT0016I NOT FOUND",server.waitForStringInLog(".*CWWKT0016I.*metrics.*",60000));
+        Assert.assertNotNull("CWWKT0016I NOT FOUND",server.waitForStringInLog(".*CWWKT0016I.*metrics.*",timeout));
         Log.info(c, testName, "------- server started -----");
       	checkStrings(getHttpsServlet("/metrics"), 
           	new String[] { "base:" }, 
@@ -141,10 +141,10 @@ public class MetricsMonitorTest {
     	Log.info(c, testName, "------- Enable microProfile-1.3 and monitor-1.0: vendor metrics should be available ------");
     	server.setServerConfigurationFile("server_microProfile13Monitor10.xml");
     	server.startServer();
-        Assert.assertNotNull("LTPA keys are not created/ready within timeout period of " + 60000 + "ms.", server.waitForStringInLog("CWWKS4104A.*|CWWKS4105I.*",60000));
-    	Assert.assertNotNull("CWWKO0219I NOT FOUND",server.waitForStringInLog("defaultHttpEndpoint-ssl",60000));
-    	Log.info(c, testName, server.waitForStringInLog("CWWKS5500I",60000));
-    	Assert.assertNotNull("CWWKT0016I NOT FOUND",server.waitForStringInLog(".*CWWKT0016I.*metrics.*",60000));
+        server.waitForLTPAConfigReady(timeout);
+    	server.waitForDefaultHTTPEndpointSSLStart(timeout);
+    	Log.info(c, testName, server.waitForStringInLog("CWWKS5500I",timeout));
+    	Assert.assertNotNull("CWWKT0016I NOT FOUND",server.waitForStringInLog(".*CWWKT0016I.*metrics.*",timeout));
     	Log.info(c, testName, "------- server started -----");
       	checkStrings(getHttpsServlet("/metrics"),
           	new String[] { "vendor:" }, 

--- a/dev/com.ibm.ws.microprofile.metrics.monitor_fat/fat/src/com/ibm/ws/microprofile/metrics/monitor_fat/TestEnableDisableFeaturesTest.java
+++ b/dev/com.ibm.ws.microprofile.metrics.monitor_fat/fat/src/com/ibm/ws/microprofile/metrics/monitor_fat/TestEnableDisableFeaturesTest.java
@@ -463,8 +463,8 @@ public class TestEnableDisableFeaturesTest {
     }
 
     private void waitForSecurityPrerequisites(LibertyServer server, int timeout) throws Exception {
-    	// Need to ensure LTPA keys and configuration are created before hitting a secure endpoint
-        server.waitForLTPAKeysCreatedAndConfigComplete(timeout);
+    	// Need to ensure LTPA configuration is ready before hitting a secure endpoint
+        server.waitForLTPAConfigReady(timeout);
         // Ensure defaultHttpEndpoint-ssl TCP Channel is started
         server.waitForDefaultHTTPEndpointSSLStart(timeout);
     }

--- a/dev/com.ibm.ws.microprofile.metrics.monitor_fat/fat/src/com/ibm/ws/microprofile/metrics/monitor_fat/TestEnableDisableFeaturesTest.java
+++ b/dev/com.ibm.ws.microprofile.metrics.monitor_fat/fat/src/com/ibm/ws/microprofile/metrics/monitor_fat/TestEnableDisableFeaturesTest.java
@@ -83,6 +83,8 @@ public class TestEnableDisableFeaturesTest {
     private static LibertyServer currentServ;
     
     private static boolean serverEDF6FirstUse = true;
+
+    private static final int timeout = 60000;
     
     @BeforeClass
     public static void setUp() throws Exception {
@@ -159,7 +161,7 @@ public class TestEnableDisableFeaturesTest {
         Log.info(c, testName, "------- No monitor-1.0: no vendor metrics should be available ------");
         serverEDF1.setServerConfigurationFile("server_mpMetric11.xml");
         serverEDF1.startServer();
-        waitForSecurityPrerequisites(serverEDF1, 60000);
+        waitForSecurityPrerequisites(serverEDF1, timeout);
         Assert.assertNotNull("Web application /metrics not loaded", serverEDF1.waitForStringInLog("CWWKT0016I.*http:\\/\\/.*:.*\\/metrics\\/"));
         Assert.assertNotNull("SRVE9103I NOT FOUND",serverEDF1.waitForStringInLogUsingMark("SRVE9103I"));
         Log.info(c, testName, "------- server started -----");
@@ -174,7 +176,7 @@ public class TestEnableDisableFeaturesTest {
     	String testName = "testEDF2";
     	Log.info(c, testName, "------- Enable mpMetrics-1.1 and monitor-1.0: threadpool metrics should be available ------");
     	serverEDF2.startServer();
-    	waitForSecurityPrerequisites(serverEDF2, 60000);
+    	waitForSecurityPrerequisites(serverEDF2, timeout);
     	serverEDF2.setServerConfigurationFile("server_monitor.xml");
         String logMsg = serverEDF2.waitForStringInLogUsingMark("CWPMI2001I");
         Log.info(c, testName, logMsg);
@@ -196,7 +198,7 @@ public class TestEnableDisableFeaturesTest {
     	currentServ = serverEDF3;
     	String testName = "testEDF3";
     	serverEDF3.startServer();
-    	waitForSecurityPrerequisites(serverEDF3, 60000);
+    	waitForSecurityPrerequisites(serverEDF3, timeout);
     	Log.info(c, testName, "------- Add session application and run session servlet ------");
        	ShrinkHelper.defaultDropinApp(serverEDF3, "testSessionApp", "com.ibm.ws.microprofile.metrics.monitor_fat.session.servlet");
        	Log.info(c, testName, "------- added testSessionApp to dropins -----");
@@ -217,7 +219,7 @@ public class TestEnableDisableFeaturesTest {
         currentServ = serverEDF4;
         String testName = "testEDF4";
         serverEDF4.startServer();
-        waitForSecurityPrerequisites(serverEDF4, 60000);
+        waitForSecurityPrerequisites(serverEDF4, timeout);
         Log.info(c, testName, "------- Add session application ------");
         ShrinkHelper.defaultDropinApp(serverEDF4, "testSessionApp",
                 "com.ibm.ws.microprofile.metrics.monitor_fat.session.servlet");
@@ -286,7 +288,7 @@ public class TestEnableDisableFeaturesTest {
     	currentServ = serverEDF5;
     	String testName = "testEDF5";
     	serverEDF5.startServer();
-    	waitForSecurityPrerequisites(serverEDF5, 60000);
+    	waitForSecurityPrerequisites(serverEDF5, timeout);
     	Log.info(c, testName, "------- Add jax-ws endpoint application and run jax-ws client servlet ------");
        	ShrinkHelper.defaultDropinApp(serverEDF5, "testJaxWsApp", "com.ibm.ws.microprofile.metrics.monitor_fat.jaxws","com.ibm.ws.microprofile.metrics.monitor_fat.jaxws.client");
        	Log.info(c, testName, "------- added testJaxWsApp to dropins -----");
@@ -318,9 +320,9 @@ public class TestEnableDisableFeaturesTest {
     	
     	if (serverEDF6FirstUse) {
     		// We only need to wait for LTPA keys if this is the first time using this server
-    		waitForSecurityPrerequisites(serverEDF6, 60000);
+    		waitForSecurityPrerequisites(serverEDF6, timeout);
     	} else {
-    		Assert.assertNotNull("TCP Channel defaultHttpEndpoint-ssl has not started (CWWKO0219I not found)",serverEDF6.waitForStringInLog("CWWKO0219I.*defaultHttpEndpoint-ssl",60000));
+    		serverEDF6.waitForDefaultHTTPEndpointSSLStart(timeout);
     	}
     	serverEDF6FirstUse = false;
     	
@@ -343,9 +345,9 @@ public class TestEnableDisableFeaturesTest {
     	
     	if (serverEDF6FirstUse) {
     		// We only need to wait for LTPA keys if this is the first time using this server
-    		waitForSecurityPrerequisites(serverEDF6, 60000);
+    		waitForSecurityPrerequisites(serverEDF6, timeout);
     	} else {
-    		Assert.assertNotNull("TCP Channel defaultHttpEndpoint-ssl has not started (CWWKO0219I not found)",serverEDF6.waitForStringInLog("CWWKO0219I.*defaultHttpEndpoint-ssl",60000));
+    		serverEDF6.waitForDefaultHTTPEndpointSSLStart(timeout);
     	}
     	serverEDF6FirstUse = false;
     	
@@ -366,7 +368,7 @@ public class TestEnableDisableFeaturesTest {
     	currentServ = serverEDF8;
     	String testName = "testEDF8";
     	serverEDF8.startServer();
-    	waitForSecurityPrerequisites(serverEDF8, 60000);
+    	waitForSecurityPrerequisites(serverEDF8, timeout);
     	checkStrings(getHttpServlet("/testJDBCApp/testJDBCServlet?operation=create", serverEDF8), 
           		new String[] { "sql: create table cities" }, new String[] {});
     	Log.info(c, testName, "------- Monitor filter Session and ConnectionPool ------");
@@ -385,7 +387,7 @@ public class TestEnableDisableFeaturesTest {
     	currentServ = serverEDF9;
     	String testName = "testEDF9";
     	serverEDF9.startServer();
-    	waitForSecurityPrerequisites(serverEDF9, 60000);
+    	waitForSecurityPrerequisites(serverEDF9, timeout);
     	checkStrings(getHttpServlet("/testJDBCApp/testJDBCServlet?operation=create", serverEDF9), 
           		new String[] { "sql: create table cities" }, new String[] {});
     	Log.info(c, testName, "------- Monitor filter ThreadPool, WebContainer, Session and ConnectionPool ------");
@@ -407,7 +409,7 @@ public class TestEnableDisableFeaturesTest {
     	currentServ = serverEDF10;
     	String testName = "testEDF10";
     	serverEDF10.startServer();
-    	waitForSecurityPrerequisites(serverEDF10, 60000);
+    	waitForSecurityPrerequisites(serverEDF10, timeout);
     	Log.info(c, testName, "------- Remove JAX-WS application ------");
     	boolean rc1 = serverEDF10.removeAndStopDropinsApplications("testJaxWsApp.war");
     	Log.info(c, testName, "------- " + (rc1 ? "successfully removed" : "failed to remove") + " JAX-WS application ------");
@@ -428,7 +430,7 @@ public class TestEnableDisableFeaturesTest {
     	currentServ = serverEDF11;
     	String testName = "testEDF11";
     	serverEDF11.startServer();
-    	waitForSecurityPrerequisites(serverEDF11, 60000);
+    	waitForSecurityPrerequisites(serverEDF11, timeout);
     	Log.info(c, testName, "------- Remove JDBC application ------");
     	boolean rc2 = serverEDF11.removeAndStopDropinsApplications("testJDBCApp.war");
     	Log.info(c, testName, "------- " + (rc2 ? "successfully removed" : "failed to remove") + " JDBC application ------");
@@ -448,7 +450,7 @@ public class TestEnableDisableFeaturesTest {
     	currentServ = serverEDF12;
     	String testName = "testEDF12";
     	serverEDF12.startServer();
-    	waitForSecurityPrerequisites(serverEDF12, 60000);
+    	waitForSecurityPrerequisites(serverEDF12, timeout);
     	Assert.assertNotNull("CWWKF0011I NOT FOUND",serverEDF12.waitForStringInLogUsingMark("CWWKF0011I"));
     	Log.info(c, testName, "------- Remove monitor-1.0 ------");
     	serverEDF12.setMarkToEndOfLog();
@@ -460,13 +462,11 @@ public class TestEnableDisableFeaturesTest {
     		new String[] { "vendor:" });
     }
 
-    private void waitForSecurityPrerequisites(LibertyServer server, int timeout) {
+    private void waitForSecurityPrerequisites(LibertyServer server, int timeout) throws Exception {
     	// Need to ensure LTPA keys and configuration are created before hitting a secure endpoint
-        Assert.assertNotNull("LTPA keys are not created within timeout period of " + timeout + "ms.", server.waitForStringInLog("CWWKS4104A",timeout));
-        Assert.assertNotNull("LTPA configuration is not ready within timeout period of " + timeout + "ms.", server.waitForStringInLog("CWWKS4105I",timeout));
-        
+        server.waitForLTPAKeysCreatedAndConfigComplete(timeout);
         // Ensure defaultHttpEndpoint-ssl TCP Channel is started
-        Assert.assertNotNull("TCP Channel defaultHttpEndpoint-ssl has not started (CWWKO0219I not found)",server.waitForStringInLog("CWWKO0219I.*defaultHttpEndpoint-ssl",timeout));
+        server.waitForDefaultHTTPEndpointSSLStart(timeout);
     }
     
     private String getHttpServlet(String servletPath, LibertyServer server) throws Exception {

--- a/dev/com.ibm.ws.microprofile.metrics_fat/fat/src/com/ibm/ws/microprofile/metrics/tck/launcher/MetricsAuthenticationTest.java
+++ b/dev/com.ibm.ws.microprofile.metrics_fat/fat/src/com/ibm/ws/microprofile/metrics/tck/launcher/MetricsAuthenticationTest.java
@@ -74,19 +74,19 @@ public class MetricsAuthenticationTest {
         waitForMetricsEndpoint(server);
     }
 
-    private void waitForMetricsEndpoint(LibertyServer server) throws Exception {
+    private void waitForMetricsEndpoint(LibertyServer server) {
         // by default waitForStringInLogUsingMark will look at the default log when a log is not specified
         assertNotNull("Web application is not available at */metrics/", server.waitForStringInLogUsingMark("CWWKT0016I.*/metrics/"));
     }
 
-    private void waitForMetricsFeature(LibertyServer server) throws Exception {
+    private void waitForMetricsFeature(LibertyServer server){
         assertNotNull("[/metrics] failed to initialize", server.waitForStringInLogUsingMark("SRVE0242I.*/metrics.*"));
     }
 
     private void waitForSecurityPrerequisites(LibertyServer server) throws Exception {
-        assertNotNull("LTPA keys are not created/ready within timeout period of " + TIMEOUT + "ms.", server.waitForStringInLog("CWWKS4104A.*|CWWKS4105I.*", TIMEOUT));
-        assertNotNull("TCP Channel defaultHttpEndpoint has not started", server.waitForStringInLog("CWWKO0219I.*defaultHttpEndpoint"));
-        assertNotNull("TCP Channel defaultHttpEndpoint-ssl has not started", server.waitForStringInLog("CWWKO0219I.*defaultHttpEndpoint-ssl"));
+        server.waitForLTPAConfigReady(TIMEOUT);
+        server.waitForDefaultHTTPEndpointStart(TIMEOUT);
+        server.waitForDefaultHTTPEndpointSSLStart(TIMEOUT);
     }
 
     private static void setMetricsAuthConfig(LibertyServer server, Boolean authentication) throws Exception {

--- a/dev/com.ibm.ws.microprofile.mpjwt.1.0_fat_tck/fat/src/com/ibm/ws/microprofile/mpjwt10/tck/Mpjwt10TCKLauncher_mpjwt.java
+++ b/dev/com.ibm.ws.microprofile.mpjwt.1.0_fat_tck/fat/src/com/ibm/ws/microprofile/mpjwt10/tck/Mpjwt10TCKLauncher_mpjwt.java
@@ -37,7 +37,7 @@ public class Mpjwt10TCKLauncher_mpjwt {
     @BeforeClass
     public static void setUp() throws Exception {
         server.startServer();
-        server.waitForStringInLog("CWWKS4105I", 30000); // wait for ltpa keys to be created and service ready, which can happen after startup.
+        server.waitForLTPAConfigReady(30000); // wait for ltpa keys to be created and service ready, which can happen after startup.
     }
 
     @AfterClass

--- a/dev/com.ibm.ws.microprofile.mpjwt.1.0_fat_tck/fat/src/com/ibm/ws/microprofile/mpjwt10/tck/Mpjwt10TCKLauncher_mpjwt_roles.java
+++ b/dev/com.ibm.ws.microprofile.mpjwt.1.0_fat_tck/fat/src/com/ibm/ws/microprofile/mpjwt10/tck/Mpjwt10TCKLauncher_mpjwt_roles.java
@@ -37,7 +37,7 @@ public class Mpjwt10TCKLauncher_mpjwt_roles {
     @BeforeClass
     public static void setUp() throws Exception {
         server.startServer();
-        server.waitForStringInLog("CWWKS4105I", 30000); // wait for ltpa keys to be created and service ready, which can happen after startup.
+        server.waitForLTPAConfigReady(30000); // wait for ltpa keys to be created and service ready, which can happen after startup.
     }
 
     @AfterClass

--- a/dev/com.ibm.ws.microprofile.mpjwt.1.1_fat_tck/fat/src/com/ibm/ws/microprofile/mpjwt11/tck/Mpjwt11TCKLauncher_aud_env.java
+++ b/dev/com.ibm.ws.microprofile.mpjwt.1.1_fat_tck/fat/src/com/ibm/ws/microprofile/mpjwt11/tck/Mpjwt11TCKLauncher_aud_env.java
@@ -37,7 +37,7 @@ public class Mpjwt11TCKLauncher_aud_env {
     @BeforeClass
     public static void setUp() throws Exception {
         server.startServer();
-        server.waitForStringInLog("CWWKS4105I", 30000); // wait for ltpa keys to be created and service ready, which can happen after startup.
+        server.waitForLTPAConfigReady(30000); // wait for ltpa keys to be created and service ready, which can happen after startup.
     }
 
     @AfterClass

--- a/dev/com.ibm.ws.microprofile.mpjwt.1.1_fat_tck/fat/src/com/ibm/ws/microprofile/mpjwt11/tck/Mpjwt11TCKLauncher_aud_noenv.java
+++ b/dev/com.ibm.ws.microprofile.mpjwt.1.1_fat_tck/fat/src/com/ibm/ws/microprofile/mpjwt11/tck/Mpjwt11TCKLauncher_aud_noenv.java
@@ -41,7 +41,7 @@ public class Mpjwt11TCKLauncher_aud_noenv {
     @BeforeClass
     public static void setUp() throws Exception {
         server.startServer();
-        server.waitForStringInLog("CWWKS4105I", 30000); // wait for ltpa keys to be created and service ready, which can happen after startup.
+        server.waitForLTPAConfigReady(30000); // wait for ltpa keys to be created and service ready, which can happen after startup.
     }
 
     @AfterClass

--- a/dev/com.ibm.ws.microprofile.mpjwt.1.1_fat_tck/fat/src/com/ibm/ws/microprofile/mpjwt11/tck/Mpjwt11TCKLauncher_aud_noenv2.java
+++ b/dev/com.ibm.ws.microprofile.mpjwt.1.1_fat_tck/fat/src/com/ibm/ws/microprofile/mpjwt11/tck/Mpjwt11TCKLauncher_aud_noenv2.java
@@ -42,7 +42,7 @@ public class Mpjwt11TCKLauncher_aud_noenv2 {
         // PrivHelper looked promising for fine grained java2sec exception management but did not work.
         //PrivHelper.generateCustomPolicy(server, "permission java.net.SocketPermission \"127.0.0.1\", \"resolve\"");
         server.startServer();
-        server.waitForStringInLog("CWWKS4105I", 30000); // wait for ltpa keys to be created and service ready, which can happen after startup.
+        server.waitForLTPAConfigReady(30000); // wait for ltpa keys to be created and service ready, which can happen after startup.
     }
 
     @AfterClass

--- a/dev/com.ibm.ws.microprofile.mpjwt.1.1_fat_tck/fat/src/com/ibm/ws/microprofile/mpjwt11/tck/Mpjwt11TCKLauncher_noaud_env.java
+++ b/dev/com.ibm.ws.microprofile.mpjwt.1.1_fat_tck/fat/src/com/ibm/ws/microprofile/mpjwt11/tck/Mpjwt11TCKLauncher_noaud_env.java
@@ -36,7 +36,7 @@ public class Mpjwt11TCKLauncher_noaud_env {
     @BeforeClass
     public static void setUp() throws Exception {
         server.startServer();
-        server.waitForStringInLog("CWWKS4105I", 30000); // wait for ltpa keys to be created and service ready, which can happen after startup.
+        server.waitForLTPAConfigReady(30000); // wait for ltpa keys to be created and service ready, which can happen after startup.
     }
 
     @AfterClass

--- a/dev/com.ibm.ws.microprofile.mpjwt.1.1_fat_tck/fat/src/com/ibm/ws/microprofile/mpjwt11/tck/Mpjwt11TCKLauncher_noaud_noenv.java
+++ b/dev/com.ibm.ws.microprofile.mpjwt.1.1_fat_tck/fat/src/com/ibm/ws/microprofile/mpjwt11/tck/Mpjwt11TCKLauncher_noaud_noenv.java
@@ -36,7 +36,7 @@ public class Mpjwt11TCKLauncher_noaud_noenv {
     @BeforeClass
     public static void setUp() throws Exception {
         server.startServer();
-        server.waitForStringInLog("CWWKS4105I", 30000); // wait for ltpa keys to be created and service ready, which can happen after startup.
+        server.waitForLTPAConfigReady(30000); // wait for ltpa keys to be created and service ready, which can happen after startup.
     }
 
     @AfterClass

--- a/dev/com.ibm.ws.microprofile.openapi_fat/fat/src/com/ibm/ws/microprofile/openapi/fat/ApplicationProcessorServletTest.java
+++ b/dev/com.ibm.ws.microprofile.openapi_fat/fat/src/com/ibm/ws/microprofile/openapi/fat/ApplicationProcessorServletTest.java
@@ -77,10 +77,8 @@ public class ApplicationProcessorServletTest {
         assertNotNull("Server did not report that it has started",
             server.waitForStringInLog("CWWKF0011I.*"));
 
-        assertNotNull("Http port not opened",
-            server.waitForStringInLog("CWWKO0219I.* defaultHttpEndpoint ")); // Wait for http port
-        assertNotNull("Https port not opened",
-            server.waitForStringInLog("CWWKO0219I.* defaultHttpEndpoint-ssl ")); // Wait for https port to open (this
+        server.waitForDefaultHTTPEndpointStart(); // Wait for http port
+        server.waitForDefaultHTTPEndpointSSLStart(); // Wait for https port to open (this
                                                                                  // can sometimes take a while)
     }
 

--- a/dev/com.ibm.ws.microprofile.openapi_fat/fat/src/com/ibm/ws/microprofile/openapi/fat/ApplicationProcessorTest.java
+++ b/dev/com.ibm.ws.microprofile.openapi_fat/fat/src/com/ibm/ws/microprofile/openapi/fat/ApplicationProcessorTest.java
@@ -107,10 +107,8 @@ public class ApplicationProcessorTest extends FATServletClient {
         assertNotNull("Server did not report that it has started",
             server.waitForStringInLog("CWWKF0011I.*"));
 
-        assertNotNull("Http port not opened",
-            server.waitForStringInLog("CWWKO0219I.* defaultHttpEndpoint ")); // Wait for http port
-        assertNotNull("Https port not opened",
-            server.waitForStringInLog("CWWKO0219I.* defaultHttpEndpoint-ssl ")); // Wait for https port to open (this
+        server.waitForDefaultHTTPEndpointStart(); // Wait for http port
+        server.waitForDefaultHTTPEndpointSSLStart(); // Wait for https port to open (this
                                                                                  // can sometimes take a while)
     }
 

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/fat/src/com/ibm/ws/microprofile/rest/client/fat/BasicTest.java
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/fat/src/com/ibm/ws/microprofile/rest/client/fat/BasicTest.java
@@ -75,7 +75,7 @@ public class BasicTest extends FATServletClient {
         }
 
         remoteAppServer.startServer();
-        remoteAppServer.waitForStringInLog("CWWKO0219I.*ssl"); // CWWKO0219I: TCP Channel defaultHttpEndpoint-ssl has been started and is now listening for requests on host *  (IPv6) port 8040.
+        remoteAppServer.waitForDefaultHTTPEndpointSSLStart();
 
         ShrinkHelper.defaultDropinApp(server, appName, new DeployOptions[] {DeployOptions.SERVER_ONLY}, "mpRestClient10.basic");
         features = server.getServerConfiguration().getFeatureManager().getFeatures();
@@ -93,7 +93,7 @@ public class BasicTest extends FATServletClient {
         }
 
         server.startServer();
-        server.waitForStringInLog("CWWKO0219I.*ssl"); // CWWKO0219I: TCP Channel defaultHttpEndpoint-ssl has been started and is now listening for requests on host *  (IPv6) port 8020.
+        server.waitForDefaultHTTPEndpointSSLStart();
 
     }
 

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/fat/src/com/ibm/ws/microprofile/rest/client/fat/CollectionsTest.java
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/fat/src/com/ibm/ws/microprofile/rest/client/fat/CollectionsTest.java
@@ -76,7 +76,7 @@ public class CollectionsTest extends FATServletClient {
             remoteAppServer.changeFeatures(Arrays.asList("componenttest-1.0","jaxrs-2.1","jsonp-1.1","ssl-1.0","jsonb-1.0"));
         }
         remoteAppServer.startServer();
-        remoteAppServer.waitForStringInLog("CWWKO0219I.*ssl"); // CWWKO0219I: TCP Channel defaultHttpEndpoint-ssl has been started and is now listening for requests on host *  (IPv6) port 8020.
+        remoteAppServer.waitForDefaultHTTPEndpointSSLStart();
 
         ShrinkHelper.defaultDropinApp(server, appName, new DeployOptions[] {DeployOptions.SERVER_ONLY}, "mpRestClient10.collections");
         Set<String>features = server.getServerConfiguration().getFeatureManager().getFeatures();
@@ -94,7 +94,7 @@ public class CollectionsTest extends FATServletClient {
         }
 
         server.startServer();
-        server.waitForStringInLog("CWWKO0219I.*ssl"); // CWWKO0219I: TCP Channel defaultHttpEndpoint-ssl has been started and is now listening for requests on host *  (IPv6) port 8020.
+        server.waitForDefaultHTTPEndpointSSLStart();
     }
 
     @AfterClass

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/fat/src/com/ibm/ws/microprofile/rest/client/fat/HandleResponsesTest.java
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/fat/src/com/ibm/ws/microprofile/rest/client/fat/HandleResponsesTest.java
@@ -66,7 +66,7 @@ public class HandleResponsesTest extends FATServletClient {
             remoteAppServer.changeFeatures(Arrays.asList("componenttest-2.0", "restfulWS-3.0", "ssl-1.0", "jsonb-2.0"));
         }
         remoteAppServer.startServer();
-        remoteAppServer.waitForStringInLog("CWWKO0219I.*ssl"); // CWWKO0219I: TCP Channel defaultHttpEndpoint-ssl has been started and is now listening for requests on host *  (IPv6) port 8020.
+        remoteAppServer.waitForDefaultHTTPEndpointSSLStart();
 
         ShrinkHelper.defaultDropinApp(server, appName, new DeployOptions[] {DeployOptions.SERVER_ONLY}, "mpRestClient10.handleresponses");
         Set<String> features = server.getServerConfiguration().getFeatureManager().getFeatures();
@@ -84,7 +84,7 @@ public class HandleResponsesTest extends FATServletClient {
         }
 
         server.startServer();
-        server.waitForStringInLog("CWWKO0219I.*ssl"); // CWWKO0219I: TCP Channel defaultHttpEndpoint-ssl has been started and is now listening for requests on host *  (IPv6) port 8020.
+        server.waitForDefaultHTTPEndpointSSLStart();
     }
 
     @AfterClass

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/fat/src/com/ibm/ws/microprofile/rest/client/fat/HeaderPropagation12Test.java
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/fat/src/com/ibm/ws/microprofile/rest/client/fat/HeaderPropagation12Test.java
@@ -47,7 +47,7 @@ public class HeaderPropagation12Test extends FATServletClient {
     public static void setUp() throws Exception {
         ShrinkHelper.defaultApp(server, appName, new DeployOptions[] { DeployOptions.SERVER_ONLY }, "mpRestClient12.headerPropagation");
         server.startServer();
-        assertNotNull("LTPA configuration should report it is ready", server.waitForStringInLog("CWWKS4105I"));
+        server.waitForLTPAConfigReady();
     }
 
     @AfterClass

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/fat/src/com/ibm/ws/microprofile/rest/client/fat/HeaderPropagationTest.java
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/fat/src/com/ibm/ws/microprofile/rest/client/fat/HeaderPropagationTest.java
@@ -48,7 +48,7 @@ public class HeaderPropagationTest extends FATServletClient {
     public static void setUp() throws Exception {
         ShrinkHelper.defaultApp(server, appName, new DeployOptions[] { DeployOptions.SERVER_ONLY }, "mpRestClient10.headerPropagation");
         server.startServer();
-        assertNotNull("LTPA configuration should report it is ready", server.waitForStringInLog("CWWKS4105I"));
+        server.waitForLTPAConfigReady();
     }
 
     @AfterClass

--- a/dev/com.ibm.ws.microprofile.rest.client_fat/fat/src/com/ibm/ws/microprofile/rest/client/fat/ProduceConsumeTest.java
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat/fat/src/com/ibm/ws/microprofile/rest/client/fat/ProduceConsumeTest.java
@@ -49,7 +49,7 @@ public class ProduceConsumeTest extends FATServletClient {
     public static void setUp() throws Exception {
         ShrinkHelper.defaultDropinApp(server, appName, new DeployOptions[] {DeployOptions.SERVER_ONLY}, "mpRestClient11.produceConsume");
         server.startServer();
-        server.waitForStringInLog("CWWKO0219I.*ssl"); // CWWKO0219I: TCP Channel defaultHttpEndpoint-ssl has been started and is now listening for requests on host *  (IPv6) port 8020.
+        server.waitForDefaultHTTPEndpointStart();
     }
 
     @AfterClass

--- a/dev/com.ibm.ws.openapi.ui_fat/fat/src/com/ibm/ws/openapi/ui/fat/tests/UIBasicTest.java
+++ b/dev/com.ibm.ws.openapi.ui_fat/fat/src/com/ibm/ws/openapi/ui/fat/tests/UIBasicTest.java
@@ -106,7 +106,7 @@ public class UIBasicTest {
     public void testPrivateUI() throws Exception {
         //Reduce possibility that Server is not listening on its HTTPS Port
         //Especially for Windows if certificates are slow to create
-        server.waitForSSLStart();
+        server.waitForDefaultHTTPEndpointSSLStart();
 
         driver.get("https://admin:test@host.testcontainers.internal:" + server.getHttpDefaultSecurePort() + "/ibm/api/explorer");
         testUI();

--- a/dev/com.ibm.ws.rest.handler.config_fat/fat/src/com/ibm/ws/rest/handler/config/fat/ConfigRESTHandlerTest.java
+++ b/dev/com.ibm.ws.rest.handler.config_fat/fat/src/com/ibm/ws/rest/handler/config/fat/ConfigRESTHandlerTest.java
@@ -81,9 +81,9 @@ public class ConfigRESTHandlerTest extends FATServletClient {
 
         // Wait for the API to become available
         assertNotNull(server.waitForStringInLog("CWWKS0008I")); // CWWKS0008I: The security service is ready.
-        assertNotNull(server.waitForStringInLog("CWWKS4105I")); // CWWKS4105I: LTPA configuration is ready after # seconds.
+        assertNotNull(server.waitForLTPAConfigReady(true)); // CWWKS4105I: LTPA configuration is ready after # seconds.
         assertNotNull(server.waitForStringInLog("CWPKI0803A")); // CWPKI0803A: SSL certificate created in # seconds. SSL key file: ...
-        assertNotNull(server.waitForStringInLog("CWWKO0219I: .* defaultHttpEndpoint-ssl")); // CWWKO0219I: TCP Channel defaultHttpEndpoint-ssl has been started and is now listening for requests on host *  (IPv6) port 8020.
+        assertNotNull(server.waitForDefaultHTTPEndpointSSLStart(true)); // CWWKO0219I: TCP Channel defaultHttpEndpoint-ssl has been started and is now listening for requests on host *  (IPv6) port 8020.
         assertNotNull(server.waitForStringInLog("CWWKT0016I")); // CWWKT0016I: Web application available (default_host): http://9.10.111.222:8010/ibm/api/
 
         // TODO remove once transactions code is fixed to use container auth for the recovery log dataSource

--- a/dev/com.ibm.ws.rest.handler.config_fat/fat/src/com/ibm/ws/rest/handler/config/fat/audit/ConfigRESTHandlerAuditTest.java
+++ b/dev/com.ibm.ws.rest.handler.config_fat/fat/src/com/ibm/ws/rest/handler/config/fat/audit/ConfigRESTHandlerAuditTest.java
@@ -89,9 +89,9 @@ public class ConfigRESTHandlerAuditTest extends FATServletClient {
                       server.waitForStringInLogUsingMark(AuditMessageConstants.CWWKS5851I_AUDIT_SERVICE_READY));
         assertNotNull("Audit file handler service did not report it was ready",
                       server.waitForStringInLogUsingMark(AuditMessageConstants.CWWKS5805I_AUDIT_FILEHANDLER_SERVICE_READY));
-        assertNotNull(server.waitForStringInLog("CWWKS4105I")); // CWWKS4105I: LTPA configuration is ready after # seconds.
+        assertNotNull(server.waitForLTPAConfigReady(true));
         assertNotNull(server.waitForStringInLog("CWPKI0803A")); // CWPKI0803A: SSL certificate created in # seconds. SSL key file: ...
-        assertNotNull(server.waitForStringInLog("CWWKO0219I.*defaultHttpEndpoint-ssl")); // CWWKO0219I: TCP Channel defaultHttpEndpoint-ssl has been started and is now listening for requests on host *  (IPv6) port 8020.
+        assertNotNull(server.waitForDefaultHTTPEndpointSSLStart(true));
         assertNotNull(server.waitForStringInLog("CWWKT0016I")); // CWWKT0016I: Web application available (default_host): http://9.10.111.222:8010/ibm/api/
 
         // TODO remove once transactions code is fixed to use container auth for the recovery log dataSource

--- a/dev/com.ibm.ws.rest.handler.config_fat/fat/src/com/ibm/ws/rest/handler/config/fat/audit/ConfigRestHandlerAuditFeatureTest.java
+++ b/dev/com.ibm.ws.rest.handler.config_fat/fat/src/com/ibm/ws/rest/handler/config/fat/audit/ConfigRestHandlerAuditFeatureTest.java
@@ -88,9 +88,9 @@ public class ConfigRestHandlerAuditFeatureTest extends FATServletClient {
                       server.waitForStringInLogUsingMark(AuditMessageConstants.CWWKS5851I_AUDIT_SERVICE_READY));
         assertNotNull("Audit file handler service did not report it was ready",
                       server.waitForStringInLogUsingMark(AuditMessageConstants.CWWKS5805I_AUDIT_FILEHANDLER_SERVICE_READY));
-        assertNotNull(server.waitForStringInLog("CWWKS4105I")); // CWWKS4105I: LTPA configuration is ready after # seconds.
+        assertNotNull(server.waitForLTPAConfigReady(true));
         assertNotNull(server.waitForStringInLog("CWPKI0803A")); // CWPKI0803A: SSL certificate created in # seconds. SSL key file: ...
-        assertNotNull(server.waitForStringInLog("CWWKO0219I")); // CWWKO0219I: TCP Channel defaultHttpEndpoint-ssl has been started and is now listening for requests on host *  (IPv6) port 8020.
+        assertNotNull(server.waitForDefaultHTTPEndpointSSLStart(true));
 
         //Audit-2.0 should not enable ibm/api
         assertTrue((server.waitForStringInLog("CWWKT0016I")) == null); // CWWKT0016I: Web application available (default_host): http://9.10.111.222:8010/ibm/api/

--- a/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/utils/AcmeFatUtils.java
+++ b/dev/com.ibm.ws.security.acme_fat/fat/src/com/ibm/ws/security/acme/utils/AcmeFatUtils.java
@@ -556,9 +556,8 @@ public class AcmeFatUtils {
      * @param server
      *            The server to check.
      */
-    public static final void waitForSslEndpoint(LibertyServer server) {
-        assertNotNull("Expected defaultHttpEndpoint-ssl to start.",
-                server.waitForStringInTrace("CWWKO0219I: TCP Channel defaultHttpEndpoint-ssl has been started"));
+    public static final void waitForSslEndpoint(LibertyServer server) throws Exception {
+        server.waitForDefaultHTTPEndpointSSLStart();
     }
 
     /**

--- a/dev/com.ibm.ws.security.authentication.filter_fat/fat/src/com/ibm/ws/security/authentication/filter/fat/CommonTest.java
+++ b/dev/com.ibm.ws.security.authentication.filter_fat/fat/src/com/ibm/ws/security/authentication/filter/fat/CommonTest.java
@@ -313,10 +313,10 @@ public class CommonTest {
 
     }
 
-    public static void serverUpdate(LibertyServer myServer) {
+    public static void serverUpdate(LibertyServer myServer) throws Exception {
         assertNotNull("FeatureManager did not report update was complete", myServer.waitForStringInLog("CWWKF0008I"));
         assertNotNull("Application did not start", myServer.waitForStringInLog("CWWKZ0001I"));
-        assertNotNull("LTPA configuration did not report it was ready", myServer.waitForStringInLog("CWWKS4105I"));
+        myServer.waitForLTPAConfigReady();
     }
 
     public void successfulServletResponse(String response, BasicAuthClient myClient, String user, boolean isEmployee, boolean isManager) {

--- a/dev/com.ibm.ws.security.client_fat/fat/src/com/ibm/ws/security/client/fat/CommonTest.java
+++ b/dev/com.ibm.ws.security.client_fat/fat/src/com/ibm/ws/security/client/fat/CommonTest.java
@@ -459,7 +459,7 @@ public class CommonTest {
         // assertNotNull("Application did not start",
         // testServer.waitForStringInLog("CWWKZ0001I"));
         if (isSecure) {
-            assertNotNull("LTPA configuration did not report it was ready", testServer.waitForStringInLog("CWWKS4105I"));
+            testServer.waitForLTPAConfigReady();
         }
 
     }

--- a/dev/com.ibm.ws.security.fat.common/src/com/ibm/ws/security/fat/common/TestServer.java
+++ b/dev/com.ibm.ws.security.fat.common/src/com/ibm/ws/security/fat/common/TestServer.java
@@ -953,7 +953,7 @@ public class TestServer extends ExternalResource {
         // if we find it, then wait for "CWWKO0219I: TCP Channel defaultHttpEndpoint-ssl has been started and is now listening for requests on host"
         String sslStopMsg = server.waitForStringInLogUsingMark("CWWKO0220I:.*defaultHttpEndpoint-ssl.*", 500);
         if (sslStopMsg != null) {
-            String sslStartMsg = server.waitForStringInLogUsingMark("CWWKO0219I:.*defaultHttpEndpoint-ssl.*");
+            String sslStartMsg = server.waitForDefaultHTTPEndpointSSLStart(true);
             if (sslStartMsg == null) {
                 Log.warning(thisClass, "SSL may not have started properly - future failures may be due to this");
                 sslWaitTimeoutCount += 1;

--- a/dev/com.ibm.ws.security.fat.common/src/com/ibm/ws/security/fat/common/servers/ServerInstanceUtils.java
+++ b/dev/com.ibm.ws.security.fat.common/src/com/ibm/ws/security/fat/common/servers/ServerInstanceUtils.java
@@ -91,41 +91,6 @@ public class ServerInstanceUtils {
 
     }
 
-    // Special case SSL ready checker - for test classes that don't enable/use SSL from server
-    // startup.  This method will check entire message log for the ssl inited msg (instead of checking
-    // from the last mark)
-    public static void waitForSSLMsg(LibertyServer server) {
-
-        waitForSSLMsg(server, System.currentTimeMillis());
-    }
-
-    private static void waitForSSLMsg(LibertyServer server, long startTime) {
-
-        String methodName = "waitForSSLMsg";
-        try {
-
-            // wait for up to 2 minutes
-            if (System.currentTimeMillis() - startTime > (2 * 60 * 1000)) {
-                Log.info(thisClass, methodName, "Timed out searching for SSL ready message - test will probably fail");
-                return;
-            }
-            // if nothing is found, sleep and request another try
-            List<String> wasFound = LibertyFileManager.findStringsInFile(".*" + MessageConstants.CWWKO0219I_SSL_CHANNEL_READY + ".*", server.getDefaultLogFile());
-            if (wasFound == null || wasFound.isEmpty()) {
-                Thread.sleep(5 * 1000);
-                waitForSSLMsg(server, startTime);
-            } else {
-                for (String msg : wasFound) {
-                    Log.info(thisClass, "waitForSSLMsg", "Found SSL MSG: " + msg);
-                }
-                Log.info(thisClass, methodName, "Found SSL ready message");
-                return;
-            }
-        } catch (Exception e) {
-            Log.info(thisClass, "waitForSSLMsg", "Something went wrong while checking for the SSL ready msg: " + e.getMessage());
-        }
-    }
-
     /**
      * Update/Set config variables for a server and push the updates to the server.
      * Method waits for server to update or indicate that no update in needed

--- a/dev/com.ibm.ws.security.javaeesec_fat.4/fat/src/com/ibm/ws/security/javaeesec/fat/SSOTest.java
+++ b/dev/com.ibm.ws.security.javaeesec_fat.4/fat/src/com/ibm/ws/security/javaeesec/fat/SSOTest.java
@@ -95,7 +95,7 @@ public class SSOTest extends JavaEESecTestBase {
         /*
          * Wait for the SSL endpoint to start.
          */
-        myServer.waitForSSLStart();
+        myServer.waitForDefaultHTTPEndpointSSLStart();
     }
 
     @AfterClass

--- a/dev/com.ibm.ws.security.javaeesec_fat.4/fat/src/com/ibm/ws/security/javaeesec/fat/ScopedTest.java
+++ b/dev/com.ibm.ws.security.javaeesec_fat.4/fat/src/com/ibm/ws/security/javaeesec/fat/ScopedTest.java
@@ -78,7 +78,7 @@ public class ScopedTest extends JavaEESecTestBase {
         /*
          * Wait for the SSL endpoint to start.
          */
-        myServer.waitForSSLStart();
+        myServer.waitForDefaultHTTPEndpointSSLStart();
     }
 
     @AfterClass

--- a/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/AutoApplySessionTest.java
+++ b/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/AutoApplySessionTest.java
@@ -78,7 +78,7 @@ public class AutoApplySessionTest extends JavaEESecTestBase {
         /*
          * Wait for the SSL endpoint to start.
          */
-        myServer.waitForSSLStart();
+        myServer.waitForDefaultHTTPEndpointSSLStart();
     }
 
     @AfterClass

--- a/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/BasicAuthenticationMechanismTest.java
+++ b/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/BasicAuthenticationMechanismTest.java
@@ -84,7 +84,7 @@ public class BasicAuthenticationMechanismTest extends JavaEESecTestBase {
         /*
          * Wait for the SSL endpoint to start.
          */
-        myServer.waitForSSLStart();
+        myServer.waitForDefaultHTTPEndpointSSLStart();
     }
 
     @AfterClass

--- a/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/FormHttpAuthenticationMechanismTest.java
+++ b/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/FormHttpAuthenticationMechanismTest.java
@@ -88,7 +88,7 @@ public class FormHttpAuthenticationMechanismTest extends JavaEESecTestBase {
         /*
          * Wait for the SSL endpoint to start.
          */
-        myServer.waitForSSLStart();
+        myServer.waitForDefaultHTTPEndpointSSLStart();
     }
 
     @AfterClass

--- a/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/ProgrammaticTest.java
+++ b/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/ProgrammaticTest.java
@@ -69,7 +69,7 @@ public class ProgrammaticTest extends JavaEESecTestBase {
         /*
          * Wait for the SSL endpoint to start.
          */
-        myServer.waitForSSLStart();
+        myServer.waitForDefaultHTTPEndpointSSLStart();
     }
 
     @AfterClass

--- a/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/RememberMeTest.java
+++ b/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/RememberMeTest.java
@@ -101,7 +101,7 @@ public class RememberMeTest extends JavaEESecTestBase {
         /*
          * Wait for the SSL endpoint to start.
          */
-        myServer.waitForSSLStart();
+        myServer.waitForDefaultHTTPEndpointSSLStart();
     }
 
     @AfterClass

--- a/dev/com.ibm.ws.security.oauth_fat/fat/src/com/ibm/ws/security/oauth20/fat/OAuth20TestCommon.java
+++ b/dev/com.ibm.ws.security.oauth_fat/fat/src/com/ibm/ws/security/oauth20/fat/OAuth20TestCommon.java
@@ -261,7 +261,7 @@ public class OAuth20TestCommon {
         assertNotNull("The security service was not ready in time",
                       server.waitForStringInLog("CWWKS0008I"));
         assertNotNull("The TCP Channel defaultHttpEndpoint-ssl did not start",
-                      server.waitForStringInLog("CWWKO0219I.*ssl"));
+                      server.waitForDefaultHTTPEndpointSSLStart(true));
         if (_server.startsWith(DERBY_STARTS_WITH) || _server.startsWith(MONG_STARTS_WITH)) {
             // The OAuthConfigDerby app works for both types of stores (database and custom), didn't rename when MongoDB was added
             assertNotNull("Provider OAuthConfigDerby config was not processed in time",

--- a/dev/com.ibm.ws.security.registry.basic_fat/fat/src/com/ibm/ws/security/registry/basic/fat/CustomCertificateMapperInBellTest.java
+++ b/dev/com.ibm.ws.security.registry.basic_fat/fat/src/com/ibm/ws/security/registry/basic/fat/CustomCertificateMapperInBellTest.java
@@ -98,7 +98,7 @@ public class CustomCertificateMapperInBellTest {
         assertNotNull("The application did not report is was started",
                       myServer.waitForStringInLog("CWWKZ0001I"));
         assertNotNull("We need to wait for the SSL port to be open",
-                      myServer.waitForStringInLog("CWWKO0219I:.*defaultHttpEndpoint-ssl"));
+                      myServer.waitForDefaultHTTPEndpointSSLStart(true));
         assertNotNull("Server did not come up",
                       myServer.waitForStringInLog("CWWKF0011I"));
 

--- a/dev/com.ibm.ws.security.registry.basic_fat/fat/src/com/ibm/ws/security/registry/basic/fat/CustomCertificateMapperInFeatureTest.java
+++ b/dev/com.ibm.ws.security.registry.basic_fat/fat/src/com/ibm/ws/security/registry/basic/fat/CustomCertificateMapperInFeatureTest.java
@@ -99,7 +99,7 @@ public class CustomCertificateMapperInFeatureTest {
         assertNotNull("The application did not report is was started",
                       myServer.waitForStringInLog("CWWKZ0001I"));
         assertNotNull("We need to wait for the SSL port to be open",
-                      myServer.waitForStringInLog("CWWKO0219I:.*defaultHttpEndpoint-ssl"));
+                      myServer.waitForDefaultHTTPEndpointSSLStart(true));
         assertNotNull("Server did not come up",
                       myServer.waitForStringInLog("CWWKF0011I"));
 

--- a/dev/com.ibm.ws.security.saml.sso_fat/fat/src/com/ibm/ws/security/saml/fat/common/BasicSAMLTests.java
+++ b/dev/com.ibm.ws.security.saml.sso_fat/fat/src/com/ibm/ws/security/saml/fat/common/BasicSAMLTests.java
@@ -62,8 +62,6 @@ public class BasicSAMLTests extends SAMLCommonTest {
 
     private static final Class<?> thisClass = BasicSAMLTests.class;
 
-    private static final String MSG_CWWKO0219I_SSL_PORT_READY = "CWWKO0219I:.*ssl.*";
-
     @Rule
     public static final SkipJavaSemeruWithFipsEnabled skipJavaSemeruWithFipsEnabled = new SkipJavaSemeruWithFipsEnabled("com.ibm.ws.security.saml.sso-2.0_fat");
 

--- a/dev/com.ibm.ws.security.spnego.fat.common/fat/src/com/ibm/ws/security/spnego/fat/config/JDK11Expectations.java
+++ b/dev/com.ibm.ws.security.spnego.fat.common/fat/src/com/ibm/ws/security/spnego/fat/config/JDK11Expectations.java
@@ -52,10 +52,10 @@ public class JDK11Expectations implements JDKExpectationTestClass {
 //Liberty Server Expectations//
 ///////////////////////////////
     @Override
-    public void serverUpdate(LibertyServer myServer) {
+    public void serverUpdate(LibertyServer myServer) throws Exception {
         assertNotNull("FeatureManager did not report update was complete", myServer.waitForStringInLog("CWWKF0008I"));
         assertNotNull("Application did not start", myServer.waitForStringInLog("CWWKZ0001I"));
-        assertNotNull("LTPA configuration did not report it was ready", myServer.waitForStringInLog("CWWKS4105I"));
+        assertNotNull("LTPA configuration did not report it was ready", myServer.waitForLTPAConfigReady(true));
     }
 
 ////////////////////

--- a/dev/com.ibm.ws.security.spnego.fat.common/fat/src/com/ibm/ws/security/spnego/fat/config/JDK8Expectations.java
+++ b/dev/com.ibm.ws.security.spnego.fat.common/fat/src/com/ibm/ws/security/spnego/fat/config/JDK8Expectations.java
@@ -50,10 +50,10 @@ public class JDK8Expectations implements JDKExpectationTestClass {
 //Liberty Server Expectations//
 ///////////////////////////////
     @Override
-    public void serverUpdate(LibertyServer myServer) {
+    public void serverUpdate(LibertyServer myServer) throws Exception {
         assertNotNull("FeatureManager did not report update was complete", myServer.waitForStringInLog("CWWKF0008I"));
         assertNotNull("Application did not start", myServer.waitForStringInLog("CWWKZ0001I"));
-        assertNotNull("LTPA configuration did not report it was ready", myServer.waitForStringInLog("CWWKS4105I"));
+        assertNotNull("LTPA configuration did not report it was ready", myServer.waitForLTPAConfigReady(true));
     }
 
 ////////////////////

--- a/dev/com.ibm.ws.security.spnego.fat.common/fat/src/com/ibm/ws/security/spnego/fat/config/JDKExpectationTestClass.java
+++ b/dev/com.ibm.ws.security.spnego.fat.common/fat/src/com/ibm/ws/security/spnego/fat/config/JDKExpectationTestClass.java
@@ -29,7 +29,7 @@ public abstract interface JDKExpectationTestClass {
     ///////////////////////////////
     //Liberty Server Expectations//
     ///////////////////////////////
-    public void serverUpdate(LibertyServer myServer);
+    public void serverUpdate(LibertyServer myServer) throws Exception;
 
     ////////////////////
     //KDC Expectations//

--- a/dev/com.ibm.ws.security.token.ltpa_fat/fat/src/com/ibm/ws/security/token/ltpa/fat/FATTest.java
+++ b/dev/com.ibm.ws.security.token.ltpa_fat/fat/src/com/ibm/ws/security/token/ltpa/fat/FATTest.java
@@ -428,8 +428,7 @@ public class FATTest {
         assertNotNull("The application did not report is was started",
                       server.waitForStringInLog("CWWKZ0001I"));
         // Wait for the LTPA configuration to be ready
-        assertNotNull("Expected LTPA configuration ready message not found in the log.",
-                      server.waitForStringInLog("CWWKS4105I"));
+        server.waitForLTPAConfigReady();
     }
 
     /**

--- a/dev/com.ibm.ws.security.token.ltpa_fat/fat/src/com/ibm/ws/security/token/ltpa/fat/LTPAKeyRotationTests.java
+++ b/dev/com.ibm.ws.security.token.ltpa_fat/fat/src/com/ibm/ws/security/token/ltpa/fat/LTPAKeyRotationTests.java
@@ -104,6 +104,8 @@ public class LTPAKeyRotationTests {
     private static String validationKeyPassword = "{xor}Lz4sLCgwLTs=";
     private static String validationKeyFIPSPassword = "{xor}CDo9Hgw=";
 
+    private static int timeoutMillis = isWindows() ? 5 * 60 * 1000 : 5 * 1000;
+
     // Initialize the FormLogin Clients
     private static final FormLoginClient flClient1 = new FormLoginClient(server, FormLoginClient.DEFAULT_SERVLET_NAME, "/formlogin1");
     private static final FormLoginClient flClient2 = new FormLoginClient(server, FormLoginClient.DEFAULT_SERVLET_NAME, "/formlogin2");
@@ -146,7 +148,6 @@ public class LTPAKeyRotationTests {
     private static String ALT_FIPS_VALIDATION_KEY7_PATH = "alternateFIPS/validation7.keys";
     private static String ALT_FIPS_VALIDATION_KEY8_PATH = "alternateFIPS/validation8.keys";
     private static String ALT_FIPS_CONFIGVALIDATION_KEY1_PATH = "alternateFIPS/configuredValidation1.keys";
-    private static String FIPS_SERVER_XML_PATH = "serverFIPS.xml";
 
     // Define the paths to the server.xml files
     private static final String relativeDirectory = server.getServerRoot();
@@ -247,8 +248,7 @@ public class LTPAKeyRotationTests {
         assertNotNull("The application did not report is was started",
                       server.waitForStringInLog("CWWKZ0001I"));
         // Wait for the LTPA configuration to be ready
-        assertNotNull("Expected LTPA configuration ready message not found in the log.",
-                      server.waitForStringInLog("CWWKS4105I"));
+        server.waitForLTPAConfigReady();
 
         if (!server.isEnhancedAlgorithmOptionsEnabled()) {
             checkFipsEnabledMessages();
@@ -497,7 +497,7 @@ public class LTPAKeyRotationTests {
 
         // Wait for the LTPA configuration to be ready after the change
         assertNotNull("Expected LTPA configuration ready message not found in the log.",
-                      server.waitForStringInLog("CWWKS4105I", 5000));
+                      server.waitForLTPAConfigReady(5000, true));
 
         // Initial login to simple servlet for form login1
         String response1 = flClient1.accessProtectedServletWithAuthorizedCredentials(FormLoginClient.PROTECTED_SIMPLE, validUser, validPassword);
@@ -511,7 +511,7 @@ public class LTPAKeyRotationTests {
 
         // Wait for the LTPA configuration to be ready after the change
         assertNotNull("Expected LTPA configuration ready message not found in the log.",
-                      server.waitForStringInLog("CWWKS4105I", 5000));
+                      server.waitForLTPAConfigReady(5000, true));
 
         // Attempt to access the simple servlet again with the same cookie and assert it fails and the server needs to login again
         assertTrue("An invalid cookie should result in authorization challenge",
@@ -564,14 +564,14 @@ public class LTPAKeyRotationTests {
 
         // Wait for the LTPA configuration to be ready after the change
         assertNotNull("Expected LTPA configuration ready message not found in the log.",
-                      server.waitForStringInLog("CWWKS4105I", 5000));
+                      server.waitForLTPAConfigReady(5000, true));
 
         // Replace the primary key with the valid key
         renameFileIfExists(VALIDATION_KEY1_PATH, DEFAULT_KEY_PATH, true);
 
         // Wait for the LTPA configuration to be ready after the change
         assertNotNull("Expected LTPA configuration ready message not found in the log.",
-                      server.waitForStringInLog("CWWKS4105I", 5000));
+                      server.waitForLTPAConfigReady(5000, true));
 
         // Initial login to simple servlet for form login1
         String response1 = flClient1.accessProtectedServletWithAuthorizedCredentials(FormLoginClient.PROTECTED_SIMPLE, validUser, validPassword);
@@ -610,7 +610,7 @@ public class LTPAKeyRotationTests {
 
         // Wait for the LTPA configuration to be ready after the change
         assertNotNull("Expected LTPA configuration ready message not found in the log.",
-                      server.waitForStringInLog("CWWKS4105I", 5000));
+                      server.waitForLTPAConfigReady(5000, true));
 
         // Attempt to access the simple servlet again with the same ltpa cookie1 and assert it fails due to the decryption failure
         assertTrue("An invalid cookie should result in authorization challenge",
@@ -663,14 +663,14 @@ public class LTPAKeyRotationTests {
 
         // Wait for the LTPA configuration to be ready after the change
         assertNotNull("Expected LTPA configuration ready message not found in the log.",
-                      server.waitForStringInLog("CWWKS4105I", 5000));
+                      server.waitForLTPAConfigReady(5000, true));
 
         // Replace the primary key with the valid key
         renameFileIfExists(VALIDATION_KEY1_PATH, DEFAULT_KEY_PATH, true);
 
         // Wait for the LTPA configuration to be ready after the change
         assertNotNull("Expected LTPA configuration ready message not found in the log.",
-                      server.waitForStringInLog("CWWKS4105I", 5000));
+                      server.waitForLTPAConfigReady(5000, true));
 
         // Initial login to simple servlet for form login1
         String response1 = flClient1.accessProtectedServletWithAuthorizedCredentials(FormLoginClient.PROTECTED_SIMPLE, validUser, validPassword);
@@ -708,7 +708,7 @@ public class LTPAKeyRotationTests {
 
         // Wait for the LTPA configuration to be ready after the change
         assertNotNull("Expected LTPA configuration ready message not found in the log.",
-                      server.waitForStringInLog("CWWKS4105I", 5000));
+                      server.waitForLTPAConfigReady(5000, true));
 
         // Attempt initial login to simple servlet for form login2
         assertTrue("Authentication should fail with decryption failure",
@@ -762,14 +762,14 @@ public class LTPAKeyRotationTests {
 
         // Wait for the LTPA configuration to be ready after the change
         assertNotNull("Expected LTPA configuration ready message not found in the log.",
-                      server.waitForStringInLog("CWWKS4105I", 5000));
+                      server.waitForLTPAConfigReady(5000, true));
 
         // Replace the primary key with the valid key
         renameFileIfExists(VALIDATION_KEY1_PATH, DEFAULT_KEY_PATH, true);
 
         // Wait for the LTPA configuration to be ready after the change
         assertNotNull("Expected LTPA configuration ready message not found in the log.",
-                      server.waitForStringInLog("CWWKS4105I", 5000));
+                      server.waitForLTPAConfigReady(5000, true));
 
         // Initial login to simple servlet for form login1
         String response1 = flClient1.accessProtectedServletWithAuthorizedCredentials(FormLoginClient.PROTECTED_SIMPLE, validUser, validPassword);
@@ -807,7 +807,7 @@ public class LTPAKeyRotationTests {
 
         // Wait for the LTPA configuration to be ready after the change
         assertNotNull("Expected LTPA configuration ready message not found in the log.",
-                      server.waitForStringInLog("CWWKS4105I", 5000));
+                      server.waitForLTPAConfigReady(5000, true));
 
         // Attempt to access the simple servlet again with the same ltpa cookie1 and assert it fails and the server needs to login again
         assertTrue("An invalid cookie should result in authorization challenge",
@@ -1011,7 +1011,7 @@ public class LTPAKeyRotationTests {
 
         // Wait for the LTPA configuration to be ready after the change
         assertNotNull("Expected LTPA configuration ready message not found in the log.",
-                      server.waitForStringInLog("CWWKS4105I", 5000));
+                      server.waitForLTPAConfigReady(5000, true));
 
         // Attempt to access the simple servlet again with the same cookie and assert it fails and the server needs to login again
         assertTrue("An invalid cookie should result in authorization challenge",
@@ -1233,7 +1233,7 @@ public class LTPAKeyRotationTests {
         // Delete the validation5.keys file and wait for the LTPA configuration to be ready after the change
         deleteKeyFileIfExists(BAD_PRIVATE_VALIDATION_KEY1_PATH, true, false);
         assertNotNull("Expected LTPA configuration ready message not found in the log.",
-                      server.waitForStringInLog("CWWKS4105I", 5000));
+                      server.waitForLTPAConfigReady(5000, true));
 
         // Set fileName back to the default ltpa.keys file
         configurationUpdateNeeded = setLTPAvalidationKeyFileNameElement(ltpa, "configuredValidation1.keys");
@@ -1403,7 +1403,7 @@ public class LTPAKeyRotationTests {
 
         // Wait for the LTPA configuration to be ready after the change
         assertNotNull("Expected LTPA configuration ready message not found in the log.",
-                      server.waitForStringInLog("CWWKS4105I", 5000));
+                      server.waitForLTPAConfigReady(5000, true));
 
         // Continued authentication to simple servlet; the element is not required to be configured
         String response2 = flClient1.accessProtectedServletWithAuthorizedCookie(FormLoginClient.PROTECTED_SIMPLE, cookie1);
@@ -1440,7 +1440,7 @@ public class LTPAKeyRotationTests {
 
         // Wait for the LTPA configuration to be ready after the change
         assertNotNull("Expected LTPA configuration ready message not found in the log.",
-                      server.waitForStringInLog("CWWKS4105I", 5000));
+                      server.waitForLTPAConfigReady(5000, true));
 
         // Successful authentication to simple servlet
         String response3 = flClient1.accessProtectedServletWithAuthorizedCookie(FormLoginClient.PROTECTED_SIMPLE, cookie1);
@@ -1911,7 +1911,7 @@ public class LTPAKeyRotationTests {
 
         // Wait for the LTPA configuration to be ready after the change
         assertNotNull("Expected LTPA configuration ready message not found in the log.",
-                      server.waitForStringInLog("CWWKS4105I", 5000));
+                      server.waitForLTPAConfigReady(5000, true));
 
         // Attempt to access the simple servlet again with the same cookie and assert it fails and the server needs to login again
         assertTrue("An expired cookie should result in authorization challenge",
@@ -2379,9 +2379,8 @@ public class LTPAKeyRotationTests {
      * Modifies the keys contained in the filePath with the keys specified in the
      * contents HashMap
      *
-     * @param filename
-     * @param newFilePath
-     * @param checkFileIsGone
+     * @param filePath, path of the file to be modified
+     * @param contents, Key, value pairs to modify the file with
      *
      * @throws Exception
      */
@@ -2730,14 +2729,12 @@ public class LTPAKeyRotationTests {
         return System.getProperty("os.name").toLowerCase().contains("windows");
     }
 
-    private static void waitForLTPAKeysCreatedMessage() {
-        int timeoutMillis = isWindows() ? 2 * 60 * 1000 : 5 * 1000;
-        assertNotNull("Expected LTPA keys created message not found in the log.", server.waitForStringInLog("CWWKS4104A", timeoutMillis));
+    private static void waitForLTPAKeysCreatedMessage() throws Exception {
+        assertNotNull("Expected LTPA keys created message not found in the log.", server.waitForLTPAKeysCreated(timeoutMillis, true));
     }
 
-    private static void waitForLTPAConfigurationReadyMessage() {
-        int timeoutMillis = isWindows() ? 2 * 60 * 1000 : 5 * 1000;
-        assertNotNull("Expected LTPA configuration ready message not found in the log.", server.waitForStringInLog("CWWKS4105I", timeoutMillis));
+    private static void waitForLTPAConfigurationReadyMessage() throws Exception {
+        assertNotNull("Expected LTPA configuration ready message not found in the log.", server.waitForLTPAConfigReady(timeoutMillis, true));
     }
 
     /**

--- a/dev/com.ibm.ws.security.token.ltpa_fat/fat/src/com/ibm/ws/security/token/ltpa/fat/LTPAValidationKeyTests.java
+++ b/dev/com.ibm.ws.security.token.ltpa_fat/fat/src/com/ibm/ws/security/token/ltpa/fat/LTPAValidationKeyTests.java
@@ -221,8 +221,7 @@ public class LTPAValidationKeyTests {
                           server.waitForStringInLogUsingMark("CWWKZ0001I"));
             // Wait for the LTPA configuration to be ready
             assertNotNull("Expected LTPA configuration ready message not found in the log.",
-                          server.waitForStringInLogUsingMark("CWWKS4105I"));
-
+                          server.waitForLTPAConfigReady(true));
         }
 
         server1FlClient1 = new FormLoginClient(server1, FormLoginClient.DEFAULT_SERVLET_NAME, "/formlogin1");
@@ -311,12 +310,12 @@ public class LTPAValidationKeyTests {
         server1.setMarkToEndOfLog();
         copyFileToServerResourcesSecurityDir(ALT_VALIDATION_KEY1_PATH, server1);
         assertNotNull("Expected LTPA configuration ready message not found in the log.",
-                      server1.waitForStringInLogUsingMark("CWWKS4105I"));
+                      server1.waitForLTPAConfigReady(true));
 
         server2.setMarkToEndOfLog();
         copyFileToServerResourcesSecurityDir(ALT_VALIDATION_KEY2_PATH, server2);
         assertNotNull("Expected LTPA configuration ready message not found in the log.",
-                      server2.waitForStringInLogUsingMark("CWWKS4105I"));
+                      server2.waitForLTPAConfigReady(true));
 
         // Replace the LTPA keys with the known valid ltpa keys and assert the change occurs
         renameKeyAndWaitForLtpaConfigReady(VALIDATION_KEY1_PATH, DEFAULT_KEY_PATH, server1);
@@ -335,7 +334,7 @@ public class LTPAValidationKeyTests {
 
         // Wait for the LTPA configuration to be ready after the change
         assertNotNull("Expected LTPA configuration ready message not found in the log.",
-                      server2.waitForStringInLogUsingMark("CWWKS4105I"));
+                      server2.waitForLTPAConfigReady(true));
 
         // Attempt to login to the simple servlet on server #2 and assert that the login is successful
         server2FlClient1.accessProtectedServletWithAuthorizedCookie(FormLoginClient.PROTECTED_SIMPLE, server1Cookie);
@@ -405,7 +404,7 @@ public class LTPAValidationKeyTests {
         // Update the server configuration to recognize the changes
         updateConfigDynamically(server2, server2Config);
         assertNotNull("Expected LTPA configuration ready message not found in the log.",
-                      server2.waitForStringInLogUsingMark("CWWKS4105I"));
+                      server2.waitForLTPAConfigReady(true));
 
         // Attempt to login to the simple servlet on server #2 and assert that the login is successful (uses validation key)
         server2FlClient1.accessProtectedServletWithAuthorizedCookie(FormLoginClient.PROTECTED_SIMPLE, server1Cookie);
@@ -456,7 +455,7 @@ public class LTPAValidationKeyTests {
         server2.setMarkToEndOfLog();
         copyFileToServerResourcesSecurityDir(ALT_VALIDATION_KEY2_PATH, server2);
         assertNotNull("Expected LTPA configuration ready message not found in the log.",
-                      server2.waitForStringInLogUsingMark("CWWKS4105I"));
+                      server2.waitForLTPAConfigReady(true));
 
         renameKeyAndWaitForLtpaConfigReady(VALIDATION_KEY2_PATH, DEFAULT_KEY_PATH, server2);
 
@@ -477,7 +476,7 @@ public class LTPAValidationKeyTests {
         server2.setMarkToEndOfLog();
         copyFileToServerResourcesSecurityDir(ALT_VALIDATION_KEY9_PATH, server2);
         assertNotNull("Expected LTPA configuration ready message not found in the log.",
-                      server2.waitForStringInLogUsingMark("CWWKS4105I"));
+                      server2.waitForLTPAConfigReady(true));
 
         // Attempt to login to the simple servlet on server #2 and assert that the login is successful (uses validation key)
         server2FlClient1.accessProtectedServletWithAuthorizedCookie(FormLoginClient.PROTECTED_SIMPLE, server1Cookie);
@@ -805,7 +804,7 @@ public class LTPAValidationKeyTests {
             if (waitForLTPAConfigReadyMessage) {
                 // Wait for the LTPA configuration to be ready after the change
                 assertNotNull("Expected LTPA configuration ready message not found in the log.",
-                              server.waitForStringInLogUsingMark("CWWKS4105I"));
+                              server.waitForLTPAConfigReady(true));
             }
         }
 

--- a/dev/com.ibm.ws.security.utility_fat/fat/src/com/ibm/ws/security/utility/test/SecurityUtilityCreateLTPAKeysTest.java
+++ b/dev/com.ibm.ws.security.utility_fat/fat/src/com/ibm/ws/security/utility/test/SecurityUtilityCreateLTPAKeysTest.java
@@ -470,7 +470,7 @@ public class SecurityUtilityCreateLTPAKeysTest {
 
         // Verify startup log contains LTPA initialization
         assertNotNull("Expected LTPA configuration ready message not found in the log.",
-                      ltpaTestServer.waitForStringInLogUsingMark("CWWKS4105I", 5000));
+                      ltpaTestServer.waitForLTPAConfigReady(5000, true));
         ltpaTestServer.stopServer();
 
         if (!JavaInfo.forCurrentVM().isCriuSupported() || ltpaTestServer.isJava2SecurityEnabled()) {
@@ -494,7 +494,7 @@ public class SecurityUtilityCreateLTPAKeysTest {
             ltpaTestServer.checkpointRestore();
             // Verify startup log contains LTPA initialization
             assertNotNull("Expected LTPA configuration ready message not found in the log.",
-                    ltpaTestServer.waitForStringInLogUsingMark("CWWKS4105I", 5000));
+                    ltpaTestServer.waitForLTPAConfigReady(5000, true));
             ltpaTestServer.stopServer();
         } finally {
             ltpaTestServer.unsetCheckpoint();
@@ -544,7 +544,7 @@ public class SecurityUtilityCreateLTPAKeysTest {
 
         // Verify startup log contains LTPA initialization
         assertNotNull("Expected LTPA configuration ready message not found in the log.",
-                      ltpaTestServer.waitForStringInLogUsingMark("CWWKS4105I", 5000));
+                      ltpaTestServer.waitForLTPAConfigReady(5000, true));
         ltpaTestServer.stopServer();
 
         if (!JavaInfo.forCurrentVM().isCriuSupported() || ltpaTestServer.isJava2SecurityEnabled()) {
@@ -568,7 +568,7 @@ public class SecurityUtilityCreateLTPAKeysTest {
             ltpaTestServer.checkpointRestore();
             // Verify startup log contains LTPA initialization
             assertNotNull("Expected LTPA configuration ready message not found in the log.",
-                    ltpaTestServer.waitForStringInLogUsingMark("CWWKS4105I", 5000));
+                    ltpaTestServer.waitForLTPAConfigReady(5000, true));
             ltpaTestServer.stopServer();
         } finally {
             ltpaTestServer.unsetCheckpoint();
@@ -606,8 +606,9 @@ public class SecurityUtilityCreateLTPAKeysTest {
 
         // Verify startup log contains LTPA initialization
         assertNotNull("Expected LTPA configuration ready message not found in the log.",
-                      ltpaTestServer.waitForStringInLogUsingMark("CWWKS4105I", 5000));
+                ltpaTestServer.waitForLTPAConfigReady(5000, true));
         ltpaTestServer.stopServer("CWWKS1865W"); // Warning for AES passwords without key
+
     }
 
     //--------------------------------------------------------------------------
@@ -809,7 +810,7 @@ public class SecurityUtilityCreateLTPAKeysTest {
 
         // Verify startup log contains LTPA initialization
         assertNotNull("Expected LTPA configuration ready message not found in the log.",
-                      ltpaTestServer.waitForStringInLogUsingMark("CWWKS4105I", 5000));
+                      ltpaTestServer.waitForLTPAConfigReady(5000, true));
         ltpaTestServer.stopServer();
     }
     
@@ -845,7 +846,7 @@ public class SecurityUtilityCreateLTPAKeysTest {
 
         // Verify startup log contains LTPA initialization
         assertNotNull("Expected LTPA configuration ready message not found in the log.",
-                      ltpaTestServer.waitForStringInLogUsingMark("CWWKS4105I", 5000));
+                      ltpaTestServer.waitForLTPAConfigReady(5000, true));
         ltpaTestServer.stopServer();
     }
 }

--- a/dev/com.ibm.ws.security.utility_fat/fat/src/com/ibm/ws/security/utility/test/SecurityUtilityGenerateAesKeyTest.java
+++ b/dev/com.ibm.ws.security.utility_fat/fat/src/com/ibm/ws/security/utility/test/SecurityUtilityGenerateAesKeyTest.java
@@ -443,14 +443,7 @@ public class SecurityUtilityGenerateAesKeyTest {
 		testServer.startServer(testName.getMethodName());
 
 		// Verify startup log contains LTPA initialization
-		String logOutput = testServer.waitForStringInLogUsingMark("CWWKS4105I", 5000);
-		if (logOutput == null) {
-			Log.info(thisClass, testName.getMethodName(), "LTPA ready not found, aesConfigFile contents: "
-					+ readStringUsingBufferedReader(new File(aesConfigFile).toPath()));
-		}
-
-		assertNotNull("Expected LTPA configuration ready message not found in the log.", logOutput);
-
+		testServer.waitForLTPAConfigReady(5000);
 		// Verify startup log contains the keystore loaded successfully message
 		assertNotNull("Expected Keystore loaded message not found in the log.",
 				testServer.waitForStringInLogUsingMark("Successfully loaded default keystore", 5000));

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/CertificateLoginOddOIDTest.java
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/CertificateLoginOddOIDTest.java
@@ -70,7 +70,7 @@ public class CertificateLoginOddOIDTest {
         assertNotNull("The application did not report is was started",
                       myServer.waitForStringInLog("CWWKZ0001I"));
         assertNotNull("We need to wait for the SSL port to be open",
-                      myServer.waitForStringInLog("CWWKO0219I:.*defaultHttpEndpoint-ssl"));
+                      myServer.waitForDefaultHTTPEndpointSSLStart(true));
         assertNotNull("Server did not came up",
                       myServer.waitForStringInLog("CWWKF0011I"));
 

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/CertificateLoginTest.java
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/CertificateLoginTest.java
@@ -78,7 +78,7 @@ public class CertificateLoginTest {
         assertNotNull("The application did not report is was started",
                       myServer.waitForStringInLog("CWWKZ0001I"));
         assertNotNull("We need to wait for the SSL port to be open",
-                      myServer.waitForStringInLog("CWWKO0219I:.*defaultHttpEndpoint-ssl"));
+                      myServer.waitForDefaultHTTPEndpointSSLStart(true));
         assertNotNull("Server did not came up",
                       myServer.waitForStringInLog("CWWKF0011I"));
 

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/CertificateLoginTestWithSquareBraceInCertificateFilter.java
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/CertificateLoginTestWithSquareBraceInCertificateFilter.java
@@ -72,7 +72,7 @@ public class CertificateLoginTestWithSquareBraceInCertificateFilter {
         assertNotNull("The application did not report is was started",
                       myServer.waitForStringInLog("CWWKZ0001I"));
         assertNotNull("We need to wait for the SSL port to be open",
-                      myServer.waitForStringInLog("CWWKO0219I:.*defaultHttpEndpoint-ssl"));
+                      myServer.waitForDefaultHTTPEndpointSSLStart(true));
         assertNotNull("Server did not came up",
                       myServer.waitForStringInLog("CWWKF0011I"));
 
@@ -142,8 +142,6 @@ public class CertificateLoginTestWithSquareBraceInCertificateFilter {
 
         // Use server.xml configuration with certificateMapMode="cn=${SubjectCN}"
         setServerConfiguration(DEFAULT_CONFIG_FILE);
-        // assertNotNull("We need to wait for the SSL port to be open",
-        //              myServer.waitForStringInLog("CWWKO0219I:.*defaultHttpEndpoint-ssl"));
 
         client = setupClient(user1CertFile, true);
         String response = client.access("/SimpleServlet", 200);

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/CustomCertificateMapperInBellTest.java
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/CustomCertificateMapperInBellTest.java
@@ -126,7 +126,7 @@ public class CustomCertificateMapperInBellTest {
         assertNotNull("The application did not report is was started",
                       myServer.waitForStringInLog("CWWKZ0001I"));
         assertNotNull("We need to wait for the SSL port to be open",
-                      myServer.waitForStringInLog("CWWKO0219I:.*defaultHttpEndpoint-ssl"));
+                      myServer.waitForDefaultHTTPEndpointSSLStart(true));
         assertNotNull("Server did not came up",
                       myServer.waitForStringInLog("CWWKF0011I"));
 

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/CustomCertificateMapperInFeatureTest.java
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/CustomCertificateMapperInFeatureTest.java
@@ -127,7 +127,7 @@ public class CustomCertificateMapperInFeatureTest {
         assertNotNull("The application did not report is was started",
                       myServer.waitForStringInLog("CWWKZ0001I"));
         assertNotNull("We need to wait for the SSL port to be open",
-                      myServer.waitForStringInLog("CWWKO0219I:.*defaultHttpEndpoint-ssl"));
+                      myServer.waitForDefaultHTTPEndpointSSLStart(true));
         assertNotNull("Server did not came up",
                       myServer.waitForStringInLog("CWWKF0011I"));
 

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/FederationCertificateLoginTest.java
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/FederationCertificateLoginTest.java
@@ -76,7 +76,7 @@ public class FederationCertificateLoginTest {
         assertNotNull("The application did not report is was started",
                       myServer.waitForStringInLog("CWWKZ0001I"));
         assertNotNull("We need to wait for the SSL port to be open",
-                      myServer.waitForStringInLog("CWWKO0219I:.*defaultHttpEndpoint-ssl"));
+                      myServer.waitForDefaultHTTPEndpointSSLStart(true));
         assertNotNull("Server did not came up",
                       myServer.waitForStringInLog("CWWKF0011I"));
 

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/OutboundSSLLDAPTest.java
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/OutboundSSLLDAPTest.java
@@ -76,7 +76,7 @@ public class OutboundSSLLDAPTest {
         assertNotNull("The application did not report is was started",
                       myServer.waitForStringInLog("CWWKZ0001I"));
         assertNotNull("We need to wait for the SSL port to be open",
-                      myServer.waitForStringInLog("CWWKO0219I:.*defaultHttpEndpoint-ssl"));
+                      myServer.waitForDefaultHTTPEndpointSSLStart(true));
         assertNotNull("Server did not came up",
                       myServer.waitForStringInLog("CWWKF0011I"));
 
@@ -107,7 +107,6 @@ public class OutboundSSLLDAPTest {
             Log.info(c, "setServerConfiguration",
                      "waitForStringInLogUsingMark: CWWKG0017I: The server configuration was successfully updated.");
             myServer.waitForStringInLogUsingMark("CWWKG0017I");
-            myServer.waitForStringInLogUsingMark("CWWKO0219I:.*defaultHttpEndpoint-ssl");
 
             serverConfigurationFile = serverXML;
         }

--- a/dev/com.ibm.ws.security.wim.scim.2.0_fat/fat/src/com/ibm/ws/security/wim/scim20/fat/SCIMTest.java
+++ b/dev/com.ibm.ws.security.wim.scim.2.0_fat/fat/src/com/ibm/ws/security/wim/scim20/fat/SCIMTest.java
@@ -80,10 +80,8 @@ public class SCIMTest {
                       server.waitForStringInLog("CWWKT0016I:.*"));
         assertNotNull("Server did not came up",
                       server.waitForStringInLog("CWWKF0011I:.*"));
-        assertNotNull("TCP non ssl Channel did not come up",
-                      server.waitForStringInLog("CWWKO0219I:.*"));
-        assertNotNull("TCP SSL Channel did not come up",
-                      server.waitForStringInLog("CWWKO0219I:.*ssl.*"));
+        server.waitForDefaultHTTPEndpointStart();
+        server.waitForDefaultHTTPEndpointSSLStart();
     }
 
     @AfterClass

--- a/dev/com.ibm.ws.ssl_fat_pkcs12/fat/src/com/ibm/ws/ssl/fat/pkcs12/DefaultJKSDoesNotExistSSLTest.java
+++ b/dev/com.ibm.ws.ssl_fat_pkcs12/fat/src/com/ibm/ws/ssl/fat/pkcs12/DefaultJKSDoesNotExistSSLTest.java
@@ -78,7 +78,7 @@ public class DefaultJKSDoesNotExistSSLTest extends CommonSSLTest {
                       server.waitForStringInLog("CWPKI0803A:.*" + DEFAULT_GENERATED_KEY_PATH));
 
         assertNotNull("SSL TCP Channel did not start in time.",
-                      server.waitForStringInLog("CWWKO0219I.*ssl"));
+                      server.waitForDefaultHTTPEndpointSSLStart(true));
         assertNotNull("Need to wait for 'smarter planet' message (server is ready).",
                       server.waitForStringInLog("CWWKF0011I"));
 
@@ -140,8 +140,7 @@ public class DefaultJKSDoesNotExistSSLTest extends CommonSSLTest {
         // Requires info trace
         server.addInstalledAppForValidation("basicauth");
 
-        assertNotNull("SSL TCP Channel did not start in time.",
-                      server.waitForStringInLog("CWWKO0219I.*ssl"));
+        server.waitForDefaultHTTPEndpointSSLStart();
         assertNotNull("Need to wait for 'smarter planet' message (server is ready).",
                       server.waitForStringInLog("CWWKF0011I"));
 

--- a/dev/com.ibm.ws.ssl_fat_pkcs12/fat/src/com/ibm/ws/ssl/fat/pkcs12/DefaultJKSExistsSSLTest.java
+++ b/dev/com.ibm.ws.ssl_fat_pkcs12/fat/src/com/ibm/ws/ssl/fat/pkcs12/DefaultJKSExistsSSLTest.java
@@ -72,7 +72,7 @@ public class DefaultJKSExistsSSLTest extends CommonSSLTest {
         server.addInstalledAppForValidation("basicauth");
 
         assertNotNull("SSL TCP Channel did not start in time.",
-                      server.waitForStringInLog("CWWKO0219I.*ssl"));
+                      server.waitForDefaultHTTPEndpointSSLStart());
         assertNotNull("Need to wait for 'smarter planet' message (server is ready).",
                       server.waitForStringInLog("CWWKF0011I"));
 
@@ -131,7 +131,7 @@ public class DefaultJKSExistsSSLTest extends CommonSSLTest {
         // Requires info trace
         server.addInstalledAppForValidation("basicauth");
         assertNotNull("SSL TCP Channel did not start in time.",
-                      server.waitForStringInLog("CWWKO0219I.*ssl"));
+                      server.waitForDefaultHTTPEndpointSSLStart());
         assertNotNull("Need to wait for 'smarter planet' message (server is ready).",
                       server.waitForStringInLog("CWWKF0011I"));
 

--- a/dev/com.ibm.ws.ssl_fat_pkcs12/fat/src/com/ibm/ws/ssl/fat/pkcs12/DefaultKeystoreNonDefaultLocation.java
+++ b/dev/com.ibm.ws.ssl_fat_pkcs12/fat/src/com/ibm/ws/ssl/fat/pkcs12/DefaultKeystoreNonDefaultLocation.java
@@ -73,7 +73,7 @@ public class DefaultKeystoreNonDefaultLocation extends CommonSSLTest {
         server.addInstalledAppForValidation("basicauth");
 
         assertNotNull("SSL TCP Channel did not start in time.",
-                      server.waitForStringInLog("CWWKO0219I.*ssl"));
+                      server.waitForDefaultHTTPEndpointSSLStart());
         assertNotNull("Need to wait for 'smarter planet' message (server is ready).",
                       server.waitForStringInLog("CWWKF0011I"));
 
@@ -127,7 +127,7 @@ public class DefaultKeystoreNonDefaultLocation extends CommonSSLTest {
         server.addInstalledAppForValidation("basicauth");
 
         assertNotNull("SSL TCP Channel did not start in time.",
-                      server.waitForStringInLog("CWWKO0219I.*ssl"));
+                      server.waitForDefaultHTTPEndpointSSLStart());
         assertNotNull("Need to wait for 'smarter planet' message (server is ready).",
                       server.waitForStringInLog("CWWKF0011I"));
 

--- a/dev/com.ibm.ws.ssl_fat_pkcs12/fat/src/com/ibm/ws/ssl/fat/pkcs12/DefaultPKCS12DoesNotExistSSLTest.java
+++ b/dev/com.ibm.ws.ssl_fat_pkcs12/fat/src/com/ibm/ws/ssl/fat/pkcs12/DefaultPKCS12DoesNotExistSSLTest.java
@@ -73,7 +73,7 @@ public class DefaultPKCS12DoesNotExistSSLTest extends CommonSSLTest {
         server.addInstalledAppForValidation("basicauth");
 
         assertNotNull("SSL TCP Channel did not start in time.",
-                      server.waitForStringInLog("CWWKO0219I.*ssl"));
+                      server.waitForDefaultHTTPEndpointSSLStart());
         assertNotNull("Need to wait for 'smarter planet' message (server is ready).",
                       server.waitForStringInLog("CWWKF0011I"));
 

--- a/dev/com.ibm.ws.ssl_fat_pkcs12/fat/src/com/ibm/ws/ssl/fat/pkcs12/DefaultPKCS12ExistsSSLTest.java
+++ b/dev/com.ibm.ws.ssl_fat_pkcs12/fat/src/com/ibm/ws/ssl/fat/pkcs12/DefaultPKCS12ExistsSSLTest.java
@@ -70,7 +70,7 @@ public class DefaultPKCS12ExistsSSLTest extends CommonSSLTest {
         // Requires info trace
         server.addInstalledAppForValidation("basicauth");
         assertNotNull("SSL TCP Channel did not start in time.",
-                      server.waitForStringInLog("CWWKO0219I.*ssl"));
+                      server.waitForDefaultHTTPEndpointSSLStart());
         assertNotNull("Need to wait for 'smarter planet' message (server is ready).",
                       server.waitForStringInLog("CWWKF0011I"));
 

--- a/dev/com.ibm.ws.ssl_fat_pkcs12/fat/src/com/ibm/ws/ssl/fat/pkcs12/NonDefaultJKSSSLTest.java
+++ b/dev/com.ibm.ws.ssl_fat_pkcs12/fat/src/com/ibm/ws/ssl/fat/pkcs12/NonDefaultJKSSSLTest.java
@@ -74,7 +74,7 @@ public class NonDefaultJKSSSLTest extends CommonSSLTest {
                       server.waitForStringInLog("CWPKI0803A:.*" + DEFAULT_GENERATED_KEY_PATH));
 
         assertNotNull("SSL TCP Channel did not start in time.",
-                      server.waitForStringInLog("CWWKO0219I.*ssl"));
+                      server.waitForDefaultHTTPEndpointSSLStart());
         assertNotNull("Need to wait for 'smarter planet' message (server is ready).",
                       server.waitForStringInLog("CWWKF0011I"));
 

--- a/dev/com.ibm.ws.ssl_fat_pkcs12/fat/src/com/ibm/ws/ssl/fat/pkcs12/NonDefaultPKCS12SSLTest.java
+++ b/dev/com.ibm.ws.ssl_fat_pkcs12/fat/src/com/ibm/ws/ssl/fat/pkcs12/NonDefaultPKCS12SSLTest.java
@@ -74,7 +74,7 @@ public class NonDefaultPKCS12SSLTest extends CommonSSLTest {
                       server.waitForStringInLog("CWPKI0803A:.*" + DEFAULT_GENERATED_KEY_PATH));
 
         assertNotNull("SSL TCP Channel did not start in time.",
-                      server.waitForStringInLog("CWWKO0219I.*ssl"));
+                      server.waitForDefaultHTTPEndpointSSLStart());
         assertNotNull("Need to wait for 'smarter planet' message (server is ready).",
                       server.waitForStringInLog("CWWKF0011I"));
 

--- a/dev/com.ibm.ws.webcontainer.servlet.3.1_fat.2/fat/src/com/ibm/ws/webcontainer/servlet31/fat/tests/FormLoginReadListenerTest.java
+++ b/dev/com.ibm.ws.webcontainer.servlet.3.1_fat.2/fat/src/com/ibm/ws/webcontainer/servlet31/fat/tests/FormLoginReadListenerTest.java
@@ -72,8 +72,7 @@ public class FormLoginReadListenerTest {
         server.startServer(FormLoginReadListenerTest.class.getSimpleName() + ".log");
 
         // CWWKS4105I: LTPA configuration is ready after x seconds
-        assertNotNull("CWWKS4105I LTPA configuration message not found.",
-                      server.waitForStringInLogUsingMark("CWWKS4105I.*"));
+        server.waitForLTPAConfigReady();
 
         if (FATSuite.isWindows) {
             FATSuite.setDynamicTrace(server, "*=info=enabled");

--- a/dev/com.ibm.ws.webcontainer.servlet.4.0_fat.2/fat/src/com/ibm/ws/fat/wc/tests/WCPartitionedCookieAttributeSecurityTest.java
+++ b/dev/com.ibm.ws.webcontainer.servlet.4.0_fat.2/fat/src/com/ibm/ws/fat/wc/tests/WCPartitionedCookieAttributeSecurityTest.java
@@ -66,7 +66,7 @@ public class WCPartitionedCookieAttributeSecurityTest {
 
         // Start the server and use the class name so we can find logs easily.
         partitionedSecurityServer.startServer(WCPartitionedCookieAttributeSecurityTest.class.getSimpleName() + ".log");
-        partitionedSecurityServer.waitForSSLStart();
+        partitionedSecurityServer.waitForDefaultHTTPEndpointSSLStart();
     }
 
     @AfterClass
@@ -97,8 +97,7 @@ public class WCPartitionedCookieAttributeSecurityTest {
         String expectedResponse = "Welcome to the SameSiteSecurityServlet!";
 
         // CWWKS4105I: LTPA configuration is ready after x seconds
-        assertNotNull("CWWKS4105I LTPA configuration message not found.",
-                      partitionedSecurityServer.waitForStringInLogUsingMark("CWWKS4105I.*"));
+        partitionedSecurityServer.waitForLTPAConfigReady();
 
         // Need to use https since we're testing SameSite=None and that requires a secure connection for the Cookies to be sent.
         String url = "https://" + partitionedSecurityServer.getHostname() + ":" + partitionedSecurityServer.getHttpDefaultSecurePort() + "/" + APP_NAME_SAMESITE_SECURITY

--- a/dev/com.ibm.ws.webcontainer.servlet.4.0_fat.2/fat/src/com/ibm/ws/fat/wc/tests/WCResponseHeadersTest.java
+++ b/dev/com.ibm.ws.webcontainer.servlet.4.0_fat.2/fat/src/com/ibm/ws/fat/wc/tests/WCResponseHeadersTest.java
@@ -1241,14 +1241,8 @@ public class WCResponseHeadersTest {
         server.waitForConfigUpdateInLogUsingMark(Collections.singleton(APP_NAME_SECURE_APP), true, "CWWKT0016I:.*SameSiteSecurityTest.*");
 
         // Wait for LTPA key to be available to avoid CWWKS4000E
-        // CWWKS4105I: LTPA configuration is ready after x seconds
-        assertNotNull("CWWKS4105I LTPA configuration message not found.",
-                      server.waitForStringInLogUsingMark("CWWKS4105I.*"));
-
-        // CWWKO0219I: TCP Channel defaultHttpEndpoint-ssl has been started and is now listening for
-        // requests on host * (IPv6) port 8020.
-        assertNotNull("CWWKO0219I: TCP Channel defaultHttpEndpoint-ssl message was not found",
-                      server.waitForStringInLogUsingMark("CWWKO0219I:.*defaultHttpEndpoint-ssl"));
+        server.waitForLTPAConfigReady();
+        server.waitForDefaultHTTPEndpointSSLStart();
 
         configuration = server.getServerConfiguration();
         Log.info(ME, testName, "Updated server configuration: " + configuration);

--- a/dev/com.ibm.ws.webcontainer.servlet.4.0_fat.2/fat/src/com/ibm/ws/fat/wc/tests/WCSameSiteCookieAttributeSecurityTest.java
+++ b/dev/com.ibm.ws.webcontainer.servlet.4.0_fat.2/fat/src/com/ibm/ws/fat/wc/tests/WCSameSiteCookieAttributeSecurityTest.java
@@ -91,9 +91,7 @@ public class WCSameSiteCookieAttributeSecurityTest {
         boolean headerFound = false;
         String expectedResponse = "Welcome to the SameSiteSecurityServlet!";
 
-        // CWWKS4105I: LTPA configuration is ready after x seconds
-        assertNotNull("CWWKS4105I LTPA configuration message not found.",
-                      sameSiteSecurityServer.waitForStringInLogUsingMark("CWWKS4105I.*"));
+        sameSiteSecurityServer.waitForLTPAConfigReady();
 
         String url = "http://" + sameSiteSecurityServer.getHostname() + ":" + sameSiteSecurityServer.getHttpDefaultPort() + "/" + APP_NAME_SAMESITE_SECURITY
                      + "/SameSiteSecurityServlet";

--- a/dev/com.ibm.ws.webcontainer.servlet.4.0_fat.2/fat/src/com/ibm/ws/fat/wc/tests/WebSphereSpiHttpRequestURLTest.java
+++ b/dev/com.ibm.ws.webcontainer.servlet.4.0_fat.2/fat/src/com/ibm/ws/fat/wc/tests/WebSphereSpiHttpRequestURLTest.java
@@ -56,7 +56,7 @@ public class WebSphereSpiHttpRequestURLTest {
         server.installSystemFeature("webcontainerlibertyinternals");
         server.startServer(WebSphereSpiHttpRequestURLTest.class.getSimpleName() + ".log");
 
-        String tcpChannelMessage = server.waitForStringInLog("CWWKO0219I: TCP Channel defaultHttpEndpoint");
+        String tcpChannelMessage = server.waitForDefaultHTTPEndpointStart();
         runningNetty = tcpChannelMessage.contains(NETTY_TCP_CLASS_NAME);
         LOG.info("Running Netty? " + runningNetty);
 

--- a/dev/com.ibm.ws.webserver.plugin.utility_fat/fat/src/com/ibm/ws/webserver/plugin/utility/fat/PluginUtilityGenerateTest.java
+++ b/dev/com.ibm.ws.webserver.plugin.utility_fat/fat/src/com/ibm/ws/webserver/plugin/utility/fat/PluginUtilityGenerateTest.java
@@ -78,8 +78,7 @@ public class PluginUtilityGenerateTest {
                 remoteAccessServer.waitForStringInLog("CWWKF0011I"));
 
         // wait for LTPA key to be available to avoid CWWKS4000E
-        assertNotNull("CWWKS4105I.* not received on remoteAccessServer",
-                remoteAccessServer.waitForStringInLog("CWWKS4105I.*"));
+        remoteAccessServer.waitForLTPAConfigReady();
     }
 
     @AfterClass

--- a/dev/com.ibm.ws.wssecurity.fat.utils.common/fat/src/com/ibm/ws/wssecurity/fat/utils/common/CommonTests.java
+++ b/dev/com.ibm.ws.wssecurity.fat.utils.common/fat/src/com/ibm/ws/wssecurity/fat/utils/common/CommonTests.java
@@ -284,7 +284,7 @@ public class CommonTests {
             portNumberSecure = "" + server.getHttpDefaultSecurePort();
             server.waitForStringInLog("port " + portNumberSecure);
 
-            assertNotNull("SSL Service is not ready.", server.waitForStringInLog("CWWKO0219I.*ssl"));
+            server.waitForDefaultHTTPEndpointSSLStart();
             clientHttpsUrl = "https://localhost:" + portNumberSecure + uniqueUrl;
 
             Log.info(thisClass, thisMethod, "****portNumberSecure is:"

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/caller/CxfCallerX509AsymTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/caller/CxfCallerX509AsymTests.java
@@ -106,11 +106,9 @@ public class CxfCallerX509AsymTests {
         server.waitForStringInLog("port " + portNumberSecure);
         // check  message.log
         // CWWKO0219I: TCP Channel defaultHttpEndpoint has been started and is now lis....Port 8010
-        assertNotNull("defaultHttpendpoint may not started at :" + portNumber,
-                      server.waitForStringInLog("CWWKO0219I.*" + portNumber));
+        server.waitForDefaultHTTPEndpointStart();
         // CWWKO0219I: TCP Channel defaultHttpEndpoint-ssl has been started and is now lis....Port 8020
-        assertNotNull("defaultHttpEndpoint SSL port may not be started at:" + portNumberSecure,
-                      server.waitForStringInLog("CWWKO0219I.*" + portNumberSecure));
+        server.waitForDefaultHTTPEndpointSSLStart();
 
         // using the original port to send the parameters
         callerUNTClientUrl = "http://localhost:" + portNumber +

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/caller/CxfCallerX509SymTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/caller/CxfCallerX509SymTests.java
@@ -106,11 +106,9 @@ public class CxfCallerX509SymTests {
         server.waitForStringInLog("port " + portNumberSecure);
         // check  message.log
         // CWWKO0219I: TCP Channel defaultHttpEndpoint has been started and is now lis....Port 8010
-        assertNotNull("defaultHttpendpoint may not started at :" + portNumber,
-                      server.waitForStringInLog("CWWKO0219I.*" + portNumber));
+        server.waitForDefaultHTTPEndpointStart();
         // CWWKO0219I: TCP Channel defaultHttpEndpoint-ssl has been started and is now lis....Port 8020
-        assertNotNull("defaultHttpEndpoint SSL port may not be started at:" + portNumberSecure,
-                      server.waitForStringInLog("CWWKO0219I.*" + portNumberSecure));
+        server.waitForDefaultHTTPEndpointSSLStart();
 
         // using the original port to send the parameters
         callerUNTClientUrl = "http://localhost:" + portNumber +
@@ -119,9 +117,6 @@ public class CxfCallerX509SymTests {
         // portNumber = "9085";                // for debugging
         Log.info(thisClass, thisMethod, "****portNumber is(2):" + portNumber);
         Log.info(thisClass, thisMethod, "****portNumberSecure is(2):" + portNumberSecure);
-
-        return;
-
     }
 
     /**

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/sample/CxfBspTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/sample/CxfBspTests.java
@@ -107,11 +107,7 @@ public class CxfBspTests {
 
         // check  message.log
         // CWWKO0219I: TCP Channel defaultHttpEndpoint has been started and is now lis....Port 8010
-        assertNotNull("defaultHttpendpoint may not started at :" + portNumber,
-                      server.waitForStringInLog("CWWKO0219I.*" + portNumber));
-        //// CWWKO0219I: TCP Channel defaultHttpEndpoint-ssl has been started and is now lis....Port 8020
-        //assertNotNull("defaultHttpEndpoint SSL port may not be started at:" + portNumberSecure,
-        //              server.waitForStringInLog("CWWKO0219I.*" + portNumberSecure));
+        server.waitForDefaultHTTPEndpointStart();
 
         // using the original port to send the parameters to CxfClientServlet in service client (webcontent)
         serviceClientUrl = "http://localhost:" + (debug ? "9085" : portNumber);

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/sample/CxfInteropX509Tests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/sample/CxfInteropX509Tests.java
@@ -107,11 +107,7 @@ public class CxfInteropX509Tests {
 
         // check  message.log
         // CWWKO0219I: TCP Channel defaultHttpEndpoint has been started and is now lis....Port 8010
-        assertNotNull("defaultHttpendpoint may not started at :" + portNumber,
-                      server.waitForStringInLog("CWWKO0219I.*" + portNumber));
-        //// CWWKO0219I: TCP Channel defaultHttpEndpoint-ssl has been started and is now lis....Port 8020
-        //assertNotNull("defaultHttpEndpoint SSL port may not be started at:" + portNumberSecure,
-        //              server.waitForStringInLog("CWWKO0219I.*" + portNumberSecure));
+        server.waitForDefaultHTTPEndpointStart();
 
         // using the original port to send the parameters to CxfClientServlet in service client (webcontent)
         serviceClientUrl = "http://localhost:" + (debug ? "9085" : portNumber);

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/sample/CxfSampleTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/sample/CxfSampleTests.java
@@ -176,11 +176,7 @@ public class CxfSampleTests {
 
         // check  message.log
         // CWWKO0219I: TCP Channel defaultHttpEndpoint has been started and is now lis....Port 8010
-        assertNotNull("defaultHttpendpoint may not started at :" + portNumber,
-                      server.waitForStringInLog("CWWKO0219I.*" + portNumber));
-        //// CWWKO0219I: TCP Channel defaultHttpEndpoint-ssl has been started and is now lis....Port 8020
-        //assertNotNull("defaultHttpEndpoint SSL port may not be started at:" + portNumberSecure,
-        //              server.waitForStringInLog("CWWKO0219I.*" + portNumberSecure));
+        server.waitForDefaultHTTPEndpointStart();
 
         // using the original port to send the parameters to CxfClientServlet in service client (webcontent)
         serviceClientUrl = "http://localhost:" + portNumber;

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/sample/CxfSymSampleTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/sample/CxfSymSampleTests.java
@@ -119,11 +119,7 @@ public class CxfSymSampleTests {
 
         // check  message.log
         // CWWKO0219I: TCP Channel defaultHttpEndpoint has been started and is now lis....Port 8010
-        assertNotNull("defaultHttpendpoint may not started at :" + portNumber,
-                      server.waitForStringInLog("CWWKO0219I.*" + portNumber));
-        //// CWWKO0219I: TCP Channel defaultHttpEndpoint-ssl has been started and is now lis....Port 8020
-        //assertNotNull("defaultHttpEndpoint SSL port may not be started at:" + portNumberSecure,
-        //              server.waitForStringInLog("CWWKO0219I.*" + portNumberSecure));
+        server.waitForDefaultHTTPEndpointStart();
 
         // using the original port to send the parameters to CxfClientServlet in service client (webcontent)
         serviceClientUrl = "http://localhost:" + portNumber;

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.2/fat/src/com/ibm/ws/wssecurity/fat/cxf/x509migtoken/CxfX509MigSymEE7LiteTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.2/fat/src/com/ibm/ws/wssecurity/fat/cxf/x509migtoken/CxfX509MigSymEE7LiteTests.java
@@ -96,11 +96,9 @@ public class CxfX509MigSymEE7LiteTests extends CommonTests {
         server.waitForStringInLog("port " + portNumberSecure);
         // check  message.log
         // CWWKO0219I: TCP Channel defaultHttpEndpoint has been started and is now lis....Port 8010
-        assertNotNull("defaultHttpendpoint may not started at :" + portNumber,
-                      server.waitForStringInLog("CWWKO0219I.*" + portNumber));
+        server.waitForDefaultHTTPEndpointStart();
         // CWWKO0219I: TCP Channel defaultHttpEndpoint-ssl has been started and is now lis....Port 8020
-        assertNotNull("defaultHttpEndpoint SSL port may not be started at:" + portNumberSecure,
-                      server.waitForStringInLog("CWWKO0219I.*" + portNumberSecure));
+        server.waitForDefaultHTTPEndpointSSLStart();
 
         // using the original port to send the parameters
         x509MigSymClientUrl = "http://localhost:" + portNumber +

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.2/fat/src/com/ibm/ws/wssecurity/fat/cxf/x509migtoken/CxfX509MigSymSha2NegativeTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.2/fat/src/com/ibm/ws/wssecurity/fat/cxf/x509migtoken/CxfX509MigSymSha2NegativeTests.java
@@ -112,11 +112,9 @@ public class CxfX509MigSymSha2NegativeTests {
         server.waitForStringInLog("port " + portNumberSecure);
         // check  message.log
         // CWWKO0219I: TCP Channel defaultHttpEndpoint has been started and is now lis....Port 8010
-        assertNotNull("defaultHttpendpoint may not started at :" + portNumber,
-                      server.waitForStringInLog("CWWKO0219I.*" + portNumber));
+        server.waitForDefaultHTTPEndpointStart();
         // CWWKO0219I: TCP Channel defaultHttpEndpoint-ssl has been started and is now lis....Port 8020
-        assertNotNull("defaultHttpEndpoint SSL port may not be started at:" + portNumberSecure,
-                      server.waitForStringInLog("CWWKO0219I.*" + portNumberSecure));
+        server.waitForDefaultHTTPEndpointSSLStart();
 
         // using the original port to send the parameters
         x509MigSymClientUrl = "http://localhost:" + portNumber +

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.2/fat/src/com/ibm/ws/wssecurity/fat/cxf/x509migtoken/CxfX509MigSymTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.2/fat/src/com/ibm/ws/wssecurity/fat/cxf/x509migtoken/CxfX509MigSymTests.java
@@ -111,11 +111,9 @@ public class CxfX509MigSymTests {
         server.waitForStringInLog("port " + portNumberSecure);
         // check  message.log
         // CWWKO0219I: TCP Channel defaultHttpEndpoint has been started and is now lis....Port 8010
-        assertNotNull("defaultHttpendpoint may not started at :" + portNumber,
-                      server.waitForStringInLog("CWWKO0219I.*" + portNumber));
+        server.waitForDefaultHTTPEndpointStart();
         // CWWKO0219I: TCP Channel defaultHttpEndpoint-ssl has been started and is now lis....Port 8020
-        assertNotNull("defaultHttpEndpoint SSL port may not be started at:" + portNumberSecure,
-                      server.waitForStringInLog("CWWKO0219I.*" + portNumberSecure));
+        server.waitForDefaultHTTPEndpointSSLStart();
 
         // using the original port to send the parameters
         x509MigSymClientUrl = "http://localhost:" + portNumber +
@@ -126,8 +124,6 @@ public class CxfX509MigSymTests {
         // portNumber = "9085";                // for debugging
         Log.info(thisClass, thisMethod, "****portNumber is(2):" + portNumber);
         Log.info(thisClass, thisMethod, "****portNumberSecure is(2):" + portNumberSecure);
-
-        return;
 
     }
 

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/fat/src/com/ibm/ws/wssecurity/fat/cxf/x509token/CxfX509BasicTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/fat/src/com/ibm/ws/wssecurity/fat/cxf/x509token/CxfX509BasicTests.java
@@ -102,11 +102,9 @@ public class CxfX509BasicTests {
         server.waitForStringInLog("port " + portNumberSecure);
         // check  message.log
         // CWWKO0219I: TCP Channel defaultHttpEndpoint has been started and is now lis....Port 8010
-        assertNotNull("defaultHttpendpoint may not started at :" + portNumber,
-                      server.waitForStringInLog("CWWKO0219I.*" + portNumber));
+        server.waitForDefaultHTTPEndpointStart();
         // CWWKO0219I: TCP Channel defaultHttpEndpoint-ssl has been started and is now lis....Port 8020
-        assertNotNull("defaultHttpEndpoint SSL port may not be started at:" + portNumberSecure,
-                      server.waitForStringInLog("CWWKO0219I.*" + portNumberSecure));
+        server.waitForDefaultHTTPEndpointSSLStart();
 
         x509ClientUrl = "http://localhost:" + portNumber
                         + "/x509client/CxfX509SvcClient";

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/fat/src/com/ibm/ws/wssecurity/fat/cxf/x509token/CxfX509ObjectTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/fat/src/com/ibm/ws/wssecurity/fat/cxf/x509token/CxfX509ObjectTests.java
@@ -103,11 +103,9 @@ public class CxfX509ObjectTests {
         server.waitForStringInLog("port " + portNumberSecure);
         // check  message.log
         // CWWKO0219I: TCP Channel defaultHttpEndpoint has been started and is now lis....Port 8010
-        assertNotNull("defaultHttpendpoint may not started at :" + portNumber,
-                      server.waitForStringInLog("CWWKO0219I.*" + portNumber));
+        server.waitForDefaultHTTPEndpointStart();
         // CWWKO0219I: TCP Channel defaultHttpEndpoint-ssl has been started and is now lis....Port 8020
-        assertNotNull("defaultHttpEndpoint SSL port may not be started at:" + portNumberSecure,
-                      server.waitForStringInLog("CWWKO0219I.*" + portNumberSecure));
+        server.waitForDefaultHTTPEndpointSSLStart();
 
         //issue 23060
         if (features.contains("usr:wsseccbh-1.0")) {

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/fat/src/com/ibm/ws/wssecurity/fat/cxf/x509token/CxfX509OverRideTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/fat/src/com/ibm/ws/wssecurity/fat/cxf/x509token/CxfX509OverRideTests.java
@@ -103,11 +103,9 @@ public class CxfX509OverRideTests {
         server.waitForStringInLog("port " + portNumberSecure);
         // check  message.log
         // CWWKO0219I: TCP Channel defaultHttpEndpoint has been started and is now lis....Port 8010
-        assertNotNull("defaultHttpendpoint may not started at :" + portNumber,
-                      server.waitForStringInLog("CWWKO0219I.*" + portNumber));
+        server.waitForDefaultHTTPEndpointStart();
         // CWWKO0219I: TCP Channel defaultHttpEndpoint-ssl has been started and is now lis....Port 8020
-        assertNotNull("defaultHttpEndpoint SSL port may not be started at:" + portNumberSecure,
-                      server.waitForStringInLog("CWWKO0219I.*" + portNumberSecure));
+        server.waitForDefaultHTTPEndpointSSLStart();
 
         //issue 23060
         if (features.contains("usr:wsseccbh-1.0")) {

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.4/fat/src/com/ibm/ws/wssecurity/fat/cxf/caller/CxfCallerUNTCBHPackageTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.4/fat/src/com/ibm/ws/wssecurity/fat/cxf/caller/CxfCallerUNTCBHPackageTests.java
@@ -111,11 +111,9 @@ public class CxfCallerUNTCBHPackageTests {
         server.waitForStringInLog("port " + portNumberSecure);
         // check  message.log
         // CWWKO0219I: TCP Channel defaultHttpEndpoint has been started and is now lis....Port 8010
-        assertNotNull("defaultHttpendpoint may not started at :" + portNumber,
-                      server.waitForStringInLog("CWWKO0219I.*" + portNumber));
+        server.waitForDefaultHTTPEndpointStart();
         // CWWKO0219I: TCP Channel defaultHttpEndpoint-ssl has been started and is now lis....Port 8020
-        assertNotNull("defaultHttpEndpoint SSL port may not be started at:" + portNumberSecure,
-                      server.waitForStringInLog("CWWKO0219I.*" + portNumberSecure));
+        server.waitForDefaultHTTPEndpointSSLStart();
 
         // using the original port to send the parameters
         callerUNTClientUrl = "http://localhost:" + portNumber +

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.4/fat/src/com/ibm/ws/wssecurity/fat/cxf/caller/CxfCallerUNTTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.4/fat/src/com/ibm/ws/wssecurity/fat/cxf/caller/CxfCallerUNTTests.java
@@ -106,11 +106,9 @@ public class CxfCallerUNTTests {
         server.waitForStringInLog("port " + portNumberSecure);
         // check  message.log
         // CWWKO0219I: TCP Channel defaultHttpEndpoint has been started and is now lis....Port 8010
-        assertNotNull("defaultHttpendpoint may not started at :" + portNumber,
-                      server.waitForStringInLog("CWWKO0219I.*" + portNumber));
+        server.waitForDefaultHTTPEndpointStart();
         // CWWKO0219I: TCP Channel defaultHttpEndpoint-ssl has been started and is now lis....Port 8020
-        assertNotNull("defaultHttpEndpoint SSL port may not be started at:" + portNumberSecure,
-                      server.waitForStringInLog("CWWKO0219I.*" + portNumberSecure));
+        server.waitForDefaultHTTPEndpointSSLStart();
 
         // using the original port to send the parameters
         callerUNTClientUrl = "http://localhost:" + portNumber +

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.5/fat/src/com/ibm/ws/wssecurity/fat/cxf/ecdh/CxfECDHCallerTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.5/fat/src/com/ibm/ws/wssecurity/fat/cxf/ecdh/CxfECDHCallerTests.java
@@ -112,11 +112,9 @@ public class CxfECDHCallerTests {
         server.waitForStringInLog("port " + portNumberSecure);
         // check  message.log
         // CWWKO0219I: TCP Channel defaultHttpEndpoint has been started and is now lis....Port 8010
-        assertNotNull("defaultHttpendpoint may not started at :" + portNumber,
-                      server.waitForStringInLog("CWWKO0219I.*" + portNumber));
+        server.waitForDefaultHTTPEndpointStart();
         // CWWKO0219I: TCP Channel defaultHttpEndpoint-ssl has been started and is now lis....Port 8020
-        assertNotNull("defaultHttpEndpoint SSL port may not be started at:" + portNumberSecure,
-                      server.waitForStringInLog("CWWKO0219I.*" + portNumberSecure));
+        server.waitForDefaultHTTPEndpointSSLStart();
 
         // using the original port to send the parameters
         callerUNTClientUrl = "http://localhost:" + portNumber +

--- a/dev/fattest.simplicity/src/com/ibm/ws/fat/util/SharedServer.java
+++ b/dev/fattest.simplicity/src/com/ibm/ws/fat/util/SharedServer.java
@@ -181,7 +181,7 @@ public class SharedServer extends ExternalResource {
                 server.startServerAndValidate(true, true, false);
             }
             if (this.waitForSecurity) {
-                server.waitForStringInLog(".*CWWKS4105I: LTPA configuration is ready.*");
+                server.waitForLTPAConfigReady();
                 server.waitForStringInLog(".*CWWKS0008I: The security service is ready.*");
             }
             LOG.info(delimiter);
@@ -208,7 +208,7 @@ public class SharedServer extends ExternalResource {
             LOG.info(delimiter);
             server.startServerAndValidate(preClean, cleanStart, validateApps); // throws exception if start fails
             if (this.waitForSecurity) {
-                server.waitForStringInLog(".*CWWKS4105I: LTPA configuration is ready.*");
+                server.waitForLTPAConfigReady();
                 server.waitForStringInLog(".*CWWKS0008I: The security service is ready.*");
             }
             LOG.info(delimiter);

--- a/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyServer.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyServer.java
@@ -1200,6 +1200,13 @@ public class LibertyServer implements LogMonitorClient {
 
     }
 
+    /**
+     * Check logs for SSL endpoint Stop and Start messages from the log
+     * 
+     * This does not initiate an SSL Restart.
+     * 
+     * @throws Exception
+     */
     public void waitForSSLRestart() throws Exception {
 
         String thisMethod = "waitForSSLRestart";
@@ -1214,7 +1221,7 @@ public class LibertyServer implements LogMonitorClient {
                 Log.info(c, thisMethod, "SSL appears have restarted properly");
             }
         } else {
-            Log.info(c, thisMethod, "Did not detect a restart of the SSL port");
+            Log.info(c, thisMethod, "Did not detect a stopping of the SSL port - unable to validate SSL has restarted");
         }
 
     }
@@ -1223,10 +1230,10 @@ public class LibertyServer implements LogMonitorClient {
      * Wait for endpoint on provided port to start
      *
      * @param port
-     * @return
-     * @throws Exception is thrown if endpoint does not start with the expected time
+     * @return the matching line in the log, or null if no matches appear before the timeout expires
+     * @throws Exception is thrown if endpoint does not start within the default time period
      */
-    public String waitForEndpointOnPortToStart(String port) throws Exception{
+    public String waitForEndpointOnPortToStart(int port) throws Exception{
         return waitForEndpointOnPortToStart(port, LOG_SEARCH_TIMEOUT);
     }
 
@@ -1234,18 +1241,36 @@ public class LibertyServer implements LogMonitorClient {
      * Wait for endpoint on provided port to start in the defined time period
      *
      * @param port
-     * @return
-     * @throws Exception is thrown if endpoint does not start with the provided time
+     * @param timeout a timeout, in milliseconds
+     * @return the matching line in the log, or null if no matches appear before the timeout expires
+     * @throws Exception is thrown if endpoint does not start within the provided time
      */
-    public String waitForEndpointOnPortToStart(String port, int timeout) throws Exception{
+    public String waitForEndpointOnPortToStart(int port, int timeout) throws Exception{
         return waitForEndpointOnPortToStart(port, timeout, false);
     }
 
-    public String waitForEndpointOnPortToStart(String port, boolean suppressException) throws Exception{
+    /**
+     * Wait for endpoint on provided port to start
+     *
+     * @param port 
+     * @param suppressException if set to 'true', method return null if the message is not found instead of throwing an exception
+     * @return the matching line in the log, or null if no matches appear before the timeout expires
+     * @throws Exception is thrown if endpoint does not start within the default timeout period and if suppressException is 'false'
+     */
+    public String waitForEndpointOnPortToStart(int port, boolean suppressException) throws Exception{
         return waitForEndpointOnPortToStart(port, LOG_SEARCH_TIMEOUT, suppressException);
     }
 
-    public String waitForEndpointOnPortToStart(String port, int timeout, boolean suppressException) throws Exception{
+    /**
+     * Wait for endpoint on provided port to start
+     * 
+     * @param port
+     * @param timeout a timeout, in milliseconds
+     * @param suppressException if set to 'true', method return null if the message is not found instead of throwing an exception
+     * @return the matching line in the log, or null if no matches appear before the timeout expires
+     * @throws Exception is thrown if endpoint does not start within the provided time and if suppressException is 'false'
+     */
+    public String waitForEndpointOnPortToStart(int port, int timeout, boolean suppressException) throws Exception{
         String endpointStarted = waitForStringInLogUsingMark("CWWKO0219I:.*" + port, timeout);
         if(endpointStarted == null){
             RuntimeException rx = new RuntimeException("Timed out waiting for the server to initialize endpoint on port: " + port);
@@ -1259,12 +1284,11 @@ public class LibertyServer implements LogMonitorClient {
 
 
     /**
-     * Wait for the server to state that it is listening on its default SSL port
+     * Wait for the server to state that it is listening on its default SSL Endpoint
      *
      * Method does respect if a Mark has been taken in the logs
      *
-     * This will throw a runtime exception if the message is not found
-     *
+     * @return the matching line in the log, or null if no matches appear before the default timeout expires
      * @throws Exception if SSL Endpoint has not been logged as started within the default timeout
      */
     public String waitForDefaultHTTPEndpointSSLStart() throws Exception {
@@ -1272,33 +1296,42 @@ public class LibertyServer implements LogMonitorClient {
     }
 
     /**
-     * Wait for the server to state that it is listening on its default SSL port
+     * Wait for the server to state that it is listening on its default SSL Endpoint
      *
      * Method does respect if a Mark has been taken in the logs
      *
-     * You can surpress the throwing of the exception, will return null if the message is not found instead
+     * You can suppress the throwing of the exception, will return null if the message is not found instead
      *
      * @param suppressException
-     * @return
-     * @throws Exception if supressException is false and message is not found
+     * @return the matching line in the log, or null if no matches appear before the default timeout expires
+     * @throws Exception if suppressException is false and message is not found
      */
     public String waitForDefaultHTTPEndpointSSLStart(boolean suppressException) throws Exception {
         return waitForDefaultHTTPEndpointSSLStart(LOG_SEARCH_TIMEOUT, suppressException);
     }
 
+    /**
+     * Wait for the server to state that it is listening on its default SSL Endpoint
+     * 
+     * Method does respect if a Mark has been taken in the logs
+     * 
+     * @param timeout a timeout, in milliseconds
+     * @return the matching line in the log, or null if no matches appear before the default timeout expires
+     * @throws Exception if SSL Endpoint has not been logged as started within the default timeout
+     */
     public String waitForDefaultHTTPEndpointSSLStart(int timeout) throws Exception {
         return waitForDefaultHTTPEndpointSSLStart(timeout, false);
     }
 
     /**
-     * Wait for the server to state that it is listening on its default SSL port in the time specified
+     * Wait for the server to state that it is listening on its default SSL Endpoint in the time specified
      *
      * Method does respect if a Mark has been taken in the logs
      *
-     * @param timeout how long to wait for the message to appear
+     * @param timeout a timeout, in milliseconds
      * @param suppressException whether to throw an exception or return null if the message is not found
-     * @return
-     * @throws Exception if SSL endpoint has not been logged as started within the provided timeout
+     * @return the matching line in the log, or null if no matches appear before the default timeout expires
+     * @throws Exception if SSL endpoint has not been logged as started within the provided timeout amd suppressException is 'false'
      */
     public String waitForDefaultHTTPEndpointSSLStart(int timeout, boolean suppressException) throws Exception {
         //wait for "CWWKO0219I: TCP Channel defaultHttpEndpoint-ssl has been started and is now listening for requests on host"
@@ -1314,25 +1347,15 @@ public class LibertyServer implements LogMonitorClient {
     }
 
     /**
-     * Wait for the server to state that it is listening on its non-SSL default port
-     *
+     * Wait for the server to state that it is listening on its default non-SSL Endpoint
+     * 
      * Method does respect if a Mark has been taken in the logs
-     *
-     * @throws Exception
+     * 
+     * @return the matching line in the log, or null if no matches appear before the default timeout expires
+     * @throws Exception if SSL endpoint has not been logged as started within the default time period
      */
     public String waitForDefaultHTTPEndpointStart() throws Exception {
         return waitForDefaultHTTPEndpointStart(LOG_SEARCH_TIMEOUT);
-    }
-
-    /**
-     * Wait for the server to state that it is listening on its non-SSL default enpoint
-     *
-     * Method does respect if a Mark has been taken in the logs
-     *
-     * @throws Exception
-     */
-    public String waitForDefaultHTTPEndpointStart(boolean supresssException) throws Exception {
-        return waitForDefaultHTTPEndpointStart(LOG_SEARCH_TIMEOUT, supresssException);
     }
 
     /**
@@ -1340,18 +1363,36 @@ public class LibertyServer implements LogMonitorClient {
      *
      * Method does respect if a Mark has been taken in the logs
      *
-     * @throws Exception
+     * @param suppressException whether to throw an exception or return null if the message is not found
+     * @return the matching line in the log, or null if no matches appear before the default timeout expires
+     * @throws Exception if the endpoint has not been logged as started within the default time period and suppressException is 'false'
+     */
+    public String waitForDefaultHTTPEndpointStart(boolean suppressException) throws Exception {
+        return waitForDefaultHTTPEndpointStart(LOG_SEARCH_TIMEOUT, suppressException);
+    }
+
+    /**
+     * Wait for the server to state that it is listening on its non-SSL default endpoint
+     *
+     * Method does respect if a Mark has been taken in the logs
+     *
+     * @param timeout a timeout, in milliseconds
+     * @return the matching line in the log, or null if no matches appear before the default timeout expires
+     * @throws Exception if the endpoint has not been logged as started within the default time period
      */
     public String waitForDefaultHTTPEndpointStart(int timeout) throws Exception {
         return waitForDefaultHTTPEndpointStart(timeout, false);
     }
 
     /**
-     * Wait for the server to state that it is listening on its non-SSL default port in the time specified
+     * Wait for the server to state that it is listening on its non-SSL default endpoint in the time provided
      *
      * Method does respect if a Mark has been taken in the logs
      *
-     * @throws Exception
+     * @param timeout a timeout, in milliseconds
+     * @param suppressException whether to throw an exception or return null if the message is not found
+     * @return the matching line in the log, or null if no matches appear before the provided timeout expires
+     * @throws Exception if the endpoint has not been logged as started within the provided time period and suppressException is 'false'
      */
     public String waitForDefaultHTTPEndpointStart(int timeout, boolean suppressException) throws Exception {
         //wait for "CWWKO0219I: TCP Channel defaultHttpEndpoint has been started and is now listening for requests on host"
@@ -1374,6 +1415,7 @@ public class LibertyServer implements LogMonitorClient {
      *
      * Method does respect if a Mark has been taken in the logs
      *
+     * @return the matching line in the log, or null if no matches appear before the default timeout expires
      * @throws Exception if LTPA Config ready message is not received within the default timeout period
      */
     public String waitForLTPAConfigReady() throws Exception {
@@ -1381,12 +1423,13 @@ public class LibertyServer implements LogMonitorClient {
     }
 
     /**
-     * Wait for the server to state that `CWWKS4105I: LTPA configuration is ready`
+     * Wait for the server to state that `CWWKS4105I: LTPA configuration is ready` in the time specified
      *
      * Method does respect if a Mark has been taken in the logs
      *
-     * @param timeout how long to wait for LTPA config ready message
-     * @throws Exception if LTPA Config ready message is not received within the default timeout period
+     * @param timeout a timeout, in milliseconds
+     * @return the matching line in the log, or null if no matches appear before the provided timeout expires
+     * @throws Exception if LTPA Config ready message is not received within the provided timeout period
      */
     public String waitForLTPAConfigReady(int timeout) throws Exception {
         return waitForLTPAConfigReady(timeout, false);
@@ -1398,7 +1441,7 @@ public class LibertyServer implements LogMonitorClient {
      * Method does respect if a Mark has been taken in the logs
      *
      * @param suppressException if true, will return null instead of throwing an exception
-     * @return
+     * @return the matching line in the log, or null if no matches appear before the default timeout expires
      * @throws Exception if LTPA Config ready message is not received within the default timeout period and suppressException is false
      */
     public String waitForLTPAConfigReady(boolean suppressException) throws Exception {
@@ -1411,9 +1454,10 @@ public class LibertyServer implements LogMonitorClient {
      *
      * Method does respect if a Mark has been taken in the logs
      *
-     * @param timeout how long in milliseconds to wait for message
+     * @param timeout a timeout, in milliseconds
      * @param suppressException if wait times out, whether to suppress the exception and return null instead
-     * @throws Exception if LTPA config ready message is not received in the provided period
+     * @return the matching line in the log, or null if no matches appear before the provided timeout expires
+     * @throws Exception if LTPA config ready message is not received in the provided period and suppressException is 'false'
      */
     public String waitForLTPAConfigReady(int timeout, boolean suppressException) throws Exception {
         // wait for "CWWKS4105I: LTPA configuration is ready"
@@ -1430,20 +1474,39 @@ public class LibertyServer implements LogMonitorClient {
     }
 
     /**
-     * Wait for the server to report `CWWKS4104A: LTPA keys created` file has been created in the time specified
+     * Wait for the server to report `CWWKS4104A: LTPA keys created`
      *
      * Method does respect if a Mark has been taken in the logs
      *
-     * @throws Exception
+     * @return the matching line in the log, or null if no matches appear before the provided timeout expires
+     * @throws Exception if LTPA keys created ready message is not received within the default timeout period
      */
     public String waitForLTPAKeysCreated() throws Exception {
         return waitForLTPAKeysCreated(LOG_SEARCH_TIMEOUT);
     }
 
+    /**
+     * Wait for the server to report `CWWKS4104A: LTPA keys created` in the time specified
+     *
+     * Method does respect if a Mark has been taken in the logs
+     *
+     * @param timeout a timeout, in milliseconds
+     * @return the matching line in the log, or null if no matches appear before the provided timeout expires
+     * @throws Exception if LTPA keys created ready message is not received within the provided timeout period
+     */
     public String waitForLTPAKeysCreated(int timeout) throws Exception {
         return waitForLTPAKeysCreated(timeout, false);
     }
 
+    /**
+     * Wait for the server to report `CWWKS4104A: LTPA keys created`
+     *
+     * Method does respect if a Mark has been taken in the logs
+     *
+     * @param suppressException if wait times out, whether to suppress the exception and return null instead
+     * @return the matching line in the log, or null if no matches appear before the default timeout expires
+     * @throws Exception if LTPA keys created ready message is not received within the default timeout period and suppressException is 'false'
+     */
     public String waitForLTPAKeysCreated(boolean suppressException) throws Exception {
         return waitForLTPAKeysCreated(LOG_SEARCH_TIMEOUT, suppressException);
     }
@@ -1453,7 +1516,10 @@ public class LibertyServer implements LogMonitorClient {
      *
      * Method does respect if a Mark has been taken in the logs
      *
-     * @throws Exception
+     * @param timeout a timeout, in milliseconds
+     * @param suppressException if wait times out, whether to suppress the exception and return null instead
+     * @return the matching line in the log, or null if no matches appear before the provided timeout expires
+     * @throws Exception if LTPA keys created ready message is not received within the provided timeout period and suppressException is 'false'
      */
     public String waitForLTPAKeysCreated(int timeout, boolean suppressException) throws Exception{
         // wait for "CWWKS4104A: LTPA keys created"
@@ -1469,51 +1535,74 @@ public class LibertyServer implements LogMonitorClient {
     }
 
     /**
-     * Some tests want to ensure LTPA keys have been created and that the config has been completed
+     * @deprecated
+     * This method is provided for existing test cases which checked for both keys create and config ready.
+     * It is recommended to just wait for the config to be stated as ready
      *
-     * @return
-     * @throws Exception
+     * Wait for LTPA keys have been created and the LTPA config to report as ready
+     *
+     * Method does respect if a Mark has been taken in the logs
+     *
+     * @return the matching line in the log, or null if no matches appear before the provided timeout expires
+     * @throws Exception if the LTPA keys created and Config ready messages are not received within the default timeout period
      */
-    public String waitForLTPAKeysCreatedandConfigComplete() throws Exception {
-        return waitForLTPAKeysCreatedAndConfigComplete(LOG_SEARCH_TIMEOUT);
+    @Deprecated
+    public String waitForLTPAKeysCreatedandConfigReady() throws Exception {
+        return waitForLTPAKeysCreatedAndConfigReady(LOG_SEARCH_TIMEOUT);
     }
 
     /**
-     * Some tests want to ensure both LTPA Keys have been created and Config has been completed
+     * @deprecated
+     * This method is provided for existing test cases which checked for both keys create and config ready.
+     * It is recommended to just wait for the config to be stated as ready
+     *
+     * Wait for LTPA keys have been created and the LTPA config to report as ready
      *
      * Method uses the a mark if one has been made
      *
-     * @param timeout, timeout applied to each check, a timeout of 60000, is a total of 1000
+     * @param timeout, timeout applied to each check, a timeout of 60000, is a total of 120000
      * @return the result of waitForLTPAConfigReady, as keys must be created before Config can be ready
-     * @throws Exception if messages aren't found in logs then a runtime exception is thrown
+     * @throws Exception if messages aren't found in logs then a runtime exception is thrown within the provided time period
      */
-    public String waitForLTPAKeysCreatedAndConfigComplete(int timeout) throws Exception {
-        return waitForLTPAKeysCreatedAndConfigComplete(timeout, false);
+    @Deprecated
+    public String waitForLTPAKeysCreatedAndConfigReady(int timeout) throws Exception {
+        return waitForLTPAKeysCreatedAndConfigReady(timeout, false);
     }
 
     /**
-     * Some tests want to ensure both LTPA Keys have been created and Config has been completed
+     * @deprecated
+     * This method is provided for existing test cases which checked for both keys create and config ready.
+     * It is recommended to just wait for the config to be stated as ready
+     *
+     * Wait for LTPA keys have been created and the LTPA config to report as ready
      *
      * Method uses the a mark if one has been made
      *
      * @param suppressException, whether to suppress the runtime exception, should only be supplied if asserting on the result.
      * @return the result of waitForLTPAConfigReady, as keys must be created before Config can be ready
-     * @throws Exception if messages aren't found in logs then a runtime exception is thrown
+     * @throws Exception if messages aren't found in logs and suppressException is 'false' then a runtime exception is thrown
      */
-    public String waitForLTPAKeysCreatedAndConfigComplete(boolean suppressException) throws Exception {
-        return waitForLTPAKeysCreatedAndConfigComplete(LOG_SEARCH_TIMEOUT, suppressException);
+    @Deprecated
+    public String waitForLTPAKeysCreatedAndConfigReady(boolean suppressException) throws Exception {
+        return waitForLTPAKeysCreatedAndConfigReady(LOG_SEARCH_TIMEOUT, suppressException);
     }
 
     /**
-     * Some tests want to ensure both LTPA Keys have been created and Config has been completed
+     * @deprecated
+     * This method is provided for existing test cases which checked for both keys create and config ready.
+     * It is recommended to just wait for the config to be stated as ready
+     *
+     * Wait for LTPA keys have been created and the LTPA config to report as ready
      *
      * Method uses the a mark if one has been made
+     *
      * @param timeout how long to wait for each check, 1000ms has a total timeout of 2000ms
      * @param suppressException whether to suppress the runtime exception, should only be supplied if asserting on the result.
      * @return the result of waitForLTPAConfigReady, as keys must be created before Config can be ready
-     * @throws Exception if messages aren't found in logs then a runtime exception is thrown
+     * @throws Exception if messages aren't found in logs and suppressException is 'false' then a runtime exception is thrown
      */
-    public String waitForLTPAKeysCreatedAndConfigComplete(int timeout, boolean suppressException) throws Exception {
+    @Deprecated
+    public String waitForLTPAKeysCreatedAndConfigReady(int timeout, boolean suppressException) throws Exception {
         waitForLTPAKeysCreated(timeout, suppressException);
         return waitForLTPAConfigReady(timeout, suppressException);
     }
@@ -6912,7 +7001,8 @@ public class LibertyServer implements LogMonitorClient {
      *
      * @param  regexp
      * @param  timeout a timeout, in milliseconds
-     * @return
+     * @return        the matching line in the log, or null if no matches
+     *                appear before the timeout expires
      */
     public String waitForStringInLog(String regexp, long timeout) {
         return waitForStringInLogUsingMark(regexp, timeout);
@@ -6927,7 +7017,7 @@ public class LibertyServer implements LogMonitorClient {
      * @param  numberOfMatches number of matches required
      * @param  regexp          a regular expression to search for
      * @param  timeout         a timeout, in milliseconds
-     * @return
+     * @return the matching line in the log, or null if no matches appear before the timeout expires
      */
     public int waitForMultipleStringsInLog(int numberOfMatches, String regexp, long timeout) {
         try {
@@ -6949,7 +7039,7 @@ public class LibertyServer implements LogMonitorClient {
      *
      * @param  regexp
      * @param  timeout a timeout, in milliseconds
-     * @return
+     * @return the matching line in the log, or null if no matches appear before the timeout expires
      */
     public String waitForStringInLogUsingLastOffset(String regexp, long timeout) {
         try {
@@ -6970,7 +7060,7 @@ public class LibertyServer implements LogMonitorClient {
      *
      * @param  regexp
      * @param  timeout a timeout, in milliseconds
-     * @return
+     * @return the matching line in the log, or null if no matches appear before the timeout expires
      */
     public String waitForStringInLogUsingMark(String regexp, long timeout) {
         return logMonitor.waitForStringInLogUsingMark(regexp, timeout);
@@ -6979,7 +7069,7 @@ public class LibertyServer implements LogMonitorClient {
     /**
      * @param  regexp
      * @param  serverConfigurationFile
-     * @return
+     * @return the matching line in the log, or null if no matches appear before the timeout expires
      */
     public String waitForStringInLog(String regexp, RemoteFile outputFile) {
         return waitForStringInLogUsingMark(regexp, outputFile);
@@ -6991,7 +7081,7 @@ public class LibertyServer implements LogMonitorClient {
      * @param  regexp     a regular expression to search for
      * @param  timeout    a timeout, in milliseconds
      * @param  outputFile file to check
-     * @return            line that matched the regexp
+     * @return the matching line in the log, or null if no matches appear before the timeout expires
      */
     public String waitForStringInLog(String regexp, long timeout, RemoteFile outputFile) {
         return waitForStringInLogUsingMark(regexp, timeout, outputFile);
@@ -7046,7 +7136,7 @@ public class LibertyServer implements LogMonitorClient {
      *
      * @param  regexp
      * @param  outputFile
-     * @return
+     * @return the matching line in the log, or null if no matches appear before the timeout expires
      */
     public String waitForStringInLogUsingMark(String regexp, RemoteFile outputFile) {
         return waitForStringInLogUsingMark(regexp, LOG_SEARCH_TIMEOUT, outputFile);
@@ -7059,7 +7149,7 @@ public class LibertyServer implements LogMonitorClient {
      * @param  regexp     a regular expression to search for
      * @param  intendedTimeout    a timeout, in milliseconds
      * @param  outputFile file to check
-     * @return            line that matched the regexp
+     * @return the matching line in the log, or null if no matches appear before the timeout expires
      */
     public String waitForStringInLogUsingLastOffset(String regexp, long intendedTimeout, RemoteFile outputFile) {
         return waitForStringInLogUsingLastOffset(regexp, intendedTimeout, 2 * intendedTimeout, outputFile);
@@ -7073,7 +7163,7 @@ public class LibertyServer implements LogMonitorClient {
      * @param  intendedTimeout a timeout, in milliseconds, within which we expect the wait to complete. Missing this is a soft fail.
      * @param  extendedTimeout a timeout, in milliseconds, within which we insist the wait complete. Missing this is an error.
      * @param  outputFile      file to check
-     * @return                 line that matched the regexp
+     * @return the matching line in the log, or null if no matches appear before the timeout expires
      */
     protected String waitForStringInLogUsingLastOffset(String regexp, long intendedTimeout, long extendedTimeout, RemoteFile outputFile) {
         final String METHOD_NAME = "waitForStringInLogUsingLastOffset";
@@ -7129,7 +7219,7 @@ public class LibertyServer implements LogMonitorClient {
      * @param  regexp     a regular expression to search for
      * @param  intendedTimeout    a timeout, in milliseconds
      * @param  outputFile file to check
-     * @return            line that matched the regexp
+     * @return the matching line in the log, or null if no matches appear before the timeout expires
      */
     public String waitForStringInLogUsingMark(String regexp, long intendedTimeout, RemoteFile outputFile) {
         return waitForStringInLogUsingMark(regexp, intendedTimeout, 2 * intendedTimeout, outputFile);
@@ -7143,7 +7233,7 @@ public class LibertyServer implements LogMonitorClient {
      * @param  intendedTimeout a timeout, in milliseconds, within which the wait should complete. Exceeding this is a soft fail.
      * @param  extendedTimeout a timeout, in milliseconds, within which the wait must complete. Exceeding this is a hard fail.
      * @param  outputFile      file to check
-     * @return                 line that matched the regexp
+     * @return the matching line in the log, or null if no matches appear before the timeout expires
      */
     protected String waitForStringInLogUsingMark(String regexp, long intendedTimeout, long extendedTimeout, RemoteFile outputFile) {
         return logMonitor.waitForStringInLogUsingMark(regexp, intendedTimeout, extendedTimeout, outputFile);

--- a/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyServer.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyServer.java
@@ -1205,9 +1205,9 @@ public class LibertyServer implements LogMonitorClient {
         String thisMethod = "waitForSSLRestart";
         // look for the "CWWKO0220I: TCP Channel defaultHttpEndpoint-ssl has stopped listening for requests on host " message
         // if we find it, then wait for "CWWKO0219I: TCP Channel defaultHttpEndpoint-ssl has been started and is now listening for requests on host"
-        String sslStopMsg = waitForStringInLogUsingMark("CWWKO0220I:.*defaultHttpEndpoint-ssl.*", 500);
+        String sslStopMsg = waitForStringInLogUsingMark("CWWKO0220I:.*defaultHttpEndpoint-ssl.*", 500 );
         if (sslStopMsg != null) {
-            String sslStartMsg = waitForStringInLogUsingMark("CWWKO0219I:.*defaultHttpEndpoint-ssl.*");
+            String sslStartMsg = waitForDefaultHTTPEndpointSSLStart(true);
             if (sslStartMsg == null) {
                 Log.warning(c, "SSL may not have started properly - future failures may be due to this");
             } else {
@@ -1220,18 +1220,302 @@ public class LibertyServer implements LogMonitorClient {
     }
 
     /**
-     * Wait for the server to state that it is listening on its SSL port
+     * Wait for endpoint on provided port to start
+     *
+     * @param port
+     * @return
+     * @throws Exception is thrown if endpoint does not start with the expected time
+     */
+    public String waitForEndpointOnPortToStart(String port) throws Exception{
+        return waitForEndpointOnPortToStart(port, LOG_SEARCH_TIMEOUT);
+    }
+
+    /**
+     * Wait for endpoint on provided port to start in the defined time period
+     *
+     * @param port
+     * @return
+     * @throws Exception is thrown if endpoint does not start with the provided time
+     */
+    public String waitForEndpointOnPortToStart(String port, int timeout) throws Exception{
+        return waitForEndpointOnPortToStart(port, timeout, false);
+    }
+
+    public String waitForEndpointOnPortToStart(String port, boolean suppressException) throws Exception{
+        return waitForEndpointOnPortToStart(port, LOG_SEARCH_TIMEOUT, suppressException);
+    }
+
+    public String waitForEndpointOnPortToStart(String port, int timeout, boolean suppressException) throws Exception{
+        String endpointStarted = waitForStringInLogUsingMark("CWWKO0219I:.*" + port, timeout);
+        if(endpointStarted == null){
+            RuntimeException rx = new RuntimeException("Timed out waiting for the server to initialize endpoint on port: " + port);
+            Log.error(c, "waitForEndpointOnPortToStart", rx);
+            if(!suppressException){
+                throw rx;
+            }
+        }
+        return endpointStarted;
+    }
+
+
+    /**
+     * Wait for the server to state that it is listening on its default SSL port
+     *
+     * Method does respect if a Mark has been taken in the logs
+     *
+     * This will throw a runtime exception if the message is not found
+     *
+     * @throws Exception if SSL Endpoint has not been logged as started within the default timeout
+     */
+    public String waitForDefaultHTTPEndpointSSLStart() throws Exception {
+        return waitForDefaultHTTPEndpointSSLStart(LOG_SEARCH_TIMEOUT);
+    }
+
+    /**
+     * Wait for the server to state that it is listening on its default SSL port
+     *
+     * Method does respect if a Mark has been taken in the logs
+     *
+     * You can surpress the throwing of the exception, will return null if the message is not found instead
+     *
+     * @param suppressException
+     * @return
+     * @throws Exception if supressException is false and message is not found
+     */
+    public String waitForDefaultHTTPEndpointSSLStart(boolean suppressException) throws Exception {
+        return waitForDefaultHTTPEndpointSSLStart(LOG_SEARCH_TIMEOUT, suppressException);
+    }
+
+    public String waitForDefaultHTTPEndpointSSLStart(int timeout) throws Exception {
+        return waitForDefaultHTTPEndpointSSLStart(timeout, false);
+    }
+
+    /**
+     * Wait for the server to state that it is listening on its default SSL port in the time specified
+     *
+     * Method does respect if a Mark has been taken in the logs
+     *
+     * @param timeout how long to wait for the message to appear
+     * @param suppressException whether to throw an exception or return null if the message is not found
+     * @return
+     * @throws Exception if SSL endpoint has not been logged as started within the provided timeout
+     */
+    public String waitForDefaultHTTPEndpointSSLStart(int timeout, boolean suppressException) throws Exception {
+        //wait for "CWWKO0219I: TCP Channel defaultHttpEndpoint-ssl has been started and is now listening for requests on host"
+        String sslStartMsg = waitForStringInLogUsingMark("CWWKO0219I:.*defaultHttpEndpoint-ssl.*", timeout);
+        if (sslStartMsg == null){
+            RuntimeException rx = new RuntimeException("Timed out waiting for the server to initialize defaultHttpEndpoint-ssl");
+            Log.error(c, "waitForDefaultHTTPEndpointSSLStart", rx);
+            if(!suppressException) {
+                throw rx;
+            }
+        }
+        return sslStartMsg;
+    }
+
+    /**
+     * Wait for the server to state that it is listening on its non-SSL default port
+     *
+     * Method does respect if a Mark has been taken in the logs
      *
      * @throws Exception
      */
-    public void waitForSSLStart() throws Exception {
-        //wait for "CWWKO0219I: TCP Channel defaultHttpEndpoint-ssl has been started and is now listening for requests on host"
-        String sslStartMsg = waitForStringInLogUsingMark("CWWKO0219I:.*defaultHttpEndpoint-ssl.*");
-        if (sslStartMsg == null) {
-            RuntimeException rx = new RuntimeException("Timed out waiting for the server to initialize defaultHttpEndpoint-ssl");
-            Log.error(c, "waitForSSLStart", rx);
-            throw rx;
+    public String waitForDefaultHTTPEndpointStart() throws Exception {
+        return waitForDefaultHTTPEndpointStart(LOG_SEARCH_TIMEOUT);
+    }
+
+    /**
+     * Wait for the server to state that it is listening on its non-SSL default enpoint
+     *
+     * Method does respect if a Mark has been taken in the logs
+     *
+     * @throws Exception
+     */
+    public String waitForDefaultHTTPEndpointStart(boolean supresssException) throws Exception {
+        return waitForDefaultHTTPEndpointStart(LOG_SEARCH_TIMEOUT, supresssException);
+    }
+
+    /**
+     * Wait for the server to state that it is listening on its non-SSL default endpoint
+     *
+     * Method does respect if a Mark has been taken in the logs
+     *
+     * @throws Exception
+     */
+    public String waitForDefaultHTTPEndpointStart(int timeout) throws Exception {
+        return waitForDefaultHTTPEndpointStart(timeout, false);
+    }
+
+    /**
+     * Wait for the server to state that it is listening on its non-SSL default port in the time specified
+     *
+     * Method does respect if a Mark has been taken in the logs
+     *
+     * @throws Exception
+     */
+    public String waitForDefaultHTTPEndpointStart(int timeout, boolean suppressException) throws Exception {
+        //wait for "CWWKO0219I: TCP Channel defaultHttpEndpoint has been started and is now listening for requests on host"
+        // space is required to prevent confusion with the SSL endpoint
+        String endpointStartMessage = waitForStringInLogUsingMark("CWWKO0219I:.*defaultHttpEndpoint ", timeout);
+        if(endpointStartMessage == null){
+            // highly unlikely unless something is really wrong.
+            RuntimeException rx = new RuntimeException("Timed out waiting for the server to initialize defaultHttpEndpoint");
+            Log.error(c, "waitForDefaultHTTPEndpointStart", rx);
+            if(!suppressException) {
+                throw rx;
+            }
         }
+        return endpointStartMessage;
+
+    }
+
+    /**
+     * Wait for the server to state that `CWWKS4105I: LTPA configuration is ready`
+     *
+     * Method does respect if a Mark has been taken in the logs
+     *
+     * @throws Exception if LTPA Config ready message is not received within the default timeout period
+     */
+    public String waitForLTPAConfigReady() throws Exception {
+       return waitForLTPAConfigReady(LOG_SEARCH_TIMEOUT);
+    }
+
+    /**
+     * Wait for the server to state that `CWWKS4105I: LTPA configuration is ready`
+     *
+     * Method does respect if a Mark has been taken in the logs
+     *
+     * @param timeout how long to wait for LTPA config ready message
+     * @throws Exception if LTPA Config ready message is not received within the default timeout period
+     */
+    public String waitForLTPAConfigReady(int timeout) throws Exception {
+        return waitForLTPAConfigReady(timeout, false);
+    }
+
+    /**
+     * Wait for the server to state that `CWWKS4105I: LTPA configuration is ready`
+     *
+     * Method does respect if a Mark has been taken in the logs
+     *
+     * @param suppressException if true, will return null instead of throwing an exception
+     * @return
+     * @throws Exception if LTPA Config ready message is not received within the default timeout period and suppressException is false
+     */
+    public String waitForLTPAConfigReady(boolean suppressException) throws Exception {
+        return waitForLTPAConfigReady(LOG_SEARCH_TIMEOUT, suppressException);
+    }
+
+
+    /**
+     * Wait for the server to state that `CWWKS4105I: LTPA configuration is ready` in the time specified
+     *
+     * Method does respect if a Mark has been taken in the logs
+     *
+     * @param timeout how long in milliseconds to wait for message
+     * @param suppressException if wait times out, whether to suppress the exception and return null instead
+     * @throws Exception if LTPA config ready message is not received in the provided period
+     */
+    public String waitForLTPAConfigReady(int timeout, boolean suppressException) throws Exception {
+        // wait for "CWWKS4105I: LTPA configuration is ready"
+        String ltpaReady = waitForStringInLogUsingMark("CWWKS4105I", timeout);
+        if(ltpaReady == null){
+            RuntimeException rx = new RuntimeException("Timed out waiting for the LTPA Config to be ready");
+            Log.error(c, "waitForLTPAConfigReady", rx);
+            if(!suppressException) {
+                throw rx;
+            }
+        }
+        return ltpaReady;
+
+    }
+
+    /**
+     * Wait for the server to report `CWWKS4104A: LTPA keys created` file has been created in the time specified
+     *
+     * Method does respect if a Mark has been taken in the logs
+     *
+     * @throws Exception
+     */
+    public String waitForLTPAKeysCreated() throws Exception {
+        return waitForLTPAKeysCreated(LOG_SEARCH_TIMEOUT);
+    }
+
+    public String waitForLTPAKeysCreated(int timeout) throws Exception {
+        return waitForLTPAKeysCreated(timeout, false);
+    }
+
+    public String waitForLTPAKeysCreated(boolean suppressException) throws Exception {
+        return waitForLTPAKeysCreated(LOG_SEARCH_TIMEOUT, suppressException);
+    }
+
+    /**
+     * Wait for the server to report `CWWKS4104A: LTPA keys created` file has been created in the time specified
+     *
+     * Method does respect if a Mark has been taken in the logs
+     *
+     * @throws Exception
+     */
+    public String waitForLTPAKeysCreated(int timeout, boolean suppressException) throws Exception{
+        // wait for "CWWKS4104A: LTPA keys created"
+        String ltpaKeysCreated = waitForStringInLogUsingMark("CWWKS4104A", timeout);
+        if(ltpaKeysCreated == null){
+            RuntimeException rx = new RuntimeException("Timed out waiting for the LTPA keys to be created");
+            Log.error(c, "waitForLTPAKeysCreated", rx);
+            if(!suppressException) {
+                throw rx;
+            }
+        }
+        return ltpaKeysCreated;
+    }
+
+    /**
+     * Some tests want to ensure LTPA keys have been created and that the config has been completed
+     *
+     * @return
+     * @throws Exception
+     */
+    public String waitForLTPAKeysCreatedandConfigComplete() throws Exception {
+        return waitForLTPAKeysCreatedAndConfigComplete(LOG_SEARCH_TIMEOUT);
+    }
+
+    /**
+     * Some tests want to ensure both LTPA Keys have been created and Config has been completed
+     *
+     * Method uses the a mark if one has been made
+     *
+     * @param timeout, timeout applied to each check, a timeout of 60000, is a total of 1000
+     * @return the result of waitForLTPAConfigReady, as keys must be created before Config can be ready
+     * @throws Exception if messages aren't found in logs then a runtime exception is thrown
+     */
+    public String waitForLTPAKeysCreatedAndConfigComplete(int timeout) throws Exception {
+        return waitForLTPAKeysCreatedAndConfigComplete(timeout, false);
+    }
+
+    /**
+     * Some tests want to ensure both LTPA Keys have been created and Config has been completed
+     *
+     * Method uses the a mark if one has been made
+     *
+     * @param suppressException, whether to suppress the runtime exception, should only be supplied if asserting on the result.
+     * @return the result of waitForLTPAConfigReady, as keys must be created before Config can be ready
+     * @throws Exception if messages aren't found in logs then a runtime exception is thrown
+     */
+    public String waitForLTPAKeysCreatedAndConfigComplete(boolean suppressException) throws Exception {
+        return waitForLTPAKeysCreatedAndConfigComplete(LOG_SEARCH_TIMEOUT, suppressException);
+    }
+
+    /**
+     * Some tests want to ensure both LTPA Keys have been created and Config has been completed
+     *
+     * Method uses the a mark if one has been made
+     * @param timeout how long to wait for each check, 1000ms has a total timeout of 2000ms
+     * @param suppressException whether to suppress the runtime exception, should only be supplied if asserting on the result.
+     * @return the result of waitForLTPAConfigReady, as keys must be created before Config can be ready
+     * @throws Exception if messages aren't found in logs then a runtime exception is thrown
+     */
+    public String waitForLTPAKeysCreatedAndConfigComplete(int timeout, boolean suppressException) throws Exception {
+        waitForLTPAKeysCreated(timeout, suppressException);
+        return waitForLTPAConfigReady(timeout, suppressException);
     }
 
     /**
@@ -1703,9 +1987,9 @@ public class LibertyServer implements LogMonitorClient {
             // Check if "websphere.java.security" has been added to bootstrapping.properties
             // as some tests will add it for their own security enable tests
             RemoteFile f = getServerBootstrapPropertiesFile();
-            java.io.BufferedReader reader = null;
+            BufferedReader reader = null;
             try {
-                reader = new java.io.BufferedReader(new java.io.InputStreamReader(f.openForReading()));
+                reader = new BufferedReader(new InputStreamReader(f.openForReading()));
                 String line = reader.readLine();
                 while (line != null) {
                     if (line != null && line.trim().equals("websphere.java.security")) {
@@ -2361,7 +2645,7 @@ public class LibertyServer implements LogMonitorClient {
     }
 
     private void addJava2SecurityPropertiesToBootstrapFile(RemoteFile f, boolean debug) throws Exception {
-        java.io.OutputStream w = f.openForWriting(true);
+        OutputStream w = f.openForWriting(true);
         try {
             w.write("\n".getBytes());
             w.write("websphere.java.security".getBytes());
@@ -2543,7 +2827,7 @@ public class LibertyServer implements LogMonitorClient {
 
             }
             String exceptionText = "Failures occured while waiting for app" + plural + " to start:";
-            for (Map.Entry<String, List<String>> entry : failedApps.entrySet()) {
+            for (Entry<String, List<String>> entry : failedApps.entrySet()) {
                 for (String failure : entry.getValue()) {
                     String text;
                     if (entry.getKey().equals("*")) {
@@ -2863,7 +3147,7 @@ public class LibertyServer implements LogMonitorClient {
     protected static String findAppNameInTokens(Map<String, Pattern> unstartedApps, String[] tokens) {
         final String method = "findAppNameInTokens";
 
-        for (Map.Entry<String, Pattern> entry : unstartedApps.entrySet()) {
+        for (Entry<String, Pattern> entry : unstartedApps.entrySet()) {
             Log.finer(c, method, "looking for app " + entry.getKey() + " in " + tokens[1]);
             if (entry.getValue().matcher(tokens[1]).matches()) {
                 Log.finer(c, method, "matched app " + entry.getKey());
@@ -2922,7 +3206,7 @@ public class LibertyServer implements LogMonitorClient {
                 //since this is going to connect to the secure port, that needs to be ready
                 //before an attempt to make the JMX connection
                 Log.info(c, method, "Checking that the JMX RestConnector is available and secured");
-                assertNotNull("CWWKO0219I.*ssl not received", waitForStringInLogUsingMark("CWWKO0219I.*ssl"));
+                assertNotNull("CWWKO0219I.*ssl not received",waitForDefaultHTTPEndpointSSLStart());
 
                 assertNotNull("IBMJMXConnectorREST app did not report as ready", waitForStringInLogUsingMark("CWWKT0016I.*IBMJMXConnectorREST"));
 
@@ -3630,7 +3914,7 @@ public class LibertyServer implements LogMonitorClient {
 
                     if (unexpectedFeatures.size() > 0) {
                         String message = "Runtime features were not of the expected version for repeat action (Server: " + serverName + ", Action: " + action.getID() + ").\n";
-                        for (Map.Entry<String, String> entry : unexpectedFeatures.entrySet()) {
+                        for (Entry<String, String> entry : unexpectedFeatures.entrySet()) {
                             message = message + "Expected: " + entry.getKey() + ", Actual: " + entry.getValue() + ".\n";
                         }
                         message = message
@@ -5291,7 +5575,7 @@ public class LibertyServer implements LogMonitorClient {
     public void setJvmOptions(Map<String, String> options) throws Exception {
         ArrayList<String> optionList = new ArrayList<String>();
         if (options != null) {
-            for (Map.Entry<String, String> entry : options.entrySet()) {
+            for (Entry<String, String> entry : options.entrySet()) {
                 String key = entry.getKey();
                 if (key == null) {
                     continue;
@@ -6282,7 +6566,7 @@ public class LibertyServer implements LogMonitorClient {
                     if (line.contains(name))
                         counters.put(name, counters.get(name) + (line.contains("009I: ") ? -1 : 1));
 
-            for (Map.Entry<String, Integer> entry : counters.entrySet())
+            for (Entry<String, Integer> entry : counters.entrySet())
                 if (entry.getValue() > 0)
                     subset.add(entry.getKey());
         }
@@ -6773,7 +7057,7 @@ public class LibertyServer implements LogMonitorClient {
      * The offset is incremented every time this method is called.
      *
      * @param  regexp     a regular expression to search for
-     * @param  timeout    a timeout, in milliseconds
+     * @param  intendedTimeout    a timeout, in milliseconds
      * @param  outputFile file to check
      * @return            line that matched the regexp
      */
@@ -6843,7 +7127,7 @@ public class LibertyServer implements LogMonitorClient {
      * The offset is also incremented every time this method is called.
      *
      * @param  regexp     a regular expression to search for
-     * @param  timeout    a timeout, in milliseconds
+     * @param  intendedTimeout    a timeout, in milliseconds
      * @param  outputFile file to check
      * @return            line that matched the regexp
      */

--- a/dev/io.openliberty.checkpoint_fat/fat/src/io/openliberty/checkpoint/fat/AppsecurityTest.java
+++ b/dev/io.openliberty.checkpoint_fat/fat/src/io/openliberty/checkpoint/fat/AppsecurityTest.java
@@ -80,8 +80,6 @@ public class AppsecurityTest extends FATServletClient {
 
     private static final String APP_NAME = "appsecurity";
 
-    private static final String TCP_CHANNEL_STARTED = "CWWKO0219I:.*defaultHttpEndpoint-ssl";
-
     private TestMethod testMethod;
 
     @ClassRule
@@ -114,7 +112,7 @@ public class AppsecurityTest extends FATServletClient {
                                  configureBeforeRestore();
                              });
         server.startServer(getTestMethodNameOnly(testName) + ".log");
-        assertNotNull("Expected CWWKO0219I message not found", server.waitForStringInLog(TCP_CHANNEL_STARTED));
+        assertNotNull("Expected CWWKO0219I message not found", server.waitForDefaultHTTPEndpointSSLStart());
     }
 
     private void configureBeforeRestore() {

--- a/dev/io.openliberty.checkpoint_fat/fat/src/io/openliberty/checkpoint/fat/RestConnectorTest.java
+++ b/dev/io.openliberty.checkpoint_fat/fat/src/io/openliberty/checkpoint/fat/RestConnectorTest.java
@@ -70,9 +70,9 @@ public class RestConnectorTest extends FATServletClient {
     public void testBasicRegistryConfigUpdate() throws Exception {
         server.checkpointRestore();
         assertNotNull(server.waitForStringInLog("CWWKS0008I")); // CWWKS0008I: The security service is ready.
-        assertNotNull(server.waitForStringInLog("CWWKS4105I")); // CWWKS4105I: LTPA configuration is ready after # seconds.
+        assertNotNull(server.waitForLTPAConfigReady(true)); // CWWKS4105I: LTPA configuration is ready after # seconds.
         assertNotNull(server.waitForStringInLog("CWPKI0803A")); // CWPKI0803A: SSL certificate created in # seconds. SSL key file: ...
-        assertNotNull(server.waitForStringInLog("CWWKO0219I:.*defaultHttpEndpoint-ssl")); // CWWKO0219I: TCP Channel defaultHttpEndpoint-ssl has been started and is now listening for requests on host *  (IPv6) port 8020.
+        assertNotNull(server.waitForDefaultHTTPEndpointSSLStart(true)); // CWWKO0219I: TCP Channel defaultHttpEndpoint-ssl has been started and is now listening for requests on host *  (IPv6) port 8020.
 
         JsonArray json = createHttpsRequestWithAdminUser(server, "/ibm/api/config").run(JsonArray.class);
         int count = json.size();
@@ -104,7 +104,7 @@ public class RestConnectorTest extends FATServletClient {
     @Test
     public void testDataSourceConfigUpdate() throws Exception {
         server.checkpointRestore();
-        assertNotNull(server.waitForStringInLog("CWWKO0219I:.*defaultHttpEndpoint-ssl")); // CWWKO0219I: TCP Channel defaultHttpEndpoint-ssl has been started and is now listening for requests on host *  (IPv6) port 8020.
+        assertNotNull(server.waitForDefaultHTTPEndpointSSLStart(true)); // CWWKO0219I: TCP Channel defaultHttpEndpoint-ssl has been started and is now listening for requests on host *  (IPv6) port 8020.
 
         JsonArray json = createHttpsRequestWithAdminUser(server, "/ibm/api/config/dataSource").run(JsonArray.class);
         assertEquals("unexpected response: " + json, 1, json.size());

--- a/dev/io.openliberty.checkpoint_fat/fat/src/io/openliberty/checkpoint/fat/SSLTest.java
+++ b/dev/io.openliberty.checkpoint_fat/fat/src/io/openliberty/checkpoint/fat/SSLTest.java
@@ -79,7 +79,6 @@ public class SSLTest {
     private static final Class<?> c = SSLTest.class;
     private final String APP_NAME = "app2";
     private final String KEYSTORE_GENERATED = "CWPKI0803A";
-    private final String TCP_CHANNEL_STARTED = "CWWKO0219I:.*defaultHttpEndpoint-ssl";
     public TestMethod testMethod;
 
     @ClassRule
@@ -301,7 +300,7 @@ public class SSLTest {
         final String tsPath = null;
         final String tsPassword = null;
 
-        assertNotNull("Ecpected CWWKO0219I message not found", server.waitForStringInLog(TCP_CHANNEL_STARTED));
+        server.waitForDefaultHTTPEndpointSSLStart();
 
         String result = sendHttpsGet("app2/request", server, ksPath, ksPassword, tsPath, tsPassword);
         assertNotNull(result);
@@ -318,7 +317,7 @@ public class SSLTest {
         final String tsPath = null;
         final String tsPassword = null;
 
-        assertNotNull("Ecpected CWWKO0219I message not found", server.waitForStringInLog(TCP_CHANNEL_STARTED));
+        server.waitForDefaultHTTPEndpointSSLStart();
 
         String result = sendHttpsGet("app2/request", server, ksPath, ksPassword, tsPath, tsPassword);
         assertNotNull(result);
@@ -336,7 +335,7 @@ public class SSLTest {
         final String tsPath = null;
         final String tsPassword = null;
 
-        assertNotNull("Ecpected CWWKO0219I message not found", server.waitForStringInLog(TCP_CHANNEL_STARTED));
+        server.waitForDefaultHTTPEndpointSSLStart();
 
         String result = sendHttpsGet("app2/request", server, ksPath, ksPassword, tsPath, tsPassword);
         assertNotNull(result);
@@ -352,7 +351,7 @@ public class SSLTest {
         final String ksPassword = "secret";
         final String tsPassword = "secret";
 
-        assertNotNull("Ecpected CWWKO0219I message not found", server.waitForStringInLog(TCP_CHANNEL_STARTED));
+        server.waitForDefaultHTTPEndpointSSLStart();
 
         String result = sendHttpsGet("app2/request", server, ksPath, ksPassword, tsPath, tsPassword);
         assertNotNull(result);

--- a/dev/io.openliberty.checkpoint_fat_mp/fat/src/io/openliberty/checkpoint/fat/mp/MPJWTTest.java
+++ b/dev/io.openliberty.checkpoint_fat_mp/fat/src/io/openliberty/checkpoint/fat/mp/MPJWTTest.java
@@ -120,7 +120,7 @@ public class MPJWTTest extends FATServletClient {
             server.checkpointRestore();
 
             // wait on LTPA to be available to avoid error "CWWKS4000E: ... The requested TokenService instance of type Ltpa2 could not be found."
-            assertNotNull("'CWWKS4105I: LTPA configuration is ready' message not found.", server.waitForStringInLog("CWWKS4105I.*"));
+            assertNotNull("'CWWKS4105I: LTPA configuration is ready' message not found.", server.waitForLTPAConfigReady(true));
 
             Response response = makeRequest(urlRoles, authHeaderAdmin);
             assertEquals("Incorrect response code from " + urlRoles, 200, response.getStatus());
@@ -142,7 +142,7 @@ public class MPJWTTest extends FATServletClient {
             server.checkpointRestore();
 
             // wait on LTPA to be available to avoid error "CWWKS4000E: ... The requested TokenService instance of type Ltpa2 could not be found."
-            assertNotNull("'CWWKS4105I: LTPA configuration is ready' message not found.", server.waitForStringInLog("CWWKS4105I.*"));
+            assertNotNull("'CWWKS4105I: LTPA configuration is ready' message not found.", server.waitForLTPAConfigReady(true));
 
             Response response = makeRequest(urlUsername, authHeaderUser);
             assertEquals("Incorrect response code from " + urlUsername, 200, response.getStatus());
@@ -179,7 +179,7 @@ public class MPJWTTest extends FATServletClient {
             server.checkpointRestore();
 
             // wait on LTPA to be available to avoid error "CWWKS4000E: ... The requested TokenService instance of type Ltpa2 could not be found."
-            assertNotNull("'CWWKS4105I: LTPA configuration is ready' message not found.", server.waitForStringInLog("CWWKS4105I.*"));
+            assertNotNull("'CWWKS4105I: LTPA configuration is ready' message not found.", server.waitForLTPAConfigReady(true));
 
             Response response = makeRequest(urlUsername, authHeaderUser);
             assertEquals("Incorrect response code from " + urlUsername, 200, response.getStatus());

--- a/dev/io.openliberty.checkpoint_fat_mp/fat/src/io/openliberty/checkpoint/fat/mp/MPMetricsTest.java
+++ b/dev/io.openliberty.checkpoint_fat_mp/fat/src/io/openliberty/checkpoint/fat/mp/MPMetricsTest.java
@@ -67,7 +67,7 @@ public class MPMetricsTest extends FATServletClient {
     @Test
     public void testMetricsEndpoint() throws Exception {
         server.checkpointRestore();
-        assertNotNull("TCP Channel defaultHttpEndpoint-ssl has not started", server.waitForStringInLog("CWWKO0219I.*defaultHttpEndpoint-ssl"));
+        server.waitForDefaultHTTPEndpointSSLStart();
 
         //server.xml has mpMetrics authentication set to true. So /metrics shouldn't be available on http port.
         assertEquals("Expected response code not found", HttpURLConnection.HTTP_NOT_FOUND,

--- a/dev/io.openliberty.checkpoint_fat_security_oidc_social/fat/src/io/openliberty/checkpoint/fat/security/jaspic/JASPIBasicAuthenticationTest.java
+++ b/dev/io.openliberty.checkpoint_fat_security_oidc_social/fat/src/io/openliberty/checkpoint/fat/security/jaspic/JASPIBasicAuthenticationTest.java
@@ -80,8 +80,6 @@ public class JASPIBasicAuthenticationTest extends JASPITestBase {
 
     private DefaultHttpClient httpclient;
 
-    private static final String TCP_CHANNEL_STARTED = "CWWKO0219I:.*defaultHttpEndpoint-ssl";
-
     @ClassRule
     public static RepeatTests r = RepeatTests.withoutModification()
                     .andWith(FeatureReplacementAction.EE9_FEATURES()
@@ -117,7 +115,7 @@ public class JASPIBasicAuthenticationTest extends JASPITestBase {
 
         server.setCheckpoint(CheckpointPhase.AFTER_APP_START);
         server.startServer();
-        assertNotNull("Expected CWWKO0219I message not found", server.waitForStringInLog(TCP_CHANNEL_STARTED));
+        server.waitForDefaultHTTPEndpointSSLStart();
         server.addInstalledAppForValidation(DEFAULT_APP);
         verifyServerStartedWithJaspiFeature(server);
         urlBase = "http://" + server.getHostname() + ":" + server.getHttpDefaultPort();

--- a/dev/io.openliberty.checkpoint_fat_security_oidc_social/fat/src/io/openliberty/checkpoint/fat/security/oidc/OidcClientBasicTests.java
+++ b/dev/io.openliberty.checkpoint_fat_security_oidc_social/fat/src/io/openliberty/checkpoint/fat/security/oidc/OidcClientBasicTests.java
@@ -53,7 +53,6 @@ public class OidcClientBasicTests extends CommonTest {
 
     private static final String[] test_GOOD_LOGIN_ACTIONS = Constants.GOOD_OIDC_LOGIN_ACTIONS_SKIP_CONSENT;
     private static final String test_FinalAction = Constants.LOGIN_USER;
-    private static final String TCP_CHANNEL_STARTED = "CWWKO0219I:.*defaultHttpEndpoint-ssl";
 
     public TestMethod testMethod;
 
@@ -110,7 +109,7 @@ public class OidcClientBasicTests extends CommonTest {
         rpServer.startServer(testMethod + ".log");
         rpServer.checkpointRestore();
 
-        assertNotNull("Expected CWWKO0219I message not found", rpServer.waitForStringInLog(TCP_CHANNEL_STARTED));
+        rpServer.waitForDefaultHTTPEndpointSSLStart();
 
         testSettings.setFlowType(Constants.RP_FLOW);
     }

--- a/dev/io.openliberty.checkpoint_fat_xmlws/fat/src/io/openliberty/checkpoint/jaxws/fat/LibertyCXFPositivePropertiesTest.java
+++ b/dev/io.openliberty.checkpoint_fat_xmlws/fat/src/io/openliberty/checkpoint/jaxws/fat/LibertyCXFPositivePropertiesTest.java
@@ -127,7 +127,7 @@ public class LibertyCXFPositivePropertiesTest {
 
         server.waitForStringInLog("CWWKF0011I");
 
-        assertNotNull("SSL service needs to be started for tests, but the HTTPS was never started", server.waitForStringInLog("CWWKO0219I.*ssl"));
+        server.waitForDefaultHTTPEndpointSSLStart();
     }
 
     @AfterClass

--- a/dev/io.openliberty.http.monitor_fat/fat/src/io/openliberty/http/monitor/fat/JSFApplicationTest.java
+++ b/dev/io.openliberty.http.monitor_fat/fat/src/io/openliberty/http/monitor/fat/JSFApplicationTest.java
@@ -63,7 +63,7 @@ public class JSFApplicationTest extends BaseTestClass {
                                              DeployOptions.SERVER_ONLY);
 
         server.startServer();
-        server.waitForSSLStart();
+        server.waitForDefaultHTTPEndpointSSLStart();
 
         //Read to run a smarter planet
         server.waitForStringInLogUsingMark("CWWKF0011I");

--- a/dev/io.openliberty.http.monitor_fat/fat/src/io/openliberty/http/monitor/fat/JSPApplicationTest.java
+++ b/dev/io.openliberty.http.monitor_fat/fat/src/io/openliberty/http/monitor/fat/JSPApplicationTest.java
@@ -60,7 +60,7 @@ public class JSPApplicationTest extends BaseTestClass {
                                              DeployOptions.SERVER_ONLY);
 
         server.startServer();
-        server.waitForSSLStart();
+        server.waitForDefaultHTTPEndpointSSLStart();
 
         //Read to run a smarter planet
         server.waitForStringInLogUsingMark("CWWKF0011I");

--- a/dev/io.openliberty.http.monitor_fat/fat/src/io/openliberty/http/monitor/fat/NoAppTest.java
+++ b/dev/io.openliberty.http.monitor_fat/fat/src/io/openliberty/http/monitor/fat/NoAppTest.java
@@ -55,7 +55,7 @@ public class NoAppTest extends BaseTestClass {
                                              DeployOptions.SERVER_ONLY);
 
         server.startServer();
-        server.waitForSSLStart();
+        server.waitForDefaultHTTPEndpointSSLStart();
 
         //Read to run a smarter planet
         server.waitForStringInLogUsingMark("CWWKF0011I");

--- a/dev/io.openliberty.http.monitor_fat/fat/src/io/openliberty/http/monitor/fat/RestApplicationTest.java
+++ b/dev/io.openliberty.http.monitor_fat/fat/src/io/openliberty/http/monitor/fat/RestApplicationTest.java
@@ -60,7 +60,7 @@ public class RestApplicationTest extends BaseTestClass {
                                              DeployOptions.SERVER_ONLY);
 
         server.startServer();
-        server.waitForSSLStart();
+        server.waitForDefaultHTTPEndpointSSLStart();
 
         //Read to run a smarter planet
         server.waitForStringInLogUsingMark("CWWKF0011I");

--- a/dev/io.openliberty.http.monitor_fat/fat/src/io/openliberty/http/monitor/fat/ServletApplicationTest.java
+++ b/dev/io.openliberty.http.monitor_fat/fat/src/io/openliberty/http/monitor/fat/ServletApplicationTest.java
@@ -64,7 +64,7 @@ public class ServletApplicationTest extends BaseTestClass {
         ShrinkHelper.exportDropinAppToServer(server, wildCardServletWAR, DeployOptions.SERVER_ONLY);
 
         server.startServer();
-        server.waitForSSLStart();
+        server.waitForDefaultHTTPEndpointSSLStart();
 
         //Read to run a smarter planet
         server.waitForStringInLogUsingMark("CWWKF0011I");

--- a/dev/io.openliberty.jakartaee10.internal_fat/fat/src/io/openliberty/jakartaee10/internal/tests/JakartaEE10Test.java
+++ b/dev/io.openliberty.jakartaee10.internal_fat/fat/src/io/openliberty/jakartaee10/internal/tests/JakartaEE10Test.java
@@ -152,7 +152,7 @@ public class JakartaEE10Test extends FATServletClient {
             server.setServerStartTimeout(15 * 60 * 1000L); // 15 minutes
         }
         server.startServer(consoleName + ".log");
-        server.waitForSSLStart();
+        server.waitForDefaultHTTPEndpointSSLStart();
     }
 
     @AfterClass

--- a/dev/io.openliberty.jakartaee11.internal_fat/fat/src/io/openliberty/jakartaee11/internal/tests/JakartaEE11Test.java
+++ b/dev/io.openliberty.jakartaee11.internal_fat/fat/src/io/openliberty/jakartaee11/internal/tests/JakartaEE11Test.java
@@ -124,7 +124,7 @@ public class JakartaEE11Test extends FATServletClient {
             server.setServerStartTimeout(15 * 60 * 1000L); // 15 min
         }
         server.startServer(consoleName + ".log");
-        server.waitForSSLStart();
+        server.waitForDefaultHTTPEndpointSSLStart();
     }
 
     @AfterClass

--- a/dev/io.openliberty.jakartaee9.internal_fat/fat/src/io/openliberty/jakartaee9/internal/tests/JakartaEE9Test.java
+++ b/dev/io.openliberty.jakartaee9.internal_fat/fat/src/io/openliberty/jakartaee9/internal/tests/JakartaEE9Test.java
@@ -147,7 +147,7 @@ public class JakartaEE9Test extends FATServletClient {
             server.setServerStartTimeout(15 * 60 * 1000L); // 15 MIN
         }
         server.startServer(consoleName + ".log");
-        server.waitForSSLStart();
+        server.waitForDefaultHTTPEndpointSSLStart();
     }
 
     @AfterClass

--- a/dev/io.openliberty.jaxws.global.handler.internal_fat/fat/src/com/ibm/ws/webservices/handler/fat/AbstractJaxWsTransportSecurityTest.java
+++ b/dev/io.openliberty.jaxws.global.handler.internal_fat/fat/src/com/ibm/ws/webservices/handler/fat/AbstractJaxWsTransportSecurityTest.java
@@ -273,7 +273,7 @@ abstract public class AbstractJaxWsTransportSecurityTest {
                 // Current configuration has SSL feature, check if the ssl port is opened
                 if (SERVER_CONFIG_WITH_SSL.contains(newServerConfigFile)) {
                     Log.info(AbstractJaxWsTransportSecurityTest.class, "updateServerConfigFile", "Wait for ssl port open.");
-                    isFound = null != server.waitForStringInLogUsingMark("CWWKO0219I:.*-ssl");
+                    isFound = null != server.waitForDefaultHTTPEndpointSSLStart(true);
                 }
             } else if (!newServerConfigFile.equals(lastServerConfig)) {// The last server config file is not the same as the current one
                 Log.info(AbstractJaxWsTransportSecurityTest.class, "updateServerConfigFile", "old: -" + lastServerConfig + "-, new: -" + newServerConfigFile + "-");
@@ -285,7 +285,7 @@ abstract public class AbstractJaxWsTransportSecurityTest {
                 // Current configuration has SSL feature, but last configuration has no SSL feature, should check if the ssl port is opened.
                 if (SERVER_CONFIG_WITH_SSL.contains(newServerConfigFile) && SERVER_CONFIG_WITHOUT_SSL.contains(lastServerConfig)) {
                     Log.info(AbstractJaxWsTransportSecurityTest.class, "updateServerConfigFile", "Wait for ssl port open.");
-                    isFound = null != server.waitForStringInLogUsingMark("CWWKO0219I:.*-ssl");
+                    isFound = null != server.waitForDefaultHTTPEndpointSSLStart(true);
                 }
             }
 

--- a/dev/io.openliberty.jaxws.global.handler.internal_fat/fat/src/com/ibm/ws/webservices/handler/fat/EJBHandlerTest.java
+++ b/dev/io.openliberty.jaxws.global.handler.internal_fat/fat/src/com/ibm/ws/webservices/handler/fat/EJBHandlerTest.java
@@ -79,7 +79,7 @@ public class EJBHandlerTest {
         //EJBHandler does not require app security things, the feature is just added there to make sure, our functions could work
         //with security enabled.
         Assert.assertNotNull("LTPA keys in not created",
-                             server.waitForStringInLog("CWWKS4104A.*LTPA"));
+                             server.waitForLTPAKeysCreated());
 
         CLIENT_HANDLER_ENDPOINT_URL = "http://" + server.getHostname() + ":" + server.getHttpDefaultPort() + "/EJBHandler/EJBHandlerClientBeanService";
 

--- a/dev/io.openliberty.jaxws.global.handler.internal_fat/fat/src/com/ibm/ws/webservices/handler/fat/TransportSecurityUsingDispatchClientCertTest.java
+++ b/dev/io.openliberty.jaxws.global.handler.internal_fat/fat/src/com/ibm/ws/webservices/handler/fat/TransportSecurityUsingDispatchClientCertTest.java
@@ -48,7 +48,7 @@ public class TransportSecurityUsingDispatchClientCertTest extends AbstractJaxWsT
 
         server.startServer("TransportSecurityUsingDispatchClientCertTest.log");
 
-        assertNotNull("Wait for the SSL port to open", server.waitForStringInLog("CWWKO0219I:.*-ssl"));
+        server.waitForDefaultHTTPEndpointSSLStart();
         server.setMarkToEndOfLog();
     }
 

--- a/dev/io.openliberty.jaxws.security_fat.1/fat/src/com/ibm/ws/jaxws/security/fat/AbstractJaxWsTransportSecurityTest.java
+++ b/dev/io.openliberty.jaxws.security_fat.1/fat/src/com/ibm/ws/jaxws/security/fat/AbstractJaxWsTransportSecurityTest.java
@@ -112,7 +112,7 @@ abstract public class AbstractJaxWsTransportSecurityTest extends AbstractJaxWsTr
                 if (SERVER_CONFIG_WITHOUT_SSL.contains(lastServerConfig)) {
                     Log.info(AbstractJaxWsTransportSecurityTest.class, "updateServerConfigFile",
                              "Wait for ssl port open.");
-                    isFound = null != server.waitForStringInLogUsingMark("CWWKO0219I:.*-ssl");
+                    isFound = null != server.waitForDefaultHTTPEndpointSSLStart(true);
                 }
             }
 

--- a/dev/io.openliberty.jaxws.security_fat.1/fat/src/com/ibm/ws/jaxws/security/fat/ClientCertificateTest.java
+++ b/dev/io.openliberty.jaxws.security_fat.1/fat/src/com/ibm/ws/jaxws/security/fat/ClientCertificateTest.java
@@ -125,7 +125,7 @@ public class ClientCertificateTest extends AbstractJaxWsTransportSecurityTest {
                                                                    new RequestParams("employee", "stateless", SCHEMA, SECURE_PORT, "/employee/employStatelessService", "From other bean: Hello, employee from SayHelloStatelessService"),
                                                                    new RequestParams("employee", "singleton", SCHEMA, SECURE_PORT, "/employee/employSingletonService", "From other bean: Hello, employee from SayHelloSingletonService")));
 
-        assertNotNull("Wait for the SSL port to open", server.waitForStringInLog("CWWKO0219I:.*-ssl"));
+        server.waitForDefaultHTTPEndpointSSLStart();
 
         runTest(params, null);
     }
@@ -142,7 +142,7 @@ public class ClientCertificateTest extends AbstractJaxWsTransportSecurityTest {
                                                                    new RequestParams("employee", "stateless", SCHEMA, SECURE_PORT, "/employee/employStatelessService", "CWPKI0023E"),
                                                                    new RequestParams("employee", "singleton", SCHEMA, SECURE_PORT, "/employee/employSingletonService", "CWPKI0023E")));
 
-        assertNotNull("Wait for the SSL port to open", server.waitForStringInLog("CWWKO0219I:.*-ssl"));
+        server.waitForDefaultHTTPEndpointSSLStart();
 
         runTest(params, INEXISTENT_ALIAS_SERVER_INFO);
     }
@@ -156,7 +156,7 @@ public class ClientCertificateTest extends AbstractJaxWsTransportSecurityTest {
 
         List<RequestParams> params = new ArrayList<>(Arrays.asList(new RequestParams("employee", "pojo", SCHEMA, SECURE_PORT, "/manager/employPojoService", "403")));
 
-        assertNotNull("Wait for the SSL port to open", server.waitForStringInLog("CWWKO0219I:.*-ssl"));
+        server.waitForDefaultHTTPEndpointSSLStart();
 
         runTest(params, NOT_AUTHORIZED_SERVER_INFO);
     }
@@ -171,7 +171,7 @@ public class ClientCertificateTest extends AbstractJaxWsTransportSecurityTest {
                                                                    new RequestParams("manager", "stateless", SCHEMA, SECURE_PORT, "/manager/employStatelessService", "From other bean: Hello, manager from SayHelloStatelessService"),
                                                                    new RequestParams("manager", "singleton", SCHEMA, SECURE_PORT, "/manager/employSingletonService", "From other bean: Hello, manager from SayHelloSingletonService")));
 
-        assertNotNull("Wait for the SSL port to open", server.waitForStringInLog("CWWKO0219I:.*-ssl"));
+        server.waitForDefaultHTTPEndpointSSLStart();
 
         runTest(params, null);
     }
@@ -195,7 +195,7 @@ public class ClientCertificateTest extends AbstractJaxWsTransportSecurityTest {
                                                                    new RequestParams("manager", "stateless", SCHEMA, SECURE_PORT, "/manager/employStatelessService", "Could not send Message"),
                                                                    new RequestParams("employee", "singleton", SCHEMA, SECURE_PORT, "/employee/employSingletonService", "Could not send Message")));
 
-        assertNotNull("Wait for the SSL port to open", server.waitForStringInLog("CWWKO0219I:.*-ssl"));
+        server.waitForDefaultHTTPEndpointSSLStart();
 
         runTest(params, CERT_NOT_TRUST_SERVER_INFO);
         } else {
@@ -219,7 +219,7 @@ public class ClientCertificateTest extends AbstractJaxWsTransportSecurityTest {
 
                                                                    new RequestParams("employee", "singleton", SCHEMA, SECURE_PORT, "/employee/employSingletonService", "From other bean: Hello, employee from SayHelloSingletonService")));
 
-        assertNotNull("Wait for the SSL port to open", server.waitForStringInLog("CWWKO0219I:.*-ssl"));
+        server.waitForDefaultHTTPEndpointSSLStart();
 
         runTest(params, null);
 
@@ -270,7 +270,7 @@ public class ClientCertificateTest extends AbstractJaxWsTransportSecurityTest {
                                                                    new RequestParams("employee", "stateless", SCHEMA, SECURE_PORT, "/manager/employStatelessService", "403"),
                                                                    new RequestParams("employee", "singleton", SCHEMA, SECURE_PORT, "/manager/employSingletonService", "403")));
 
-        assertNotNull("Wait for the SSL port to open", server.waitForStringInLog("CWWKO0219I:.*-ssl"));
+        server.waitForDefaultHTTPEndpointSSLStart();
 
         runTest(params, NOT_AUTHORIZED_SERVER_INFO);
     }
@@ -287,7 +287,7 @@ public class ClientCertificateTest extends AbstractJaxWsTransportSecurityTest {
                                                                    new RequestParams("employee", "stateless", SCHEMA, SECURE_PORT, "/employee/employStatelessService", "disableCNCheck"),
                                                                    new RequestParams("employee", "singleton", SCHEMA, SECURE_PORT, "/employee/employSingletonService", "disableCNCheck")));
 
-        assertNotNull("Wait for the SSL port to open", server.waitForStringInLog("CWWKO0219I:.*-ssl"));
+        server.waitForDefaultHTTPEndpointSSLStart();
 
         runTest(params, null);
     }
@@ -303,7 +303,7 @@ public class ClientCertificateTest extends AbstractJaxWsTransportSecurityTest {
                                                                    new RequestParams("employee", TestMode.DISPATCH, "stateless", SCHEMA, SECURE_PORT, "/employee/employStatelessService", "From other bean: Hello, employee from SayHelloStatelessService"),
                                                                    new RequestParams("employee", TestMode.DISPATCH, "singleton", SCHEMA, SECURE_PORT, "/employee/employSingletonService", "From other bean: Hello, employee from SayHelloSingletonService")));
 
-        assertNotNull("Wait for the SSL port to open", server.waitForStringInLog("CWWKO0219I:.*-ssl"));
+        server.waitForDefaultHTTPEndpointSSLStart();
 
         runTest(params, null);
         checkAppUpdate = false;
@@ -335,7 +335,7 @@ public class ClientCertificateTest extends AbstractJaxWsTransportSecurityTest {
                                                                    new RequestParams("employee", TestMode.DISPATCH, "stateless", SCHEMA, SECURE_PORT, "/employee/employStatelessService", "From other bean: Hello, employee from SayHelloStatelessService"),
                                                                    new RequestParams("employee", TestMode.DISPATCH, "singleton", SCHEMA, SECURE_PORT, "/employee/employSingletonService", "From other bean: Hello, employee from SayHelloSingletonService")));
 
-        assertNotNull("Wait for the SSL port to open", server.waitForStringInLog("CWWKO0219I:.*-ssl"));
+        server.waitForDefaultHTTPEndpointSSLStart();
 
         runTest(params, null);
         checkAppUpdate = false;
@@ -352,7 +352,7 @@ public class ClientCertificateTest extends AbstractJaxWsTransportSecurityTest {
                                                                    new RequestParams("employee", TestMode.DISPATCH, "stateless", SCHEMA, SECURE_PORT, "/unauthorized/employStatelessService", "From other bean: Hello, employee from SayHelloStatelessService"),
                                                                    new RequestParams("employee", TestMode.DISPATCH, "singleton", SCHEMA, SECURE_PORT, "/unauthorized/employSingletonService", "From other bean: Hello, employee from SayHelloSingletonService")));
 
-        assertNotNull("Wait for the SSL port to open", server.waitForStringInLog("CWWKO0219I:.*-ssl"));
+        server.waitForDefaultHTTPEndpointSSLStart();
 
         runTest(params, null);
     }

--- a/dev/io.openliberty.jaxws.security_fat.ssl/fat/src/com/ibm/ws/jaxws/security/fat/AbstractJaxWsTransportSecuritySSLTest.java
+++ b/dev/io.openliberty.jaxws.security_fat.ssl/fat/src/com/ibm/ws/jaxws/security/fat/AbstractJaxWsTransportSecuritySSLTest.java
@@ -60,7 +60,7 @@ abstract public class AbstractJaxWsTransportSecuritySSLTest extends AbstractJaxW
             server.waitForStringInLog("CWWKZ0001I.*TransportSecurityProvider");
             server.waitForStringInLog("CWWKZ0001I.*TransportSecurityClient");
             if (SERVER_CONFIG_WITH_SSL.contains(serverConfigFile)) {
-                server.waitForStringInLog("CWWKO0219I:.*-ssl");
+                server.waitForDefaultHTTPEndpointSSLStart();
             }
         }
     }
@@ -114,7 +114,7 @@ abstract public class AbstractJaxWsTransportSecuritySSLTest extends AbstractJaxW
                 if (SERVER_CONFIG_WITH_SSL.contains(newServerConfigFile)) {
                     Log.info(AbstractJaxWsTransportSecuritySSLTest.class, "updateServerConfigFile",
                              "Wait for ssl port open.");
-                    isFound = null != server.waitForStringInLogUsingMark("CWWKO0219I:.*-ssl");
+                    isFound = null != server.waitForDefaultHTTPEndpointSSLStart(true);
                 }
             } else if (!newServerConfigFile.equals(lastServerConfig)) {// The last server config file is not the same as
                                                                        // the current one
@@ -133,7 +133,7 @@ abstract public class AbstractJaxWsTransportSecuritySSLTest extends AbstractJaxW
                 if (SERVER_CONFIG_WITH_SSL.contains(newServerConfigFile)) {
                     Log.info(AbstractJaxWsTransportSecuritySSLTest.class, "updateServerConfigFile",
                              "Wait for ssl port open.");
-                    isFound = null != server.waitForStringInLogUsingMark("CWWKO0219I:.*-ssl");
+                    isFound = null != server.waitForDefaultHTTPEndpointSSLStart(true);
                 }
             }
 

--- a/dev/io.openliberty.jaxws.security_fat/fat/src/com/ibm/ws/jaxws/security/fat/AbstractJaxWsTransportSecurityTest.java
+++ b/dev/io.openliberty.jaxws.security_fat/fat/src/com/ibm/ws/jaxws/security/fat/AbstractJaxWsTransportSecurityTest.java
@@ -106,7 +106,7 @@ abstract public class AbstractJaxWsTransportSecurityTest extends AbstractJaxWsTr
                 if (SERVER_CONFIG_WITHOUT_SSL.contains(lastServerConfig)) {
                     Log.info(AbstractJaxWsTransportSecurityTest.class, "updateServerConfigFile",
                              "Wait for ssl port open.");
-                    isFound = null != server.waitForStringInLogUsingMark("CWWKO0219I:.*-ssl");
+                    isFound = null != server.waitForDefaultHTTPEndpointSSLStart(true);
                 }
             }
 

--- a/dev/io.openliberty.jaxws.security_fat/fat/src/com/ibm/ws/jaxws/security/fat/EJBInJarServiceSecurityTest.java
+++ b/dev/io.openliberty.jaxws.security_fat/fat/src/com/ibm/ws/jaxws/security/fat/EJBInJarServiceSecurityTest.java
@@ -93,9 +93,10 @@ public abstract class EJBInJarServiceSecurityTest {
         }
     }
 
-    private static void checkAppsReady() {
+    private static void checkAppsReady() throws Exception {
         Assert.assertNotNull("The application EJBInJarServiceSecurity did not appear to have started",
                              server.waitForStringInLog("CWWKZ0001I.*EJBInJarServiceSecurity"));
         Assert.assertNotNull("Security service did not report it was ready", server.waitForStringInLog("CWWKS0008I"));
+        server.waitForDefaultHTTPEndpointStart();
     }
 }

--- a/dev/io.openliberty.jaxws.security_fat/fat/src/com/ibm/ws/jaxws/security/fat/EJBInWarServiceSecurityTest.java
+++ b/dev/io.openliberty.jaxws.security_fat/fat/src/com/ibm/ws/jaxws/security/fat/EJBInWarServiceSecurityTest.java
@@ -167,12 +167,12 @@ public class EJBInWarServiceSecurityTest {
         }
     }
 
-    private void checkAppsReady() {
+    private void checkAppsReady() throws Exception {
         Assert.assertNotNull("The application EJBInWarServiceSecurity did not appear to have started",
                              server.waitForStringInLog("CWWKZ0001I.*EJBInWarServiceSecurity"));
         Assert.assertNotNull("Security service did not report it was ready", server.waitForStringInLog("CWWKS0008I"));
 
-        server.waitForStringInLog("CWWKO0219I:.*-ssl");
+        server.waitForDefaultHTTPEndpointStart();
 
     }
 

--- a/dev/io.openliberty.jcache.internal_fat.hazelcast/fat/src/io/openliberty/jcache/internal/fat/BaseTestCase.java
+++ b/dev/io.openliberty.jcache.internal_fat.hazelcast/fat/src/io/openliberty/jcache/internal/fat/BaseTestCase.java
@@ -423,9 +423,8 @@ public abstract class BaseTestCase {
      *
      * @param server The server to check the logs for the message.
      */
-    protected static void waitForDefaultHttpsEndpoint(LibertyServer server) {
-        assertNotNull("The SSL TCP Channel for default HTTPS endpoint did not start in time.",
-                      server.waitForStringInLog("CWWKO0219I.*defaultHttpEndpoint-ssl.*" + server.getHttpDefaultSecurePort()));
+    protected static void waitForDefaultHttpsEndpoint(LibertyServer server) throws Exception {
+        server.waitForDefaultHTTPEndpointSSLStart();
     }
 
     /**

--- a/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/security/AdminsRoleAllowedTests.java
+++ b/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/security/AdminsRoleAllowedTests.java
@@ -55,7 +55,7 @@ public class AdminsRoleAllowedTests extends AbstractRolesAllowed {
         server.startServer();
         assertNotNull(server.findStringsInLogs("MCP server endpoint: .*/mcp$")); // regex matches string that ends with /mcp e.g. "MCP server endpoint: http://macbookpro.home:8010/toolTest/mcp"
         // Wait for LTPA configuration to be ready
-        server.waitForStringInLog("CWWKS4105I.*");
+        server.waitForLTPAConfigReady();
     }
 
     @AfterClass

--- a/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/security/AdminsRoleAllowedTestsStateless.java
+++ b/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/security/AdminsRoleAllowedTestsStateless.java
@@ -56,7 +56,7 @@ public class AdminsRoleAllowedTestsStateless extends AbstractRolesAllowed {
         server.startServer();
         assertNotNull(server.findStringsInLogs("MCP server endpoint: .*/mcp$")); // regex matches string that ends with /mcp e.g. "MCP server endpoint: http://macbookpro.home:8010/toolTest/mcp"
         // Wait for LTPA configuration to be ready
-        server.waitForStringInLog("CWWKS4105I.*");
+        server.waitForLTPAConfigReady();
     }
 
     @AfterClass

--- a/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/security/AsyncAdminsRoleAllowedTests.java
+++ b/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/security/AsyncAdminsRoleAllowedTests.java
@@ -53,7 +53,7 @@ public class AsyncAdminsRoleAllowedTests extends FATServletClient {
         server.startServer();
         assertNotNull(server.findStringsInLogs("MCP server endpoint: .*/mcp$")); // regex matches string that ends with /mcp e.g. "MCP server endpoint: http://macbookpro.home:8010/toolTest/mcp"
         // Wait for LTPA configuration to be ready
-        server.waitForStringInLog("CWWKS4105I.*");
+        server.waitForLTPAConfigReady();
     }
 
     @AfterClass

--- a/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/security/AsyncDenyAllTests.java
+++ b/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/security/AsyncDenyAllTests.java
@@ -53,7 +53,7 @@ public class AsyncDenyAllTests extends FATServletClient {
         server.startServer();
         assertNotNull(server.findStringsInLogs("MCP server endpoint: .*/mcp$")); // regex matches string that ends with /mcp e.g. "MCP server endpoint: http://macbookpro.home:8010/toolTest/mcp"
         // Wait for LTPA configuration to be ready
-        server.waitForStringInLog("CWWKS4105I.*");
+        server.waitForLTPAConfigReady();
     }
 
     @AfterClass

--- a/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/security/AsyncNoClassAnnotationTests.java
+++ b/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/security/AsyncNoClassAnnotationTests.java
@@ -53,7 +53,7 @@ public class AsyncNoClassAnnotationTests extends FATServletClient {
         server.startServer();
         assertNotNull(server.findStringsInLogs("MCP server endpoint: .*/mcp$")); // regex matches string that ends with /mcp e.g. "MCP server endpoint: http://macbookpro.home:8010/toolTest/mcp"
         // Wait for LTPA configuration to be ready
-        server.waitForStringInLog("CWWKS4105I.*");
+        server.waitForLTPAConfigReady();
     }
 
     @AfterClass

--- a/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/security/AsyncPermitAllTests.java
+++ b/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/security/AsyncPermitAllTests.java
@@ -53,7 +53,7 @@ public class AsyncPermitAllTests extends FATServletClient {
         server.startServer();
         assertNotNull(server.findStringsInLogs("MCP server endpoint: .*/mcp$")); // regex matches string that ends with /mcp e.g. "MCP server endpoint: http://macbookpro.home:8010/toolTest/mcp"
         // Wait for LTPA configuration to be ready
-        server.waitForStringInLog("CWWKS4105I.*");
+        server.waitForLTPAConfigReady();
     }
 
     @AfterClass

--- a/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/security/DenyAllTests.java
+++ b/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/security/DenyAllTests.java
@@ -55,7 +55,7 @@ public class DenyAllTests extends AbstractDenyAll {
         server.startServer();
         assertNotNull(server.findStringsInLogs("MCP server endpoint: .*/mcp$")); // regex matches string that ends with /mcp e.g. "MCP server endpoint: http://macbookpro.home:8010/toolTest/mcp"
         // Wait for LTPA configuration to be ready
-        server.waitForStringInLog("CWWKS4105I.*");
+        server.waitForLTPAConfigReady();
     }
 
     @AfterClass

--- a/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/security/DenyAllTestsStateless.java
+++ b/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/security/DenyAllTestsStateless.java
@@ -56,7 +56,7 @@ public class DenyAllTestsStateless extends AbstractDenyAll {
         server.startServer();
         assertNotNull(server.findStringsInLogs("MCP server endpoint: .*/mcp$")); // regex matches string that ends with /mcp e.g. "MCP server endpoint: http://macbookpro.home:8010/toolTest/mcp"
         // Wait for LTPA configuration to be ready
-        server.waitForStringInLog("CWWKS4105I.*");
+        server.waitForLTPAConfigReady();
     }
 
     @AfterClass

--- a/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/security/NoClassAnnotationTests.java
+++ b/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/security/NoClassAnnotationTests.java
@@ -55,7 +55,7 @@ public class NoClassAnnotationTests extends AbstractNoClassAnnotation {
         server.startServer();
         assertNotNull(server.findStringsInLogs("MCP server endpoint: .*/mcp$")); // regex matches string that ends with /mcp e.g. "MCP server endpoint: http://macbookpro.home:8010/toolTest/mcp"
         // Wait for LTPA configuration to be ready
-        server.waitForStringInLog("CWWKS4105I.*");
+        server.waitForLTPAConfigReady();
     }
 
     @AfterClass

--- a/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/security/NoClassAnnotationTestsStateless.java
+++ b/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/security/NoClassAnnotationTestsStateless.java
@@ -56,7 +56,7 @@ public class NoClassAnnotationTestsStateless extends AbstractNoClassAnnotation {
         server.startServer();
         assertNotNull(server.findStringsInLogs("MCP server endpoint: .*/mcp$")); // regex matches string that ends with /mcp e.g. "MCP server endpoint: http://macbookpro.home:8010/toolTest/mcp"
         // Wait for LTPA configuration to be ready
-        server.waitForStringInLog("CWWKS4105I.*");
+        server.waitForLTPAConfigReady();
     }
 
     @AfterClass

--- a/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/security/PermitAllTests.java
+++ b/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/security/PermitAllTests.java
@@ -55,7 +55,7 @@ public class PermitAllTests extends AbstractPermitAll {
         server.startServer();
         assertNotNull(server.findStringsInLogs("MCP server endpoint: .*/mcp$")); // regex matches string that ends with /mcp e.g. "MCP server endpoint: http://macbookpro.home:8010/toolTest/mcp"
         // Wait for LTPA configuration to be ready
-        server.waitForStringInLog("CWWKS4105I.*");
+        server.waitForLTPAConfigReady();
     }
 
     @AfterClass

--- a/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/security/PermitAllTestsStateless.java
+++ b/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/security/PermitAllTestsStateless.java
@@ -56,7 +56,7 @@ public class PermitAllTestsStateless extends AbstractPermitAll {
         server.startServer();
         assertNotNull(server.findStringsInLogs("MCP server endpoint: .*/mcp$")); // regex matches string that ends with /mcp e.g. "MCP server endpoint: http://macbookpro.home:8010/toolTest/mcp"
         // Wait for LTPA configuration to be ready
-        server.waitForStringInLog("CWWKS4105I.*");
+        server.waitForLTPAConfigReady();
     }
 
     @AfterClass

--- a/dev/io.openliberty.microprofile.jwt.1.2.internal_fat_tck/fat/src/io/openliberty/microprofile/jwt12/internal/tck/Mpjwt12TCKLauncher_aud_env.java
+++ b/dev/io.openliberty.microprofile.jwt.1.2.internal_fat_tck/fat/src/io/openliberty/microprofile/jwt12/internal/tck/Mpjwt12TCKLauncher_aud_env.java
@@ -37,7 +37,7 @@ public class Mpjwt12TCKLauncher_aud_env {
     @BeforeClass
     public static void setUp() throws Exception {
         server.startServer();
-        server.waitForStringInLog("CWWKS4105I", 30000); // wait for ltpa keys to be created and service ready, which can happen after startup.
+        server.waitForLTPAConfigReady(30000); // wait for ltpa keys to be created and service ready, which can happen after startup.
     }
 
     @AfterClass

--- a/dev/io.openliberty.microprofile.jwt.1.2.internal_fat_tck/fat/src/io/openliberty/microprofile/jwt12/internal/tck/Mpjwt12TCKLauncher_aud_noenv.java
+++ b/dev/io.openliberty.microprofile.jwt.1.2.internal_fat_tck/fat/src/io/openliberty/microprofile/jwt12/internal/tck/Mpjwt12TCKLauncher_aud_noenv.java
@@ -41,7 +41,7 @@ public class Mpjwt12TCKLauncher_aud_noenv {
     @BeforeClass
     public static void setUp() throws Exception {
         server.startServer();
-        server.waitForStringInLog("CWWKS4105I", 30000); // wait for ltpa keys to be created and service ready, which can happen after startup.
+        server.waitForLTPAConfigReady(30000); // wait for ltpa keys to be created and service ready, which can happen after startup.
     }
 
     @AfterClass

--- a/dev/io.openliberty.microprofile.jwt.1.2.internal_fat_tck/fat/src/io/openliberty/microprofile/jwt12/internal/tck/Mpjwt12TCKLauncher_aud_noenv2.java
+++ b/dev/io.openliberty.microprofile.jwt.1.2.internal_fat_tck/fat/src/io/openliberty/microprofile/jwt12/internal/tck/Mpjwt12TCKLauncher_aud_noenv2.java
@@ -42,7 +42,7 @@ public class Mpjwt12TCKLauncher_aud_noenv2 {
         // PrivHelper looked promising for fine grained java2sec exception management but did not work.
         //PrivHelper.generateCustomPolicy(server, "permission java.net.SocketPermission \"127.0.0.1\", \"resolve\"");
         server.startServer();
-        server.waitForStringInLog("CWWKS4105I", 30000); // wait for ltpa keys to be created and service ready, which can happen after startup.
+        server.waitForLTPAConfigReady(30000); // wait for ltpa keys to be created and service ready, which can happen after startup.
     }
 
     @AfterClass

--- a/dev/io.openliberty.microprofile.jwt.1.2.internal_fat_tck/fat/src/io/openliberty/microprofile/jwt12/internal/tck/Mpjwt12TCKLauncher_noaud_env.java
+++ b/dev/io.openliberty.microprofile.jwt.1.2.internal_fat_tck/fat/src/io/openliberty/microprofile/jwt12/internal/tck/Mpjwt12TCKLauncher_noaud_env.java
@@ -37,7 +37,7 @@ public class Mpjwt12TCKLauncher_noaud_env {
     @BeforeClass
     public static void setUp() throws Exception {
         server.startServer();
-        server.waitForStringInLog("CWWKS4105I", 30000); // wait for ltpa keys to be created and service ready, which can happen after startup.
+        server.waitForLTPAConfigReady(30000); // wait for ltpa keys to be created and service ready, which can happen after startup.
     }
 
     @AfterClass

--- a/dev/io.openliberty.microprofile.jwt.1.2.internal_fat_tck/fat/src/io/openliberty/microprofile/jwt12/internal/tck/Mpjwt12TCKLauncher_noaud_noenv.java
+++ b/dev/io.openliberty.microprofile.jwt.1.2.internal_fat_tck/fat/src/io/openliberty/microprofile/jwt12/internal/tck/Mpjwt12TCKLauncher_noaud_noenv.java
@@ -37,7 +37,7 @@ public class Mpjwt12TCKLauncher_noaud_noenv {
     @BeforeClass
     public static void setUp() throws Exception {
         server.startServer();
-        server.waitForStringInLog("CWWKS4105I", 30000); // wait for ltpa keys to be created and service ready, which can happen after startup.
+        server.waitForLTPAConfigReady(30000); // wait for ltpa keys to be created and service ready, which can happen after startup.
     }
 
     @AfterClass

--- a/dev/io.openliberty.microprofile.jwt.2.0.internal_fat_tck/fat/src/io/openliberty/microprofile/jwt20/internal/tck/Mpjwt20TCKLauncher_aud_env.java
+++ b/dev/io.openliberty.microprofile.jwt.2.0.internal_fat_tck/fat/src/io/openliberty/microprofile/jwt20/internal/tck/Mpjwt20TCKLauncher_aud_env.java
@@ -37,7 +37,7 @@ public class Mpjwt20TCKLauncher_aud_env {
     @BeforeClass
     public static void setUp() throws Exception {
         server.startServer();
-        server.waitForStringInLog("CWWKS4105I", 30000); // wait for ltpa keys to be created and service ready, which can happen after startup.
+        server.waitForLTPAConfigReady(30000); // wait for ltpa keys to be created and service ready, which can happen after startup.
     }
 
     @AfterClass

--- a/dev/io.openliberty.microprofile.jwt.2.0.internal_fat_tck/fat/src/io/openliberty/microprofile/jwt20/internal/tck/Mpjwt20TCKLauncher_aud_noenv.java
+++ b/dev/io.openliberty.microprofile.jwt.2.0.internal_fat_tck/fat/src/io/openliberty/microprofile/jwt20/internal/tck/Mpjwt20TCKLauncher_aud_noenv.java
@@ -41,7 +41,7 @@ public class Mpjwt20TCKLauncher_aud_noenv {
     @BeforeClass
     public static void setUp() throws Exception {
         server.startServer();
-        server.waitForStringInLog("CWWKS4105I", 30000); // wait for ltpa keys to be created and service ready, which can happen after startup.
+        server.waitForLTPAConfigReady(30000); // wait for ltpa keys to be created and service ready, which can happen after startup.
     }
 
     @AfterClass

--- a/dev/io.openliberty.microprofile.jwt.2.0.internal_fat_tck/fat/src/io/openliberty/microprofile/jwt20/internal/tck/Mpjwt20TCKLauncher_aud_noenv2.java
+++ b/dev/io.openliberty.microprofile.jwt.2.0.internal_fat_tck/fat/src/io/openliberty/microprofile/jwt20/internal/tck/Mpjwt20TCKLauncher_aud_noenv2.java
@@ -42,7 +42,7 @@ public class Mpjwt20TCKLauncher_aud_noenv2 {
         // PrivHelper looked promising for fine grained java2sec exception management but did not work.
         //PrivHelper.generateCustomPolicy(server, "permission java.net.SocketPermission \"127.0.0.1\", \"resolve\"");
         server.startServer();
-        server.waitForStringInLog("CWWKS4105I", 30000); // wait for ltpa keys to be created and service ready, which can happen after startup.
+        server.waitForLTPAConfigReady(30000); // wait for ltpa keys to be created and service ready, which can happen after startup.
     }
 
     @AfterClass

--- a/dev/io.openliberty.microprofile.jwt.2.0.internal_fat_tck/fat/src/io/openliberty/microprofile/jwt20/internal/tck/Mpjwt20TCKLauncher_noaud_env.java
+++ b/dev/io.openliberty.microprofile.jwt.2.0.internal_fat_tck/fat/src/io/openliberty/microprofile/jwt20/internal/tck/Mpjwt20TCKLauncher_noaud_env.java
@@ -37,7 +37,7 @@ public class Mpjwt20TCKLauncher_noaud_env {
     @BeforeClass
     public static void setUp() throws Exception {
         server.startServer();
-        server.waitForStringInLog("CWWKS4105I", 30000); // wait for ltpa keys to be created and service ready, which can happen after startup.
+        server.waitForLTPAConfigReady(30000); // wait for ltpa keys to be created and service ready, which can happen after startup.
     }
 
     @AfterClass

--- a/dev/io.openliberty.microprofile.jwt.2.0.internal_fat_tck/fat/src/io/openliberty/microprofile/jwt20/internal/tck/Mpjwt20TCKLauncher_noaud_noenv.java
+++ b/dev/io.openliberty.microprofile.jwt.2.0.internal_fat_tck/fat/src/io/openliberty/microprofile/jwt20/internal/tck/Mpjwt20TCKLauncher_noaud_noenv.java
@@ -37,7 +37,7 @@ public class Mpjwt20TCKLauncher_noaud_noenv {
     @BeforeClass
     public static void setUp() throws Exception {
         server.startServer();
-        server.waitForStringInLog("CWWKS4105I", 30000); // wait for ltpa keys to be created and service ready, which can happen after startup.
+        server.waitForLTPAConfigReady(30000); // wait for ltpa keys to be created and service ready, which can happen after startup.
     }
 
     @AfterClass

--- a/dev/io.openliberty.microprofile.jwt.2.1.internal_fat_tck/fat/src/io/openliberty/microprofile/jwt21/internal/tck/Mpjwt21TCKLauncher_aud_env.java
+++ b/dev/io.openliberty.microprofile.jwt.2.1.internal_fat_tck/fat/src/io/openliberty/microprofile/jwt21/internal/tck/Mpjwt21TCKLauncher_aud_env.java
@@ -37,7 +37,7 @@ public class Mpjwt21TCKLauncher_aud_env {
     @BeforeClass
     public static void setUp() throws Exception {
         server.startServer();
-        server.waitForStringInLog("CWWKS4105I", 30000); // wait for ltpa keys to be created and service ready, which can happen after startup.
+        server.waitForLTPAConfigReady(30000); // wait for ltpa keys to be created and service ready, which can happen after startup.
     }
 
     @AfterClass

--- a/dev/io.openliberty.microprofile.jwt.2.1.internal_fat_tck/fat/src/io/openliberty/microprofile/jwt21/internal/tck/Mpjwt21TCKLauncher_aud_noenv.java
+++ b/dev/io.openliberty.microprofile.jwt.2.1.internal_fat_tck/fat/src/io/openliberty/microprofile/jwt21/internal/tck/Mpjwt21TCKLauncher_aud_noenv.java
@@ -41,7 +41,7 @@ public class Mpjwt21TCKLauncher_aud_noenv {
     @BeforeClass
     public static void setUp() throws Exception {
         server.startServer();
-        server.waitForStringInLog("CWWKS4105I", 30000); // wait for ltpa keys to be created and service ready, which can happen after startup.
+        server.waitForLTPAConfigReady(30000); // wait for ltpa keys to be created and service ready, which can happen after startup.
     }
 
     @AfterClass

--- a/dev/io.openliberty.microprofile.jwt.2.1.internal_fat_tck/fat/src/io/openliberty/microprofile/jwt21/internal/tck/Mpjwt21TCKLauncher_aud_noenv2.java
+++ b/dev/io.openliberty.microprofile.jwt.2.1.internal_fat_tck/fat/src/io/openliberty/microprofile/jwt21/internal/tck/Mpjwt21TCKLauncher_aud_noenv2.java
@@ -42,7 +42,7 @@ public class Mpjwt21TCKLauncher_aud_noenv2 {
         // PrivHelper looked promising for fine grained java2sec exception management but did not work.
         //PrivHelper.generateCustomPolicy(server, "permission java.net.SocketPermission \"127.0.0.1\", \"resolve\"");
         server.startServer();
-        server.waitForStringInLog("CWWKS4105I", 30000); // wait for ltpa keys to be created and service ready, which can happen after startup.
+        server.waitForLTPAConfigReady(30000); // wait for ltpa keys to be created and service ready, which can happen after startup.
     }
 
     @AfterClass

--- a/dev/io.openliberty.microprofile.jwt.2.1.internal_fat_tck/fat/src/io/openliberty/microprofile/jwt21/internal/tck/Mpjwt21TCKLauncher_noaud_env.java
+++ b/dev/io.openliberty.microprofile.jwt.2.1.internal_fat_tck/fat/src/io/openliberty/microprofile/jwt21/internal/tck/Mpjwt21TCKLauncher_noaud_env.java
@@ -37,7 +37,7 @@ public class Mpjwt21TCKLauncher_noaud_env {
     @BeforeClass
     public static void setUp() throws Exception {
         server.startServer();
-        server.waitForStringInLog("CWWKS4105I", 30000); // wait for ltpa keys to be created and service ready, which can happen after startup.
+        server.waitForLTPAConfigReady(30000); // wait for ltpa keys to be created and service ready, which can happen after startup.
     }
 
     @AfterClass

--- a/dev/io.openliberty.microprofile.jwt.2.1.internal_fat_tck/fat/src/io/openliberty/microprofile/jwt21/internal/tck/Mpjwt21TCKLauncher_noaud_noenv.java
+++ b/dev/io.openliberty.microprofile.jwt.2.1.internal_fat_tck/fat/src/io/openliberty/microprofile/jwt21/internal/tck/Mpjwt21TCKLauncher_noaud_noenv.java
@@ -36,7 +36,7 @@ public class Mpjwt21TCKLauncher_noaud_noenv {
     @BeforeClass
     public static void setUp() throws Exception {
         server.startServer();
-        server.waitForStringInLog("CWWKS4105I", 30000); // wait for ltpa keys to be created and service ready, which can happen after startup.
+        server.waitForLTPAConfigReady(30000); // wait for ltpa keys to be created and service ready, which can happen after startup.
     }
 
     @AfterClass

--- a/dev/io.openliberty.microprofile.metrics.internal.3.x.monitor_fat/fat/src/io/openliberty/microprofile/metrics/internal/monitor_fat/ComputedMetricsTest.java
+++ b/dev/io.openliberty.microprofile.metrics.internal.3.x.monitor_fat/fat/src/io/openliberty/microprofile/metrics/internal/monitor_fat/ComputedMetricsTest.java
@@ -578,8 +578,8 @@ public class ComputedMetricsTest {
     private void waitForSecurityPrerequisites(LibertyServer server, int timeout) throws Exception {
         // We only need to wait for LTPA keys if this is the first time using this server.
        if (initialServerStart) {
-            // Need to ensure LTPA keys and configuration are created before hitting a secure endpoint.
-            server.waitForLTPAKeysCreatedAndConfigComplete(timeout);
+            // Need to ensure LTPA configuration is ready before hitting a secure endpoint.
+            server.waitForLTPAConfigReady(timeout);
        }
         // Ensure defaultHttpEndpoint-ssl TCP Channel is started
         server.waitForDefaultHTTPEndpointSSLStart(timeout);

--- a/dev/io.openliberty.microprofile.metrics.internal.3.x.monitor_fat/fat/src/io/openliberty/microprofile/metrics/internal/monitor_fat/ComputedMetricsTest.java
+++ b/dev/io.openliberty.microprofile.metrics.internal.3.x.monitor_fat/fat/src/io/openliberty/microprofile/metrics/internal/monitor_fat/ComputedMetricsTest.java
@@ -575,16 +575,14 @@ public class ComputedMetricsTest {
         }
     }
 
-    private void waitForSecurityPrerequisites(LibertyServer server, int timeout) {
+    private void waitForSecurityPrerequisites(LibertyServer server, int timeout) throws Exception {
         // We only need to wait for LTPA keys if this is the first time using this server.
        if (initialServerStart) {
             // Need to ensure LTPA keys and configuration are created before hitting a secure endpoint.
-            Assert.assertNotNull("LTPA keys are not created within timeout period of " + timeout + "ms.", server.waitForStringInLog("CWWKS4104A", timeout));
-            Assert.assertNotNull("LTPA configuration is not ready within timeout period of " + timeout + "ms.", server.waitForStringInLog("CWWKS4105I", timeout));
+            server.waitForLTPAKeysCreatedAndConfigComplete(timeout);
        }
-
         // Ensure defaultHttpEndpoint-ssl TCP Channel is started
-        Assert.assertNotNull("TCP Channel defaultHttpEndpoint-ssl has not started (CWWKO0219I not found)", server.waitForStringInLog("CWWKO0219I.*defaultHttpEndpoint-ssl", timeout));
+        server.waitForDefaultHTTPEndpointSSLStart(timeout);
     }
 
     private String getHttpServlet(String servletPath, LibertyServer server) throws Exception {

--- a/dev/io.openliberty.microprofile.metrics.internal.3.x.monitor_fat/fat/src/io/openliberty/microprofile/metrics/internal/monitor_fat/MetricsMonitorTest.java
+++ b/dev/io.openliberty.microprofile.metrics.internal.3.x.monitor_fat/fat/src/io/openliberty/microprofile/metrics/internal/monitor_fat/MetricsMonitorTest.java
@@ -104,7 +104,7 @@ public class MetricsMonitorTest {
                 "------- Enable mpMetrics-3.0 and monitor-1.0: vendor metrics should be available ------");
         server.setServerConfigurationFile("server_monitor30.xml");
         server.startServer();
-        server.waitForLTPAKeysCreatedAndConfigComplete(60000);
+        server.waitForLTPAConfigReady(60000);
         server.waitForDefaultHTTPEndpointSSLStart(60000);
         Log.info(c, testName, "------- server started -----");
         Assert.assertNotNull("CWWKT0016I NOT FOUND", server.waitForStringInLogUsingMark("CWWKT0016I"));

--- a/dev/io.openliberty.microprofile.metrics.internal.3.x.monitor_fat/fat/src/io/openliberty/microprofile/metrics/internal/monitor_fat/MetricsMonitorTest.java
+++ b/dev/io.openliberty.microprofile.metrics.internal.3.x.monitor_fat/fat/src/io/openliberty/microprofile/metrics/internal/monitor_fat/MetricsMonitorTest.java
@@ -104,9 +104,8 @@ public class MetricsMonitorTest {
                 "------- Enable mpMetrics-3.0 and monitor-1.0: vendor metrics should be available ------");
         server.setServerConfigurationFile("server_monitor30.xml");
         server.startServer();
-        Assert.assertNotNull("LTPA keys are not created/ready within timeout period of " + 60000 + "ms.",
-                server.waitForStringInLog("CWWKS4104A.*|CWWKS4105I.*", 60000));
-        Assert.assertNotNull("CWWKO0219I NOT FOUND", server.waitForStringInLog("defaultHttpEndpoint-ssl", 60000));
+        server.waitForLTPAKeysCreatedAndConfigComplete(60000);
+        server.waitForDefaultHTTPEndpointSSLStart(60000);
         Log.info(c, testName, "------- server started -----");
         Assert.assertNotNull("CWWKT0016I NOT FOUND", server.waitForStringInLogUsingMark("CWWKT0016I"));
         checkStrings(getHttpsServlet("/metrics"), new String[] { "base_", "vendor_" }, new String[] {});

--- a/dev/io.openliberty.microprofile.metrics.internal.3.x.monitor_fat/fat/src/io/openliberty/microprofile/metrics/internal/monitor_fat/TestEnableDisableFeaturesTest.java
+++ b/dev/io.openliberty.microprofile.metrics.internal.3.x.monitor_fat/fat/src/io/openliberty/microprofile/metrics/internal/monitor_fat/TestEnableDisableFeaturesTest.java
@@ -318,8 +318,7 @@ public class TestEnableDisableFeaturesTest {
             // server
             waitForSecurityPrerequisites(serverEDF6, 60000);
         } else {
-            Assert.assertNotNull("TCP Channel defaultHttpEndpoint-ssl has not started (CWWKO0219I not found)",
-                    serverEDF6.waitForStringInLog("CWWKO0219I.*defaultHttpEndpoint-ssl", 60000));
+            serverEDF6.waitForDefaultHTTPEndpointSSLStart(60000);
         }
         serverEDF6FirstUse = false;
 
@@ -346,8 +345,7 @@ public class TestEnableDisableFeaturesTest {
             // server
             waitForSecurityPrerequisites(serverEDF6, 60000);
         } else {
-            Assert.assertNotNull("TCP Channel defaultHttpEndpoint-ssl has not started (CWWKO0219I not found)",
-                    serverEDF6.waitForStringInLog("CWWKO0219I.*defaultHttpEndpoint-ssl", 60000));
+            serverEDF6.waitForDefaultHTTPEndpointSSLStart(60000);
         }
         serverEDF6FirstUse = false;
 
@@ -447,17 +445,12 @@ public class TestEnableDisableFeaturesTest {
                 new String[] { "vendor_connectionpool", "vendor_servlet", "{servlet=\"testJDBCApp\"}" });
     }
 
-    private void waitForSecurityPrerequisites(LibertyServer server, int timeout) {
+    private void waitForSecurityPrerequisites(LibertyServer server, int timeout) throws Exception {
         // Need to ensure LTPA keys and configuration are created before hitting a
         // secure endpoint
-        Assert.assertNotNull("LTPA keys are not created within timeout period of " + timeout + "ms.",
-                server.waitForStringInLog("CWWKS4104A", timeout));
-        Assert.assertNotNull("LTPA configuration is not ready within timeout period of " + timeout + "ms.",
-                server.waitForStringInLog("CWWKS4105I", timeout));
-
+        server.waitForLTPAKeysCreatedAndConfigComplete(timeout);
         // Ensure defaultHttpEndpoint-ssl TCP Channel is started
-        Assert.assertNotNull("TCP Channel defaultHttpEndpoint-ssl has not started (CWWKO0219I not found)",
-                server.waitForStringInLog("CWWKO0219I.*defaultHttpEndpoint-ssl", timeout));
+        server.waitForDefaultHTTPEndpointSSLStart(timeout);
     }
 
     private String getHttpServlet(String servletPath, LibertyServer server) throws Exception {

--- a/dev/io.openliberty.microprofile.metrics.internal.3.x.monitor_fat/fat/src/io/openliberty/microprofile/metrics/internal/monitor_fat/TestEnableDisableFeaturesTest.java
+++ b/dev/io.openliberty.microprofile.metrics.internal.3.x.monitor_fat/fat/src/io/openliberty/microprofile/metrics/internal/monitor_fat/TestEnableDisableFeaturesTest.java
@@ -446,9 +446,8 @@ public class TestEnableDisableFeaturesTest {
     }
 
     private void waitForSecurityPrerequisites(LibertyServer server, int timeout) throws Exception {
-        // Need to ensure LTPA keys and configuration are created before hitting a
-        // secure endpoint
-        server.waitForLTPAKeysCreatedAndConfigComplete(timeout);
+        // Need to ensure LTPA configuration is ready before hitting a secure endpoint
+        server.waitForLTPAConfigReady(timeout);
         // Ensure defaultHttpEndpoint-ssl TCP Channel is started
         server.waitForDefaultHTTPEndpointSSLStart(timeout);
     }

--- a/dev/io.openliberty.microprofile.metrics.internal.4.x.monitor_fat/fat/src/io/openliberty/microprofile/metrics/internal/monitor_fat/ComputedMetricsTest.java
+++ b/dev/io.openliberty.microprofile.metrics.internal.4.x.monitor_fat/fat/src/io/openliberty/microprofile/metrics/internal/monitor_fat/ComputedMetricsTest.java
@@ -578,8 +578,8 @@ public class ComputedMetricsTest {
     private void waitForSecurityPrerequisites(LibertyServer server, int timeout) throws Exception {
         // We only need to wait for LTPA keys if this is the first time using this server.
        if (initialServerStart) {
-            // Need to ensure LTPA keys and configuration are created before hitting a secure endpoint.
-            server.waitForLTPAKeysCreatedAndConfigComplete(timeout);
+           // Need to ensure LTPA configuration is ready before hitting a secure endpoint.
+           server.waitForLTPAConfigReady(timeout);
        }
 
         // Ensure defaultHttpEndpoint-ssl TCP Channel is started

--- a/dev/io.openliberty.microprofile.metrics.internal.4.x.monitor_fat/fat/src/io/openliberty/microprofile/metrics/internal/monitor_fat/ComputedMetricsTest.java
+++ b/dev/io.openliberty.microprofile.metrics.internal.4.x.monitor_fat/fat/src/io/openliberty/microprofile/metrics/internal/monitor_fat/ComputedMetricsTest.java
@@ -575,16 +575,15 @@ public class ComputedMetricsTest {
         }
     }
 
-    private void waitForSecurityPrerequisites(LibertyServer server, int timeout) {
+    private void waitForSecurityPrerequisites(LibertyServer server, int timeout) throws Exception {
         // We only need to wait for LTPA keys if this is the first time using this server.
        if (initialServerStart) {
             // Need to ensure LTPA keys and configuration are created before hitting a secure endpoint.
-            Assert.assertNotNull("LTPA keys are not created within timeout period of " + timeout + "ms.", server.waitForStringInLog("CWWKS4104A", timeout));
-            Assert.assertNotNull("LTPA configuration is not ready within timeout period of " + timeout + "ms.", server.waitForStringInLog("CWWKS4105I", timeout));
+            server.waitForLTPAKeysCreatedAndConfigComplete(timeout);
        }
 
         // Ensure defaultHttpEndpoint-ssl TCP Channel is started
-        Assert.assertNotNull("TCP Channel defaultHttpEndpoint-ssl has not started (CWWKO0219I not found)", server.waitForStringInLog("CWWKO0219I.*defaultHttpEndpoint-ssl", timeout));
+        server.waitForDefaultHTTPEndpointSSLStart(timeout);
     }
 
     private String getHttpServlet(String servletPath, LibertyServer server) throws Exception {

--- a/dev/io.openliberty.microprofile.metrics.internal.4.x.monitor_fat/fat/src/io/openliberty/microprofile/metrics/internal/monitor_fat/MetricsMonitorTest.java
+++ b/dev/io.openliberty.microprofile.metrics.internal.4.x.monitor_fat/fat/src/io/openliberty/microprofile/metrics/internal/monitor_fat/MetricsMonitorTest.java
@@ -105,8 +105,8 @@ public class MetricsMonitorTest {
         server.setServerConfigurationFile("server_monitor40.xml");
         server.startServer();
         Assert.assertNotNull("LTPA keys are not created/ready within timeout period of " + 60000 + "ms.",
-                server.waitForStringInLog("CWWKS4104A.*|CWWKS4105I.*", 60000));
-        Assert.assertNotNull("CWWKO0219I NOT FOUND", server.waitForStringInLog("defaultHttpEndpoint-ssl", 60000));
+                server.waitForLTPAKeysCreatedAndConfigComplete(60000, true));
+        Assert.assertNotNull("CWWKO0219I NOT FOUND", server.waitForDefaultHTTPEndpointSSLStart(60000, true));
         Log.info(c, testName, "------- server started -----");
         Assert.assertNotNull("CWWKT0016I NOT FOUND", server.waitForStringInLogUsingMark("CWWKT0016I"));
         checkStrings(getHttpsServlet("/metrics"), new String[] { "base_", "vendor_" }, new String[] {});

--- a/dev/io.openliberty.microprofile.metrics.internal.4.x.monitor_fat/fat/src/io/openliberty/microprofile/metrics/internal/monitor_fat/MetricsMonitorTest.java
+++ b/dev/io.openliberty.microprofile.metrics.internal.4.x.monitor_fat/fat/src/io/openliberty/microprofile/metrics/internal/monitor_fat/MetricsMonitorTest.java
@@ -104,9 +104,8 @@ public class MetricsMonitorTest {
                 "------- Enable mpMetrics-4.0 and monitor-1.0: vendor metrics should be available ------");
         server.setServerConfigurationFile("server_monitor40.xml");
         server.startServer();
-        Assert.assertNotNull("LTPA keys are not created/ready within timeout period of " + 60000 + "ms.",
-                server.waitForLTPAKeysCreatedAndConfigComplete(60000, true));
-        Assert.assertNotNull("CWWKO0219I NOT FOUND", server.waitForDefaultHTTPEndpointSSLStart(60000, true));
+        server.waitForLTPAConfigReady(60000);
+        server.waitForDefaultHTTPEndpointSSLStart(60000);
         Log.info(c, testName, "------- server started -----");
         Assert.assertNotNull("CWWKT0016I NOT FOUND", server.waitForStringInLogUsingMark("CWWKT0016I"));
         checkStrings(getHttpsServlet("/metrics"), new String[] { "base_", "vendor_" }, new String[] {});

--- a/dev/io.openliberty.microprofile.metrics.internal.4.x.monitor_fat/fat/src/io/openliberty/microprofile/metrics/internal/monitor_fat/TestEnableDisableFeaturesTest.java
+++ b/dev/io.openliberty.microprofile.metrics.internal.4.x.monitor_fat/fat/src/io/openliberty/microprofile/metrics/internal/monitor_fat/TestEnableDisableFeaturesTest.java
@@ -445,16 +445,11 @@ public class TestEnableDisableFeaturesTest {
                 new String[] { "vendor_connectionpool", "vendor_servlet", "{servlet=\"testJDBCApp\"}" });
     }
 
-    private void waitForSecurityPrerequisites(LibertyServer server, int timeout) {
-        // Need to ensure LTPA keys and configuration are created before hitting a
-        // secure endpoint
-        try {
-            server.waitForLTPAKeysCreatedAndConfigComplete(timeout);
-            // Ensure defaultHttpEndpoint-ssl TCP Channel is started
-            server.waitForDefaultHTTPEndpointSSLStart(timeout);
-        } catch (Exception e){
-            // The assertions will cause the test to bail out, so the exception that could of been thrown has been suppressed
-        }
+    private void waitForSecurityPrerequisites(LibertyServer server, int timeout) throws Exception {
+        // Need to ensure LTPA configuration is ready before hitting a secure endpoint
+        server.waitForLTPAConfigReady(timeout);
+        // Ensure defaultHttpEndpoint-ssl TCP Channel is started
+        server.waitForDefaultHTTPEndpointSSLStart(timeout);
     }
 
     private String getHttpServlet(String servletPath, LibertyServer server) throws Exception {

--- a/dev/io.openliberty.microprofile.metrics.internal.4.x.monitor_fat/fat/src/io/openliberty/microprofile/metrics/internal/monitor_fat/TestEnableDisableFeaturesTest.java
+++ b/dev/io.openliberty.microprofile.metrics.internal.4.x.monitor_fat/fat/src/io/openliberty/microprofile/metrics/internal/monitor_fat/TestEnableDisableFeaturesTest.java
@@ -318,8 +318,7 @@ public class TestEnableDisableFeaturesTest {
             // server
             waitForSecurityPrerequisites(serverEDF6, 60000);
         } else {
-            Assert.assertNotNull("TCP Channel defaultHttpEndpoint-ssl has not started (CWWKO0219I not found)",
-                    serverEDF6.waitForStringInLog("CWWKO0219I.*defaultHttpEndpoint-ssl", 60000));
+            serverEDF6.waitForDefaultHTTPEndpointSSLStart(60000);
         }
         serverEDF6FirstUse = false;
 
@@ -346,8 +345,7 @@ public class TestEnableDisableFeaturesTest {
             // server
             waitForSecurityPrerequisites(serverEDF6, 60000);
         } else {
-            Assert.assertNotNull("TCP Channel defaultHttpEndpoint-ssl has not started (CWWKO0219I not found)",
-                    serverEDF6.waitForStringInLog("CWWKO0219I.*defaultHttpEndpoint-ssl", 60000));
+            serverEDF6.waitForDefaultHTTPEndpointSSLStart(60000);
         }
         serverEDF6FirstUse = false;
 
@@ -450,14 +448,13 @@ public class TestEnableDisableFeaturesTest {
     private void waitForSecurityPrerequisites(LibertyServer server, int timeout) {
         // Need to ensure LTPA keys and configuration are created before hitting a
         // secure endpoint
-        Assert.assertNotNull("LTPA keys are not created within timeout period of " + timeout + "ms.",
-                server.waitForStringInLog("CWWKS4104A", timeout));
-        Assert.assertNotNull("LTPA configuration is not ready within timeout period of " + timeout + "ms.",
-                server.waitForStringInLog("CWWKS4105I", timeout));
-
-        // Ensure defaultHttpEndpoint-ssl TCP Channel is started
-        Assert.assertNotNull("TCP Channel defaultHttpEndpoint-ssl has not started (CWWKO0219I not found)",
-                server.waitForStringInLog("CWWKO0219I.*defaultHttpEndpoint-ssl", timeout));
+        try {
+            server.waitForLTPAKeysCreatedAndConfigComplete(timeout);
+            // Ensure defaultHttpEndpoint-ssl TCP Channel is started
+            server.waitForDefaultHTTPEndpointSSLStart(timeout);
+        } catch (Exception e){
+            // The assertions will cause the test to bail out, so the exception that could of been thrown has been suppressed
+        }
     }
 
     private String getHttpServlet(String servletPath, LibertyServer server) throws Exception {

--- a/dev/io.openliberty.microprofile.metrics.internal.5.0_fat/fat/src/io/openliberty/microprofile/metrics50/internal/tck/launcher/LibraryRefTest.java
+++ b/dev/io.openliberty.microprofile.metrics.internal.5.0_fat/fat/src/io/openliberty/microprofile/metrics50/internal/tck/launcher/LibraryRefTest.java
@@ -120,7 +120,7 @@ public class LibraryRefTest {
     public void nonExistentLibrary() throws Exception {
         server = serverNonExistentLibrary;
         server.startServer();
-        server.waitForSSLStart();
+        server.waitForDefaultHTTPEndpointSSLStart();
 
         //CWWKG0033W The value [<value>] specified for the reference attribute [libraryRef] was not found in the configuration.
         Assert.assertNotNull("CWWKG0033W Not found", server.waitForStringInLogUsingMark("CWWKG0033W"));
@@ -137,7 +137,7 @@ public class LibraryRefTest {
     public void noMicrometerCore() throws Exception {
         server = serverNoMicrometerCore;
         server.startServer();
-        server.waitForSSLStart();
+        server.waitForDefaultHTTPEndpointSSLStart();
 
         //CWMMC0014I emits that metrics is using libraryRef
         Assert.assertNotNull("CWMMC0014I Not found", server.waitForStringInLogUsingMark("CWMMC0014I"));
@@ -192,7 +192,7 @@ public class LibraryRefTest {
         }
 
         server.startServer();
-        server.waitForSSLStart();
+        server.waitForDefaultHTTPEndpointSSLStart();
 
         //CWMMC0014I emits that metrics is using libraryRef
         Assert.assertNotNull("CWMMC0014I Not found", server.waitForStringInLogUsingMark("CWMMC0014I"));
@@ -202,7 +202,7 @@ public class LibraryRefTest {
 
         server.resetLogMarks();
 
-        Assert.assertNotNull("CWWKO0219I Not found", server.waitForStringInLogUsingMark("CWWKO0219I: TCP Channel defaultHttpEndpoint-ssl"));
+        Assert.assertNotNull("CWWKO0219I Not found", server.waitForDefaultHTTPEndpointSSLStart());
 
         //Check SR implementation log that Promethues Registry created
         //Note that SR makes THIS explicit log for Prometheus, other meter registries are logged differently following a template
@@ -239,7 +239,7 @@ public class LibraryRefTest {
     public void externalMicrometerUselessJar() throws Exception {
         server = serverMicrometerUseless;
         server.startServer();
-        server.waitForSSLStart();
+        server.waitForDefaultHTTPEndpointSSLStart();
 
         //CWMMC0014I emits that metrics is using libraryRef
         Assert.assertNotNull("CWMMC0014I Not found", server.waitForStringInLogUsingMark("CWMMC0014I"));

--- a/dev/io.openliberty.microprofile.metrics.internal.5.1_fat/fat/src/io/openliberty/microprofile/metrics/internal/fat/DefaultHistogramBucketsTest.java
+++ b/dev/io.openliberty.microprofile.metrics.internal.5.1_fat/fat/src/io/openliberty/microprofile/metrics/internal/fat/DefaultHistogramBucketsTest.java
@@ -101,11 +101,12 @@ public class DefaultHistogramBucketsTest {
 	}
 
 	@Before
-	public void beforeTest() {
+	public void beforeTest() throws Exception {
 
-		// Check that both CWWKO0219I messages for non-secure and secured http
+		// Check that both for HTTP and HTTPS
 		// endpoints are initialized
-		server.waitForMultipleStringsInLog(2, "CWWKO0219I");
+		server.waitForDefaultHTTPEndpointStart();
+        server.waitForDefaultHTTPEndpointSSLStart();
 
 	}
 

--- a/dev/io.openliberty.microprofile.metrics.internal.5.1_fat/fat/src/io/openliberty/microprofile/metrics/internal/fat/LibraryRefTest.java
+++ b/dev/io.openliberty.microprofile.metrics.internal.5.1_fat/fat/src/io/openliberty/microprofile/metrics/internal/fat/LibraryRefTest.java
@@ -129,7 +129,7 @@ public class LibraryRefTest {
 	public void nonExistentLibrary() throws Exception {
 		server = serverNonExistentLibrary;
 		server.startServer();
-		server.waitForSSLStart();
+		server.waitForDefaultHTTPEndpointSSLStart();
 
 		// CWWKG0033W The value [<value>] specified for the reference attribute
 		// [libraryRef] was not found in the configuration.
@@ -147,7 +147,7 @@ public class LibraryRefTest {
 	public void noMicrometerCore() throws Exception {
 		server = serverNoMicrometerCore;
 		server.startServer();
-		server.waitForSSLStart();
+		server.waitForDefaultHTTPEndpointSSLStart();
 		// CWMMC0014I emits that metrics is using libraryRef
 		Assert.assertNotNull("CWMMC0014I Not found",
 				server.waitForStringInLogUsingMark("CWMMC0014I"));
@@ -217,7 +217,7 @@ public class LibraryRefTest {
 		}
 
 		server.startServer();
-		server.waitForSSLStart();
+		server.waitForDefaultHTTPEndpointSSLStart();
 
 		// CWMMC0014I emits that metrics is using libraryRef
 		Assert.assertNotNull("CWMMC0014I Not found",
@@ -230,8 +230,7 @@ public class LibraryRefTest {
 		server.resetLogMarks();
 
 		Assert.assertNotNull("CWWKO0219I Not found",
-				server.waitForStringInLogUsingMark(
-						"CWWKO0219I: TCP Channel defaultHttpEndpoint-ssl"));
+				server.waitForDefaultHTTPEndpointSSLStart(true));
 
 		// Check SR implementation log that Promethues Registry created
 		// Note that SR makes THIS explicit log for Prometheus, other meter
@@ -278,7 +277,7 @@ public class LibraryRefTest {
 	public void externalMicrometerUselessJar() throws Exception {
 		server = serverMicrometerUseless;
 		server.startServer();
-		server.waitForSSLStart();
+		server.waitForDefaultHTTPEndpointSSLStart();
 
 		// CWMMC0014I emits that metrics is using libraryRef
 		Assert.assertNotNull("CWMMC0014I Not found",

--- a/dev/io.openliberty.microprofile.metrics.internal.5.x.monitor_fat/fat/src/io/openliberty/microprofile/metrics/internal/monitor_fat/ComputedMetricsTest.java
+++ b/dev/io.openliberty.microprofile.metrics.internal.5.x.monitor_fat/fat/src/io/openliberty/microprofile/metrics/internal/monitor_fat/ComputedMetricsTest.java
@@ -633,16 +633,14 @@ public class ComputedMetricsTest {
         }
     }
 
-    private void waitForSecurityPrerequisites(LibertyServer server, int timeout) {
+    private void waitForSecurityPrerequisites(LibertyServer server, int timeout) throws Exception {
         // We only need to wait for LTPA keys if this is the first time using this server.
        if (initialServerStart) {
             // Need to ensure LTPA keys and configuration are created before hitting a secure endpoint.
-            Assert.assertNotNull("LTPA keys are not created within timeout period of " + timeout + "ms.", server.waitForStringInLog("CWWKS4104A", timeout));
-            Assert.assertNotNull("LTPA configuration is not ready within timeout period of " + timeout + "ms.", server.waitForStringInLog("CWWKS4105I", timeout));
+            server.waitForLTPAKeysCreatedAndConfigComplete(timeout);
        }
-
         // Ensure defaultHttpEndpoint-ssl TCP Channel is started
-        Assert.assertNotNull("TCP Channel defaultHttpEndpoint-ssl has not started (CWWKO0219I not found)", server.waitForStringInLog("CWWKO0219I.*defaultHttpEndpoint-ssl", timeout));
+        server.waitForDefaultHTTPEndpointSSLStart(timeout);
     }
 
     private String getHttpServlet(String servletPath, LibertyServer server) throws Exception {

--- a/dev/io.openliberty.microprofile.metrics.internal.5.x.monitor_fat/fat/src/io/openliberty/microprofile/metrics/internal/monitor_fat/ComputedMetricsTest.java
+++ b/dev/io.openliberty.microprofile.metrics.internal.5.x.monitor_fat/fat/src/io/openliberty/microprofile/metrics/internal/monitor_fat/ComputedMetricsTest.java
@@ -636,8 +636,8 @@ public class ComputedMetricsTest {
     private void waitForSecurityPrerequisites(LibertyServer server, int timeout) throws Exception {
         // We only need to wait for LTPA keys if this is the first time using this server.
        if (initialServerStart) {
-            // Need to ensure LTPA keys and configuration are created before hitting a secure endpoint.
-            server.waitForLTPAKeysCreatedAndConfigComplete(timeout);
+           // Need to ensure LTPA configuration is ready before hitting a secure endpoint.
+           server.waitForLTPAConfigReady(timeout);
        }
         // Ensure defaultHttpEndpoint-ssl TCP Channel is started
         server.waitForDefaultHTTPEndpointSSLStart(timeout);

--- a/dev/io.openliberty.microprofile.metrics.internal.5.x.monitor_fat/fat/src/io/openliberty/microprofile/metrics/internal/monitor_fat/MetricsMonitorTest.java
+++ b/dev/io.openliberty.microprofile.metrics.internal.5.x.monitor_fat/fat/src/io/openliberty/microprofile/metrics/internal/monitor_fat/MetricsMonitorTest.java
@@ -105,8 +105,8 @@ public class MetricsMonitorTest {
                 "------- Enable mpMetrics-5.0 vendor metrics should be available ------");
         server.startServer();
         Assert.assertNotNull("LTPA keys are not created/ready within timeout period of " + 60000 + "ms.",
-                server.waitForStringInLog("CWWKS4104A.*|CWWKS4105I.*", 60000));
-        Assert.assertNotNull("CWWKO0219I NOT FOUND", server.waitForStringInLog("defaultHttpEndpoint-ssl", 60000));
+                server.waitForLTPAKeysCreatedAndConfigComplete(60000));
+        Assert.assertNotNull("CWWKO0219I NOT FOUND", server.waitForDefaultHTTPEndpointSSLStart(60000, true));
         Log.info(c, testName, "------- server started -----");
         Assert.assertNotNull("CWWKT0016I NOT FOUND", server.waitForStringInLogUsingMark("CWWKT0016I"));
 

--- a/dev/io.openliberty.microprofile.metrics.internal.5.x.monitor_fat/fat/src/io/openliberty/microprofile/metrics/internal/monitor_fat/MetricsMonitorTest.java
+++ b/dev/io.openliberty.microprofile.metrics.internal.5.x.monitor_fat/fat/src/io/openliberty/microprofile/metrics/internal/monitor_fat/MetricsMonitorTest.java
@@ -104,9 +104,8 @@ public class MetricsMonitorTest {
         Log.info(c, testName,
                 "------- Enable mpMetrics-5.0 vendor metrics should be available ------");
         server.startServer();
-        Assert.assertNotNull("LTPA keys are not created/ready within timeout period of " + 60000 + "ms.",
-                server.waitForLTPAKeysCreatedAndConfigComplete(60000));
-        Assert.assertNotNull("CWWKO0219I NOT FOUND", server.waitForDefaultHTTPEndpointSSLStart(60000, true));
+        server.waitForLTPAConfigReady(60000);
+        server.waitForDefaultHTTPEndpointSSLStart(60000);
         Log.info(c, testName, "------- server started -----");
         Assert.assertNotNull("CWWKT0016I NOT FOUND", server.waitForStringInLogUsingMark("CWWKT0016I"));
 

--- a/dev/io.openliberty.microprofile.metrics.internal.5.x.monitor_fat/fat/src/io/openliberty/microprofile/metrics/internal/monitor_fat/TestEnableDisableFeaturesTest.java
+++ b/dev/io.openliberty.microprofile.metrics.internal.5.x.monitor_fat/fat/src/io/openliberty/microprofile/metrics/internal/monitor_fat/TestEnableDisableFeaturesTest.java
@@ -332,8 +332,7 @@ public class TestEnableDisableFeaturesTest {
             // server
             waitForSecurityPrerequisites(serverEDF6, 60000);
         } else {
-            Assert.assertNotNull("TCP Channel defaultHttpEndpoint-ssl has not started (CWWKO0219I not found)",
-                    serverEDF6.waitForStringInLog("CWWKO0219I.*defaultHttpEndpoint-ssl", 60000));
+            serverEDF6.waitForDefaultHTTPEndpointSSLStart(60000);
         }
         serverEDF6FirstUse = false;
 
@@ -360,8 +359,7 @@ public class TestEnableDisableFeaturesTest {
             // server
             waitForSecurityPrerequisites(serverEDF6, 60000);
         } else {
-            Assert.assertNotNull("TCP Channel defaultHttpEndpoint-ssl has not started (CWWKO0219I not found)",
-                    serverEDF6.waitForStringInLog("CWWKO0219I.*defaultHttpEndpoint-ssl", 60000));
+                serverEDF6.waitForDefaultHTTPEndpointSSLStart(60000);
         }
         serverEDF6FirstUse = false;
 
@@ -461,17 +459,12 @@ public class TestEnableDisableFeaturesTest {
                 new String[] { "connectionpool_", "servlet_", "{mp_scope=\"vendor\",servlet=\"testJDBCApp\"}" });
     }
 
-    private void waitForSecurityPrerequisites(LibertyServer server, int timeout) {
+    private void waitForSecurityPrerequisites(LibertyServer server, int timeout) throws Exception {
         // Need to ensure LTPA keys and configuration are created before hitting a
         // secure endpoint
-        Assert.assertNotNull("LTPA keys are not created within timeout period of " + timeout + "ms.",
-                server.waitForStringInLog("CWWKS4104A", timeout));
-        Assert.assertNotNull("LTPA configuration is not ready within timeout period of " + timeout + "ms.",
-                server.waitForStringInLog("CWWKS4105I", timeout));
-
+        server.waitForLTPAKeysCreatedAndConfigComplete(timeout);
         // Ensure defaultHttpEndpoint-ssl TCP Channel is started
-        Assert.assertNotNull("TCP Channel defaultHttpEndpoint-ssl has not started (CWWKO0219I not found)",
-                server.waitForStringInLog("CWWKO0219I.*defaultHttpEndpoint-ssl", timeout));
+        server.waitForDefaultHTTPEndpointSSLStart(timeout);
     }
 
     private String getHttpServlet(String servletPath, LibertyServer server) throws Exception {

--- a/dev/io.openliberty.microprofile.metrics.internal.5.x.monitor_fat/fat/src/io/openliberty/microprofile/metrics/internal/monitor_fat/TestEnableDisableFeaturesTest.java
+++ b/dev/io.openliberty.microprofile.metrics.internal.5.x.monitor_fat/fat/src/io/openliberty/microprofile/metrics/internal/monitor_fat/TestEnableDisableFeaturesTest.java
@@ -460,9 +460,8 @@ public class TestEnableDisableFeaturesTest {
     }
 
     private void waitForSecurityPrerequisites(LibertyServer server, int timeout) throws Exception {
-        // Need to ensure LTPA keys and configuration are created before hitting a
-        // secure endpoint
-        server.waitForLTPAKeysCreatedAndConfigComplete(timeout);
+        // Need to ensure LTPA is ready before invoking secure endpoint
+        server.waitForLTPAConfigReady(timeout);
         // Ensure defaultHttpEndpoint-ssl TCP Channel is started
         server.waitForDefaultHTTPEndpointSSLStart(timeout);
     }

--- a/dev/io.openliberty.microprofile.openapi.ui.internal_fat/fat/src/io/openliberty/microprofile/openapi/ui/internal/fat/tests/UIBasicTest.java
+++ b/dev/io.openliberty.microprofile.openapi.ui.internal_fat/fat/src/io/openliberty/microprofile/openapi/ui/internal/fat/tests/UIBasicTest.java
@@ -128,7 +128,7 @@ public class UIBasicTest {
     public void testHttpsUI() throws Exception {
         //Reduce possibility that Server is not listening on its HTTPS Port
         //Especially for Windows if certificates are slow to create
-        server.waitForSSLStart();
+        server.waitForDefaultHTTPEndpointSSLStart();
 
         driver.get("https://host.testcontainers.internal:" + server.getHttpDefaultSecurePort() + "/openapi/ui");
         testUI();

--- a/dev/io.openliberty.microprofile.openapi.ui.internal_fat/fat/src/io/openliberty/microprofile/openapi/ui/internal/fat/tests/UIOauthTest.java
+++ b/dev/io.openliberty.microprofile.openapi.ui.internal_fat/fat/src/io/openliberty/microprofile/openapi/ui/internal/fat/tests/UIOauthTest.java
@@ -152,7 +152,7 @@ public class UIOauthTest {
         server.addEnvVar(UI_PATH_PROPERTY, UI_PATH_VALUE);
 
         server.startServer();
-        server.waitForStringInLog("CWWKO0219I: TCP Channel defaultHttpEndpoint-ssl", 60000);
+        server.waitForDefaultHTTPEndpointSSLStart(60000);
         OAuthTest(UI_PATH_VALUE);
 
     }
@@ -170,7 +170,7 @@ public class UIOauthTest {
         server.startServer();
         //Reduce possibility that Server is not listening on its HTTPS Port
         //Especially for Windows if certificates are slow to create
-        server.waitForSSLStart();
+        server.waitForDefaultHTTPEndpointSSLStart();
 
         OAuthTest(CUSTOM_UI_PATH_VALUE);
     }

--- a/dev/io.openliberty.reporting.internal_fat/fat/src/io/openliberty/reporting/internal/fat/CVEResponseTest.java
+++ b/dev/io.openliberty.reporting.internal_fat/fat/src/io/openliberty/reporting/internal/fat/CVEResponseTest.java
@@ -120,7 +120,7 @@ public class CVEResponseTest extends FATServletClient {
     @Test
     public void testConnectionAndDataRecorded() throws Exception {
         server.startServer();
-        server.waitForSSLStart();
+        server.waitForDefaultHTTPEndpointSSLStart();
         copyTrustStore(server, testServer);
         testServer.setJvmOptions(Arrays.asList("-Dcom.ibm.ws.beta.edition=true", "-Dcve.insight.enabled=true",
                                                "-Djavax.net.ssl.trustStore=" + testServer.getServerRoot() + "/resources/security/key.p12",
@@ -189,7 +189,7 @@ public class CVEResponseTest extends FATServletClient {
     @Test
     public void testResponse() throws Exception {
         server.startServer();
-        server.waitForSSLStart();
+        server.waitForDefaultHTTPEndpointSSLStart();
         copyTrustStore(server, testServer);
         testServer.setJvmOptions(Arrays.asList("-Dcom.ibm.ws.beta.edition=true", "-Dcve.insight.enabled=true",
                                                "-Djavax.net.ssl.trustStore=" + testServer.getServerRoot() + "/resources/security/key.p12",
@@ -225,7 +225,7 @@ public class CVEResponseTest extends FATServletClient {
         features.add("ssl-1.0");
         server.updateServerConfiguration(config);
         server.startServer();
-        server.waitForSSLStart();
+        server.waitForDefaultHTTPEndpointSSLStart();
         copyTrustStore(server, testServer);
         Process createKeyStore = Runtime.getRuntime().exec(getCertGenerationCommand(testServer.getServerRoot() + "/" + STORE_PATH + "/" + NEW_KEYSTORE_FILENAME, STORE_PASSWORD));
         createKeyStore.waitFor();
@@ -253,7 +253,7 @@ public class CVEResponseTest extends FATServletClient {
     @Test
     public void testTrustWithInvalidCertificate() throws Exception {
         server.startServer();
-        server.waitForSSLStart();
+        server.waitForDefaultHTTPEndpointSSLStart();
         testServer.setJvmOptions(Arrays.asList("-Dcom.ibm.ws.beta.edition=true", "-Dcve.insight.enabled=true"));
         testServer.startServer();
         List<String> warnings = Arrays.asList("CWWKF1702W", "CWWKF1705W");
@@ -277,7 +277,7 @@ public class CVEResponseTest extends FATServletClient {
         features.add("transportSecurity-1.0");
         server.updateServerConfiguration(config);
         server.startServer();
-        server.waitForSSLStart();
+        server.waitForDefaultHTTPEndpointSSLStart();
         copyTrustStore(server, testServer);
         Process createKeyStore = Runtime.getRuntime().exec(getCertGenerationCommand(testServer.getServerRoot() + "/" + STORE_PATH + "/" + NEW_KEYSTORE_FILENAME, STORE_PASSWORD));
         createKeyStore.waitFor();

--- a/dev/io.openliberty.security.authorization.internal.3.0_fat/fat/src/io/openliberty/security/authorization/internal/tests/AnnotationRolesTest.java
+++ b/dev/io.openliberty.security.authorization.internal.3.0_fat/fat/src/io/openliberty/security/authorization/internal/tests/AnnotationRolesTest.java
@@ -84,6 +84,7 @@ public class AnnotationRolesTest extends AbstractRolesTest {
         if (!server.isStarted()) {
             ShrinkHelper.exportAppToServer(server, war, DeployOptions.SERVER_ONLY);
             server.startServer();
+            server.waitForLTPAConfigReady();
         } else {
             server.setMarkToEndOfLog();
             ShrinkHelper.exportAppToServer(server, war, DeployOptions.SERVER_ONLY, DeployOptions.DISABLE_VALIDATION);
@@ -127,6 +128,7 @@ public class AnnotationRolesTest extends AbstractRolesTest {
         if (!server.isStarted()) {
             ShrinkHelper.exportAppToServer(server, war, DeployOptions.SERVER_ONLY);
             server.startServer();
+            server.waitForLTPAConfigReady();
         } else {
             server.setMarkToEndOfLog();
             ShrinkHelper.exportAppToServer(server, war, DeployOptions.SERVER_ONLY, DeployOptions.DISABLE_VALIDATION);
@@ -170,6 +172,7 @@ public class AnnotationRolesTest extends AbstractRolesTest {
         if (!server.isStarted()) {
             ShrinkHelper.exportAppToServer(server, war, DeployOptions.SERVER_ONLY);
             server.startServer();
+            server.waitForLTPAConfigReady();
         } else {
             server.setMarkToEndOfLog();
             ShrinkHelper.exportAppToServer(server, war, DeployOptions.SERVER_ONLY, DeployOptions.DISABLE_VALIDATION);

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config.commonTest/fat/src/io/openliberty/security/jakartasec/fat/config/tests/ConfigurationClaimsDefinitionTests.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config.commonTest/fat/src/io/openliberty/security/jakartasec/fat/config/tests/ConfigurationClaimsDefinitionTests.java
@@ -95,6 +95,8 @@ public class ConfigurationClaimsDefinitionTests extends CommonAnnotatedSecurityT
 
         deployMyApps(); // run this after starting the RP so we have the rp port to update the openIdConfig.properties file within the apps
 
+        rpServer.waitForLTPAConfigReady();
+        opServer.waitForLTPAConfigReady();
     }
 
     /**

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config.commonTest/fat/src/io/openliberty/security/jakartasec/fat/config/tests/ConfigurationDisplayTests.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config.commonTest/fat/src/io/openliberty/security/jakartasec/fat/config/tests/ConfigurationDisplayTests.java
@@ -92,7 +92,7 @@ public class ConfigurationDisplayTests extends CommonAnnotatedSecurityTests {
         rpHttpsBase = "https://localhost:" + rpServer.getBvtSecurePort();
 
         deployMyApps(); // run this after starting the RP so we have the rp port to update the openIdConfig.properties file within the apps
-        rpServer.waitForStringInLog("CWWKS4105I.*",60000);
+        rpServer.waitForLTPAConfigReady(60000);
     }
 
     /**

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config.commonTest/fat/src/io/openliberty/security/jakartasec/fat/config/tests/ConfigurationELValuesOverrideTests.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config.commonTest/fat/src/io/openliberty/security/jakartasec/fat/config/tests/ConfigurationELValuesOverrideTests.java
@@ -86,6 +86,9 @@ public class ConfigurationELValuesOverrideTests extends CommonAnnotatedSecurityT
 
         deployMyApps(); // run this after starting the RP so we have the rp port to update the openIdConfig.properties file within the apps
 
+        opServer.waitForLTPAConfigReady();
+        rpServer.waitForLTPAConfigReady();
+
     }
 
     /**

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config.commonTest/fat/src/io/openliberty/security/jakartasec/fat/config/tests/ConfigurationELValuesOverrideWithoutHttpSessionTests.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config.commonTest/fat/src/io/openliberty/security/jakartasec/fat/config/tests/ConfigurationELValuesOverrideWithoutHttpSessionTests.java
@@ -84,6 +84,8 @@ public class ConfigurationELValuesOverrideWithoutHttpSessionTests extends Common
 
         deployMyApps(); // run this after starting the RP so we have the rp port to update the openIdConfig.properties file within the apps
 
+        opServer.waitForLTPAConfigReady();
+        rpServer.waitForLTPAConfigReady();
     }
 
     /**

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config.commonTest/fat/src/io/openliberty/security/jakartasec/fat/config/tests/ConfigurationExtraParametersTests.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config.commonTest/fat/src/io/openliberty/security/jakartasec/fat/config/tests/ConfigurationExtraParametersTests.java
@@ -99,6 +99,8 @@ public class ConfigurationExtraParametersTests extends CommonAnnotatedSecurityTe
 
         deployMyApps(); // run this after starting the RP so we have the rp port to update the openIdConfig.properties file within the apps
 
+        opServer.waitForLTPAConfigReady();
+        rpServer.waitForLTPAConfigReady();
     }
 
     /**

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config.commonTest/fat/src/io/openliberty/security/jakartasec/fat/config/tests/ConfigurationPromptTests.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config.commonTest/fat/src/io/openliberty/security/jakartasec/fat/config/tests/ConfigurationPromptTests.java
@@ -104,6 +104,8 @@ public class ConfigurationPromptTests extends CommonAnnotatedSecurityTests {
 
         deployMyApps(); // run this after starting the RP so we have the rp port to update the openIdConfig.properties file within the apps
 
+        opServer.waitForLTPAConfigReady();
+        rpServer.waitForLTPAConfigReady();
     }
 
     /**

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config.commonTest/fat/src/io/openliberty/security/jakartasec/fat/config/tests/ConfigurationProviderMetadataTests.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config.commonTest/fat/src/io/openliberty/security/jakartasec/fat/config/tests/ConfigurationProviderMetadataTests.java
@@ -121,6 +121,9 @@ public class ConfigurationProviderMetadataTests extends CommonAnnotatedSecurityT
 
         deployMyApps(); // run this after starting the RP so we have the rp port to update the openIdConfig.properties file within the apps
 
+
+        opServer.waitForLTPAConfigReady();
+        rpServer.waitForLTPAConfigReady();
     }
 
     /**

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config.commonTest/fat/src/io/openliberty/security/jakartasec/fat/config/tests/ConfigurationResponseModeTests.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config.commonTest/fat/src/io/openliberty/security/jakartasec/fat/config/tests/ConfigurationResponseModeTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022, 2026 IBM Corporation and others.
+ * Copyright (c) 2022, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -107,6 +107,8 @@ public class ConfigurationResponseModeTests extends CommonAnnotatedSecurityTests
 
         deployMyApps(); // run this after starting the RP so we have the rp port to update the openIdConfig.properties file within the apps
 
+        opServer.waitForLTPAConfigReady();
+        rpServer.waitForLTPAConfigReady();
     }
 
     /**

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config.commonTest/fat/src/io/openliberty/security/jakartasec/fat/config/tests/ConfigurationScopeTests.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config.commonTest/fat/src/io/openliberty/security/jakartasec/fat/config/tests/ConfigurationScopeTests.java
@@ -101,6 +101,8 @@ public class ConfigurationScopeTests extends CommonAnnotatedSecurityTests {
 
         deployMyApps(); // run this after starting the RP so we have the rp port to update the openIdConfig.properties file within the apps
 
+        opServer.waitForLTPAConfigReady();
+        rpServer.waitForLTPAConfigReady();
     }
 
     /**

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config.commonTest/fat/src/io/openliberty/security/jakartasec/fat/config/tests/ConfigurationSigningTests.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config.commonTest/fat/src/io/openliberty/security/jakartasec/fat/config/tests/ConfigurationSigningTests.java
@@ -126,6 +126,8 @@ public class ConfigurationSigningTests extends CommonAnnotatedSecurityTests {
 
         deployMyApps(); // run this after starting the RP so we have the rp port to update the openIdConfig.properties file within the apps
 
+        opServer.waitForLTPAConfigReady();
+        rpServer.waitForLTPAConfigReady();
     }
 
     /**

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config.commonTest/fat/src/io/openliberty/security/jakartasec/fat/config/tests/ConfigurationTests.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config.commonTest/fat/src/io/openliberty/security/jakartasec/fat/config/tests/ConfigurationTests.java
@@ -90,6 +90,8 @@ public class ConfigurationTests extends CommonAnnotatedSecurityTests {
 
         deployMyApps(); // run this after starting the RP so we have the rp port to update the openIdConfig.properties file within the apps
 
+        opServer.waitForLTPAConfigReady();
+        rpServer.waitForLTPAConfigReady();
     }
 
     /**

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config.commonTest/fat/src/io/openliberty/security/jakartasec/fat/config/tests/ConfigurationTokenMinValidityTests.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config.commonTest/fat/src/io/openliberty/security/jakartasec/fat/config/tests/ConfigurationTokenMinValidityTests.java
@@ -107,11 +107,12 @@ public class ConfigurationTokenMinValidityTests extends CommonAnnotatedSecurityT
 
         deployMyApps(); // run this after starting the RP so we have the rp port to update the openIdConfig.properties file within the apps
 
+        opServer.waitForLTPAConfigReady();
+        rpServer.waitForLTPAConfigReady();
         ShortTokenLifetimePrep s = new ShortTokenLifetimePrep();
         s.shortTokenLifetimePrep(opServer, rpHttpsBase, "TokenMinValidity5s/TokenMinValidity5sServlet", "TokenMinValidity20s/TokenMinValidity20sServlet",
                                  "TokenMinValidity60s/TokenMinValidity60sServlet", "TokenMinValidity90s/TokenMinValidity90sServlet",
                                  "TokenMinValidity0s/TokenMinValidity0sServlet");
-
     }
 
     /**

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config.commonTest/fat/src/io/openliberty/security/jakartasec/fat/config/tests/ConfigurationUseNonceTests.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config.commonTest/fat/src/io/openliberty/security/jakartasec/fat/config/tests/ConfigurationUseNonceTests.java
@@ -105,6 +105,8 @@ public class ConfigurationUseNonceTests extends CommonAnnotatedSecurityTests {
 
         deployMyApps(); // run this after starting the RP so we have the rp port to update the openIdConfig.properties file within the apps
 
+        opServer.waitForLTPAConfigReady();
+        rpServer.waitForLTPAConfigReady();
     }
 
     /**

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config.commonTest/fat/src/io/openliberty/security/jakartasec/fat/config/tests/ConfigurationUserInfoTests.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.config.commonTest/fat/src/io/openliberty/security/jakartasec/fat/config/tests/ConfigurationUserInfoTests.java
@@ -193,6 +193,8 @@ public class ConfigurationUserInfoTests extends CommonAnnotatedSecurityTests {
 
         deployMyApps(); // run this after starting the RP so we have the rp port to update the openIdConfig.properties file within the apps
 
+        opServer.waitForLTPAConfigReady();
+        rpServer.waitForLTPAConfigReady();
     }
 
     /**

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat/fat/src/io/openliberty/security/jakartasec/fat/sharedTests/BasicOIDCAnnotationTests.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat/fat/src/io/openliberty/security/jakartasec/fat/sharedTests/BasicOIDCAnnotationTests.java
@@ -95,8 +95,8 @@ public class BasicOIDCAnnotationTests extends CommonAnnotatedSecurityTests {
         //  app need to be updated by the test case - the app is updated by the invokeApp* methods)
 
         // Wait to ensure LTPA configuration has completed before starting tests.
-        opServer.waitForStringInLog("CWWKS4105I");
-        rpServer.waitForStringInLog("CWWKS4105I");
+        opServer.waitForLTPAConfigReady();
+        rpServer.waitForLTPAConfigReady();
     }
 
     /**

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat/fat/src/io/openliberty/security/jakartasec/fat/tests/AuthenticationEndpointValidationTests.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat/fat/src/io/openliberty/security/jakartasec/fat/tests/AuthenticationEndpointValidationTests.java
@@ -95,8 +95,8 @@ public class AuthenticationEndpointValidationTests extends CommonAnnotatedSecuri
         deployMyApps(); // run this after starting the RP so we have the rp port to update the openIdConfig.properties file within the apps
 
         // Wait to ensure LTPA configuration has completed before starting tests.
-        opServer.waitForStringInLog("CWWKS4105I");
-        rpServer.waitForStringInLog("CWWKS4105I");
+        opServer.waitForLTPAConfigReady();
+        rpServer.waitForLTPAConfigReady();
 
     }
 

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat/fat/src/io/openliberty/security/jakartasec/fat/tests/AuthenticationTests.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat/fat/src/io/openliberty/security/jakartasec/fat/tests/AuthenticationTests.java
@@ -123,8 +123,8 @@ public class AuthenticationTests extends CommonAnnotatedSecurityTests {
         rpServer.addIgnoredErrors(Arrays.asList(MessageConstants.SESN0066E_RSP_COMMITTED_COOKIE_CANNOT_BE_SET, MessageConstants.SRVE8114W_CANNOT_SET_SESSION_COOKIE));
 
         // Wait to ensure LTPA configuration has completed before starting tests
-        opServer.waitForStringInLog("CWWKS4105I");
-        rpServer.waitForStringInLog("CWWKS4105I");
+        opServer.waitForLTPAConfigReady();
+        rpServer.waitForLTPAConfigReady();
         // rspValues used to validate the app output will be initialized before each test - any unique values (other than the
         //  app need to be updated by the test case - the app is updated by the invokeApp* methods)
     }

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat/fat/src/io/openliberty/security/jakartasec/fat/tests/IdentityStoreTests.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat/fat/src/io/openliberty/security/jakartasec/fat/tests/IdentityStoreTests.java
@@ -85,8 +85,8 @@ public class IdentityStoreTests extends CommonAnnotatedSecurityTests {
         deployMyApps();
 
         // Wait to ensure LTPA configuration has completed before starting tests
-        opServer.waitForStringInLog("CWWKS4105I");
-        rpServer.waitForStringInLog("CWWKS4105I");
+        opServer.waitForLTPAConfigReady();
+        rpServer.waitForLTPAConfigReady();
 
         // rspValues used to validate the app output will be initialized before each test - any unique values (other than the
         //  app need to be updated by the test case - the app is updated by the invokeApp* methods)

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat/fat/src/io/openliberty/security/jakartasec/fat/tests/InjectionScopedTests.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat/fat/src/io/openliberty/security/jakartasec/fat/tests/InjectionScopedTests.java
@@ -83,8 +83,8 @@ public class InjectionScopedTests extends CommonAnnotatedSecurityTests {
         deployMyApps();
 
         // Wait to ensure LTPA configuration has completed before starting tests
-        opServer.waitForStringInLog("CWWKS4105I");
-        rpServer.waitForStringInLog("CWWKS4105I");
+        opServer.waitForLTPAConfigReady();
+        rpServer.waitForLTPAConfigReady();
 
         // rspValues used to validate the app output will be initialized before each test - any unique values (other than the
         //  app need to be updated by the test case - the app is updated by the invokeApp* methods)

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat/fat/src/io/openliberty/security/jakartasec/fat/tests/TokenValidationTests.java
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat/fat/src/io/openliberty/security/jakartasec/fat/tests/TokenValidationTests.java
@@ -121,8 +121,8 @@ public class TokenValidationTests extends CommonAnnotatedSecurityTests {
         deployMyApps();
 
         // Wait to ensure LTPA configuration has completed before starting tests
-        opServer.waitForStringInLog("CWWKS4105I");
-        rpServer.waitForStringInLog("CWWKS4105I");
+        opServer.waitForLTPAConfigReady();
+        rpServer.waitForLTPAConfigReady();
 
     }
 

--- a/dev/io.openliberty.security.jakartasec.4.0.internal_fat/fat/src/io/openliberty/security/jakartasec/fat/tests/AppBndRolesTests.java
+++ b/dev/io.openliberty.security.jakartasec.4.0.internal_fat/fat/src/io/openliberty/security/jakartasec/fat/tests/AppBndRolesTests.java
@@ -51,7 +51,7 @@ public class AppBndRolesTests {
         server.addDropinDefaultConfiguration("dropins/app1_noRoles.xml");
 
         server.startServer();
-        assertNotNull(server.waitForStringInLog("CWWKS4105I"));
+        server.waitForLTPAConfigReady();
 
         url = "http://localhost:" + server.getHttpDefaultPort() + "/" + APP_NAME;
 

--- a/dev/io.openliberty.security.jakartasec.4.0.internal_fat/fat/src/io/openliberty/security/jakartasec/fat/tests/AppRolesTests.java
+++ b/dev/io.openliberty.security.jakartasec.4.0.internal_fat/fat/src/io/openliberty/security/jakartasec/fat/tests/AppRolesTests.java
@@ -55,8 +55,7 @@ public class AppRolesTests {
 
         server.startServer();
 
-        assertNotNull(server.waitForStringInLog("CWWKS4105I"));
-
+        server.waitForLTPAConfigReady();
         urlApp1 = "http://localhost:" + server.getHttpDefaultPort() + "/" + APP_NAME + RESOURCE_PATH;
         urlApp2 = "http://localhost:" + server.getHttpDefaultPort() + "/" + APP_NAME_2 + RESOURCE_PATH;
         Log.info(c, "setUp", "Server started successfully");

--- a/dev/io.openliberty.security.jakartasec.4.0.internal_fat/fat/src/io/openliberty/security/jakartasec/fat/tests/InMemoryIdentityStoreELWarningTest.java
+++ b/dev/io.openliberty.security.jakartasec.4.0.internal_fat/fat/src/io/openliberty/security/jakartasec/fat/tests/InMemoryIdentityStoreELWarningTest.java
@@ -82,6 +82,8 @@ public class InMemoryIdentityStoreELWarningTest extends BaseJakartaSecurity40Tes
         ShrinkHelper.exportDropinAppToServer(server, app, DeployOptions.SERVER_ONLY);
 
         instance.startServer();
+
+        server.waitForLTPAConfigReady();
     }
 
     /**

--- a/dev/io.openliberty.security.jakartasec.4.0.internal_fat/fat/src/io/openliberty/security/jakartasec/fat/tests/InMemoryIdentityStoreEnablementTests.java
+++ b/dev/io.openliberty.security.jakartasec.4.0.internal_fat/fat/src/io/openliberty/security/jakartasec/fat/tests/InMemoryIdentityStoreEnablementTests.java
@@ -96,6 +96,8 @@ public class InMemoryIdentityStoreEnablementTests extends BaseJakartaSecurity40T
         ShrinkHelper.exportDropinAppToServer(server, app, DeployOptions.SERVER_ONLY);
 
         instance.startServer();
+
+        server.waitForLTPAConfigReady();
     }
 
     @After

--- a/dev/io.openliberty.security.jakartasec.4.0.internal_fat/fat/src/io/openliberty/security/jakartasec/fat/tests/InMemoryIdentityStoreTests.java
+++ b/dev/io.openliberty.security.jakartasec.4.0.internal_fat/fat/src/io/openliberty/security/jakartasec/fat/tests/InMemoryIdentityStoreTests.java
@@ -89,6 +89,8 @@ public class InMemoryIdentityStoreTests extends BaseJakartaSecurity40Test {
         ShrinkHelper.exportDropinAppToServer(server, app, DeployOptions.SERVER_ONLY);
 
         instance.startServer();
+
+        server.waitForLTPAConfigReady();
     }
 
     /**

--- a/dev/io.openliberty.security.jakartasec.4.0.internal_fat/fat/src/io/openliberty/security/jakartasec/fat/tests/UnauthenticatedDeclaredRolesTests.java
+++ b/dev/io.openliberty.security.jakartasec.4.0.internal_fat/fat/src/io/openliberty/security/jakartasec/fat/tests/UnauthenticatedDeclaredRolesTests.java
@@ -60,7 +60,7 @@ public class UnauthenticatedDeclaredRolesTests extends FATServletClient {
         ShrinkHelper.exportDropinAppToServer(server, app, ShrinkHelper.DeployOptions.SERVER_ONLY);
         server.startServer();
 
-        server.waitForStringInLog("CWWKS4105I");
+        server.waitForLTPAConfigReady();
         Log.info(c, "setUp", "Server started successfully");
     }
 

--- a/dev/io.openliberty.transport.http_fat/fat/src/io/openliberty/transport/http_fat/InactivityTimeoutTests.java
+++ b/dev/io.openliberty.transport.http_fat/fat/src/io/openliberty/transport/http_fat/InactivityTimeoutTests.java
@@ -67,8 +67,7 @@ public class InactivityTimeoutTests {
 
         // Go through logs and check if Netty is being used.
         // Wait for the TCP Channel to finish loading and get the TCP Channel started message.
-        // CWWKO0219I: TCP Channel defaultHttpEndpoint has been started and is now listening for requests on host *  (IPv6) port 8010.
-        String tcpChannelMessage = server.waitForStringInLog("CWWKO0219I: TCP Channel defaultHttpEndpoint");
+        String tcpChannelMessage = server.waitForDefaultHTTPEndpointStart();
         LOG.info("Endpoint: " + tcpChannelMessage);
 
         runningNetty = tcpChannelMessage.contains(NETTY_TCP_CLASS_NAME);
@@ -324,8 +323,7 @@ public class InactivityTimeoutTests {
         assertNotNull("The configured value of inactivityTimeout was not 5000!", server.waitForStringInTraceUsingMark("inactivityTimeout: 5000"));
 
         // Ensure the TCP Channel has started.
-        // CWWKO0219I: TCP Channel defaultHttpEndpoint has been started and is now listening for requests on host *  (IPv4) port 8010.
-        assertNotNull("The TCP Channel was not started!", server.waitForStringInLogUsingMark("CWWKO0219I"));
+        server.waitForDefaultHTTPEndpointStart();
 
         LOG.info("Creating a Socket connection.");
         URL url = HttpUtils.createURL(server, "/InactivityTimeoutServlet");
@@ -423,8 +421,7 @@ public class InactivityTimeoutTests {
         assertNotNull("The configured value of inactivityTimeout was not 5000!", server.waitForStringInTraceUsingMark("inactivityTimeout: 5000"));
 
         // Ensure the TCP Channel has started.
-        // CWWKO0219I: TCP Channel defaultHttpEndpoint has been started and is now listening for requests on host *  (IPv4) port 8010.
-        assertNotNull("The TCP Channel was not started!", server.waitForStringInLogUsingMark("CWWKO0219I"));
+        server.waitForDefaultHTTPEndpointStart();
 
         LOG.info("Creating a Socket connection.");
         URL url = HttpUtils.createURL(server, "/InactivityTimeoutServlet");
@@ -520,8 +517,7 @@ public class InactivityTimeoutTests {
         assertNotNull("The configured value of inactivityTimeout was not 5000!", server.waitForStringInTraceUsingMark("inactivityTimeout: 5000"));
 
         // Ensure the TCP Channel has started.
-        // CWWKO0219I: TCP Channel defaultHttpEndpoint has been started and is now listening for requests on host *  (IPv4) port 8010.
-        assertNotNull("The TCP Channel was not started!", server.waitForStringInLogUsingMark("CWWKO0219I"));
+        server.waitForDefaultHTTPEndpointStart();
 
         LOG.info("Creating a Socket connection.");
         URL url = HttpUtils.createURL(server, "/InactivityTimeoutServlet");
@@ -606,8 +602,7 @@ public class InactivityTimeoutTests {
         assertNotNull("The configured value of inactivityTimeout was not 5000!", server.waitForStringInTraceUsingMark("inactivityTimeout: 5000"));
 
         // Ensure the TCP Channel has started.
-        // CWWKO0219I: TCP Channel defaultHttpEndpoint has been started and is now listening for requests on host *  (IPv4) port 8010.
-        assertNotNull("The TCP Channel was not started!", server.waitForStringInLogUsingMark("CWWKO0219I"));
+        server.waitForDefaultHTTPEndpointStart();
 
         LOG.info("Creating a Socket connection.");
         URL url = HttpUtils.createURL(server, "/InactivityTimeoutServlet");
@@ -690,8 +685,7 @@ public class InactivityTimeoutTests {
         assertNotNull("The configured value of inactivityTimeout was not 0!", server.waitForStringInTraceUsingMark("inactivityTimeout: 0"));
 
         // Ensure the TCP Channel has started.
-        // CWWKO0219I: TCP Channel defaultHttpEndpoint has been started and is now listening for requests on host *  (IPv4) port 8010.
-        assertNotNull("The TCP Channel was not started!", server.waitForStringInLogUsingMark("CWWKO0219I"));
+        server.waitForDefaultHTTPEndpointStart();
 
         LOG.info("Creating a Socket connection.");
         URL url = HttpUtils.createURL(server, "/InactivityTimeoutServlet");

--- a/dev/io.openliberty.transport.http_fat/fat/src/io/openliberty/transport/http_fat/MaxMessageSizeLimitTests.java
+++ b/dev/io.openliberty.transport.http_fat/fat/src/io/openliberty/transport/http_fat/MaxMessageSizeLimitTests.java
@@ -63,8 +63,7 @@ public class MaxMessageSizeLimitTests {
 
         // Go through logs and check if Netty is being used.
         // Wait for the TCP Channel to finish loading and get the TCP Channel started message.
-        // CWWKO0219I: TCP Channel defaultHttpEndpoint has been started and is now listening for requests on host *  (IPv6) port 8010.
-        String tcpChannelMessage = server.waitForStringInLog("CWWKO0219I: TCP Channel defaultHttpEndpoint");
+        String tcpChannelMessage = server.waitForDefaultHTTPEndpointStart();
         LOG.info("Endpoint: " + tcpChannelMessage);
 
         runningNetty = tcpChannelMessage.contains(NETTY_TCP_CLASS_NAME);

--- a/dev/io.openliberty.transport.http_fat/fat/src/io/openliberty/transport/http_fat/MaxOpenConnectionsTests.java
+++ b/dev/io.openliberty.transport.http_fat/fat/src/io/openliberty/transport/http_fat/MaxOpenConnectionsTests.java
@@ -58,8 +58,7 @@ public class MaxOpenConnectionsTests {
 
         // Go through logs and check if Netty is being used.
         // Wait for the TCP Channel to finish loading and get the TCP Channel started message.
-        // CWWKO0219I: TCP Channel defaultHttpEndpoint has been started and is now listening for requests on host *  (IPv6) port 8010.
-        String tcpChannelMessage = server.waitForStringInLog("CWWKO0219I: TCP Channel defaultHttpEndpoint");
+        String tcpChannelMessage = server.waitForDefaultHTTPEndpointStart();
         LOG.info("Endpoint: " + tcpChannelMessage);
 
         runningNetty = tcpChannelMessage.contains(NETTY_TCP_CLASS_NAME);
@@ -229,8 +228,7 @@ public class MaxOpenConnectionsTests {
         assertNotNull("The configured value of maxOpenConnections was not 2!", server.waitForStringInTraceUsingMark("maxOpenConnections: 2"));
 
         // Ensure the TCP Channel has started.
-        // CWWKO0219I: TCP Channel defaultHttpEndpoint has been started and is now listening for requests on host *  (IPv4) port 8010.
-        assertNotNull("The TCP Channel was not started!", server.waitForStringInLogUsingMark("CWWKO0219I: TCP Channel defaultHttpEndpoint"));
+        server.waitForDefaultHTTPEndpointStart();
 
         // Create three Socket connections.
         Socket socket1 = null;
@@ -316,7 +314,7 @@ public class MaxOpenConnectionsTests {
 
         // Ensure the TCP Channel has started.
         // CWWKO0219I: TCP Channel defaultHttpEndpoint has been started and is now listening for requests on host *  (IPv4) port 8010.
-        assertNotNull("The TCP Channel defaultHttpEndpoint was not started!", server.waitForStringInLogUsingMark("CWWKO0219I: TCP Channel defaultHttpEndpoint"));
+        assertNotNull("The TCP Channel defaultHttpEndpoint was not started!", server.waitForDefaultHTTPEndpointStart());
 
         // Add another httpEndpoint and set its maxOpenConnections to 1.
         HttpEndpoint endpoint2 = new HttpEndpoint();

--- a/dev/io.openliberty.transport.http_fat/fat/src/io/openliberty/transport/http_fat/RequestSocketTest.java
+++ b/dev/io.openliberty.transport.http_fat/fat/src/io/openliberty/transport/http_fat/RequestSocketTest.java
@@ -55,8 +55,7 @@ public class RequestSocketTest extends FATServletClient {
         server.installSystemFeature("webcontainerlibertyinternals");
         server.startServer();
         server.resetLogMarks();
-        assertNotNull("defaultHttpEndpoint-ssl was not started",
-                      server.waitForStringInLog("CWWKO0219I:(.*)defaultHttpEndpoint-ssl"));
+        server.waitForDefaultHTTPEndpointSSLStart();
     }
 
     /**

--- a/dev/io.openliberty.transport.http_fat/fat/src/io/openliberty/transport/http_fat/SoReuseAddrTest.java
+++ b/dev/io.openliberty.transport.http_fat/fat/src/io/openliberty/transport/http_fat/SoReuseAddrTest.java
@@ -62,10 +62,9 @@ public class SoReuseAddrTest {
      */
     @Test
     public void testSoReuseAddr_nonDefault() throws Exception {
-        // CWWKO0219I: TCP Channel defaultHttpEndpoint has been started and is now listening for requests on host *  (IPv6) port 8010.
         // We should wait for the TCP Channel to start before checking the trace. If we don't it is possible we try to start shutting down
         // the server before we even have finished starting up causing quiesce issues.
-        server.waitForStringInLog("CWWKO0219I");
+        server.waitForDefaultHTTPEndpointStart();
 
         // Validate that soReuseAddr is set to false.
         assertNotNull("The configured value of soReuseAddr was not false!", server.waitForStringInTrace("soReuseAddr: false"));

--- a/dev/io.openliberty.transport.ssl_fat/fat/src/io/openliberty/transport/ssl/SSLOptionsTest.java
+++ b/dev/io.openliberty.transport.ssl_fat/fat/src/io/openliberty/transport/ssl/SSLOptionsTest.java
@@ -83,8 +83,7 @@ public class SSLOptionsTest{
 
         server.startServer(SSLOptionsTest.class.getSimpleName() + ".log");
         // Wait for SSL endpoint to start
-        assertNotNull("We need to wait for the SSL port to open",
-                      server.waitForStringInLog("CWWKO0219I:.*-ssl"));
+        server.waitForDefaultHTTPEndpointSSLStart();
     }
 
     @AfterClass
@@ -125,7 +124,7 @@ public class SSLOptionsTest{
         server.waitForConfigUpdateInLogUsingMark(null);
         if(server.findStringsInLogsUsingMark("CWWKG0018I", server.getDefaultLogFile()).size() == 0) { // Server configuration was updated so need to wait for ssl port
             assertNotNull("We need to wait for the SSL port to open after config update",
-                      server.waitForStringInLogUsingMark("CWWKO0219I:.*-ssl"));
+                      server.waitForDefaultHTTPEndpointSSLStart(true));
         }
         
     }
@@ -159,8 +158,7 @@ public class SSLOptionsTest{
         server.waitForConfigUpdateInLogUsingMark(null);
 
         // Requires info trace
-        assertNotNull("We need to wait for the SSL port to open",
-                      server.waitForStringInLogUsingMark("CWWKO0219I:.*-ssl"));
+        server.waitForDefaultHTTPEndpointSSLStart();
 
         // Hit the servlet on the SSL port
         hitServerWithBadHandshake();
@@ -193,7 +191,7 @@ public class SSLOptionsTest{
         server.waitForConfigUpdateInLogUsingMark(null);
 
         assertNotNull("We need to wait for the SSL port to start (again)",
-                      server.waitForStringInLogUsingMark("CWWKO0219I:.*-ssl"));
+                      server.waitForDefaultHTTPEndpointSSLStart(true));
         saveCnt = server.findStringsInLogs("CWWKO0801E").size();
 
         // Hit the servlet on the SSL port
@@ -209,7 +207,7 @@ public class SSLOptionsTest{
 
         // Requires info trace
         assertNotNull("We need to wait for the SSL port to start (again)",
-                      server.waitForStringInLogUsingMark("CWWKO0219I:.*-ssl"));
+                      server.waitForDefaultHTTPEndpointSSLStart(true));
 
         // Hit the servlet on the SSL port
         server.setMarkToEndOfLog();
@@ -233,8 +231,7 @@ public class SSLOptionsTest{
         server.waitForConfigUpdateInLogUsingMark(null);
 
         // Requires info trace
-        assertNotNull("We need to wait for the SSL port to open",
-                      server.waitForStringInLogUsingMark("CWWKO0219I:.*-ssl"));
+        server.waitForDefaultHTTPEndpointSSLStart();
         server.setMarkToEndOfLog();
 
         // Hit the servlet on the SSL port

--- a/dev/io.openliberty.webcontainer.servlet.6.1.internal_fat/fat/src/io/openliberty/webcontainer/servlet61/fat/tests/Servlet61SecureProtocolTLSDefaultAttributeTest.java
+++ b/dev/io.openliberty.webcontainer.servlet.6.1.internal_fat/fat/src/io/openliberty/webcontainer/servlet61/fat/tests/Servlet61SecureProtocolTLSDefaultAttributeTest.java
@@ -57,7 +57,7 @@ public class Servlet61SecureProtocolTLSDefaultAttributeTest {
         server.startServer(Servlet61SecureProtocolTLSDefaultAttributeTest.class.getSimpleName() + ".log");
 
         //MUST WAIT FOR SECURE PORT...else this test will fail.
-        assertNotNull("SSL port is not ready", server.waitForStringInLog("CWWKO0219I:.*defaultHttpEndpoint-ssl.*"));
+        server.waitForDefaultHTTPEndpointSSLStart();
 
         LOG.info("Setup : startServer, ready for Tests.");
     }

--- a/dev/io.openliberty.webcontainer.servlet.6.1.internal_fat/fat/src/io/openliberty/webcontainer/servlet61/fat/tests/Servlet61SecureProtocolTLSv1_2AttributeTest.java
+++ b/dev/io.openliberty.webcontainer.servlet.6.1.internal_fat/fat/src/io/openliberty/webcontainer/servlet61/fat/tests/Servlet61SecureProtocolTLSv1_2AttributeTest.java
@@ -57,7 +57,7 @@ public class Servlet61SecureProtocolTLSv1_2AttributeTest {
         server.startServer(Servlet61SecureProtocolTLSv1_2AttributeTest.class.getSimpleName() + ".log");
 
         //MUST WAIT FOR SECURE PORT...else this test will fail.
-        assertNotNull("SSL port is not ready", server.waitForStringInLog("CWWKO0219I:.*defaultHttpEndpoint-ssl.*"));
+        server.waitForDefaultHTTPEndpointSSLStart();
 
         LOG.info("Setup : startServer, ready for Tests.");
     }

--- a/dev/io.openliberty.wsoc.2.1.internal_fat/fat/src/io/openliberty/wsoc/tests/SSLBasic21Test.java
+++ b/dev/io.openliberty.wsoc.2.1.internal_fat/fat/src/io/openliberty/wsoc/tests/SSLBasic21Test.java
@@ -83,10 +83,8 @@ public class SSLBasic21Test {
         wt_secure = new WsocTest(LS, true);
         ssl = new SSLTest(wt_secure);
         bwst.setUp();
-
-        LS.waitForStringInLog("CWWKS4105I:.*configuration is ready.*");
         // tests cannot work until ssl is up
-        LS.waitForStringInLog("CWWKO0219I:.*ssl.*");
+        LS.waitForDefaultHTTPEndpointSSLStart();
     }
 
     @AfterClass

--- a/dev/io.openliberty.wsoc.internal_fat/fat/src/io/openliberty/wsoc/tests/SecureTest.java
+++ b/dev/io.openliberty.wsoc.internal_fat/fat/src/io/openliberty/wsoc/tests/SecureTest.java
@@ -83,9 +83,9 @@ public class SecureTest {
         LS.startServer();
 
         // tests cannot work until ssl is up
-        LS.waitForStringInLog("CWWKS4105I:.*configuration is ready.*");
+        LS.waitForLTPAConfigReady();
         // tests cannot work until ssl is up
-        LS.waitForStringInLog("CWWKO0219I:.*ssl.*");
+        LS.waitForDefaultHTTPEndpointSSLStart();
     }
 
     @AfterClass


### PR DESCRIPTION
Centralize LTPA and SSL checks where the defaults are being expected.

To reduce range of various regex's and look towards improving windows SSL certificate and LTPA key creation timeout issues.

Checks also include those for the default HTTP port, not just the HTTPS port

These changes are aimed at the 99% cases where for example SSL is required to be there, but the default SSL configuration is being used. if a non-default SSL config is supposed to be available, that has been kept where it was obvious.

includes fixes for
Fixes [#307625](https://wasrtc.hursley.ibm.com:9443/jazz/web/projects/WS-CD#action=com.ibm.team.workitem.viewWorkItem&id=307625)
Fixes [#306559](https://wasrtc.hursley.ibm.com:9443/jazz/web/projects/WS-CD#action=com.ibm.team.workitem.viewWorkItem&id=306559)
Fixes [#308773](https://wasrtc.hursley.ibm.com:9443/jazz/web/projects/WS-CD#action=com.ibm.team.workitem.viewWorkItem&id=308773)
Fixes [#309450](https://wasrtc.hursley.ibm.com:9443/jazz/web/projects/WS-CD#action=com.ibm.team.workitem.viewWorkItem&id=309450)

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

