### PR TITLE
jaxb-2.2: Add doPriv to JAXBContext API

### DIFF
--- a/dev/com.ibm.websphere.javaee.jaxb.2.2/.classpath
+++ b/dev/com.ibm.websphere.javaee.jaxb.2.2/.classpath
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
+	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>
+

--- a/dev/com.ibm.websphere.javaee.jaxb.2.2/bnd.bnd
+++ b/dev/com.ibm.websphere.javaee.jaxb.2.2/bnd.bnd
@@ -10,6 +10,7 @@
 # Contributors:
 #     IBM Corporation - initial API and implementation
 #*******************************************************************************
+# This bundle provides the The Apache Geronimo JAXB 2.2 Specification. 
 -include= ~../cnf/resources/bnd/bundle.props
 bVersion=1.0
 
@@ -37,7 +38,8 @@ Include-Resource:\
  @\${repo;org.apache.geronimo.specs:geronimo-jaxb_2.2_spec;1.0.1}!/org/apache/geronimo/osgi/locator/*, \
  @\${repo;org.apache.geronimo.specs:geronimo-jaxb_2.2_spec;1.0.1}!/javax/xml/bind/ContextFinder.class, \
  @\${repo;org.apache.geronimo.specs:geronimo-jaxb_2.2_spec;1.0.1}!/javax/xml/bind/JAXBContext.class, \
- @\${repo;org.apache.geronimo.specs:geronimo-jaxb_2.2_spec;1.0.1}!/javax/xml/bind/JAXBContext$1.class
+ @\${repo;org.apache.geronimo.specs:geronimo-jaxb_2.2_spec;1.0.1}!/javax/xml/bind/JAXBContext$1.class,\
+ javax.xml.bind=${bin}/javax/xml/bind
 
 instrument.disabled: true
 

--- a/dev/com.ibm.websphere.javaee.jaxb.2.2/src/javax/xml/bind/JAXBContext.java
+++ b/dev/com.ibm.websphere.javaee.jaxb.2.2/src/javax/xml/bind/JAXBContext.java
@@ -1,0 +1,86 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package javax.xml.bind;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Map;
+
+import org.w3c.dom.Node;
+
+public abstract class JAXBContext {
+
+    public static final String JAXB_CONTEXT_FACTORY = "javax.xml.bind.context.factory";
+
+    protected JAXBContext() {
+    }
+
+    public Binder<Node> createBinder() {
+        throw new UnsupportedOperationException();
+    }
+
+    public <T> Binder<T> createBinder(Class<T> domType) {
+        throw new UnsupportedOperationException();
+    }
+
+    public JAXBIntrospector createJAXBIntrospector() {
+        throw new UnsupportedOperationException();
+    }
+
+    public abstract Marshaller createMarshaller() throws JAXBException;
+
+    public abstract Unmarshaller createUnmarshaller() throws JAXBException;
+
+    public abstract Validator createValidator() throws JAXBException;
+
+    public void generateSchema(SchemaOutputResolver resolver) throws IOException {
+        throw new UnsupportedOperationException();
+    }
+
+    public static JAXBContext newInstance(Class... classesToBeBound) throws JAXBException {
+        return newInstance(classesToBeBound, Collections.<String, Object> emptyMap());
+    }
+
+    public static JAXBContext newInstance(Class[] classesToBeBound, Map<String, ?> properties) throws JAXBException {
+        for (Class cl : classesToBeBound) {
+            if (cl == null)
+                throw new IllegalArgumentException();
+        }
+        return ContextFinder.find(classesToBeBound, properties);
+    }
+
+    public static JAXBContext newInstance(String contextPath) throws JAXBException {
+        return newInstance(contextPath, Thread.currentThread().getContextClassLoader());
+    }
+
+    public static JAXBContext newInstance(String contextPath, ClassLoader classLoader) throws JAXBException {
+        return newInstance(contextPath, classLoader, Collections.<String, Object> emptyMap());
+    }
+
+    public static JAXBContext newInstance(String contextPath, ClassLoader classLoader, Map<String, ?> properties) throws JAXBException {
+        return ContextFinder.find(contextPath, classLoader, properties);
+    }
+}

--- a/dev/com.ibm.websphere.javaee.jaxb.2.2/src/javax/xml/bind/JAXBContext.java
+++ b/dev/com.ibm.websphere.javaee.jaxb.2.2/src/javax/xml/bind/JAXBContext.java
@@ -26,6 +26,9 @@
 package javax.xml.bind;
 
 import java.io.IOException;
+import java.security.AccessController;
+import java.security.PrivilegedActionException;
+import java.security.PrivilegedExceptionAction;
 import java.util.Collections;
 import java.util.Map;
 
@@ -66,10 +69,22 @@ public abstract class JAXBContext {
 
     public static JAXBContext newInstance(Class[] classesToBeBound, Map<String, ?> properties) throws JAXBException {
         for (Class cl : classesToBeBound) {
-            if (cl == null)
+            if (cl == null) {
                 throw new IllegalArgumentException();
+            }
         }
-        return ContextFinder.find(classesToBeBound, properties);
+        // Liberty Change Start: Add doPriv
+        try {
+            return AccessController.doPrivileged(new PrivilegedExceptionAction<JAXBContext>() {
+                @Override
+                public JAXBContext run() throws JAXBException {
+                    return ContextFinder.find(classesToBeBound, properties);
+                }
+            });
+        } catch (PrivilegedActionException e) {
+            throw (JAXBException) e.getException();
+        }
+        // Liberty Change End
     }
 
     public static JAXBContext newInstance(String contextPath) throws JAXBException {
@@ -81,6 +96,17 @@ public abstract class JAXBContext {
     }
 
     public static JAXBContext newInstance(String contextPath, ClassLoader classLoader, Map<String, ?> properties) throws JAXBException {
-        return ContextFinder.find(contextPath, classLoader, properties);
+        // Liberty Change Start: Add doPriv
+        try {
+            return AccessController.doPrivileged(new PrivilegedExceptionAction<JAXBContext>() {
+                @Override
+                public JAXBContext run() throws JAXBException {
+                    return ContextFinder.find(contextPath, classLoader, properties);
+                }
+            });
+        } catch (PrivilegedActionException e) {
+            throw (JAXBException) e.getException();
+        }
+        // Liberty Change End
     }
 }


### PR DESCRIPTION
- [X] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [ ] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

################################################################################################

This PR fixes the following error when running with Java 2 Security enabled:
```
java.security.AccessControlException: Access denied ("java.lang.RuntimePermission" "getClassLoader")
    at java.base/java.security.AccessController.throwACE(AccessController.java:182)
    at java.base/java.security.AccessController.checkPermissionHelper(AccessController.java:246)
    at java.base/java.security.AccessController.checkPermission(AccessController.java:393)
    at java.base/java.lang.SecurityManager.checkPermission(SecurityManager.java:416)
    at java.base/java.lang.Class.getClassLoader(Class.java:598)
    at javax.xml.bind.ContextFinder.find(ContextFinder.java:89)
    at javax.xml.bind.JAXBContext.newInstance(JAXBContext.java:65)
    at javax.xml.bind.JAXBContext.newInstance(JAXBContext.java:56)
```