### PR TITLE
Fix bugs with different forms of queries

### DIFF
--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
@@ -478,7 +478,7 @@ public class QueryInfo {
         StringBuilder q = new StringBuilder(source.jpql);
 
         if (restriction != null) {
-            q.append(" AND ");
+            q.append(hasWhere ? " AND " : " WHERE ");
             jpqlParamCount = entityInfo.builder.provider.compat //
                             .generateRestrictions(q,
                                                   entityVar_,
@@ -491,13 +491,14 @@ public class QueryInfo {
         boolean forward = pageReq == null ||
                           pageReq.mode() != PageRequest.Mode.CURSOR_PREVIOUS;
         StringBuilder order = null; // ORDER BY clause based on Sorts
-        for (Sort<?> sort : sorts) {
-            validateSort(sort);
-            order = order == null //
-                            ? new StringBuilder(100).append(" ORDER BY ") //
-                            : order.append(", ");
-            generateSort(order, sort, forward);
-        }
+        if (sorts != null)
+            for (Sort<?> sort : sorts) {
+                validateSort(sort);
+                order = order == null //
+                                ? new StringBuilder(100).append(" ORDER BY ") //
+                                : order.append(", ");
+                generateSort(order, sort, forward);
+            }
 
         if (pageReq == null ||
             pageReq.mode() == PageRequest.Mode.OFFSET) {


### PR DESCRIPTION
Appending to a `@Find` query when there is no `WHERE` clause.
Allowing for the possibility that the sort list was null.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
