### PR TITLE
Perform Java.security for java>8

### DIFF
--- a/dev/io.openliberty.security.fips.internal_fat/fat/src/io/openliberty/security/fips/fat/FIPSTestUtils.java
+++ b/dev/io.openliberty.security.fips.internal_fat/fat/src/io/openliberty/security/fips/fat/FIPSTestUtils.java
@@ -74,7 +74,7 @@ public class FIPSTestUtils {
                     validEnv = false;
                     Log.warning(FIPSTestUtils.class, "Java 8 install does not support FIPS140-3");
                 }
-            } else if (javaInfo.majorVersion() < 25) {
+            } else {
                 String javaSecurityPath = javaInfo.javaHome() + "/conf/security/java.security";
                 Path path = Paths.get(javaSecurityPath);
 


### PR DESCRIPTION
The updates to the checks, meant any Java25+ would now actually run the FIPS tests which given we only support Semeru and Semeru configuration means these all failed

Fixes [#308081](https://wasrtc.hursley.ibm.com:9443/jazz/web/projects/WS-CD#action=com.ibm.team.workitem.viewWorkItem&id=308081)

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
