### PR TITLE
Use the new label property for more precise filtering

### DIFF
--- a/.ci-orchestrator/externalIssueNotice.yml
+++ b/.ci-orchestrator/externalIssueNotice.yml
@@ -12,9 +12,9 @@ triggers:
     include: labeled
   - property: repo
     include: open-liberty
-  - property: labels
+  - property: label
     include: "Opened by external contributor"
-  - property: labels
+  - property: label
     exclude: "test"
   - property: userExternal
     include: true

--- a/.ci-orchestrator/regressionLabelIssue.yml
+++ b/.ci-orchestrator/regressionLabelIssue.yml
@@ -12,9 +12,9 @@ triggers:
     include: labeled
   - property: repo
     include: open-liberty
-  - property: labels
+  - property: label
     include: "regression"
-  - property: labels
+  - property: label
     exclude: "test"
   propertyDefinitions:
     - name: user

--- a/.ci-orchestrator/targetGALabelIssue.yml
+++ b/.ci-orchestrator/targetGALabelIssue.yml
@@ -12,9 +12,9 @@ triggers:
     include: labeled
   - property: repo
     include: open-liberty
-  - property: labels
+  - property: label
     include: "target:ga"
-  - property: labels
+  - property: label
     exclude: "test"
   propertyDefinitions:
     - name: user


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

Using the `labels` property as a filter for triggering event is not good practice. This usage results in duplicate automation pipelines for an issue that has already been serviced; if the issue has the specified label already existing in the array, when another and unrelated label is added, the pipeline is triggered. That is unwanted behavior.