### PR TITLE
Move task steps to execution phase instead of config

### DIFF
--- a/dev/build.image/build.gradle
+++ b/dev/build.image/build.gradle
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2025 IBM Corporation and others.
+ * Copyright (c) 2017, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -63,7 +63,7 @@ task copyPublicKeyToBuildImage (type:Copy) {
 }
 
 task addServiceFingerprint() {
-
+  doLast {
     // Create a File object representing the folder
     def folder = new File( "$projectDir/wlp/lib/versions" )
 
@@ -71,6 +71,7 @@ task addServiceFingerprint() {
         folder.mkdirs()
     }
     new File(folder,"service.fingerprint").text = "\n${bnd.libertyRelease}"
+  }
 }
 
 task copyReadmeToBuildImage (type:Copy) {

--- a/dev/com.ibm.ws.jpa.tests.beanvalidation_jpa_3.2_fat/build.gradle
+++ b/dev/com.ibm.ws.jpa.tests.beanvalidation_jpa_3.2_fat/build.gradle
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022, 2025 IBM Corporation and others.
+ * Copyright (c) 2022, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -49,18 +49,20 @@ task addhibernateJPA31(type: Copy) {
 }
 
 task copyFAT {
-    def commonProject = project(':com.ibm.ws.jpa.tests.beanvalidation_fat.common')
-    def common32Project = project(':com.ibm.ws.jpa.tests.beanvalidation_3.2_fat.common')
-    dependsOn ':com.ibm.ws.jpa.tests.beanvalidation_fat.common:build'
+  def commonProject = project(':com.ibm.ws.jpa.tests.beanvalidation_fat.common')
+  def common32Project = project(':com.ibm.ws.jpa.tests.beanvalidation_3.2_fat.common')
+  dependsOn ':com.ibm.ws.jpa.tests.beanvalidation_fat.common:build'
+  dependsOn ':com.ibm.ws.jpa.tests.beanvalidation_3.2_fat.common:build'
+  doLast {
     copy {
       from commonProject.file('fat/src/com/ibm/ws/jpa/tests/beanvalidation/tests')
       into new File('fat/src/com/ibm/ws/jpa/tests/beanvalidation/tests')
     }
-    dependsOn ':com.ibm.ws.jpa.tests.beanvalidation_3.2_fat.common:build'
     copy {
       from common32Project.file('fat/src/com/ibm/ws/jpa/tests/beanvalidation/tests/jpa32')
       into new File('fat/src/com/ibm/ws/jpa/tests/beanvalidation/tests/jpa32')
     }
+  }
 }
 
 task copyCommonFiles {

--- a/dev/com.ibm.ws.repository.parsers/build.gradle
+++ b/dev/com.ibm.ws.repository.parsers/build.gradle
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 IBM Corporation and others.
+ * Copyright (c) 2024, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -28,52 +28,54 @@ configurations {
  }
 
 task copyFilesForUnittest() {
-  copy {
-    from configurations.anno_esa
-    into esaDir
-    rename 'anno-esa-*.*.*.*', 'com.ibm.websphere.appserver.anno-1.0.esa'
-  }
+  doLast {
+    copy {
+      from configurations.anno_esa
+      into esaDir
+      rename 'anno-esa-*.*.*.*', 'com.ibm.websphere.appserver.anno-1.0.esa'
+    }
 
-  copy {
-    from configurations.anno_esa
-    into esaAssetDir
-    rename 'anno-esa-*.*.*.*', 'com.ibm.websphere.appserver.anno-1.0.esa'
-  }
+    copy {
+      from configurations.anno_esa
+      into esaAssetDir
+      rename 'anno-esa-*.*.*.*', 'com.ibm.websphere.appserver.anno-1.0.esa'
+    }
 
-  copy {
-    from configurations.anno_metadata
-    into esaDir
-    rename 'anno-metadata-*.*.*.*', 'com.ibm.websphere.appserver.anno-1.0.esa.metadata.zip'
-  }
+    copy {
+      from configurations.anno_metadata
+      into esaDir
+      rename 'anno-metadata-*.*.*.*', 'com.ibm.websphere.appserver.anno-1.0.esa.metadata.zip'
+    }
 
-  copy {
-    from configurations.anno_metadata
-    into esaMetadataDir
-    rename 'anno-metadata-*.*.*.*', 'com.ibm.websphere.appserver.anno-1.0.esa.metadata.zip'
-  }
+    copy {
+      from configurations.anno_metadata
+      into esaMetadataDir
+      rename 'anno-metadata-*.*.*.*', 'com.ibm.websphere.appserver.anno-1.0.esa.metadata.zip'
+    }
 
-  copy {
-    from configurations.jsp_esa
-    into esaDir
-    rename 'jsp-esa-*.*.*.*', 'com.ibm.websphere.appserver.jsp-2.3.esa'
-  }
+    copy {
+      from configurations.jsp_esa
+      into esaDir
+      rename 'jsp-esa-*.*.*.*', 'com.ibm.websphere.appserver.jsp-2.3.esa'
+    }
 
-  copy {
-    from configurations.jsp_esa
-    into esaAssetDir
-    rename 'jsp-esa-*.*.*.*', 'com.ibm.websphere.appserver.jsp-2.3.esa'
-  }
+    copy {
+      from configurations.jsp_esa
+      into esaAssetDir
+      rename 'jsp-esa-*.*.*.*', 'com.ibm.websphere.appserver.jsp-2.3.esa'
+    }
 
-  copy {
-    from configurations.jsp_metadata
-    into esaDir
-    rename 'jsp-metadata-*.*.*.*', 'com.ibm.websphere.appserver.jsp-2.3.esa.metadata.zip'
-  }
+    copy {
+      from configurations.jsp_metadata
+      into esaDir
+      rename 'jsp-metadata-*.*.*.*', 'com.ibm.websphere.appserver.jsp-2.3.esa.metadata.zip'
+    }
 
-  copy {
-    from configurations.jsp_metadata
-    into esaMetadataDir
-    rename 'jsp-metadata-*.*.*.*', 'com.ibm.websphere.appserver.jsp-2.3.esa.metadata.zip'
+    copy {
+      from configurations.jsp_metadata
+      into esaMetadataDir
+      rename 'jsp-metadata-*.*.*.*', 'com.ibm.websphere.appserver.jsp-2.3.esa.metadata.zip'
+    }
   }
 }
 

--- a/dev/com.ibm.ws.security.audit_fat.common.tooling/build.gradle
+++ b/dev/com.ibm.ws.security.audit_fat.common.tooling/build.gradle
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2025 IBM Corporation and others.
+ * Copyright (c) 2020, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -122,16 +122,17 @@ assemble {
     AuditBasicAuthServlet_WAR,
     AuditFormLoginServlet_WAR
     
-  /* 
-   * Collect all the required jars and put them in one uniform place
-   * so that we don't need to keep adding them in each external
-   * project.
-   */
-  copy { 
-    from configurations.collectedDeps
-    into "${buildDir}/collectedJars"
+  doLast {
+    /*
+     * Collect all the required jars and put them in one uniform place
+     * so that we don't need to keep adding them in each external
+     * project.
+     */
+    copy {
+      from configurations.collectedDeps
+      into "${buildDir}/collectedJars"
+    }
   }
-  
 }
 
 // We aren't making a war for the entire project

--- a/dev/com.ibm.ws.security.fat.common.SSO.clientTests/build.gradle
+++ b/dev/com.ibm.ws.security.fat.common.SSO.clientTests/build.gradle
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023, 2025 IBM Corporation and others.
+ * Copyright (c) 2023, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -80,7 +80,9 @@ task tokenEndpoint(type: War, dependsOn: classes) {
   destinationDirectory = file("${appBuildDir}")
   archiveFileName = "${appName}.war"
 
- println "In tokenEndpoint"
+  doLast {
+    println "In tokenEndpoint"
+  }
   from("test-applications/${appName}/resources") {
     include "**/*"
   }

--- a/dev/com.ibm.ws.security.oauth.oidc_fat.common/build.gradle
+++ b/dev/com.ibm.ws.security.oauth.oidc_fat.common/build.gradle
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2024 IBM Corporation and others.
+ * Copyright (c) 2020, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -431,14 +431,14 @@ assemble.dependsOn testUserinfoEndpoint_ZIP
  **
  ******************************************************************
  ******************************************************************/
-assemble { 
-  /* 
+assemble.doLast {
+  /*
    * Collect all the required jars and put them in one uniform place
    * so that we don't need to keep adding them in each external
    * project.
    */
   println "in assemble"
-  copy { 
+  copy {
     from configurations.collectedDeps
     into "${buildDir}/collectedJars"
   }

--- a/dev/com.ibm.ws.security.saml.sso_fat.common/build.gradle
+++ b/dev/com.ibm.ws.security.saml.sso_fat.common/build.gradle
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2025 IBM Corporation and others.
+ * Copyright (c) 2020, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -283,8 +283,10 @@ task updateIdp_4_0_x_WAR(type: Zip, dependsOn: copy_40x_IDP) {
 
 task updateIdp_4_1_x_WAR(type: Zip, dependsOn: copy_41x_IDP) {
 
-  println "In updateIdp_4_1_x_WAR"
-  
+  doLast {
+    println "In updateIdp_4_1_x_WAR"
+  }
+
   def originalWar = new File(downloadDir, 'idp-war-4.1.0.war')
   
   destinationDirectory = file(appBuildDir)
@@ -328,23 +330,21 @@ assemble.dependsOn httpServletRequestApp_WAR
  * Configure any other additional artifacts.
  */
 assemble.doLast {
-  /* 
+  /*
    * Collect all the required jars and put them in one uniform place
    * so that we don't need to keep adding them in each external
    * project.
    */
-  copy { 
+  copy {
     from configurations.collectedDeps
     into "${buildDir}/collectedJars"
   }
-
 
   /*
    * Copy the Shibboleth configuration to the build directory
    */
   copy {
-  	from new File(projectDir, 'shibboleth-idp')
+    from new File(projectDir, 'shibboleth-idp')
     into new File(buildDir, 'shibboleth-idp')
   }
-
 }

--- a/dev/io.openliberty.checkpoint_fat_jcache_hazelcast/build.gradle
+++ b/dev/io.openliberty.checkpoint_fat_jcache_hazelcast/build.gradle
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2025 IBM Corporation and others.
+ * Copyright (c) 2021, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -51,7 +51,9 @@ addRequiredLibraries.dependsOn copyTestContainers
 addRequiredLibraries.dependsOn addJakartaTransformer
 
 task addHazelcastToSharedDir(type: Copy) {
-  println configurations.hazelcast.resolve()
+  doLast {
+    println configurations.hazelcast.resolve()
+  }
 
   from configurations.hazelcast
   into new File(autoFvtDir, 'publish/shared/resources/hazelcast')

--- a/dev/io.openliberty.data.internal_fat_jpa_hibernate/build.gradle
+++ b/dev/io.openliberty.data.internal_fat_jpa_hibernate/build.gradle
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024, 2025 IBM Corporation and others.
+ * Copyright (c) 2024, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -61,68 +61,70 @@ task addHibernatePermissions() {
     !isAutomatedBuild
   }
 
-  // Find server.xml files
-  def serverConfigs = []
-  fileTree(project.file('publish/servers')).visit { FileVisitDetails d ->
-    if(d.file.name == "server.xml") {
-      serverConfigs << d.file.path
+  doLast {
+    // Find server.xml files
+    def serverConfigs = []
+    fileTree(project.file('publish/servers')).visit { FileVisitDetails d ->
+      if(d.file.name == "server.xml") {
+        serverConfigs << d.file.path
+      }
     }
-  }
-  
-  println "serverConfigs: "
-  serverConfigs.sort()
-  serverConfigs.each { serverConfig -> println "- " + serverConfig }
 
-  // Generate permissions
-  def permissions = []
-  configurations.hibernateJPA32.resolvedConfiguration.resolvedArtifacts.each { ResolvedArtifact a ->
-    permissions << "<javaPermission className=\"java.security.AllPermission\" codebase=\"\${shared.resource.dir}/jpa32_hibernate/${a.file.name}\"/>"
-  }
-  
-  println "permissions: "
-  permissions.sort()
-  permissions.each { permission -> println "- " + permission }
+    println "serverConfigs: "
+    serverConfigs.sort()
+    serverConfigs.each { serverConfig -> println "- " + serverConfig }
 
-  // Replace existing permissions
-  serverConfigs.each { String p ->
-    String START_TAG = "<!-- START:"
-    String END_TAG   = "<!-- END:"
+    // Generate permissions
+    def permissions = []
+    configurations.hibernateJPA32.resolvedConfiguration.resolvedArtifacts.each { ResolvedArtifact a ->
+      permissions << "<javaPermission className=\"java.security.AllPermission\" codebase=\"\${shared.resource.dir}/jpa32_hibernate/${a.file.name}\"/>"
+    }
+  
+    println "permissions: "
+    permissions.sort()
+    permissions.each { permission -> println "- " + permission }
+
+    // Replace existing permissions
+    serverConfigs.each { String p ->
+      String START_TAG = "<!-- START:"
+      String END_TAG   = "<!-- END:"
     
-    java.nio.file.Path path = java.nio.file.Paths.get(p)
+      java.nio.file.Path path = java.nio.file.Paths.get(p)
 
-    List<String> original = java.nio.file.Files.readAllLines(path)
-    List<String> updated  = new ArrayList<>(original.size())
+      List<String> original = java.nio.file.Files.readAllLines(path)
+      List<String> updated  = new ArrayList<>(original.size())
 
-    boolean inSection = false
-    for (String line : original) {
-      // Keep start tag, mark in section, and add in all new permissions
-      if (line.contains(START_TAG)) {
-        updated.add(line)
-        inSection = true
-        String whitespace = line.substring(0, line.indexOf(START_TAG));
-        for (String permission : permissions) {
+      boolean inSection = false
+      for (String line : original) {
+        // Keep start tag, mark in section, and add in all new permissions
+        if (line.contains(START_TAG)) {
+          updated.add(line)
+          inSection = true
+          String whitespace = line.substring(0, line.indexOf(START_TAG));
+          for (String permission : permissions) {
             updated.add(whitespace + permission)
+          }
+          continue;
         }
-        continue;
-      }
-      
-      // Keep end tag, mark out of section
-      if (line.contains(END_TAG)) {
-        inSection = false
-        updated.add(line)
-        continue
-      }
-      
-      // Keep all lines outside the tagged section
-      if (!inSection) {
-        updated.add(line)
-      }
-      
-      // Ignore all lines inside the tagged section
-    }
 
-    // overwrite the file with the updated lines
-    java.nio.file.Files.write(path, updated)
+        // Keep end tag, mark out of section
+        if (line.contains(END_TAG)) {
+          inSection = false
+          updated.add(line)
+          continue
+        }
+
+        // Keep all lines outside the tagged section
+        if (!inSection) {
+          updated.add(line)
+        }
+      
+        // Ignore all lines inside the tagged section
+      }
+
+      // overwrite the file with the updated lines
+      java.nio.file.Files.write(path, updated)
+    }
   }
 }
 

--- a/dev/io.openliberty.jcache.internal_fat.hazelcast/build.gradle
+++ b/dev/io.openliberty.jcache.internal_fat.hazelcast/build.gradle
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2025 IBM Corporation and others.
+ * Copyright (c) 2021, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -51,7 +51,9 @@ addRequiredLibraries.dependsOn copyTestContainers
 addRequiredLibraries.dependsOn addJakartaTransformer
 
 task addHazelcastToSharedDir(type: Copy) {
-  println configurations.hazelcast.resolve()
+  doLast {
+    println configurations.hazelcast.resolve()
+  }
 
   from configurations.hazelcast
   into new File(autoFvtDir, 'publish/shared/resources/hazelcast')

--- a/dev/io.openliberty.security.jakartasec.3.0.internal_fat.common/build.gradle
+++ b/dev/io.openliberty.security.jakartasec.3.0.internal_fat.common/build.gradle
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022, 2023 IBM Corporation and others.
+ * Copyright (c) 2022, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -19,7 +19,9 @@ task testmarker(type: War, dependsOn: classes) {
   destinationDirectory = file("${appBuildDir}")
   archiveFileName = "${appName}.war"
 
- println "In testmarker"
+  doLast {
+    println "In testmarker"
+  }
   from("test-applications/${appName}/resources") {
     include "**/*"
   }
@@ -34,7 +36,9 @@ task tokenEndpoint(type: War, dependsOn: classes) {
   destinationDirectory = file("${appBuildDir}")
   archiveFileName = "${appName}.war"
 
- println "In tokenEndpoint"
+  doLast {
+    println "In tokenEndpoint"
+  }
   from("test-applications/${appName}/resources") {
     include "**/*"
   }
@@ -45,7 +49,9 @@ task tokenEndpoint(type: War, dependsOn: classes) {
 }
 assemble {
 
-   println "In assemble"
+  doLast {
+    println "In assemble"
+  }
   dependsOn \
     testmarker,\
     tokenEndpoint


### PR DESCRIPTION
- Move steps in tasks to execution phase instead of config phase since that is where the work should be done.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
