### PR TITLE
Dummy test to overcome long running featurelist generation

### DIFF
--- a/dev/io.openliberty.microprofile.health.file.healthcheck.longinterval_fat/fat/src/io/openliberty/microprofile/health/file/healthcheck/fat/LongIntervalHealthCheckTest.java
+++ b/dev/io.openliberty.microprofile.health.file.healthcheck.longinterval_fat/fat/src/io/openliberty/microprofile/health/file/healthcheck/fat/LongIntervalHealthCheckTest.java
@@ -24,6 +24,7 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -70,6 +71,33 @@ public class LongIntervalHealthCheckTest {
     @Server(SERVER_LONG_CHECK_INTERVAL)
     public static LibertyServer serverLongCheck;
 
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        /*
+         *
+         * The first test/server-start sometimes?/always? needs to generate a fatFeatureList.xml.
+         * Sometimes this takes a VERY LONG TIME. This happens on Windows OS the majority of the time.
+         * Other OS platforms can also take a long time, but is much less likely.
+         *
+         * Previously, the StartedhealthCheckTestLongStartupInterval was the first test to run.
+         * If this encountered a long featFeatureList generation then the window of time we wanted
+         * to test would already be complete (i.e., health check files have already reached their final state).
+         * The test would "start" testing after the fact and would fail.
+         *
+         * This dummy test is put in place to take the brunt of FAT feature generation.
+         *
+         **/
+        //Test infra checks for fatfeatureList as part of start server.
+        Log.info(LongIntervalHealthCheckTest.class, "beforeClass", "starting dummy server");
+        server.startServer();
+
+        // Read to run a smarter planet
+        server.waitForStringInLogUsingMark("CWWKF0011I");
+
+        server.stopServer();
+        Log.info(LongIntervalHealthCheckTest.class, "beforeClass", "stopping/stopped dummy server");
+    }
+
     @Before
     public void before() throws Exception {
         if (serverLongCheck != null) {
@@ -79,10 +107,6 @@ public class LongIntervalHealthCheckTest {
         if (serverLongStart != null) {
             serverLongStart.removeAllInstalledAppsForValidation();
             serverLongStart.deleteAllDropinApplications();
-        }
-        if (server != null) {
-            server.removeAllInstalledAppsForValidation();
-            server.deleteAllDropinApplications();
         }
     }
 
@@ -95,37 +119,6 @@ public class LongIntervalHealthCheckTest {
         if (serverLongStart != null && serverLongStart.isStarted()) {
             serverLongStart.stopServer(IGNORED_FAILURES);
         }
-
-        if (server != null && server.isStarted()) {
-            server.stopServer(IGNORED_FAILURES);
-        }
-    }
-
-    @Test
-    /*
-     *
-     * The first test/server-start sometimes?/always? needs to generate a fatFeatureList.xml.
-     * Sometimes this takes a VERY LONG TIME. This happens on Windows OS the majority of the time.
-     * Other OS platforms can also take a long time, but is much less likely.
-     *
-     * Previously, the StartedhealthCheckTestLongStartupInterval was the first test to run.
-     * If this encountered a long featFeatureList generation then the window of time we wanted
-     * to test would already be complete (i.e., health check files have already reached their final state).
-     * The test would "start" testing after the fact and would fail.
-     *
-     * This dummy test is put in place to take the brunt of FAT feature generation.
-     *
-     **/
-    public void emptyTestToForceFeatureListGeneration() throws Exception {
-        final String METHOD_NAME = "emptyTest";
-
-        //Test infra checks for fatfeatureList as part of start server.
-        server.startServer();
-
-        // Read to run a smarter planet
-        server.waitForStringInLogUsingMark("CWWKF0011I");
-
-        Log.info(getClass(), METHOD_NAME, "Doing absolutely nothing");
     }
 
     @Test

--- a/dev/io.openliberty.microprofile.health.file.healthcheck.longinterval_fat/fat/src/io/openliberty/microprofile/health/file/healthcheck/fat/LongIntervalHealthCheckTest.java
+++ b/dev/io.openliberty.microprofile.health.file.healthcheck.longinterval_fat/fat/src/io/openliberty/microprofile/health/file/healthcheck/fat/LongIntervalHealthCheckTest.java
@@ -45,6 +45,7 @@ import io.openliberty.microprofile.health.internal_fat.shared.HealthActions;
 @RunWith(FATRunner.class)
 public class LongIntervalHealthCheckTest {
 
+    final static String SERVER_DUMMY = "DummyServer";
     final static String SERVER_LONG_STARTUP_CHECK_INTERVAL = "HealthServerLongStartupCheckInterval";
     final static String SERVER_LONG_CHECK_INTERVAL = "HealthServerLongCheckInterval";
     final static String FAIL_START_APP = "FailStartApp";
@@ -54,11 +55,14 @@ public class LongIntervalHealthCheckTest {
 
     @ClassRule
     public static RepeatTests r = MicroProfileActions.repeat(FeatureReplacementAction.ALL_SERVERS,
-                                                             MicroProfileActions.MP61, // mpHealth-4.0 w/ EE9
+                                                             MicroProfileActions.MP61, // mpHealth-4.0 w/ EE10
                                                              MicroProfileActions.MP70_EE10, // mpHealth-4.0 FULL EE10
                                                              MicroProfileActions.MP70_EE11, // mpHealth-4.0 FULL EE11
                                                              HealthActions.MP14_MPHEALTH40, // mpHealth-4.0 FULL EE7
                                                              HealthActions.MP41_MPHEALTH40); //mpHealth-4.0 FULL EE8
+
+    @Server(SERVER_DUMMY)
+    public static LibertyServer server;
 
     @Server(SERVER_LONG_STARTUP_CHECK_INTERVAL)
     public static LibertyServer serverLongStart;
@@ -76,6 +80,10 @@ public class LongIntervalHealthCheckTest {
             serverLongStart.removeAllInstalledAppsForValidation();
             serverLongStart.deleteAllDropinApplications();
         }
+        if (server != null) {
+            server.removeAllInstalledAppsForValidation();
+            server.deleteAllDropinApplications();
+        }
     }
 
     @After
@@ -87,6 +95,37 @@ public class LongIntervalHealthCheckTest {
         if (serverLongStart != null && serverLongStart.isStarted()) {
             serverLongStart.stopServer(IGNORED_FAILURES);
         }
+
+        if (server != null && server.isStarted()) {
+            server.stopServer(IGNORED_FAILURES);
+        }
+    }
+
+    @Test
+    /*
+     *
+     * The first test/server-start sometimes?/always? needs to generate a fatFeatureList.xml.
+     * Sometimes this takes a VERY LONG TIME. This happens on Windows OS the majority of the time.
+     * Other OS platforms can also take a long time, but is much less likely.
+     *
+     * Previously, the StartedhealthCheckTestLongStartupInterval was the first test to run.
+     * If this encountered a long featFeatureList generation then the window of time we wanted
+     * to test would already be complete (i.e., health check files have already reached their final state).
+     * The test would "start" testing after the fact and would fail.
+     *
+     * This dummy test is put in place to take the brunt of FAT feature generation.
+     *
+     **/
+    public void emptyTestToForceFeatureListGeneration() throws Exception {
+        final String METHOD_NAME = "emptyTest";
+
+        //Test infra checks for fatfeatureList as part of start server.
+        server.startServer();
+
+        // Read to run a smarter planet
+        server.waitForStringInLogUsingMark("CWWKF0011I");
+
+        Log.info(getClass(), METHOD_NAME, "Doing absolutely nothing");
     }
 
     @Test

--- a/dev/io.openliberty.microprofile.health.file.healthcheck.longinterval_fat/publish/servers/DummyServer/bootstrap.properties
+++ b/dev/io.openliberty.microprofile.health.file.healthcheck.longinterval_fat/publish/servers/DummyServer/bootstrap.properties
@@ -1,0 +1,4 @@
+bootstrap.include=../testports.properties
+osgi.console=7771
+com.ibm.ws.logging.trace.specification=*=info:HEALTH=all
+com.ibm.ws.logging.isoDateFormat=true

--- a/dev/io.openliberty.microprofile.health.file.healthcheck.longinterval_fat/publish/servers/DummyServer/server.xml
+++ b/dev/io.openliberty.microprofile.health.file.healthcheck.longinterval_fat/publish/servers/DummyServer/server.xml
@@ -1,0 +1,20 @@
+<server description="Dummy server">
+
+    <include location="../fatTestPorts.xml"/>
+
+    <featureManager>
+        <feature>localConnector-1.0</feature>
+        <feature>mpHealth-4.0</feature>
+        <feature>mpConfig-3.0</feature>
+        <feature>servlet-4.0</feature>
+    </featureManager>
+    	
+	<logging traceSpecification="*=info:HEALTH=all" isoDateFormat="true"/>
+	
+    <webContainer deferServletLoad="false"/>
+
+	<httpEndpoint id="defaultHttpEndpoint" host="*" httpPort="${bvt.prop.HTTP_default}" httpsPort="${bvt.prop.HTTP_default.secure}">
+		<tcpOptions portOpenRetries="60" />                   
+	</httpEndpoint>
+	
+</server>

--- a/dev/io.openliberty.microprofile.health.file.healthcheck.longinterval_fat/publish/servers/HealthServerLongCheckInterval/server.xml
+++ b/dev/io.openliberty.microprofile.health.file.healthcheck.longinterval_fat/publish/servers/HealthServerLongCheckInterval/server.xml
@@ -1,4 +1,4 @@
-<server description="Server for testing Config Admin with dropin applications">
+<server description="Server for testing the check interval attribute">
 
     <include location="../fatTestPorts.xml"/>
 

--- a/dev/io.openliberty.microprofile.health.file.healthcheck.longinterval_fat/publish/servers/HealthServerLongStartupCheckInterval/server.xml
+++ b/dev/io.openliberty.microprofile.health.file.healthcheck.longinterval_fat/publish/servers/HealthServerLongStartupCheckInterval/server.xml
@@ -1,4 +1,4 @@
-<server description="Server for testing Config Admin with dropin applications">
+<server description="Server for testing the startupCheckInterval">
 
     <include location="../fatTestPorts.xml"/>
 


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".


fixes #31714

Sometimes, featurelist generation runs for a long time. This featurelist generation occurs on the first server run.
Given the nature of this test, we rely on the tests being able to "track" states during the startup of the server.  When a feature generation takes too long, the first test will fail. This Dummy test buffers the first "real" test from a long running feature list generation.