### PR TITLE
30943 redo the jandex feature and dependency code

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.anno-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.anno-1.0.feature
@@ -16,7 +16,8 @@ Manifest-Version: 1.0
 IBM-Process-Types: server, \
  client
 -features=com.ibm.websphere.appserver.javax.annotation-1.1; ibm.tolerates:="1.2,1.3", \
-  com.ibm.websphere.appserver.artifact-1.0
+  com.ibm.websphere.appserver.artifact-1.0, \
+  io.openliberty.io.smallrye.jandex-3.0; ibm.tolerates:="2.0"
 -bundles=com.ibm.ws.anno
 -jars=com.ibm.websphere.appserver.spi.anno; location:=dev/spi/ibm/
 -files=dev/spi/ibm/javadoc/com.ibm.websphere.appserver.spi.anno_1.1-javadoc.zip

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.anno-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.anno-2.0.feature
@@ -15,7 +15,8 @@ Manifest-Version: 1.0
 IBM-Process-Types: server, \
  client
 -features=io.openliberty.jakarta.annotation-2.0; ibm.tolerates:="2.1, 3.0", \
-  com.ibm.websphere.appserver.artifact-1.0
+  com.ibm.websphere.appserver.artifact-1.0, \
+  io.openliberty.io.smallrye.jandex-3.0; ibm.tolerates:="2.0"
 -bundles=com.ibm.ws.anno
 -jars=com.ibm.websphere.appserver.spi.anno; location:=dev/spi/ibm/
 -files=dev/spi/ibm/javadoc/com.ibm.websphere.appserver.spi.anno_1.1-javadoc.zip

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.internal.jandex.2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.internal.jandex.2.0.feature
@@ -1,0 +1,8 @@
+-include= ~${workspace}/cnf/resources/bnd/feature.props
+symbolicName=io.openliberty.io.smallrye.jandex-2.0
+singleton=true
+-bundles=com.ibm.ws.org.jboss.jandex
+kind=ga
+edition=core
+WLP-Activation-Type: parallel
+

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.internal.jandex.3.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.internal.jandex.3.0.feature
@@ -1,7 +1,8 @@
 -include= ~${workspace}/cnf/resources/bnd/feature.props
-symbolicName=io.openliberty.jandex.internal-3.0
+symbolicName=io.openliberty.io.smallrye.jandex-3.0
 singleton=true
 -bundles=io.openliberty.io.smallrye.jandex3
 kind=ga
 edition=core
 WLP-Activation-Type: parallel
+

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpGraphQL-1.0/com.ibm.websphere.appserver.mpGraphQL-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpGraphQL-1.0/com.ibm.websphere.appserver.mpGraphQL-1.0.feature
@@ -16,7 +16,8 @@ Subsystem-Name: MicroProfile GraphQL 1.0
   com.ibm.websphere.appserver.org.eclipse.microprofile.graphql-1.0, \
   com.ibm.websphere.appserver.org.reactivestreams.reactive-streams-1.0, \
   com.ibm.websphere.appserver.cdi-2.0, \
-  com.ibm.websphere.appserver.jsonb-1.0
+  com.ibm.websphere.appserver.jsonb-1.0, \
+  io.openliberty.io.smallrye.jandex-2.0
 -bundles= \
  com.ibm.ws.com.graphql.java, \
  com.ibm.ws.io.smallrye.graphql, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpGraphQL-2.0/io.openliberty.mpGraphQL-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpGraphQL-2.0/io.openliberty.mpGraphQL-2.0.feature
@@ -17,7 +17,8 @@ Subsystem-Name: MicroProfile GraphQL 2.0
   io.openliberty.mpConfig-3.0; ibm.tolerates:="3.1", \
   io.openliberty.concurrent-2.0; ibm.tolerates:="3.0,3.1", \
   io.openliberty.mpContextPropagation-1.3, \
-  io.openliberty.org.eclipse.microprofile.graphql-2.0
+  io.openliberty.org.eclipse.microprofile.graphql-2.0, \
+  io.openliberty.io.smallrye.jandex-2.0
 -bundles= \
  com.ibm.ws.com.graphql.java.jakarta, \
  com.ibm.ws.io.smallrye.graphql.jakarta, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpOpenAPI-1.0/com.ibm.websphere.appserver.mpOpenAPI-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpOpenAPI-1.0/com.ibm.websphere.appserver.mpOpenAPI-1.0.feature
@@ -40,7 +40,8 @@ IBM-API-Package: \
   com.ibm.websphere.appserver.servlet-3.1; ibm.tolerates:="4.0", \
   io.openliberty.servlet.internal-3.1; ibm.tolerates:="4.0", \
   com.ibm.websphere.appserver.org.eclipse.microprofile.openapi-1.0, \
-  com.ibm.websphere.appserver.jaxrs-2.0; ibm.tolerates:="2.1"
+  com.ibm.websphere.appserver.jaxrs-2.0; ibm.tolerates:="2.1", \
+  io.openliberty.io.smallrye.jandex-2.0
 -bundles=\
  com.ibm.ws.microprofile.openapi,\
  com.ibm.ws.microprofile.openapi.servlet,\

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpOpenAPI-1.1/com.ibm.websphere.appserver.mpOpenAPI-1.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpOpenAPI-1.1/com.ibm.websphere.appserver.mpOpenAPI-1.1.feature
@@ -40,7 +40,8 @@ IBM-API-Package: \
   com.ibm.websphere.appserver.servlet-3.1; ibm.tolerates:="4.0", \
   io.openliberty.servlet.internal-3.1; ibm.tolerates:="4.0", \
   com.ibm.websphere.appserver.org.eclipse.microprofile.openapi-1.1, \
-  com.ibm.websphere.appserver.jaxrs-2.0; ibm.tolerates:="2.1"
+  com.ibm.websphere.appserver.jaxrs-2.0; ibm.tolerates:="2.1", \
+  io.openliberty.io.smallrye.jandex-2.0
 -bundles=\
  com.ibm.ws.microprofile.openapi,\
  com.ibm.ws.microprofile.openapi.servlet,\

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpOpenAPI-2.0/com.ibm.websphere.appserver.mpOpenAPI-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpOpenAPI-2.0/com.ibm.websphere.appserver.mpOpenAPI-2.0.feature
@@ -40,7 +40,8 @@ IBM-API-Package: \
   io.openliberty.servlet.internal-4.0, \
   com.ibm.websphere.appserver.jaxrs-2.1, \
   io.openliberty.mpCompatible-4.0, \
-  com.ibm.websphere.appserver.org.eclipse.microprofile.openapi-2.0
+  com.ibm.websphere.appserver.org.eclipse.microprofile.openapi-2.0, \
+  io.openliberty.io.smallrye.jandex-2.0
 -bundles=\
     io.openliberty.io.smallrye.openapi.core, \
     io.openliberty.io.smallrye.openapi.jaxrs, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpOpenAPI-3.0/io.openliberty.mpOpenAPI-3.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpOpenAPI-3.0/io.openliberty.mpOpenAPI-3.0.feature
@@ -40,7 +40,8 @@ IBM-API-Package: \
   io.openliberty.servlet.internal-5.0, \
   io.openliberty.restfulWS-3.0, \
   io.openliberty.mpCompatible-5.0, \
-  io.openliberty.org.eclipse.microprofile.openapi-3.0
+  io.openliberty.org.eclipse.microprofile.openapi-3.0, \
+  io.openliberty.io.smallrye.jandex-2.0
 -bundles=\
     io.openliberty.io.smallrye.openapi.core, \
     io.openliberty.io.smallrye.openapi.jaxrs, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpOpenAPI-3.1/io.openliberty.mpOpenAPI-3.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpOpenAPI-3.1/io.openliberty.mpOpenAPI-3.1.feature
@@ -38,8 +38,8 @@ IBM-API-Package: \
   io.openliberty.webBundle.internal-1.0,\
   io.openliberty.restfulWS-3.1, \
   io.openliberty.mpCompatible-6.0; ibm.tolerates:="6.1", \
-  io.openliberty.org.eclipse.microprofile.openapi-3.1,\
-  io.openliberty.jandex.internal-3.0
+  io.openliberty.org.eclipse.microprofile.openapi-3.1, \
+  io.openliberty.io.smallrye.jandex-2.0
 -bundles=\
     io.openliberty.io.smallrye.openapi3.core, \
     io.openliberty.io.smallrye.openapi3.jaxrs, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpOpenAPI-4.0/io.openliberty.mpOpenAPI-4.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpOpenAPI-4.0/io.openliberty.mpOpenAPI-4.0.feature
@@ -39,7 +39,7 @@ IBM-API-Package: \
   io.openliberty.restfulWS-3.1; ibm.tolerates:="4.0", \
   io.openliberty.mpCompatible-7.0,\
   io.openliberty.org.eclipse.microprofile.openapi-4.0,\
-  io.openliberty.jandex.internal-3.0
+  io.openliberty.io.smallrye.jandex-3.0
 -bundles=\
     io.openliberty.io.smallrye.openapi4.core, \
     io.openliberty.io.smallrye.openapi4.jaxrs, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpOpenAPI-4.1/io.openliberty.mpOpenAPI-4.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpOpenAPI-4.1/io.openliberty.mpOpenAPI-4.1.feature
@@ -39,7 +39,7 @@ IBM-API-Package: \
   io.openliberty.restfulWS-3.1; ibm.tolerates:="4.0", \
   io.openliberty.mpCompatible-7.1, \
   io.openliberty.org.eclipse.microprofile.openapi-4.1,\
-  io.openliberty.jandex.internal-3.0
+  io.openliberty.io.smallrye.jandex-3.0
 -bundles=\
     io.openliberty.io.smallrye.openapi41.core, \
     io.openliberty.io.smallrye.openapi41.jaxrs, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/opentracing-1.0/com.ibm.websphere.appserver.opentracing-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/opentracing-1.0/com.ibm.websphere.appserver.opentracing-1.0.feature
@@ -12,7 +12,8 @@ IBM-API-Package: io.opentracing;  type="third-party",\
                  io.opentracing.propagation;  type="third-party"
 IBM-SPI-Package: com.ibm.ws.opentracing.tracer
 -features=com.ibm.websphere.appserver.jaxrs-2.0; ibm.tolerates:="2.1", \
-  com.ibm.websphere.appserver.cdi-1.2; ibm.tolerates:="2.0"
+  com.ibm.websphere.appserver.cdi-1.2; ibm.tolerates:="2.0", \
+  io.openliberty.io.smallrye.jandex-2.0
 -bundles=com.ibm.ws.jaxrs.defaultexceptionmapper, \
          com.ibm.ws.jaxrs.2.x.defaultexceptionmapper, \
          com.ibm.ws.opentracing, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/opentracing-1.1/com.ibm.websphere.appserver.opentracing-1.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/opentracing-1.1/com.ibm.websphere.appserver.opentracing-1.1.feature
@@ -12,7 +12,8 @@ IBM-API-Package: io.opentracing;  type="third-party",\
                  io.opentracing.propagation;  type="third-party"
 IBM-SPI-Package: com.ibm.ws.opentracing.tracer
 -features=com.ibm.websphere.appserver.jaxrs-2.0; ibm.tolerates:="2.1", \
-  com.ibm.websphere.appserver.cdi-1.2; ibm.tolerates:="2.0"
+  com.ibm.websphere.appserver.cdi-1.2; ibm.tolerates:="2.0", \
+  io.openliberty.io.smallrye.jandex-2.0
 -bundles=com.ibm.ws.jaxrs.defaultexceptionmapper, \
          com.ibm.ws.jaxrs.2.x.defaultexceptionmapper, \
          com.ibm.ws.opentracing.1.1, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/opentracing-1.2/com.ibm.websphere.appserver.opentracing-1.2.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/opentracing-1.2/com.ibm.websphere.appserver.opentracing-1.2.feature
@@ -13,7 +13,8 @@ IBM-API-Package: io.opentracing;  type="third-party",\
 IBM-SPI-Package: com.ibm.ws.opentracing.tracer
 -features=com.ibm.websphere.appserver.mpConfig-1.3; ibm.tolerates:="1.4", \
   com.ibm.websphere.appserver.jaxrs-2.0; ibm.tolerates:="2.1", \
-  com.ibm.websphere.appserver.cdi-1.2; ibm.tolerates:="2.0"
+  com.ibm.websphere.appserver.cdi-1.2; ibm.tolerates:="2.0", \
+  io.openliberty.io.smallrye.jandex-2.0
 -bundles=com.ibm.ws.jaxrs.defaultexceptionmapper, \
          com.ibm.ws.jaxrs.2.x.defaultexceptionmapper, \
          com.ibm.ws.opentracing.1.2, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/opentracing-1.3/com.ibm.websphere.appserver.opentracing-1.3.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/opentracing-1.3/com.ibm.websphere.appserver.opentracing-1.3.feature
@@ -13,7 +13,8 @@ IBM-API-Package: io.opentracing;  type="third-party",\
 IBM-SPI-Package: com.ibm.ws.opentracing.tracer
 -features=com.ibm.websphere.appserver.mpConfig-1.3; ibm.tolerates:="1.4", \
   com.ibm.websphere.appserver.jaxrs-2.1, \
-  com.ibm.websphere.appserver.cdi-2.0
+  com.ibm.websphere.appserver.cdi-2.0, \
+  io.openliberty.io.smallrye.jandex-2.0
 -bundles=com.ibm.ws.jaxrs.defaultexceptionmapper, \
          com.ibm.ws.jaxrs.2.x.defaultexceptionmapper, \
          com.ibm.ws.opentracing.1.3, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/opentracing-2.0/com.ibm.websphere.appserver.opentracing-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/opentracing-2.0/com.ibm.websphere.appserver.opentracing-2.0.feature
@@ -12,7 +12,8 @@ IBM-API-Package: io.opentracing;  type="third-party",\
 IBM-SPI-Package: io.openliberty.opentracing.spi.tracer
 -features=com.ibm.websphere.appserver.mpConfig-2.0, \
   com.ibm.websphere.appserver.jaxrs-2.1, \
-  com.ibm.websphere.appserver.cdi-2.0
+  com.ibm.websphere.appserver.cdi-2.0, \
+  io.openliberty.io.smallrye.jandex-2.0
 -bundles=com.ibm.ws.jaxrs.defaultexceptionmapper, \
          com.ibm.ws.jaxrs.2.x.defaultexceptionmapper, \
          io.openliberty.opentracing.2.0.internal, \

--- a/dev/com.ibm.ws.anno/bnd.bnd
+++ b/dev/com.ibm.ws.anno/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017, 2024 IBM Corporation and others.
+# Copyright (c) 2017, 2026 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -19,6 +19,10 @@ Bundle-SymbolicName: com.ibm.ws.anno; singleton:=true
 Private-Package: \
 	com.ibm.ws.anno.*, \
 	com.ibm.ws.annocache.*
+
+Import-Package: \
+        org.jboss.jandex; version="[2.4,4)", \
+        *
 
 Export-Package: \
 	com.ibm.wsspi.anno.service;provide:=true, \

--- a/dev/com.ibm.ws.kernel.boot/publish/platform/kernelCore-1.0.mf
+++ b/dev/com.ibm.ws.kernel.boot/publish/platform/kernelCore-1.0.mf
@@ -4,7 +4,6 @@ Subsystem-Version: 1.0.0
 Subsystem-Content: org.eclipse.osgi; version="[3.10, 4)"; type="boot.jar",
  com.ibm.ws.kernel.equinox.module; version="[1.0, 1.1)"; type="boot.jar",
  com.ibm.ws.org.objectweb.asm; version="[1.0, 1.1)"; start-phase:="BOOTSTRAP",
- com.ibm.ws.org.jboss.jandex; version="[1.0, 1.1)"; start-phase:="BOOTSTRAP",
  com.ibm.ws.kernel.service; version="[1.3, 1.4)"; start-phase:="BOOTSTRAP",
  com.ibm.ws.org.eclipse.equinox.metatype; version="[1.0, 1.1)"; start-phase:="BOOTSTRAP",
  com.ibm.ws.org.eclipse.equinox.coordinator; version="[1.0, 1.1)"; start-phase:="KERNEL_CONFIG",

--- a/dev/io.openliberty.io.smallrye.openapi.core/bnd.bnd
+++ b/dev/io.openliberty.io.smallrye.openapi.core/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2020, 2023 IBM Corporation and others.
+# Copyright (c) 2020, 2026 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -22,6 +22,7 @@ src: src
 Import-Package: \
     io.smallrye.openapi.jaxrs,\
     org.eclipse.microprofile.config;version="[2.0,4.0)",\
+    org.jboss.jandex; version="[2.4,4)", \
     *
 
 Export-Package: \
@@ -34,7 +35,6 @@ Export-Package: \
     com.ibm.ws.logging;version=latest,\
     com.ibm.websphere.javaee.validation.2.0;version=latest,\
     com.ibm.websphere.org.osgi.service.component;version=latest,\
-    com.ibm.ws.org.jboss.jandex;version=latest,\
     com.ibm.ws.org.jboss.logging;version=latest,\
     io.openliberty.com.fasterxml.jackson;version=latest,\
     io.openliberty.org.eclipse.microprofile.config.2.0;version=latest

--- a/dev/io.openliberty.io.smallrye.openapi.jaxrs/bnd.bnd
+++ b/dev/io.openliberty.io.smallrye.openapi.jaxrs/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2020, 2025 IBM Corporation and others.
+# Copyright (c) 2020, 2026 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -30,6 +30,7 @@ Service-Component: \
     properties:="resources=META-INF/services/io.smallrye.openapi.runtime.scanner.spi.AnnotationScanner"
 
 Import-Package: \
+   org.jboss.jandex; version="[2.4,4)", \
    *
 
 Export-Package: \
@@ -44,5 +45,4 @@ Export-Package: \
     com.ibm.ws.classloading;version=latest,\
     com.ibm.websphere.javaee.validation.2.0;version=latest,\
     com.ibm.websphere.org.osgi.service.component;version=latest,\
-    com.ibm.ws.org.jboss.jandex;version=latest,\
     com.ibm.ws.org.jboss.logging;version=latest

--- a/dev/io.openliberty.microprofile.openapi.2.0.internal.services/bnd.bnd
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal.services/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2022, 2024 IBM Corporation and others.
+# Copyright (c) 2022, 2026 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -31,7 +31,6 @@ WS-TraceGroup: MPOPENAPI
     io.openliberty.microprofile.openapi.2.0.internal;version=latest,\
     io.openliberty.microprofile.openapi.internal.common;version=latest,\
     io.openliberty.org.eclipse.microprofile.openapi.2.0,\
-    com.ibm.ws.org.jboss.jandex;version=latest,\
     com.ibm.ws.adaptable.module;version=latest,\
     com.ibm.ws.logging;version=latest,\
     com.ibm.websphere.org.osgi.core;version=latest,\

--- a/dev/io.openliberty.microprofile.openapi.2.0.internal_test/bnd.bnd
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal_test/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2024, 2025 IBM Corporation and others.
+# Copyright (c) 2024, 2026 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -28,7 +28,6 @@ test.project: true
 	io.openliberty.io.smallrye.openapi.core;version=latest,\
 	io.openliberty.microprofile.openapi.2.0.internal;version=latest,\
 	io.openliberty.org.eclipse.microprofile.openapi.2.0,\
-	com.ibm.ws.org.jboss.jandex;version=latest,\
 	com.ibm.ws.adaptable.module;version=latest,\
 	com.ibm.ws.logging;version=latest,\
 	com.ibm.ws.kernel.service;version=latest,\

--- a/dev/io.openliberty.org.jboss.narayana.rts/bnd.bnd
+++ b/dev/io.openliberty.org.jboss.narayana.rts/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2020, 2023 IBM Corporation and others.
+# Copyright (c) 2020, 2026 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -38,6 +38,5 @@ Private-Package: io.openliberty.microprofile.lra.internal
     com.ibm.wsspi.org.osgi.service.component.annotations;version=latest, \
     com.ibm.ws.logging.core;version=latest,\
     com.ibm.ws.cdi.interfaces;version=latest,\
-    com.ibm.websphere.javaee.cdi.2.0,\
-    com.ibm.ws.org.jboss.jandex;version=latest
+    com.ibm.websphere.javaee.cdi.2.0
 

--- a/dev/io.openliberty.org.jboss.resteasy.common.ee10/bnd.bnd
+++ b/dev/io.openliberty.org.jboss.resteasy.common.ee10/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2022, 2025 IBM Corporation and others.
+# Copyright (c) 2022, 2026 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -128,6 +128,7 @@ Import-Package: \
   jakarta.enterprise.event;version="[4.0,5.0)", \
   jakarta.enterprise.inject.spi;version="[4.0,5.0)", \
   jakarta.enterprise.util;version="[4.0,5.0)", \
+  org.jboss.jandex; version="[2.4,4)", \
   !jakarta.json.bind, \
   !jakarta.json.bind.spi, \
   !jakarta.mail, \
@@ -231,7 +232,6 @@ Include-Resource:\
   com.ibm.ws.kernel.service,\
   io.openliberty.webcontainer.security.internal,\
   com.ibm.websphere.security,\
-  com.ibm.ws.org.jboss.jandex,\
   org.eclipse.osgi
 
 -testpath: \

--- a/dev/io.openliberty.org.jboss.resteasy.common.ee11/bnd.bnd
+++ b/dev/io.openliberty.org.jboss.resteasy.common.ee11/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2022, 2025 IBM Corporation and others.
+# Copyright (c) 2022, 2026 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -128,6 +128,7 @@ Import-Package: \
   jakarta.enterprise.event;version="[4.1,5.0)", \
   jakarta.enterprise.inject.spi;version="[4.1,5.0)", \
   jakarta.enterprise.util;version="[4.1,5.0)", \
+  org.jboss.jandex; version="[2.4,4)", \
   !jakarta.json.bind, \
   !jakarta.json.bind.spi, \
   !jakarta.mail, \
@@ -231,7 +232,6 @@ Include-Resource:\
 	com.ibm.ws.kernel.service,\
 	io.openliberty.webcontainer.security.internal,\
 	com.ibm.websphere.security,\
-	com.ibm.ws.org.jboss.jandex,\
 	org.eclipse.osgi
 
 -testpath: \


### PR DESCRIPTION
- [ ] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [ ] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

Part two of #30943

**This PR does the following:**

- It removes the jandex from the `kernelCore` feature file. As far as I can see there was never a need to put it in the kernel itself.
- Adds a dependency from `com.ibm.ws.anno` to jandex, to replace the dependency removed from `kernelCore`. This dependency points to the most recent Jandex but tolerates the older one.
- Various MicroProfile features that used jandex without declaring a dependency, now declare a dependency on jandex.

**Old Behavior:**

- `Jandex 2` is loaded by the kernel. 
- `com.ibm.ws.anno` uses an unregestered dependency on `Jandex 2`. 
- Older MicroProfile features use an unregistered dependency on `Jandex 2`. 
- Newer MicroProfile features use a registered dependency on `Jandex 3`.
- We may have two jandexes loaded in the runtime.

**New Behavior:**

- The kernel does not load jandex.
- `com.ibm.ws.anno` uses an regestered dependency on `Jandex 3` but tolerates Jandex 2. 
- Older MicroProfile features use an registered dependency on `Jandex 2`. 
- Newer MicroProfile features use a registered dependency on `Jandex 3`.
- We may not have two Jandexes loaded in the runtime. 