### PR TITLE
Update to use springboot 3.5.9 to build data app

### DIFF
--- a/dev/io.openliberty.springboot.fat30.data.app/build.gradle
+++ b/dev/io.openliberty.springboot.fat30.data.app/build.gradle
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2025 IBM Corporation and others.
+ * Copyright (c) 2025, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -10,7 +10,7 @@
  ********************************************************************************/
 
 plugins {
-  id 'org.springframework.boot' version '3.5.3'
+  id 'org.springframework.boot' version '3.5.9'
   id 'war'
   id 'io.spring.dependency-management' version '1.1.7'
 }


### PR DESCRIPTION
- Move from using 3.5.3 to 3.5.9 to build the springboot fat30 data app to use updated versions of Byte Buddy and aspectj so that the tests using the application work with Java 26.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
