### PR TITLE
find single attribute replaced by Select

### DIFF
--- a/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
+++ b/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2022,2025 IBM Corporation and others.
+# Copyright (c) 2022,2026 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -71,9 +71,9 @@ CWWKD1004.general.rtrn.err.useraction=Refer to the Jakarta Data Javadoc \
 CWWKD1005.find.rtrn.err=CWWKD1005E: The {0} method of the {1} repository \
  interface is not valid. The method specifies a {2} return type that is \
  not convertible from the {3} entity type. The result type of a \
- find operation must be the entity type, a type of an entity attribute, \
- a Java record composed of entity attributes, or a type constructed \
- by the query that is supplied to the \
+ find operation must be the entity type, a type of an entity attribute \
+ chosen by the Select annotation, a Java record composed of entity \
+ attributes, or a type selected by the query that is supplied to the \
  Query annotation. The return type of the repository find method can be \
  the result type, an array of the result type, or any of the following types \
  parameterized with the result type: {4}.

--- a/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
+++ b/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
@@ -73,7 +73,7 @@ CWWKD1005.find.rtrn.err=CWWKD1005E: The {0} method of the {1} repository \
  not convertible from the {3} entity type. The result type of a \
  find operation must be the entity type, a type of an entity attribute \
  that is chosen by the Select annotation, a Java record that is composed of entity \
- attributes, or a type selected by the query that is supplied to the \
+ attributes, or a type that is selected by the query that is supplied to the \
  Query annotation. The return type of the repository find method can be \
  the result type, an array of the result type, or any of the following types \
  parameterized with the result type: {4}.

--- a/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
+++ b/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
@@ -72,7 +72,7 @@ CWWKD1005.find.rtrn.err=CWWKD1005E: The {0} method of the {1} repository \
  interface is not valid. The method specifies a {2} return type that is \
  not convertible from the {3} entity type. The result type of a \
  find operation must be the entity type, a type of an entity attribute \
- chosen by the Select annotation, a Java record composed of entity \
+ that is chosen by the Select annotation, a Java record that is composed of entity \
  attributes, or a type selected by the query that is supplied to the \
  Query annotation. The return type of the repository find method can be \
  the result type, an array of the result type, or any of the following types \

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
@@ -3101,40 +3101,19 @@ public class QueryInfo {
                 // TODO enable this once #29073 is fixed
                 // q.append("SELECT ID(").append(entityVar).append(')');
             } else {
-                // Is the result type a record or a single attribute?
+                // Is the result type a record?
                 RecordComponent[] recordComponents = singleType.getRecordComponents();
                 if (recordComponents == null) {
-                    // Look for single entity attribute with the desired type:
-                    String singleAttributeName = null;
-                    for (Map.Entry<String, Class<?>> entry : entityInfo.attributeTypes.entrySet()) {
-                        Class<?> attributeType = entry.getValue();
-                        if (attributeType.isPrimitive())
-                            attributeType = Util.wrapperClassIfPrimitive(attributeType);
-                        if (singleType.isAssignableFrom(attributeType))
-                            if (singleAttributeName == null)
-                                singleAttributeName = entry.getKey();
-                            else
-                                throw exc(MappingException.class,
-                                          "CWWKD1008.ambig.rtrn.err",
-                                          method.getGenericReturnType().getTypeName(),
-                                          method.getName(),
-                                          repositoryInterface.getName(),
-                                          List.of(singleAttributeName, entry.getKey()));
-                    }
-
-                    if (singleAttributeName == null)
-                        throw exc(MappingException.class,
-                                  "CWWKD1005.find.rtrn.err",
-                                  method.getName(),
-                                  repositoryInterface.getName(),
-                                  method.getGenericReturnType().getTypeName(),
-                                  entityInfo.entityClass.getName(),
-                                  List.of("List", "Optional",
-                                          "Page", "CursoredPage",
-                                          "Stream"));
-
-                    else
-                        q.append("SELECT ").append(o_).append(singleAttributeName);
+                    // not a record, not an entity, and app did not use @Select
+                    throw exc(MappingException.class,
+                              "CWWKD1005.find.rtrn.err",
+                              method.getName(),
+                              repositoryInterface.getName(),
+                              method.getGenericReturnType().getTypeName(),
+                              entityInfo.entityClass.getName(),
+                              List.of("List", "Optional",
+                                      "Page", "CursoredPage",
+                                      "Stream"));
                 } else {
                     // Construct new instance for record
                     q.append("SELECT NEW ").append(singleType.getName()).append('(');

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
@@ -32,7 +32,6 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.Deque;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.LinkedList;
@@ -593,27 +592,34 @@ public class DataTestServlet extends FATServlet {
 
         Order<Prime> asc = Order.by(Sort.asc(ID));
 
-        CompletableFuture<Page<Long>> cf1 = //
+        CompletableFuture<Page<Prime>> cf1 = //
                         primes.divisibleByTwo(false, page1req, asc);
 
-        CompletableFuture<Page<Long>> cf3 = //
+        CompletableFuture<Page<Prime>> cf3 = //
                         primes.divisibleByTwo(false, page3req, asc);
 
-        Page<Long> page1 = cf1.get(TIMEOUT_MINUTES, TimeUnit.MINUTES);
-        Page<Long> page3 = cf3.get(TIMEOUT_MINUTES, TimeUnit.MINUTES);
+        Page<Prime> page1 = cf1.get(TIMEOUT_MINUTES, TimeUnit.MINUTES);
+        Page<Prime> page3 = cf3.get(TIMEOUT_MINUTES, TimeUnit.MINUTES);
 
         assertEquals(List.of(3L, 5L, 7L, 11L),
-                     page1.content());
+                     page1.stream()
+                                     .map(prime -> prime.numberId)
+                                     .collect(Collectors.toList()));
 
         assertEquals(List.of(29L, 31L, 37L, 41L),
-                     page3.content());
+                     page3.stream()
+                                     .map(prime -> prime.numberId)
+                                     .collect(Collectors.toList()));
 
         PageRequest page2req = page3.previousPageRequest();
         assertEquals(page2req, page1.nextPageRequest());
 
         assertEquals(List.of(13L, 17L, 19L, 23L),
                      primes.divisibleByTwo(false, page2req, asc)
-                                     .thenApply(Page::content)
+                                     .thenApply(page -> page
+                                                     .stream()
+                                                     .map(prime -> prime.numberId)
+                                                     .collect(Collectors.toList()))
                                      .get(TIMEOUT_MINUTES, TimeUnit.MINUTES));
     }
 
@@ -1153,7 +1159,7 @@ public class DataTestServlet extends FATServlet {
         Package pkg = packages.deleteFirst5ByWidthLessThan(10.5f);
         assertEquals(10004, pkg.id);
 
-        List<Package> pkgs = packages.deleteFirst2();
+        List<Package> pkgs = packages.deleteFirst3();
         assertEquals(3, pkgs.size());
 
         assertEquals(0, packages.deleteAll()); //cleanup after test
@@ -1872,43 +1878,56 @@ public class DataTestServlet extends FATServlet {
     }
 
     /**
-     * Find-and-delete repository operations that return one or more IDs, corresponding to removed entities.
+     * Find-and-delete repository operations that return one or more removed
+     * entities.
      */
     @Test
-    public void testFindAndDeleteReturnsIds() throws Exception {
+    public void testFindAndDeleteReturnsEntities() throws Exception {
         String jdbcJarName = System.getenv().getOrDefault("DB_DRIVER", "UNKNOWN");
         boolean supportsOrderByForUpdate = !jdbcJarName.startsWith("derby");
 
         packages.deleteAll();
 
-        packages.save(new Package(80081, 18.0f, 18.1f, 8.8f, "testFindAndDeleteReturnsIds#80081"));
-        packages.save(new Package(80080, 80.0f, 80.0f, 8.0f, "testFindAndDeleteReturnsIds#80080"));
-        packages.save(new Package(80088, 88.0f, 18.8f, 8.8f, "testFindAndDeleteReturnsIds#80088"));
-        packages.save(new Package(80008, 80.0f, 10.8f, 0.8f, "testFindAndDeleteReturnsIds#80008"));
+        packages.save(new Package(80081, 18.0f, 18.1f, 8.8f, //
+                        "testFindAndDeleteReturnsEntities#80081"));
+        packages.save(new Package(80080, 80.0f, 80.0f, 8.0f, //
+                        "testFindAndDeleteReturnsEntities#80080"));
+        packages.save(new Package(80088, 88.0f, 18.8f, 8.8f, //
+                        "testFindAndDeleteReturnsEntities#80088"));
+        packages.save(new Package(80008, 80.0f, 10.8f, 0.8f, //
+                        "testFindAndDeleteReturnsEntities#80008"));
 
         Set<Integer> remaining = new TreeSet<>();
         remaining.addAll(Set.of(80008, 80080, 80081, 80088));
 
         Sort<Package> sort = supportsOrderByForUpdate ? Sort.desc("width") : null;
-        Integer id = packages.delete1(Limit.of(1), sort).orElseThrow();
+        Integer id = packages.deleteFirst1(Limit.of(1), sort).orElseThrow().id;
         if (supportsOrderByForUpdate)
             assertEquals(Integer.valueOf(80080), id);
         assertEquals("Found " + id + "; expected one of " + remaining, true, remaining.remove(id));
 
         Sort<?>[] sorts = supportsOrderByForUpdate ? new Sort[] { Sort.desc("height"), Sort.asc("length") } : null;
-        int[] ids = packages.delete2(Limit.of(2), sorts);
-        assertEquals(Arrays.toString(ids), 2, ids.length);
+        Package[] deleted = packages.deleteFirst2(Limit.of(2), sorts);
+        assertEquals(Arrays.toString(deleted), 2, deleted.length);
+
         if (supportsOrderByForUpdate) {
-            assertEquals(80081, ids[0]);
-            assertEquals(80088, ids[1]);
+            assertEquals(80081, deleted[0].id);
+            assertEquals(80088, deleted[1].id);
         }
-        assertEquals("Found " + ids[0] + "; expected one of " + remaining, true, remaining.remove(ids[0]));
-        assertEquals("Found " + ids[1] + "; expected one of " + remaining, true, remaining.remove(ids[1]));
+
+        assertEquals("Found " + deleted[0].id + "; expected one of " + remaining,
+                     true,
+                     remaining.remove(deleted[0].id));
+
+        assertEquals("Found " + deleted[1].id + "; expected one of " + remaining,
+                     true,
+                     remaining.remove(deleted[1].id));
 
         // should have only 1 remaining
-        ids = packages.delete2(Limit.of(2), sorts);
-        assertEquals(Arrays.toString(ids), 1, ids.length);
-        assertEquals(remaining.iterator().next(), Integer.valueOf(ids[0]));
+        deleted = packages.deleteFirst2(Limit.of(2), sorts);
+        assertEquals(Arrays.toString(deleted), 1, deleted.length);
+        assertEquals(remaining.iterator().next(),
+                     Integer.valueOf(deleted[0].id));
     }
 
     /**
@@ -1953,7 +1972,7 @@ public class DataTestServlet extends FATServlet {
         Sort<?>[] sorts = supportsOrderByForUpdate //
                         ? new Sort[] { Sort.desc("description"), Sort.asc("length") } //
                         : null;
-        LinkedList<?> deletesList = packages.delete2ByHeightLessThan(8.0f, Limit.of(2), sorts);
+        LinkedList<?> deletesList = packages.deleteFirst2ByHeightLessThan(8.0f, Limit.of(2), sorts);
         assertEquals("Deleted " + deletesList, 2, deletesList.size());
         Package p0 = (Package) deletesList.get(0);
         Package p1 = (Package) deletesList.get(1);
@@ -2008,7 +2027,10 @@ public class DataTestServlet extends FATServlet {
 
         assertEquals(List.of(551, 589),
                      packages.deleteByDescriptionOrderByWidthAsc(testName,
-                                                                 Limit.of(2)));
+                                                                 Limit.of(2))
+                                     .stream()
+                                     .map(p -> p.id)
+                                     .collect(Collectors.toList()));
 
         // remaining entities are:
         //         id   length  width   height  description
@@ -2016,10 +2038,16 @@ public class DataTestServlet extends FATServlet {
         // Package(533, 925.0f, 756.0f, 533.0f, testName))
 
         assertEquals(List.of(533),
-                     packages.removeIfDescriptionMatches(testName, Limit.of(1)));
+                     packages.removeIfDescriptionMatches(testName, Limit.of(1))
+                                     .stream()
+                                     .map(p -> p.id)
+                                     .collect(Collectors.toList()));
 
         assertEquals(List.of(527),
-                     packages.removeIfDescriptionMatches(testName, Limit.of(10)));
+                     packages.removeIfDescriptionMatches(testName, Limit.of(10))
+                                     .stream()
+                                     .map(p -> p.id)
+                                     .collect(Collectors.toList()));
     }
 
     /**
@@ -2863,7 +2891,7 @@ public class DataTestServlet extends FATServlet {
     @Test
     public void testIntStreamResult() {
         assertEquals(List.of(5, 4, 3, 3, 5, 4, 4),
-                     primes.findSumOfBitsByNumberIdBetween(20, 49)
+                     primes.findSumOfBitsWhereNumberWithin(20, 49)
                                      .mapToObj(i -> Integer.valueOf(i))
                                      .collect(Collectors.toList()));
     }
@@ -3994,8 +4022,11 @@ public class DataTestServlet extends FATServlet {
      */
     @Test
     public void testOrderedSet() {
-        assertEquals(new HashSet<>(List.of(47L, 43L, 41L, 37L, 31L, 29L, 23L)),
-                     primes.findNumberIdByNumberIdBetween(20, 49));
+        assertEquals(List.of(47L, 43L, 41L, 37L, 31L, 29L, 23L),
+                     primes.findPrimeByNumberIdBetween(20L, 49L)
+                                     .stream()
+                                     .map(prime -> prime.numberId)
+                                     .collect(Collectors.toList()));
     }
 
     /**
@@ -4006,7 +4037,10 @@ public class DataTestServlet extends FATServlet {
         List<Long> l;
         l = primes.findByNumberIdLessThanOrNumberIdGreaterThanAndNumberIdLessThan(10,
                                                                                   40,
-                                                                                  50);
+                                                                                  50)
+                        .stream()
+                        .map(prime -> prime.numberId)
+                        .collect(Collectors.toList());
         assertEquals(List.of(2L, 3L, 5L, 7L, 41L, 43L, 47L),
                      l);
     }

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Packages.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Packages.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022,2025 IBM Corporation and others.
+ * Copyright (c) 2022,2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -56,7 +56,7 @@ public interface Packages extends BasicRepository<Package, Integer> {
 
     Package[] deleteByDescriptionEndsWith(String ending, Sort<?>... sorts);
 
-    List<Integer> deleteByDescriptionOrderByWidthAsc(String desc, Limit limit);
+    List<Package> deleteByDescriptionOrderByWidthAsc(String desc, Limit limit);
 
     Package[] deleteByDescriptionOrderByWidthDesc(String desc, Limit limit);
 
@@ -65,15 +65,20 @@ public interface Packages extends BasicRepository<Package, Integer> {
     @Query("DELETE FROM Package")
     int deleteEverything();
 
-    Optional<Integer> delete1(Limit limit, Sort<Package> sort);
+    Optional<Package> deleteFirst1(Limit limit, Sort<Package> sort);
 
-    int[] delete2(Limit limit, Sort<?>... sorts);
+    Package[] deleteFirst2(Limit limit, Sort<?>... sorts);
 
-    LinkedList<?> delete2ByHeightLessThan(float maxHeight, Limit limit, Sort<?>... sorts);
+    LinkedList<?> deleteFirst2ByHeightLessThan(float maxHeight,
+                                               Limit limit,
+                                               Sort<?>... sorts);
 
-    List<Package> deleteFirst2(); // 'first2' should be ignored and this should delete all entities
+    // 'First3' should be ignored and this should delete all entities
+    List<Package> deleteFirst3();
 
-    Package deleteFirst5ByWidthLessThan(float maxWidth); // 'first5' should be ignored and the number of results should be limited by the condition
+    // 'First5' should be ignored and the number of results should be
+    // limited by the condition
+    Package deleteFirst5ByWidthLessThan(float maxWidth);
 
     @Delete
     Object[] destroy(Limit limit, Sort<Package> sort);
@@ -149,7 +154,7 @@ public interface Packages extends BasicRepository<Package, Integer> {
 
     @Delete
     @OrderBy(value = "length", descending = true)
-    List<Integer> removeIfDescriptionMatches(String description, Limit limit);
+    List<Package> removeIfDescriptionMatches(String description, Limit limit);
 
     @Delete
     Package take(@By("id") int packageNum);

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Primes.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/Primes.java
@@ -104,9 +104,9 @@ public interface Primes {
 
     @Asynchronous
     @Find
-    CompletableFuture<Page<Long>> divisibleByTwo(boolean even,
-                                                 PageRequest req,
-                                                 Order<Prime> order);
+    CompletableFuture<Page<Prime>> divisibleByTwo(boolean even,
+                                                  PageRequest req,
+                                                  Order<Prime> order);
 
     @Asynchronous
     CompletionStage<Boolean> existsByNameIgnoreCase(String name);
@@ -223,9 +223,10 @@ public interface Primes {
     CompletionStage<CursoredPage<Prime>> findByNumberIdLessThanOrderByNumberIdDesc(long max, PageRequest pagination);
 
     @OrderBy(ID)
-    List<Long> findByNumberIdLessThanOrNumberIdGreaterThanAndNumberIdLessThan(int exclusiveMax,
-                                                                              int exclusiveRangeMin,
-                                                                              int exclusiveRangeMax);
+    List<Prime> findByNumberIdLessThanOrNumberIdGreaterThanAndNumberIdLessThan//
+    (int exclusiveMax,
+     int exclusiveRangeMin,
+     int exclusiveRangeMax);
 
     Iterator<Prime> findByNumberIdNotGreaterThan(long max, Sort<?>... order);
 
@@ -265,10 +266,11 @@ public interface Primes {
     List<Object[]> findNumberIdAndName(Sort<?>... sort);
 
     @OrderBy(value = ID, descending = true)
-    Set<Long> findNumberIdByNumberIdBetween(long min, long max);
+    Set<Prime> findPrimeByNumberIdBetween(long min, long max);
 
     @OrderBy(value = ID, descending = true)
-    IntStream findSumOfBitsByNumberIdBetween(long min, long max);
+    @Query("SELECT sumOfBits WHERE numberId BETWEEN :min and :max")
+    IntStream findSumOfBitsWhereNumberWithin(long min, long max);
 
     // Can omit entity identification variable after EclipseLink #33842 is fixed
     @Query("""

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/eclipselink/DataEclipseLinkServlet.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/eclipselink/DataEclipseLinkServlet.java
@@ -632,7 +632,10 @@ public class DataEclipseLinkServlet extends FATServlet {
         assertEquals(1L, receipts.removeByPurchaseId(3000L));
 
         assertEquals(Set.of(3002L, 3010L, 3012L),
-                     receipts.removeByTotalBetween(10.00f, 20.00f));
+                     receipts.removeByTotalBetween(10.00f, 20.00f)
+                                     .stream()
+                                     .map(Receipt::purchaseId)
+                                     .collect(Collectors.toSet()));
 
         // remove data to avoid interference with other tests
         assertEquals(12, receipts.removeIfTotalUnder(1000000.0f));

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/eclipselink/Receipts.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/eclipselink/Receipts.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024,2025 IBM Corporation and others.
+ * Copyright (c) 2024,2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -99,7 +99,7 @@ public interface Receipts extends CrudRepository<Receipt, Long> {
 
     long removeByPurchaseId(long purchaseId);
 
-    Set<Long> removeByTotalBetween(float min, float max);
+    Set<Receipt> removeByTotalBetween(float min, float max);
 
     @Query("DELETE FROM Receipt WHERE total < :max")
     int removeIfTotalUnder(float max);

--- a/dev/io.openliberty.data.internal_fat_errorpaths/fat/src/test/jakarta/data/errpaths/DataErrPathsTest.java
+++ b/dev/io.openliberty.data.internal_fat_errorpaths/fat/src/test/jakarta/data/errpaths/DataErrPathsTest.java
@@ -54,6 +54,7 @@ public class DataErrPathsTest extends FATServletClient {
                                    "CWWKD1003E.*existsByAddress", // exists method returning int
                                    "CWWKD1003E.*existsByBirthday", // exists method returning Page<Boolean>
                                    "CWWKD1003E.*existsByName", // exists method returning CompletableFuture<Long>
+                                   "CWWKD1005E.*findByBirthdayOrderBySSN", // Non-entity return without Select
                                    "CWWKD1006E.*deleteReturn.*ByAddress", // invalid result type for delete
                                    "CWWKD1006E.*removeBySSN", // delete method attempts to return record
                                    "CWWKD1009E.*addNothing", // Insert method without parameters
@@ -84,7 +85,6 @@ public class DataErrPathsTest extends FATServletClient {
                                    "CWWKD1024E.*inTownship", // @OrderBy with empty string value
                                    "CWWKD1028E.*findFirst2147483648", // exceeds Integer.MAX_VALUE
                                    "CWWKD1033E.*selectByFirstName", // CursoredPage with ORDER BY in Query
-                                   "CWWKD1037E.*findByBirthdayOrderBySSN", // CursoredPage of non-entity
                                    "CWWKD1037E.*registrations", // CursoredPage of non-entity
                                    "CWWKD1041E.*findBySsnBetweenAnd.*NotNull", // CursoredPage without PageRequest
                                    "CWWKD1046E.*firstLetterOfName", // unsafe conversion to Character

--- a/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/DataErrPathsTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/DataErrPathsTestServlet.java
@@ -428,9 +428,9 @@ public class DataErrPathsTestServlet extends FATServlet {
                                                             PageRequest.ofSize(8));
             fail("Should not be able to retrieve CursoredPage of a non-entity." +
                  " Found: " + page);
-        } catch (UnsupportedOperationException x) {
+        } catch (MappingException x) {
             if (x.getMessage() == null ||
-                !x.getMessage().startsWith("CWWKD1037E:") ||
+                !x.getMessage().startsWith("CWWKD1005E:") ||
                 !x.getMessage().contains("CursoredPage<java.lang.Integer>"))
                 throw x;
         }

--- a/dev/io.openliberty.data.internal_fat_exp/test-applications/DataExperimentalWeb/src/test/jakarta/data/experimental/web/PrimeNumbers.java
+++ b/dev/io.openliberty.data.internal_fat_exp/test-applications/DataExperimentalWeb/src/test/jakarta/data/experimental/web/PrimeNumbers.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022,2025 IBM Corporation and others.
+ * Copyright (c) 2022,2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -59,6 +59,7 @@ public interface PrimeNumbers {
                                  @By("NumberId") @Is(LessThan.class) long exclusiveMax);
 
     @Find
+    @Select(ID)
     @OrderBy(value = ID, descending = true)
     List<Long> inRangeHavingNumeralLikeAndNamePattern(@By(ID) @Is(AtLeast.class) long min,
                                                       @By(ID) @Is(AtMost.class) long max,

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Accounts.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Accounts.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023,2025 IBM Corporation and others.
+ * Copyright (c) 2023,2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -59,6 +59,7 @@ public interface Accounts {
     @OrderBy("owner")
     Stream<Account> findByAccountIdRoutingNum(long routingNum);
 
+    @Query("SELECT accountId WHERE bankName = :bank")
     @OrderBy("accountId")
     Stream<AccountId> findByBankName(String bank);
 

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Businesses.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Businesses.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022,2025 IBM Corporation and others.
+ * Copyright (c) 2022,2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -72,6 +72,7 @@ public interface Businesses extends BasicRepository<Business, Integer> {
     Business[] findByLocation_Address_Street_NameIgnoreCaseEndsWithOrderByLocation_Address_Street_DirectionIgnoreCaseAscNameAsc(String streetName);
 
     // embeddable as result type
+    @Query("SELECT location WHERE location.address.zip = :zipCode")
     @OrderBy("location.address.street")
     @OrderBy("location.address.houseNum")
     Stream<Location> findByLocationAddressZip(ZipCode zipCode);
@@ -86,7 +87,8 @@ public interface Businesses extends BasicRepository<Business, Integer> {
     // embeddable 3 levels deep as result type
     @OrderBy("location.address.street")
     @OrderBy("location.address.houseNum")
-    Stream<Street> findByLocationAddressZipNotAndLocationAddressCity(ZipCode excludeZipCode, String city);
+    Stream<Business> findByLocationAddressZipNotAndLocationAddressCity(ZipCode excludeZipCode,
+                                                                       String city);
 
     @OrderBy("id")
     Business findFirstByName(String name);

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Cities.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Cities.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023,2025 IBM Corporation and others.
+ * Copyright (c) 2023,2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -38,7 +38,7 @@ import jakarta.data.repository.Update;
  */
 @Repository(dataStore = "java:app/env/data/DataStoreRef")
 public interface Cities {
-    @Find
+    @Query("SELECT areaCodes WHERE name = :name AND stateName = :stateName")
     Optional<Set<Integer>> areaCodes(String name, String stateName);
 
     @Find

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Counties.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Counties.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023,2025 IBM Corporation and others.
+ * Copyright (c) 2023,2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -51,6 +51,7 @@ public interface Counties {
     @OrderBy("name")
     List<Set<CityId>> findCitiesByNameStartsWith(String beginning);
 
+    @Query("SELECT lastUpdated WHERE ID(this) = :name")
     LocalDateTime findLastUpdatedByName(String name);
 
     @Query("SELECT zipcodes WHERE name = ?1")

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022, 2025 IBM Corporation and others.
+ * Copyright (c) 2022, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -1371,9 +1371,16 @@ public class DataJPATestServlet extends FATServlet {
                                           .thenComparing(Comparator.<ShippingAddress, String> comparing(o -> o.streetAddress.streetName))
                                           .thenComparing(Comparator.<ShippingAddress, Integer> comparing(o -> o.zipCode)));
 
-        assertEquals(List.of("200 1st Ave SW", "151 4th St SE", "201 4th St SE"),
-                     Stream.of(shippingAddresses.findByStreetAddress_houseNumberBetweenOrderByStreetAddress_streetNameAscStreetAddress_houseNumber(150, 250))
-                                     .map(a -> a.houseNumber + " " + a.streetName)
+        ShippingAddress[] addresses = shippingAddresses
+                        .findByStreetAddress_houseNumberBetweenOrderByStreetAddress_streetNameAscStreetAddress_houseNumber//
+                        (150,
+                         250);
+        assertEquals(List.of("200 1st Ave SW",
+                             "151 4th St SE",
+                             "201 4th St SE"),
+                     Stream.of(addresses)
+                                     .map(a -> a.streetAddress.houseNumber + " " +
+                                               a.streetAddress.streetName)
                                      .collect(Collectors.toList()));
 
         assertEquals(4, shippingAddresses.removeAll());
@@ -1680,10 +1687,11 @@ public class DataJPATestServlet extends FATServlet {
     }
 
     /**
-     * Repository method where the result type is an embeddable class 3 levels deep on the entity.
+     * Repository method where the resulting entity type includes an
+     * embeddable class 3 levels deep.
      */
     @Test
-    public void testEmbeddableTypeAsResultDepth3() {
+    public void testEmbeddableTypeAtDepth3() {
 
         assertEquals(List.of("N Broadway Ave",
                              "NE Wellner Dr",
@@ -1693,6 +1701,7 @@ public class DataJPATestServlet extends FATServlet {
                              "SW Greenview Dr"),
                      businesses.findByLocationAddressZipNotAndLocationAddressCity(ZipCode.of(55901),
                                                                                   "Rochester")
+                                     .map(b -> b.location.address.street)
                                      .map(street -> street.direction + " " + street.name)
                                      .collect(Collectors.toList()));
     }
@@ -1956,11 +1965,13 @@ public class DataJPATestServlet extends FATServlet {
             // expected
         }
 
-        // verify that the second entity remains at its second version (22.99) and that the addition of the sixth entity was rolled back
-        List<Float> orderTotals = orders.findTotalByPurchasedByIn(List.of("testEntitiesAsParameters-Customer2",
-                                                                          "testEntitiesAsParameters-Customer6"));
+        // verify that the second entity remains at its second version (22.99)
+        // and that the addition of the sixth entity was rolled back
+        List<PurchaseOrder> orderTotals = orders.findOrdersByPurchasedByIn(List
+                        .of("testEntitiesAsParameters-Customer2",
+                            "testEntitiesAsParameters-Customer6"));
         assertEquals(orderTotals.toString(), 1, orderTotals.size());
-        assertEquals(22.99f, orderTotals.get(0), 0.001f);
+        assertEquals(22.99f, orderTotals.get(0).total, 0.001f);
 
         orders.deleteAll(List.of(o3, o2));
 
@@ -2064,14 +2075,15 @@ public class DataJPATestServlet extends FATServlet {
         assertEquals(77.99f, updated.total, 0.001f);
         assertEquals(false, updatesIt.hasNext());
 
-        List<Float> totals = orders.findTotalByPurchasedByIn(Set.of("testEntitiesAsParameters-Customer8",
-                                                                    "testEntitiesAsParameters-Customer7",
-                                                                    "testEntitiesAsParameters-Customer1"),
-                                                             Sort.desc("total"));
-        assertEquals(totals.toString(), 3, totals.size());
-        assertEquals(88.99f, totals.get(0), 0.001f);
-        assertEquals(77.99f, totals.get(1), 0.001f);
-        assertEquals(11.99f, totals.get(2), 0.001f); // not updated due to version mismatch
+        List<PurchaseOrder> found = orders.findOrdersByPurchasedByIn(Set
+                        .of("testEntitiesAsParameters-Customer8",
+                            "testEntitiesAsParameters-Customer7",
+                            "testEntitiesAsParameters-Customer1"),
+                                                                   Sort.desc("total"));
+        assertEquals(found.toString(), 3, found.size());
+        assertEquals(88.99f, found.get(0).total, 0.001f);
+        assertEquals(77.99f, found.get(1).total, 0.001f);
+        assertEquals(11.99f, found.get(2).total, 0.001f); // not updated due to version mismatch
 
         try {
             orders.update(o1);
@@ -2080,7 +2092,7 @@ public class DataJPATestServlet extends FATServlet {
             // pass
         }
 
-        assertEquals(11.99f, totals.get(2), 0.001f); // still not updated due to version mismatch
+        assertEquals(11.99f, found.get(2).total, 0.001f); // still not updated due to version mismatch
 
         // use correct version for update:
         o1 = orders.findFirstByPurchasedBy("testEntitiesAsParameters-Customer1").orElseThrow();
@@ -2091,9 +2103,10 @@ public class DataJPATestServlet extends FATServlet {
         assertEquals("testEntitiesAsParameters-Customer1", updated.purchasedBy);
         assertEquals(0.99f, updated.total, 0.001f);
 
-        totals = orders.findTotalByPurchasedByIn(Set.of("testEntitiesAsParameters-Customer1"));
-        assertEquals(totals.toString(), 1, totals.size());
-        assertEquals(0.99f, totals.get(0), 0.001f);
+        found = orders.findOrdersByPurchasedByIn(Set
+                        .of("testEntitiesAsParameters-Customer1"));
+        assertEquals(found.toString(), 1, found.size());
+        assertEquals(0.99f, found.get(0).total, 0.001f);
 
         orders.deleteAll();
     }
@@ -3151,6 +3164,7 @@ public class DataJPATestServlet extends FATServlet {
 
         assertEquals(List.of("Badge#2636 Level A", "Badge#4948 Level A", "Badge#5310 Level C", "Badge#8171 Level B"),
                      employees.findByLastName("testIdThatIsNotTheUniqueIdentifier")
+                                     .map(emp -> emp.badge)
                                      .map(Badge::toString)
                                      .collect(Collectors.toList()));
 
@@ -3234,11 +3248,17 @@ public class DataJPATestServlet extends FATServlet {
                                           .thenComparing(Comparator.<ShippingAddress, Integer> comparing(o -> o.streetAddress.houseNumber))
                                           .thenComparing(Comparator.<ShippingAddress, Integer> comparing(o -> o.zipCode)));
 
-        StreetAddress[] streetAddresses = shippingAddresses.findByStreetAddress_houseNumberBetweenOrderByStreetAddress_streetNameAscStreetAddress_houseNumber(1000, 3000);
+        ShippingAddress[] addresses = shippingAddresses
+                        .findByStreetAddress_houseNumberBetweenOrderByStreetAddress_streetNameAscStreetAddress_houseNumber//
+                        (1000,
+                         3000);
 
-        assertArrayEquals(new StreetAddress[] { work.streetAddress, home.streetAddress }, streetAddresses,
-                          Comparator.<StreetAddress, Integer> comparing(o -> o.houseNumber)
-                                          .thenComparing(Comparator.<StreetAddress, String> comparing(o -> o.streetName)));
+        assertEquals(List.of("2800 37th St NW",
+                             "1234 5th St SW"),
+                     Stream.of(addresses)
+                                     .map(addr -> addr.streetAddress.houseNumber + " " +
+                                                  addr.streetAddress.streetName)
+                                     .collect(Collectors.toList()));
 
         shippingAddresses.removeAll();
     }

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Demographics.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Demographics.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024,2025 IBM Corporation and others.
+ * Copyright (c) 2024,2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -103,7 +103,7 @@ public interface Demographics {
     Optional<DemographicInfo> read(Instant collectedOn);
 
     @OrderBy("numFullTimeWorkers")
-    @Query("WHERE numFullTimeWorkers >= :min AND numFullTimeWorkers <= :max")
+    @Query("SELECT collectedOn WHERE numFullTimeWorkers >= :min AND numFullTimeWorkers <= :max")
     List<Instant> whenFullTimeEmploymentWithin(BigInteger min, BigInteger max);
 
     @Insert

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Employees.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Employees.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023,2025 IBM Corporation and others.
+ * Copyright (c) 2023,2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -52,7 +52,7 @@ public interface Employees {
 
     @OrderBy("badge.number")
     @OrderBy("badge.accessLevel")
-    Stream<Badge> findByLastName(String lastName);
+    Stream<Employee> findByLastName(String lastName);
 
     // "IN" is not supported for embeddables, but EclipseLink generates SQL that leads to an SQLDataException rather than rejecting outright
     @Query("SELECT e FROM Employee e WHERE e.badge IN ?1")

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Models.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Models.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024,2025 IBM Corporation and others.
+ * Copyright (c) 2024,2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -19,6 +19,7 @@ import java.util.UUID;
 
 import jakarta.data.repository.CrudRepository;
 import jakarta.data.repository.Find;
+import jakarta.data.repository.Query;
 import jakarta.data.repository.Repository;
 
 /**
@@ -26,7 +27,7 @@ import jakarta.data.repository.Repository;
  */
 @Repository(dataStore = "java:app/env/data/DataStoreRef")
 public interface Models extends CrudRepository<Model, UUID> {
-    @Find
+    @Query("SELECT updatedAt WHERE id=?1")
     Optional<Instant> lastModified(UUID id);
 
     @Find

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Orders.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Orders.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022,2025 IBM Corporation and others.
+ * Copyright (c) 2022,2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -61,7 +61,8 @@ public interface Orders extends CrudRepository<PurchaseOrder, UUID> {
     @OrderBy("id")
     Optional<PurchaseOrder> findFirstByPurchasedBy(String purchaser);
 
-    List<Float> findTotalByPurchasedByIn(Iterable<String> purchasers, Sort<?>... sorts);
+    List<PurchaseOrder> findOrdersByPurchasedByIn(Iterable<String> purchasers,
+                                                  Sort<?>... sorts);
 
     @Update
     void modify(PurchaseOrder order);

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/ShippingAddresses.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/ShippingAddresses.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022,2025 IBM Corporation and others.
+ * Copyright (c) 2022,2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -25,7 +25,9 @@ import jakarta.data.repository.Save;
 @Repository(dataStore = "java:app/env/data/DataStoreRef")
 public interface ShippingAddresses {
 
-    StreetAddress[] findByStreetAddress_houseNumberBetweenOrderByStreetAddress_streetNameAscStreetAddress_houseNumber(int minHouseNumber, int maxHouseNumber);
+    ShippingAddress[] findByStreetAddress_houseNumberBetweenOrderByStreetAddress_streetNameAscStreetAddress_houseNumber//
+    (int minHouseNumber,
+     int maxHouseNumber);
 
     WorkAddress[] findByStreetAddress_streetNameAndFloorNumber(String streetName, int floorNumber);
 

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/TaxPayers.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/TaxPayers.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023,2025 IBM Corporation and others.
+ * Copyright (c) 2023,2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -35,6 +35,7 @@ public interface TaxPayers extends DataRepository<TaxPayer, Long> {
     @Query("SELECT bankAccounts WHERE ssn=?1")
     Set<AccountId> findAccountsBySSN(long ssn);
 
+    @Query("SELECT bankAccounts WHERE filingStatus=?1")
     @OrderBy("numDependents")
     @OrderBy("ssn")
     List<Set<AccountId>> findBankAccountsByFilingStatus(TaxPayer.FilingStatus status);

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/eclipselink/DataJPAEclipseLinkServlet.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/eclipselink/DataJPAEclipseLinkServlet.java
@@ -319,7 +319,10 @@ public class DataJPAEclipseLinkServlet extends FATServlet {
         r = paid.get(2);
         assertEquals(5.0f, r.amount(), 0.001);
 
-        List<Double> amounts = rebates.amounts("testRecordEntityInferredFromReturnType-CustomerA");
+        List<Double> amounts = rebates.byCustomer("testRecordEntityInferredFromReturnType-CustomerA")
+                        .stream()
+                        .map(Rebate::amount)
+                        .collect(Collectors.toList());
 
         assertEquals(4.0f, amounts.get(0), 0.001);
         assertEquals(5.0f, amounts.get(1), 0.001);
@@ -329,7 +332,11 @@ public class DataJPAEclipseLinkServlet extends FATServlet {
         assertEquals(Rebate.Status.VERIFIED, rebates.status(all[4 - 1].id()).orElseThrow());
         assertEquals(Rebate.Status.PAID, rebates.status(all[3 - 1].id()).orElseThrow());
 
-        List<LocalDate> purchaseDates = rebates.findByCustomerIdOrderByPurchaseMadeOnDesc("testRecordEntityInferredFromReturnType-CustomerA");
+        List<LocalDate> purchaseDates = rebates
+                        .findForCustomer("testRecordEntityInferredFromReturnType-CustomerA")
+                        .stream()
+                        .map(Rebate::purchaseMadeOn)
+                        .toList();
 
         assertEquals(LocalDate.of(2024, Month.MAY, 1), purchaseDates.get(0));
         assertEquals(LocalDate.of(2024, Month.MAY, 1), purchaseDates.get(1));

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/eclipselink/Rebates.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/eclipselink/Rebates.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022,2025 IBM Corporation and others.
+ * Copyright (c) 2022,2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
 
+import jakarta.data.repository.By;
 import jakarta.data.repository.Delete;
 import jakarta.data.repository.Find;
 import jakarta.data.repository.Insert;
@@ -53,20 +54,22 @@ public interface Rebates { // Do not allow this interface to inherit from other
 
     @Query("WHERE customerId=?1")
     @OrderBy("amount")
-    List<Double> amounts(String customerId);
+    List<Rebate> byCustomer(String customerId);
 
     // It should be acceptable for the return type to be more general
     // when using @Query
     @Query("SELECT purchaseMadeOn WHERE ID(THIS) = :id")
     Optional<Temporal> dayOfPurchase(int id);
 
-    List<LocalDate> findByCustomerIdOrderByPurchaseMadeOnDesc(String customer);
+    @Find
+    @OrderBy(value = "purchaseMadeOn", descending = true)
+    List<Rebate> findForCustomer(@By("customerId") String customer);
 
     @OrderBy("purchaseMadeOn")
     @OrderBy("purchaseMadeAt")
     PurchaseTime[] findTimeOfPurchaseByCustomerId(String customer);
 
-    @Find
+    @Query("SELECT updatedAt WHERE :id = id(this)")
     Optional<LocalDateTime> lastUpdated(int id);
 
     @Update
@@ -122,7 +125,7 @@ public interface Rebates { // Do not allow this interface to inherit from other
     @Delete
     void reset();
 
-    @Find
+    @Query("SELECT status WHERE id(this) = ?1")
     Optional<Rebate.Status> status(int id);
 
     @Query("SELECT EXTRACT(TIME FROM updatedAt)")


### PR DESCRIPTION
Replaces the experimental capability to find single entity attributes based on their type matching the result type of the repository method return type. It is replaced by the Select annotation being added to the Jakarta Data spec in 1.1, and we do not need an extra vendor-specific way of accomplishing the same thing.

Resolves #28636

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
