### PR TITLE
fix: Jakarta nosql version error

### DIFF
--- a/dev/io.openliberty.jakarta.nosql.1.0/bnd.bnd
+++ b/dev/io.openliberty.jakarta.nosql.1.0/bnd.bnd
@@ -26,7 +26,7 @@ javac.target: 17
 Require-Capability: osgi.ee; filter:="(&(osgi.ee=JavaSE)(version=17))"
 
 Export-Package: \
-  jakarta.nosql;version="1.0.0"
+  jakarta.nosql;version="${jnosql-version}"
 
 -includeresource: \
   @\${repo;jakarta.nosql:jakarta.nosql-api;${jnosql-version};EXACT}!/!(META-INF/maven/*|module-info.class)


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

Jakarta NoSQL API artifact version was updated, without updating the OSGi export version. 
