### PR TITLE
Fixes reoccurence of NPE when inserting empty string into `@Lob` field in Oracle DB 

### DIFF
--- a/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartapersistence/src/io/openliberty/jpa/persistence/tests/web/JakartaPersistenceServlet.java
+++ b/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartapersistence/src/io/openliberty/jpa/persistence/tests/web/JakartaPersistenceServlet.java
@@ -1881,7 +1881,7 @@ public class JakartaPersistenceServlet extends FATServlet {
     }
 
     @Test
-    @SkipIfSysProp(DB_Oracle) // Reference issue: https://github.com/OpenLiberty/open-liberty/issues/33573
+    // Reference issue: https://github.com/OpenLiberty/open-liberty/issues/33573
     public void testLobInsertAndRetrieve() throws Exception {
         try {
             DocumentEntity e1 = new DocumentEntity(1L, "");

--- a/dev/io.openliberty.persistence.3.1.thirdparty/src/org/eclipse/persistence/platform/database/Oracle21Platform.java
+++ b/dev/io.openliberty.persistence.3.1.thirdparty/src/org/eclipse/persistence/platform/database/Oracle21Platform.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2022, 2025 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2026 IBM Corporation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -40,21 +41,24 @@ public class Oracle21Platform extends Oracle19Platform {
     }
 
     /**
-    * INTERNAL:
-    * Allow for conversion from the Oracle type to the Java type. Used in cases when DB connection is needed like BLOB, CLOB.
-    */
+     * INTERNAL:
+     * Allow for conversion from the Oracle type to the Java type. Used in cases when DB connection is needed like BLOB, CLOB.
+     */
     public <T> T convertObject(Object sourceObject, Class<T> javaClass, CoreSession<?, ?, ? ,?, ?> session) throws ConversionException, DatabaseException {
         //Handle special case when empty String ("") is passed from the entity into CLOB type column
         if (ClassConstants.CLOB.equals(javaClass) && sourceObject instanceof String && "".equals(sourceObject)) {
-        	Connection connection = ((AbstractSession) session).getAccessor().getConnection();
-            Clob clob = null;
+            AbstractSession abstractSession = (AbstractSession) session;
             try {
-                clob = connection.createClob();
+                abstractSession.getAccessor().incrementCallCount(abstractSession);
+                Connection connection = abstractSession.getAccessor().getConnection();
+                Clob clob = connection.createClob();
                 clob.setString(1, (String)sourceObject);
+                return (T) clob;
             } catch (SQLException e) {
                 throw ConversionException.couldNotBeConvertedToClass(sourceObject, ClassConstants.CLOB, e);
+            } finally {
+                abstractSession.getAccessor().decrementCallCount();
             }
-            return (T) clob;
         }
         return super.convertObject(sourceObject, javaClass);
     }

--- a/dev/io.openliberty.persistence.3.2.thirdparty/src/org/eclipse/persistence/platform/database/Oracle23Platform.java
+++ b/dev/io.openliberty.persistence.3.2.thirdparty/src/org/eclipse/persistence/platform/database/Oracle23Platform.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2025 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2026 IBM Corporation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -49,15 +50,18 @@ public class Oracle23Platform extends Oracle21Platform {
     public <T> T convertObject(Object sourceObject, Class<T> javaClass, CoreSession<?, ?, ? ,?, ?> session) throws ConversionException, DatabaseException {
         //Handle special case when empty String ("") is passed from the entity into CLOB type column
         if (ClassConstants.CLOB.equals(javaClass) && sourceObject instanceof String && "".equals(sourceObject)) {
-            Connection connection = ((AbstractSession) session).getAccessor().getConnection();
-            Clob clob = null;
+            AbstractSession abstractSession = (AbstractSession) session;
             try {
-                clob = connection.createClob();
+                abstractSession.getAccessor().incrementCallCount(abstractSession);
+                Connection connection = abstractSession.getAccessor().getConnection();
+                Clob clob = connection.createClob();
                 clob.setString(1, (String)sourceObject);
+                return (T) clob;
             } catch (SQLException e) {
                 throw ConversionException.couldNotBeConvertedToClass(sourceObject, ClassConstants.CLOB, e);
+            } finally {
+                abstractSession.getAccessor().decrementCallCount();
             }
-            return (T) clob;
         }
         return super.convertObject(sourceObject, javaClass);
     }

--- a/dev/io.openliberty.persistence.3.2.thirdparty/src/org/eclipse/persistence/platform/database/Oracle23Platform.java
+++ b/dev/io.openliberty.persistence.3.2.thirdparty/src/org/eclipse/persistence/platform/database/Oracle23Platform.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2025 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Oracle - initial API and implementation
+package org.eclipse.persistence.platform.database;
+
+import org.eclipse.persistence.core.sessions.CoreSession;
+import org.eclipse.persistence.exceptions.ConversionException;
+import org.eclipse.persistence.exceptions.DatabaseException;
+import org.eclipse.persistence.internal.helper.ClassConstants;
+import org.eclipse.persistence.internal.sessions.AbstractSession;
+
+import java.sql.Clob;
+import java.sql.Connection;
+import java.sql.SQLException;
+
+public class Oracle23Platform extends Oracle21Platform {
+
+    public Oracle23Platform() {
+        super();
+    }
+
+    /**
+     * INTERNAL:
+     * Check whether current platform is Oracle 23c or later.
+     * @return Always returns {@code true} for instances of Oracle 23c platform.
+     * @since 4.0.2
+     */
+    @Override
+    public boolean isOracle23() {
+        return true;
+    }
+
+    /**
+     * INTERNAL:
+     * Allow for conversion from the Oracle type to the Java type. Used in cases when DB connection is needed like BLOB, CLOB.
+     */
+    @Override
+    public <T> T convertObject(Object sourceObject, Class<T> javaClass, CoreSession<?, ?, ? ,?, ?> session) throws ConversionException, DatabaseException {
+        //Handle special case when empty String ("") is passed from the entity into CLOB type column
+        if (ClassConstants.CLOB.equals(javaClass) && sourceObject instanceof String && "".equals(sourceObject)) {
+            Connection connection = ((AbstractSession) session).getAccessor().getConnection();
+            Clob clob = null;
+            try {
+                clob = connection.createClob();
+                clob.setString(1, (String)sourceObject);
+            } catch (SQLException e) {
+                throw ConversionException.couldNotBeConvertedToClass(sourceObject, ClassConstants.CLOB, e);
+            }
+            return (T) clob;
+        }
+        return super.convertObject(sourceObject, javaClass);
+    }
+}


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

Fixes #33573 re-occurrence through overlay. The reoccurrence was happening in EclipseLink 4.x in 4.0.9 and EclipseLink 5.x in 5.0.0-B13.