### PR TITLE
Increase ds.lock.timeout to 30s in servlet31_wcServer

### DIFF
--- a/dev/com.ibm.ws.webcontainer.servlet.3.1_fat/publish/servers/servlet31_wcServer/bootstrap.properties
+++ b/dev/com.ibm.ws.webcontainer.servlet.3.1_fat/publish/servers/servlet31_wcServer/bootstrap.properties
@@ -1,15 +1,13 @@
 ###############################################################################
-# Copyright (c) 2013 IBM Corporation and others.
+# Copyright (c) 2013, 2026 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-2.0/
 # 
 # SPDX-License-Identifier: EPL-2.0
-#
-# Contributors:
-#     IBM Corporation - initial API and implementation
 ###############################################################################
 bootstrap.include=../testports.properties
 osgi.console=7777
 com.ibm.ws.logging.trace.specification=*=info:com.ibm.ws.webcontainer*=all:com.ibm.wsspi.webcontainer*=all:HttpTransport=all:HTTPChannel=all:TCPChannel=all:GenericBNF=all:com.ibm.ws.jsp*=all:com.ibm.ws.session.*=all:com.ibm.ws.runtime.update.internal*=all:ChannelFramework=all
+ds.lock.timeout.milliseconds=30000


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

