### PR TITLE
Intermittent deadlock on SIP Netty

### DIFF
--- a/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/stack/transport/GenericEndpointImpl.java
+++ b/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/stack/transport/GenericEndpointImpl.java
@@ -88,7 +88,7 @@ public class GenericEndpointImpl {
 	 * Required, dynamic reference to an executor service to schedule chain
 	 * operations
 	 */
-	private ExecutorService executorService = null;
+	private static ExecutorService executorService = null;
 
 	/**
 	 * Optional, dynamic reference to an SSL channel factory provider: used to
@@ -905,6 +905,10 @@ public class GenericEndpointImpl {
 	protected void unsetExecutorService(
 			ServiceReference<ExecutorService> executorService) {
 		this.executorService = null;
+	}
+
+	public static ExecutorService getExecutorService() {
+		return executorService;
 	}
 
 	/**

--- a/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/stack/transport/sip/netty/SipOutboundConnLink.java
+++ b/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/stack/transport/sip/netty/SipOutboundConnLink.java
@@ -192,7 +192,7 @@ public abstract class SipOutboundConnLink extends SipConnLink {
 				Tr.debug(this, tc, "channelRead0",
 						ctx.channel() + ". [" + msg.getMarkedBytesNumber() + "] bytes received");
 			}
-			complete(msg);
+			GenericEndpointImpl.getExecutorService().execute(() -> complete(msg));
 		}
 
 		@Override
@@ -200,7 +200,7 @@ public abstract class SipOutboundConnLink extends SipConnLink {
 			if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
 				Tr.debug(this, tc, "channelInactive", ctx.channel().remoteAddress() + " has been disconnected");
 			}
-			destroy(null);
+			GenericEndpointImpl.getExecutorService().execute(() -> destroy(null));
 		}
 
 		@Override
@@ -208,8 +208,7 @@ public abstract class SipOutboundConnLink extends SipConnLink {
 			if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
 				Tr.debug(this, tc, "exceptionCaught", cause);
 			}
-
-			connectionError(new Exception(cause));
+			GenericEndpointImpl.getExecutorService().execute(() -> connectionError(new Exception(cause)));
 			ctx.close();
 		}
 	}

--- a/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/stack/transport/sip/netty/SipOutboundConnLink.java
+++ b/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/stack/transport/sip/netty/SipOutboundConnLink.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2025 IBM Corporation and others.
+ * Copyright (c) 2008, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -12,6 +12,7 @@ package com.ibm.ws.sip.stack.transport.sip.netty;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.util.*;
+import java.util.concurrent.LinkedBlockingQueue;
 
 import javax.net.ssl.SSLEngine;
 
@@ -34,6 +35,7 @@ import io.netty.handler.ssl.*;
 import io.openliberty.netty.internal.*;
 import jain.protocol.ip.sip.ListeningPoint;
 import io.netty.util.concurrent.GenericFutureListener;
+import io.netty.util.ReferenceCountUtil;
 import io.openliberty.netty.internal.exception.NettyException;
 
 /**
@@ -177,13 +179,20 @@ public abstract class SipOutboundConnLink extends SipConnLink {
 
 	private class SipStreamHandler extends SimpleChannelInboundHandler<SipMessageByteBuffer> {
 
+		private boolean processingMessage = false;
+		private static final int DEFAULT_MAX_QUEUE = 50;
+		private final LinkedBlockingQueue<SipMessageByteBuffer> messageQueue;
+
+		public SipStreamHandler() {
+			this.messageQueue = new LinkedBlockingQueue<SipMessageByteBuffer>(DEFAULT_MAX_QUEUE);
+		}
+
 		/** Called when a new connection is established */
 		@Override
 		public void channelActive(ChannelHandlerContext ctx) throws Exception {
 			if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
 				Tr.debug(this, tc, "channelActive", ctx.channel().remoteAddress() + " connected");
 			}
-
 		}
 
 		@Override
@@ -192,13 +201,49 @@ public abstract class SipOutboundConnLink extends SipConnLink {
 				Tr.debug(this, tc, "channelRead0",
 						ctx.channel() + ". [" + msg.getMarkedBytesNumber() + "] bytes received");
 			}
-			GenericEndpointImpl.getExecutorService().execute(() -> complete(msg));
+			messageQueue.offer(ReferenceCountUtil.retain(msg));
+			if (processingMessage) {
+				if (messageQueue.remainingCapacity() == 0) {
+					if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+						Tr.debug(this, tc, "Queue reached capacity. Reads are paused.");
+					}
+					pauseReading(ctx);
+				}
+			} else {
+				processingMessage = true;
+				processNextMessage(ctx);
+			}
+		}
+
+		// This is designed so that the logic besides what runs in the Liberty executor pool
+		// needs to run on the event loop, otherwise there could be race conditions that show up.
+		private void processNextMessage(final ChannelHandlerContext ctx) {
+			SipMessageByteBuffer msg = messageQueue.poll();
+			if(!ctx.channel().config().isAutoRead() && messageQueue.remainingCapacity() > 0){
+				resumeReading(ctx);
+			}
+			if (msg == null) {
+				processingMessage = false;
+				return;
+			}
+			GenericEndpointImpl.getExecutorService().execute(() -> {
+				try {
+					complete(msg);
+				} finally {
+					ReferenceCountUtil.release(msg);
+				}
+				ctx.channel().eventLoop().execute(() -> processNextMessage(ctx));
+			});
 		}
 
 		@Override
 		public void channelInactive(ChannelHandlerContext ctx) throws Exception {
 			if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
 				Tr.debug(this, tc, "channelInactive", ctx.channel().remoteAddress() + " has been disconnected");
+			}
+			SipMessageByteBuffer msg;
+			while ((msg = messageQueue.poll()) != null) {
+				ReferenceCountUtil.safeRelease(msg);
 			}
 			GenericEndpointImpl.getExecutorService().execute(() -> destroy(null));
 		}
@@ -211,5 +256,20 @@ public abstract class SipOutboundConnLink extends SipConnLink {
 			GenericEndpointImpl.getExecutorService().execute(() -> connectionError(new Exception(cause)));
 			ctx.close();
 		}
+
+		private void pauseReading(ChannelHandlerContext context) {
+			ChannelConfig config = context.channel().config();
+			if (config.isAutoRead()) {
+				config.setAutoRead(false);
+			}
+		}
+
+		private void resumeReading(ChannelHandlerContext context) {
+			ChannelConfig config = context.channel().config();
+			if (!config.isAutoRead()) {
+				config.setAutoRead(true);
+			}
+		}
 	}
+
 }


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [ ] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

A connection could lock a Netty thread by running synchronized logic while another attempts to start an outbound connection. The sync block waiting for a connection [here](https://github.com/OpenLiberty/open-liberty/blob/962295bbffbccd23f462a0369c8fbff01a24f6ec/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/stack/transaction/transport/SIPConnectionsModel.java#L346) along with other handler logic could cause the issue. In general, Netty threads should never be blocked so the handler logic should never attempt to synchronize at all. I added changes to address the dead lock by running all synchronized logic in the Liberty pool. We should consider if we should also have that sync block at all in the code as well.