### PR TITLE
Fix LDAP encoding for plus sign in usernames

### DIFF
--- a/dev/com.ibm.ws.security.wim.adapter.ldap/src/com/ibm/ws/security/wim/adapter/ldap/LdapHelper.java
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap/src/com/ibm/ws/security/wim/adapter/ldap/LdapHelper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2025 IBM Corporation and others.
+ * Copyright (c) 2012, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -1002,7 +1002,7 @@ public class LdapHelper {
     }
 
     /**
-     * Encode \ * ( ) for LDAP queries.
+     * Encode \ * ( ) + for LDAP queries.
      *
      * @param input          The principalName to encode
      * @param encodeAsterisk True if asterisks should also be encoded
@@ -1031,6 +1031,9 @@ public class LdapHelper {
                     break;
                 case ')':
                     sb.append("\\29");
+                    break;
+                case '+':
+                    sb.append("\\2b");
                     break;
                 case '\0':
                     sb.append("\\00");

--- a/dev/com.ibm.ws.security.wim.adapter.ldap/test/com/ibm/ws/security/wim/adapter/ldap/LdapHelperTest.java
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap/test/com/ibm/ws/security/wim/adapter/ldap/LdapHelperTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -97,5 +97,21 @@ public class LdapHelperTest {
         assertEquals("get Valid RDN with LDAPSyntaxException and multiple escaped commas should return the original DN", "uid=user\\,\\, \\#",
                      LdapHelper.getRDN("uid=user\\,\\, \\#"));
 
+    }
+
+    @Test
+    public void testEncodeForLDAP_PlusSign(){
+        String input ="user+test@example.com";
+        String expected ="user\\2btest@example.com";
+        String actual = LdapHelper.encode(input,true);
+        assertEquals("Plus sign should be hex-encoded as \\2b", expected, actual);
+    }
+
+    @Test
+    public void testEncodeForLDAP_PlusSignWithOtherSpecialChars() {
+        String input = "user+test(special)@example.com";
+        String expected = "user\\2btest\\28special\\29@example.com";
+        String actual = LdapHelper.encode(input, true);
+        assertEquals("Plus sign and other special chars should all be encoded", expected, actual);
     }
 }

--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat.2/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/EncodeSpecialCharactersTest.java
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat.2/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/EncodeSpecialCharactersTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022 IBM Corporation and others.
+ * Copyright (c) 2022, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -72,6 +72,8 @@ public class EncodeSpecialCharactersTest {
     private static final String USER_DN = "uid=" + userUid + "," + DN;
     private static final String userSn = "user1sn)((testsn*";
     private static final String userCn = "user1cn";
+    private static final String userUidWithPlus = "user+test";
+    private static final String USER_DN_WITH_PLUS = "uid=user\\+test," + DN;
 
     /**
      * Setup the test case.
@@ -166,6 +168,17 @@ public class EncodeSpecialCharactersTest {
         entry.addAttribute("uid", userUid);
         entry.addAttribute("sn", userSn);
         entry.addAttribute("cn", userCn);
+        entry.addAttribute("userPassword", "password");
+        ds.add(entry);
+
+        /*
+        * Create the user and group.
+        */
+        entry = new Entry(USER_DN_WITH_PLUS);
+        entry.addAttribute("objectclass", "inetorgperson");
+        entry.addAttribute("uid", userUidWithPlus);
+        entry.addAttribute("sn", "TestUser");
+        entry.addAttribute("cn", "Test User Plus");
         entry.addAttribute("userPassword", "password");
         ds.add(entry);
 
@@ -304,5 +317,72 @@ public class EncodeSpecialCharactersTest {
         assertEquals("There should be three entries :" + result.toString(), 1, result.getList().size());
         result = servlet.getUsers(userUid, 0);
         assertEquals("There should be three entries :" + result.toString(), 1, result.getList().size());
+    }
+
+    /**
+     * Test that users with plus signs in their username can
+     * successfully authenticate.
+     * This goes along LDAP Filter queries (RFC 4525)
+     */
+    @Test
+    public void testPlusSignInUsername() throws Exception{
+        updateLibertyServer(false,false);
+
+        assertDNsEqual("Authentication should succeed with plus sign in username.",
+        USER_DN_WITH_PLUS,
+        servlet.checkPassword(userUidWithPlus,"password"));
+
+        SearchResult result = servlet.getUsers(USER_DN_WITH_PLUS, 0);
+        assertEquals("Should find exactly one user with plus sign", 1, result.getList().size());
+    }
+
+    /**
+     * Test multiple plus signs in username
+     */
+    @Test
+    public void testMultiplePlusSignInUsername() throws Exception{
+        String userWithMultiplePlus = "user+test+extra";
+        String dnWithMultiplePlus = "uid=user\\+test\\+extra," + DN;
+
+        // Add test user
+        Entry entry = new Entry(dnWithMultiplePlus);
+        entry.addAttribute("objectclass", "inetorgperson");
+        entry.addAttribute("uid", userWithMultiplePlus);
+        entry.addAttribute("sn", "TestUser");
+        entry.addAttribute("cn", "Test User Multiple Plus");
+        entry.addAttribute("userPassword", "password");
+        ds.add(entry);
+
+        updateLibertyServer(false,false);
+
+        assertDNsEqual("Authentication should succeed with plus sign in username.",
+        dnWithMultiplePlus,
+        servlet.checkPassword(userWithMultiplePlus,"password"));
+    }
+
+
+    /**
+     * Test multiple plus signs and other special characters in username
+     */
+    @Test
+    public void testPlusSignInUsernameOtherSpecialChars() throws Exception{
+        
+        String userWithMixedChars = "user+test(special)";
+        String dnWithMixedChars = "uid=user\\+test(special)," + DN;
+
+        // Add test user
+        Entry entry = new Entry(dnWithMixedChars);
+        entry.addAttribute("objectclass", "inetorgperson");
+        entry.addAttribute("uid", userWithMixedChars);
+        entry.addAttribute("sn", "TestUser");
+        entry.addAttribute("cn", "Test User Mixed Chars");
+        entry.addAttribute("userPassword", "password");
+        ds.add(entry);
+
+        updateLibertyServer(false,false);
+
+        assertDNsEqual("Authentication should succeed with plus sign in username.",
+        dnWithMixedChars,
+        servlet.checkPassword(userWithMixedChars,"password"));
     }
 }


### PR DESCRIPTION
Users with plus signs in their usernames (such as user+test or user+tag@example.com) cannot authenticate through Liberty's LDAP adapter. The authentication fails with error CWIML4537E indicating the principal name is not found in the repository.  The reason is because `LdapHelper.encodeForLDAP()` method does not properly encode the plus sign character when building LDAP filter queries. As a result, when Liberty searches for a user with a plus sign in their username, it builds a filter query without encoding the plus sign, causing the LDAP query to fail to match entries in the directory.

This fix adds hex encoding for the plus sign character in the encodeForLDAP() method, encoding it as \2b per it's hexadecimal representation. This is consistent with how other LDAP filter special characters are already handled: asterisk (\2a), parentheses (\28, \29), and backslash (\5c). 

Test cases have been added to verify authentication succeeds for usernames containing plus signs, including edge cases with multiple plus signs and combinations with other special characters.

Fixes #OLGH33883

- [ ] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [ ] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [X] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
