### PR TITLE
Page count of query with CASE expression

### DIFF
--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
@@ -562,6 +562,27 @@ public class DataTestServlet extends FATServlet {
     }
 
     /**
+     * Include a CASE expression within the SELECT clause of a query.
+     */
+    @Test
+    public void testCaseInSelectClause() {
+
+        Page<Object[]> page1 = primes.getParity(1, 40, PageRequest.ofSize(5));
+
+        assertEquals(3L, page1.totalPages());
+        assertEquals(12L, page1.totalElements());
+
+        assertEquals(List.of("2: even",
+                             "3: odd",
+                             "5: odd",
+                             "7: odd",
+                             "11: odd"),
+                     page1.stream()
+                                     .map(a -> a[0] + ": " + a[1])
+                                     .collect(Collectors.toList()));
+    }
+
+    /**
      * Asynchronous repository method that returns a CompletableFuture of Page.
      */
     @Test

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Primes.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Primes.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022,2024 IBM Corporation and others.
+ * Copyright (c) 2022,2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -269,6 +269,16 @@ public interface Primes {
 
     @OrderBy(value = ID, descending = true)
     IntStream findSumOfBitsByNumberIdBetween(long min, long max);
+
+    // Can omit entity identification variable after EclipseLink #33842 is fixed
+    @Query("""
+                    SELECT p.numberId,
+                           CASE WHEN p.even = TRUE THEN 'even' ELSE 'odd' END
+                      FROM Prime p
+                     WHERE p.numberId BETWEEN ?1 and ?2
+                     ORDER BY p.numberId ASC
+                    """)
+    Page<Object[]> getParity(int first, int last, PageRequest pageRequest);
 
     @Query(value = "Select name" +
                    " Where numberId < 50 and" +


### PR DESCRIPTION
JPQL query with a CASE expression used on a repository method that performs pagination. Test that a page count query can be inferred from it.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
