### PR TITLE
Fix CDI Initialization errors

### DIFF
--- a/dev/com.ibm.ws.security.javaeesec_fat/test-applications/JavaEESecAnnotatedBasicAuthServletDeferred.war/src/web/war/annotatedbasic/deferred/LdapSettingsBean.java
+++ b/dev/com.ibm.ws.security.javaeesec_fat/test-applications/JavaEESecAnnotatedBasicAuthServletDeferred.war/src/web/war/annotatedbasic/deferred/LdapSettingsBean.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2021 IBM Corporation and others.
+ * Copyright (c) 2017, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -19,7 +19,9 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Properties;
 import java.util.Set;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 
+import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Named;
 import javax.security.enterprise.identitystore.IdentityStore.ValidationType;
@@ -32,67 +34,109 @@ import com.ibm.websphere.ras.annotation.Trivial;
  * allowing tests to update the LDAP identity store dynamically by simply updating the
  * well-known file.
  */
+
 @Named
 @ApplicationScoped
 public class LdapSettingsBean {
     private static final String CLASS_NAME = LdapSettingsBean.class.getName();
-
+    private static final String PROPS_FILE = "LdapSettingsBean.props";
+    
     private Properties props;
+    private final ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
+    private volatile long lastModified = 0;
+    private volatile boolean initialized = false;
 
     public LdapSettingsBean() {
     }
 
-    public String getBindDn() throws IOException {
-        refreshConfiguration();
+    @PostConstruct
+    public void init() {
+        try {
+            loadConfiguration();
+            initialized = true;
+        } catch (IOException e) {
+            System.err.println(CLASS_NAME + ".init() failed to load configuration: " + e.getMessage());
+            e.printStackTrace();
+        }
+    }
 
+    /**
+     * Load configuration from file. This method is synchronized to prevent
+     * concurrent file access during CDI initialization.
+     */
+    private void loadConfiguration() throws IOException {
+        lock.writeLock().lock();
+        try {
+            props = new Properties();
+            FileReader fr = null;
+            try {
+                fr = new FileReader(PROPS_FILE);
+                props.load(fr);
+                System.out.println(CLASS_NAME + ".loadConfiguration() loaded properties from " + PROPS_FILE);
+            } finally {
+                if (fr != null) {
+                    fr.close();
+                }
+            }
+        } finally {
+            lock.writeLock().unlock();
+        }
+    }
+
+    /**
+     * Get property value with read lock protection.
+     */
+    private String getProperty(String prop) {
+        if (!initialized) {
+            System.err.println(CLASS_NAME + ".getProperty() called before initialization for: " + prop);
+            return null;
+        }
+        
+        lock.readLock().lock();
+        try {
+            String value = props.getProperty(prop);
+            return "null".equalsIgnoreCase(value) ? null : value;
+        } finally {
+            lock.readLock().unlock();
+        }
+    }
+
+    public String getBindDn() {
         String prop = getProperty("bindDn");
         System.out.println(CLASS_NAME + ".getBindDn() returns: " + prop);
         return prop;
     }
 
     @Trivial
-    public String getBindDnPassword() throws IOException {
-        refreshConfiguration();
-
-        String prop = getProperty("bindDnPassword");
-        return prop;
+    public String getBindDnPassword() {
+        return getProperty("bindDnPassword");
     }
 
-    public String getCallerBaseDn() throws IOException {
-        refreshConfiguration();
-
+    public String getCallerBaseDn() {
         String prop = getProperty("callerBaseDn");
         System.out.println(CLASS_NAME + ".getCallerBaseDn() returns: " + prop);
         return prop;
     }
 
-    public String getCallerNameAttribute() throws IOException {
-        refreshConfiguration();
-
+    public String getCallerNameAttribute() {
         String prop = getProperty("callerNameAttribute");
         System.out.println(CLASS_NAME + ".getCallerNameAttribute() returns: " + prop);
         return prop;
     }
 
-    public String getCallerSearchBase() throws IOException {
-        refreshConfiguration();
-
+    public String getCallerSearchBase() {
         String prop = getProperty("callerSearchBase");
         System.out.println(CLASS_NAME + ".getCallerSearchBase() returns: " + prop);
         return prop;
     }
 
-    public String getCallerSearchFilter() throws IOException {
-        refreshConfiguration();
-
+    public String getCallerSearchFilter() {
         String prop = getProperty("callerSearchFilter");
         System.out.println(CLASS_NAME + ".getCallerSearchFilter() returns: " + prop);
         return prop;
     }
 
-    public LdapSearchScope getCallerSearchScope() throws IOException {
-        refreshConfiguration();
-
+    public LdapSearchScope getCallerSearchScope() {
         String prop = getProperty("callerSearchScope");
         LdapSearchScope result = null;
         if (prop != null) {
@@ -102,54 +146,41 @@ public class LdapSettingsBean {
                 result = LdapSearchScope.ONE_LEVEL;
             }
         }
-
         System.out.println(CLASS_NAME + ".getCallerSearchScope() returns: " + result);
         return result;
     }
 
-    public String getGroupMemberAttribute() throws IOException {
-        refreshConfiguration();
-
+    public String getGroupMemberAttribute() {
         String prop = getProperty("groupMemberAttribute");
         System.out.println(CLASS_NAME + ".getGroupMemberAttribute() returns: " + prop);
         return prop;
     }
 
-    public String getGroupMemberOfAttribute() throws IOException {
-        refreshConfiguration();
-
+    public String getGroupMemberOfAttribute() {
         String prop = getProperty("groupMemberOfAttribute");
         System.out.println(CLASS_NAME + ".getGroupMemberOfAttribute() returns: " + prop);
         return prop;
     }
 
-    public String getGroupNameAttribute() throws IOException {
-        refreshConfiguration();
-
+    public String getGroupNameAttribute() {
         String prop = getProperty("groupNameAttribute");
         System.out.println(CLASS_NAME + ".getGroupNameAttribute() returns: " + prop);
         return prop;
     }
 
-    public String getGroupSearchBase() throws IOException {
-        refreshConfiguration();
-
+    public String getGroupSearchBase() {
         String prop = getProperty("groupSearchBase");
         System.out.println(CLASS_NAME + ".getGroupSearchBase() returns: " + prop);
         return prop;
     }
 
-    public String getGroupSearchFilter() throws IOException {
-        refreshConfiguration();
-
+    public String getGroupSearchFilter() {
         String prop = getProperty("groupSearchFilter");
         System.out.println(CLASS_NAME + ".getGroupSearchFilter() returns: " + prop);
         return prop;
     }
 
-    public LdapSearchScope getGroupSearchScope() throws IOException {
-        refreshConfiguration();
-
+    public LdapSearchScope getGroupSearchScope() {
         String prop = getProperty("groupSearchScope");
         LdapSearchScope result = null;
         if (prop != null) {
@@ -159,63 +190,48 @@ public class LdapSettingsBean {
                 result = LdapSearchScope.ONE_LEVEL;
             }
         }
-
         System.out.println(CLASS_NAME + ".getGroupSearchScope() returns: " + result);
         return result;
     }
 
-    public Integer getMaxResults() throws IOException {
-        refreshConfiguration();
-
+    public Integer getMaxResults() {
         String prop = getProperty("maxResults");
         Integer result = null;
         if (prop != null) {
             result = Integer.valueOf(prop);
         }
-
         System.out.println(CLASS_NAME + ".getMaxResults() returns: " + result);
         return result;
     }
 
-    public Integer getPriority() throws IOException {
-        refreshConfiguration();
-
+    public Integer getPriority() {
         String prop = getProperty("priority");
         Integer result = null;
         if (prop != null) {
             result = Integer.valueOf(prop);
         }
-
         System.out.println(CLASS_NAME + ".getPriority() returns: " + result);
         return result;
     }
 
-    public Integer getReadTimeout() throws IOException {
-        refreshConfiguration();
-
+    public Integer getReadTimeout() {
         String prop = getProperty("readTimeout");
         Integer result = null;
         if (prop != null) {
             result = Integer.valueOf(prop);
         }
-
         System.out.println(CLASS_NAME + ".getReadTimeout() returns: " + result);
         return result;
     }
 
-    public String getUrl() throws IOException {
-        refreshConfiguration();
-
+    public String getUrl() {
         String prop = getProperty("url");
         System.out.println(CLASS_NAME + ".getUrl() returns: " + prop);
         return prop;
     }
 
-    public ValidationType[] getUseFor() throws IOException {
-        refreshConfiguration();
-
+    public ValidationType[] getUseFor() {
         Set<ValidationType> resultsSet = new HashSet<ValidationType>();
-
         String prop = getProperty("useFor");
         if (prop != null) {
             if (prop.contains("VALIDATE")) {
@@ -231,29 +247,5 @@ public class LdapSettingsBean {
         }
         System.out.println(CLASS_NAME + ".getUseFor() returns: " + Arrays.toString(results));
         return results;
-    }
-
-    private void refreshConfiguration() throws IOException {
-        props = new Properties();
-        FileReader fr = new FileReader("LdapSettingsBean.props");
-        try {
-            props.load(fr);
-        } finally {
-            if (fr != null) {
-                fr.close();
-            }
-        }
-    }
-
-    /**
-     * Common logic for returning a property. If the property's value is a string "null",
-     * return null. This will allow testing null handling from beans.
-     *
-     * @param prop
-     * @return
-     */
-    private String getProperty(String prop) {
-        String value = props.getProperty(prop);
-        return "null".equalsIgnoreCase(value) ? null : value;
     }
 }

--- a/dev/com.ibm.ws.security.javaeesec_fat/test-applications/JavaEESecAnnotatedBasicAuthServletDeferred.war/src/web/war/annotatedbasic/deferred/LdapSettingsBean.java
+++ b/dev/com.ibm.ws.security.javaeesec_fat/test-applications/JavaEESecAnnotatedBasicAuthServletDeferred.war/src/web/war/annotatedbasic/deferred/LdapSettingsBean.java
@@ -70,8 +70,10 @@ public class LdapSettingsBean {
             props = new Properties();
             FileReader fr = null;
             try {
-                fr = new FileReader(PROPS_FILE);
+                java.io.File file = new java.io.File(PROPS_FILE);
+                fr = new FileReader(file);
                 props.load(fr);
+                lastModified = file.lastModified();
                 System.out.println(CLASS_NAME + ".loadConfiguration() loaded properties from " + PROPS_FILE);
             } finally {
                 if (fr != null) {
@@ -84,6 +86,23 @@ public class LdapSettingsBean {
     }
 
     /**
+     * Check if the properties file has been modified and reload if necessary.
+     */
+    private void checkAndReloadIfModified() {
+        try {
+            java.io.File file = new java.io.File(PROPS_FILE);
+            long currentModified = file.lastModified();
+            
+            if (currentModified != lastModified) {
+                System.out.println(CLASS_NAME + ".checkAndReloadIfModified() detected file change, reloading...");
+                loadConfiguration();
+            }
+        } catch (IOException e) {
+            System.err.println(CLASS_NAME + ".checkAndReloadIfModified() failed: " + e.getMessage());
+        }
+    }
+
+    /**
      * Get property value with read lock protection.
      */
     private String getProperty(String prop) {
@@ -91,6 +110,9 @@ public class LdapSettingsBean {
             System.err.println(CLASS_NAME + ".getProperty() called before initialization for: " + prop);
             return null;
         }
+        
+        // Check for file modifications before reading
+        checkAndReloadIfModified();
         
         lock.readLock().lock();
         try {


### PR DESCRIPTION
The Liberty server hangs during CDI initialization when using deferred LDAP identity store settings. The root cause is **blocking file I/O operations performed during CDI bean creation**. This issue is particularly visible on z/OS due to platform-specific timing characteristics.


- [X] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [ ] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
