### PR TITLE
Use ephemeral fileservers for pbs

### DIFF
--- a/.ci-orchestrator/compilePersonal.properties
+++ b/.ci-orchestrator/compilePersonal.properties
@@ -11,6 +11,8 @@ cognitive_auto_resolve_hung_builds=abandon
 create.im.repo=false
 dhe.server=w3-transfer.boulder.ibm.com
 disable.run.createDocumentation=true
+# Use ephemeral fileservers
+ebc.fileserver_type=personal
 # Normally 100. Used internally by the EBC to adjust the order builds are queued in.
 ebc.priority=100
 ebc.shortlist=parentbuild-personal.yml

--- a/.ci-orchestrator/pb.yml
+++ b/.ci-orchestrator/pb.yml
@@ -274,6 +274,7 @@ steps:
       allowFailures: true
   properties:
     aggregationId: ${Compile Liberty Images:execution_id}
+    fileserverType: personal
     product_image_artifact_execution_id: ${Compile Liberty Images:execution_id}
     bucket_image_artifact_execution_id: ${Compile FATs:execution_id}
     changes_summary_artifact_execution_id: ${Compile Liberty Images:execution_id}


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

Update personal builds to use ephemeral fileservers in the closest location to the build rather than libertyfs, meaning they can be retained in a more reliable way and should upload significantly faster.

For https://github.ibm.com/WAS-CD-Area/WAS-CD-Area/issues/2237
