### PR TITLE
More performant version of changes from PR #33443

### DIFF
--- a/dev/com.ibm.ws.kernel.boot.ws-server/publish/bin/server
+++ b/dev/com.ibm.ws.kernel.boot.ws-server/publish/bin/server
@@ -1433,7 +1433,13 @@ restoreServer()
   # Use the log dir settings from checkpoint
   # The exception is for the CUR_X_LOG_DIR which gets used for the checkpoint restore log
   CUR_X_LOG_DIR=${X_LOG_DIR}
-  readServerEnv "${SERVER_OUTPUT_DIR}/workarea/checkpoint/.logdir.properties"
+  if [ -f "${SERVER_OUTPUT_DIR}/workarea/checkpoint/.logdir.properties" ]; then
+    eval ". ${SERVER_OUTPUT_DIR}/workarea/checkpoint/.logdir.properties"
+    export REAL_X_LOG_DIR
+    export LOG_DIR
+    export X_LOG_DIR
+    export X_LOG_FILE
+  fi
 
   # no good way to check for criu support since fast startup is imperative
   #   just let criu invocation fail with a hopefully informative error message.


### PR DESCRIPTION
- Instead of reading the `.logdir.properties` file during restore, source it instead and export the known env variables that are in the file
- This changes resolved the regression introduced by PR #33443 which resulted in a 20 to 60 ms increase in startup for instant on scenarios

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
