### PR TITLE
Fix missing timestamp in console.log when consoleFormat=simple

### DIFF
--- a/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/boot/internal/KernelBootstrap.java
+++ b/dev/com.ibm.ws.kernel.boot.core/src/com/ibm/ws/kernel/boot/internal/KernelBootstrap.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2024 IBM Corporation and others.
+ * Copyright (c) 2013, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -32,6 +32,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
+import java.text.DateFormat;
 
 import com.ibm.ws.kernel.boot.BootstrapConfig;
 import com.ibm.ws.kernel.boot.EmbeddedServerImpl;
@@ -513,6 +514,10 @@ public class KernelBootstrap {
             if ("json".equals(consoleFormat)) {
                 String jsonConsoleHeader = constructJSONHeader(consoleLogHeader, bootProps);
                 System.out.println(jsonConsoleHeader);
+            } else if ("simple".equals(consoleFormat)) {
+                String bsIsoDateFormat = bootProps.get("com.ibm.ws.logging.isoDateFormat");
+                boolean useIsoDateFormat = Boolean.parseBoolean(bsIsoDateFormat);
+                System.out.println(formatSimpleLogLine(consoleLogHeader, useIsoDateFormat));
             } else {
                 System.out.println(consoleLogHeader);
             }
@@ -633,6 +638,40 @@ public class KernelBootstrap {
         SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ");
         String datetime = dateFormat.format(System.currentTimeMillis());
         return datetime;
+    }
+
+    private static String getLocaleDatetime() {
+        DateFormat formatter = DateFormat.getDateTimeInstance(DateFormat.SHORT, DateFormat.MEDIUM);
+        if (formatter instanceof SimpleDateFormat) {
+            SimpleDateFormat sdFormatter = (SimpleDateFormat) formatter;
+            String pattern = sdFormatter.toPattern();
+            int endOfSecsIndex = pattern.lastIndexOf('s') + 1;
+            String newPattern = pattern.substring(0, endOfSecsIndex) + ":SSS z";
+            if (endOfSecsIndex < pattern.length())
+                newPattern += pattern.substring(endOfSecsIndex);
+            newPattern = newPattern.replace('h', 'H').replace('K', 'H').replace('k', 'H').replace('a', ' ').trim();
+            sdFormatter.applyPattern(newPattern);
+            formatter = sdFormatter;
+        } else {
+            formatter = new SimpleDateFormat("yy.MM.dd HH:mm:ss:SSS z");
+        }
+        return formatter.format(System.currentTimeMillis());
+    }
+
+    private static String formatSimpleLogLine(String consoleLogHeader, boolean useIsoDateFormat) {
+        String timestamp;
+        if (useIsoDateFormat) {
+            timestamp = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ")
+                            .format(System.currentTimeMillis());
+        } else {
+            timestamp = getLocaleDatetime();
+        }
+
+        String threadId = String.format("%08x", Thread.currentThread().getId());
+
+        // Logger name padded to 60 chars (matches enhancedNameLength in BaseTraceFormatter)
+        String loggerName = String.format("%-60s", "SystemOut");
+        return "[" + timestamp + "] " + threadId + " " + loggerName + " O " + consoleLogHeader;
     }
 
     /**

--- a/dev/com.ibm.ws.logging_fat/fat/src/com/ibm/ws/logging/fat/HeaderFormatTest.java
+++ b/dev/com.ibm.ws.logging_fat/fat/src/com/ibm/ws/logging/fat/HeaderFormatTest.java
@@ -42,6 +42,7 @@ public class HeaderFormatTest {
                                                    "\\{.*\"type\":\"liberty_audit\".*\\}" };
     public static final String[] BASIC_MESSSAGE = { "\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*" };
     public static final String[] JSON_CONSOLE = { "\\{\".*Launching.*\"\\}" };
+    public static final String[] SIMPLE_CONSOLE = { "\\[\\d.*\\]\\s+[0-9a-f]{8}\\s+.*Launching.*" };
     private static final String TBASIC_FORMAT_REGEX_PATTERN = "([a-zA-Z0-9- ]{8} [aA-zZ ]{13} [aA-zZ]{1}\\s{3})";
 
     private static LibertyServer server;
@@ -107,6 +108,30 @@ public class HeaderFormatTest {
         hasNoJSON = checkStringsNotInLog(JSON_MESSAGES, traceLogFile);
         assertTrue("There a json header in trace.log", hasNoJSON);
 
+    }
+
+    /*
+     * This tests if the simple console header contains a timestamp when consoleFormat=simple
+     */
+    @Test
+    public void simpleHeaderTest() throws Exception {
+        //start server
+        server = LibertyServerFactory.getLibertyServer("com.ibm.ws.logging.headerformatsimple");
+        System.out.println("Starting server...");
+        server.startServer();
+        System.out.println("Started server.");
+
+        //retrieve log files
+        RemoteFile consoleLogFile = server.getConsoleLogFile();
+        /* Check that the console log contains the simple format header with timestamp */
+        boolean hasNoSimpleHeader = checkStringsNotInLog(SIMPLE_CONSOLE, consoleLogFile);
+        assertFalse("There is no simple header with timestamp in console.log", hasNoSimpleHeader);
+        /* Check that the console log does not contain json header */
+        boolean hasNoJSON = checkStringsNotInLog(JSON_CONSOLE, consoleLogFile);
+        assertTrue("There is a json header in console.log", hasNoJSON);
+        /* Check that the console log does not contain basic header */
+        boolean hasNoBasic = checkStringsNotInLog(BASIC_MESSSAGE, consoleLogFile);
+        assertTrue("There is a basic header in console.log", hasNoBasic);
     }
 
     /*

--- a/dev/com.ibm.ws.logging_fat/publish/servers/com.ibm.ws.logging.headerformatsimple/bootstrap.properties
+++ b/dev/com.ibm.ws.logging_fat/publish/servers/com.ibm.ws.logging.headerformatsimple/bootstrap.properties
@@ -1,0 +1,14 @@
+###############################################################################
+# Copyright (c) 2026 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+###############################################################################
+bootstrap.include=../testports.properties
+com.ibm.ws.logging.hideMessage=CWWKZ0058I

--- a/dev/com.ibm.ws.logging_fat/publish/servers/com.ibm.ws.logging.headerformatsimple/server.env
+++ b/dev/com.ibm.ws.logging_fat/publish/servers/com.ibm.ws.logging.headerformatsimple/server.env
@@ -1,0 +1,3 @@
+keystore_password=YvhNyUE7nCplVUTHkwshOMN
+WLP_SKIP_MAXPERMSIZE=true
+WLP_LOGGING_CONSOLE_FORMAT=simple

--- a/dev/com.ibm.ws.logging_fat/publish/servers/com.ibm.ws.logging.headerformatsimple/server.xml
+++ b/dev/com.ibm.ws.logging_fat/publish/servers/com.ibm.ws.logging.headerformatsimple/server.xml
@@ -1,0 +1,19 @@
+<!--
+    Copyright (c) 2026 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License 2.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-2.0/
+
+    SPDX-License-Identifier: EPL-2.0
+
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<server>
+    <featureManager>
+        <feature>jsp-2.2</feature>
+    </featureManager>
+
+    <include location="../fatTestPorts.xml"/>
+</server>


### PR DESCRIPTION
## Summary
When `consoleFormat` is set to `simple`, the server launch message ("Launching...") was missing the timestamp prefix that other log messages have.

This fix adds the timestamp to match the format of other log lines.

**Before:**
```
Launching testserver (Open Liberty...) on OpenJDK...
[1/19/26, 19:47:02:963 AST] 00000001 com.ibm.ws...
```

**After:**
```
[1/19/26, 21:00:08:554 AST] Launching testserver (Open Liberty...) on OpenJDK...
[1/19/26, 21:00:08:624 AST] 00000001 com.ibm.ws...
```

## Test plan
- Manually verified the fix by setting `com.ibm.ws.logging.console.format=simple` in bootstrap.properties
- Ran existing unit tests (`./gradlew com.ibm.ws.kernel.boot:test`)

Fixes #33817