### PR TITLE
Refactor NLS props to remove Liberty message codes from client

### DIFF
--- a/dev/io.openliberty.mcp.internal/resources/io/openliberty/mcp/internal/resources/CWMCM.nlsprops
+++ b/dev/io.openliberty.mcp.internal/resources/io/openliberty/mcp/internal/resources/CWMCM.nlsprops
@@ -67,15 +67,15 @@ CWMCM0007E.invalid.arguments.useraction=Check whether you have the correct class
 
 # Used as part of a response to a client
 # {0} = Request id
-CWMCM0008E.invalid.request.params=CWMCM0008E: A request with the {0} ID is in progress.
-CWMCM0008E.invalid.request.params.explanation=A request with the same ID is in progress. Requests from the same client must have unique IDs.
-CWMCM0008E.invalid.request.params.useraction=Use a unique ID for every request.
+invalid.request.params=A request with the {0} ID is in progress.
+invalid.request.params.explanation=A request with the same ID is in progress. Requests from the same client must have unique IDs.
+invalid.request.params.useraction=Use a unique ID for every request.
 
 # Used as part of a response to a client
 # do not translate GET, POST
-CWMCM0009I.get.disallowed=CWMCM0009I: GET requests are not supported.
-CWMCM0009I.get.disallowed.explanation=A GET request was sent but this functionality is not supported.
-CWMCM0009I.get.disallowed.useraction=No action is required.
+get.disallowed=GET requests are not supported.
+get.disallowed.explanation=A GET request was sent but this functionality is not supported.
+get.disallowed.useraction=No action is required.
 
 # Used for server logging
 # {0} = tool name
@@ -85,9 +85,9 @@ CWMCM0010E.internal.server.error.detailed.explanation=The tool method threw an u
 CWMCM0010E.internal.server.error.detailed.useraction=Review the server message.log and FFDC logs to identify the problem.
 
 # Used as part of a response to a client
-CWMCM0011E.internal.server.error=CWMCM0011E: An internal server error occurred while running the tool.
-CWMCM0011E.internal.server.error.explanation=The server was not able to complete the tool call request.
-CWMCM0011E.internal.server.error.useraction=Check that the request is correct. More information about the failure might be in the server messages.log.
+internal.server.error=An internal server error occurred while running the tool.
+internal.server.error.explanation=The server was not able to complete the tool call request.
+internal.server.error.useraction=Check that the request is correct. More information about the failure might be in the server messages.log.
 
 # Used for server logging
 # do not translate bean
@@ -100,17 +100,17 @@ CWMCM0012E.bean.release.fail.useraction=Review the server message.log and FFDC l
 # Used for server logging and client response
 # do not translate MCP-Protocol-Version, MCP
 # {0} = List of supported MCP-Protocol-Version values
-CWMCM0013E.unsupported.mcp.http.version=CWMCM0013E: An unsupported MCP-Protocol-Version header was provided. Supported values: {0}
-CWMCM0013E.unsupported.mcp.http.version.explanation=The protocol version in the MCP-Protocol-Version header is not supported by the server.
-CWMCM0013E.unsupported.mcp.http.version.useraction=Use a supported protocol version.
+unsupported.mcp.http.version=An unsupported MCP-Protocol-Version header was provided. Supported values: {0}
+unsupported.mcp.http.version.explanation=The protocol version in the MCP-Protocol-Version header is not supported by the server.
+unsupported.mcp.http.version.useraction=Use a supported protocol version.
 
 # Used as part of a response to a client
 # {0} = Method
 # {1} = RequestURI
 # {2} = RequestQuery
-CWMCM0014E.unexpected.server.error=CWMCM0014E: Unexpected Server Error. Method={0} RequestURI={1} RequestQuery={2}
-CWMCM0014E.unexpected.server.error.explanation=An unexpected server error occurred while processing the request. The request cannot be completed.
-CWMCM0014E.unexpected.server.error.useraction=No action is required.
+unexpected.server.error=Unexpected Server Error. Method={0} RequestURI={1} RequestQuery={2}
+unexpected.server.error.explanation=An unexpected server error occurred while processing the request. The request cannot be completed.
+unexpected.server.error.useraction=No action is required.
 
 # Used for server logging
 # {0} = Method

--- a/dev/io.openliberty.mcp.internal/src/io/openliberty/mcp/internal/McpRequestTracker.java
+++ b/dev/io.openliberty.mcp.internal/src/io/openliberty/mcp/internal/McpRequestTracker.java
@@ -53,7 +53,7 @@ public class McpRequestTracker {
         CancellationImpl previous = ongoingRequests.putIfAbsent(requestId, cancellation);
         if (previous != null) {
             throw new JSONRPCException(JSONRPCErrorCode.INVALID_PARAMS,
-                                       Tr.formatMessage(tc, "CWMCM0008E.invalid.request.params", requestId.id()));
+                                       Tr.formatMessage(tc, "invalid.request.params", requestId.id()));
         }
     }
 

--- a/dev/io.openliberty.mcp.internal/src/io/openliberty/mcp/internal/McpServlet.java
+++ b/dev/io.openliberty.mcp.internal/src/io/openliberty/mcp/internal/McpServlet.java
@@ -95,7 +95,7 @@ public class McpServlet extends HttpServlet {
     @Override
     protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
         McpTransport transport = new McpTransport(req, resp, jsonb);
-        String excpetionMessage = Tr.formatMessage(tc, "CWMCM0009I.get.disallowed");
+        String excpetionMessage = Tr.formatMessage(tc, "get.disallowed");
         HttpResponseException e = new HttpResponseException(
                                                             HttpServletResponse.SC_METHOD_NOT_ALLOWED,
                                                             excpetionMessage).withHeader("Allow", "POST");
@@ -187,7 +187,7 @@ public class McpServlet extends HttpServlet {
 
         if (requestId != null && requestTracker.isOngoingRequest(requestId)) {
             throw new JSONRPCException(JSONRPCErrorCode.INVALID_PARAMS,
-                                       Tr.formatMessage(tc, "CWMCM0008E.invalid.request.params", requestId.id()));
+                                       Tr.formatMessage(tc, "invalid.request.params", requestId.id()));
         }
 
         try {

--- a/dev/io.openliberty.mcp.internal/src/io/openliberty/mcp/internal/McpTransport.java
+++ b/dev/io.openliberty.mcp.internal/src/io/openliberty/mcp/internal/McpTransport.java
@@ -89,7 +89,7 @@ public class McpTransport {
             String supportedValues = Arrays.stream(McpProtocolVersion.values())
                                            .map(McpProtocolVersion::getVersion)
                                            .collect(Collectors.joining(", "));
-            String excpetionMesaage = Tr.formatMessage(tc, "CWMCM0013E.unsupported.mcp.http.version", supportedValues);
+            String excpetionMesaage = Tr.formatMessage(tc, "unsupported.mcp.http.version", supportedValues);
             throw new HttpResponseException(HttpServletResponse.SC_BAD_REQUEST, excpetionMesaage);
         }
         this.mcpRequest = toRequest();
@@ -236,7 +236,7 @@ public class McpTransport {
      * @throws IOException
      */
     public void sendError(Throwable e) throws IOException {
-        String excpetionMessage = Tr.formatMessage(tc, "CWMCM0014E.unexpected.server.error", new Object[] { req.getMethod(), req.getRequestURI(), req.getQueryString() });
+        String excpetionMessage = Tr.formatMessage(tc, "unexpected.server.error", new Object[] { req.getMethod(), req.getRequestURI(), req.getQueryString() });
         Tr.error(tc, "CWMCM0015E.unexpected.server.error.exception", req.getMethod(), req.getRequestURI(), req.getQueryString(), e.getMessage());
         res.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, excpetionMessage);
     }
@@ -298,7 +298,7 @@ public class McpTransport {
                 }
             } catch (Exception e) {
                 Tr.error(tc, "CWMCM0016E.error.sending.response.exception", e);
-                sendResponse(ToolResponse.error(Tr.formatMessage(tc, "CWMCM0011E.internal.server.error")));
+                sendResponse(ToolResponse.error(Tr.formatMessage(tc, "internal.server.error")));
             } finally {
                 asyncContext.complete();
             }

--- a/dev/io.openliberty.mcp.internal/src/io/openliberty/mcp/internal/tools/BeanMethodHandler.java
+++ b/dev/io.openliberty.mcp.internal/src/io/openliberty/mcp/internal/tools/BeanMethodHandler.java
@@ -195,7 +195,7 @@ public abstract class BeanMethodHandler<RESPONSE> implements Function<ToolArgume
                  "CWMCM0010E.internal.server.error.detailed",
                  method.name(),
                  t);
-        return ToolResponse.error(Tr.formatMessage(tc, "CWMCM0011E.internal.server.error"));
+        return ToolResponse.error(Tr.formatMessage(tc, "internal.server.error"));
     }
 
     protected boolean isBusinessException(Throwable t) {

--- a/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/lifecycle/tests/AsyncToolLifecycleTest.java
+++ b/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/lifecycle/tests/AsyncToolLifecycleTest.java
@@ -185,7 +185,7 @@ public class AsyncToolLifecycleTest {
         String response = client.callMCP(request);
 
         String expectedResponseString = """
-                        {"id":"2","jsonrpc":"2.0","result":{"content":[{"type":"text","text":"CWMCM0011E: An internal server error occurred while running the tool."}], "isError": true}}
+                        {"id":"2","jsonrpc":"2.0","result":{"content":[{"type":"text","text":"An internal server error occurred while running the tool."}], "isError": true}}
                         """;
 
         JSONAssert.assertEquals(expectedResponseString, response, true);

--- a/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/protocol/HttpTest.java
+++ b/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/protocol/HttpTest.java
@@ -71,7 +71,7 @@ public class HttpTest {
         String response = request.run(String.class);
 
         assertNotNull("Expected response body for 405 error", response);
-        assertEquals("CWMCM0009I: GET requests are not supported.", response);
+        assertEquals("GET requests are not supported.", response);
     }
 
     @Test
@@ -84,7 +84,7 @@ public class HttpTest {
         String response = request.run(String.class);
 
         assertNotNull("Expected response body for 405 error", response);
-        assertEquals("CWMCM0009I: GET requests are not supported.", response);
+        assertEquals("GET requests are not supported.", response);
     }
 
     @Test

--- a/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/protocol/ProtocolVersionTest.java
+++ b/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/protocol/ProtocolVersionTest.java
@@ -168,7 +168,7 @@ public class ProtocolVersionTest {
                                                                              .run(String.class);
 
         assertThat("Expected error message about invalid protocol version",
-                   response, containsString("CWMCM0013E: An unsupported MCP-Protocol-Version header was provided."));
+                   response, containsString("An unsupported MCP-Protocol-Version header was provided."));
         assertThat("Expected error message to contain expected version",
                    response, containsString("Supported values: 2025-11-25, 2025-06-18, 2025-03-26"));
     }

--- a/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/statelessMode/StatefulModeTest.java
+++ b/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/statelessMode/StatefulModeTest.java
@@ -127,7 +127,7 @@ public class StatefulModeTest extends FATServletClient {
                             "error": {
                                 "code": -32602,
                                 "message": "Invalid params",
-                                "data": "CWMCM0008E: A request with the 2 ID is in progress."
+                                "data": "A request with the 2 ID is in progress."
                             }
                         }
                         """;

--- a/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/tool/AsyncToolCancellationTest.java
+++ b/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/tool/AsyncToolCancellationTest.java
@@ -117,7 +117,7 @@ public class AsyncToolCancellationTest extends FATServletClient {
         String response = future.get(10, TimeUnit.SECONDS);
 
         String expectedResponseString = """
-                        {"id":"2","jsonrpc":"2.0","result":{"content":[{"text":"CWMCM0011E: An internal server error occurred while running the tool.", "type":"text"}],"isError":true}}
+                        {"id":"2","jsonrpc":"2.0","result":{"content":[{"text":"An internal server error occurred while running the tool.", "type":"text"}],"isError":true}}
                         """;
         JSONAssert.assertEquals(expectedResponseString, response, true);
     }

--- a/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/tool/AsyncToolsErrorHandlingTest.java
+++ b/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/tool/AsyncToolsErrorHandlingTest.java
@@ -206,7 +206,7 @@ public class AsyncToolsErrorHandlingTest extends FATServletClient {
                             "content": [
                               {
                                 "type": "text",
-                                "text": "CWMCM0011E: An internal server error occurred while running the tool."
+                                "text": "An internal server error occurred while running the tool."
                               }
                             ],
                             "isError": true

--- a/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/tool/AsyncToolsTest.java
+++ b/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/tool/AsyncToolsTest.java
@@ -139,7 +139,7 @@ public class AsyncToolsTest extends FATServletClient {
         String response = client.callMCP(request);
 
         String expectedResponseString = """
-                        {"id":"2","jsonrpc":"2.0","result":{"content":[{"type":"text","text":"CWMCM0011E: An internal server error occurred while running the tool."}], "isError": true}}
+                        {"id":"2","jsonrpc":"2.0","result":{"content":[{"type":"text","text":"An internal server error occurred while running the tool."}], "isError": true}}
                         """;
 
         JSONAssert.assertEquals(expectedResponseString, response, true);
@@ -165,7 +165,7 @@ public class AsyncToolsTest extends FATServletClient {
         String response = client.callMCP(request);
 
         String expectedResponseString = """
-                        {"id":"2","jsonrpc":"2.0","result":{"content":[{"type":"text","text":"CWMCM0011E: An internal server error occurred while running the tool."}], "isError": true}}
+                        {"id":"2","jsonrpc":"2.0","result":{"content":[{"type":"text","text":"An internal server error occurred while running the tool."}], "isError": true}}
                         """;
 
         JSONAssert.assertEquals(expectedResponseString, response, true);

--- a/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/tool/CancellationTest.java
+++ b/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/tool/CancellationTest.java
@@ -67,8 +67,7 @@ public class CancellationTest extends FATServletClient {
     @AfterClass
     public static void teardown() throws Exception {
         server.stopServer(
-                          "CWMCM0010E", //  Tool method threw an unexpected exception
-                          "CWMCM0011E" // An internal server error occurred
+                          "CWMCM0010E" //  Tool method threw an unexpected exception
         );
     }
 
@@ -122,7 +121,7 @@ public class CancellationTest extends FATServletClient {
         String response = future.get(10, TimeUnit.SECONDS);
 
         String expectedResponseString = """
-                        {"id":"2","jsonrpc":"2.0","result":{"content":[{"text":"CWMCM0011E: An internal server error occurred while running the tool.", "type":"text"}],"isError":true}}
+                        {"id":"2","jsonrpc":"2.0","result":{"content":[{"text":"An internal server error occurred while running the tool.", "type":"text"}],"isError":true}}
                         """;
         JSONAssert.assertEquals(expectedResponseString, response, true);
     }
@@ -178,7 +177,7 @@ public class CancellationTest extends FATServletClient {
         String response = future.get(10, TimeUnit.SECONDS);
 
         String expectedResponseString = """
-                        {"id":2,"jsonrpc":"2.0","result":{"content":[{"text":"CWMCM0011E: An internal server error occurred while running the tool.", "type":"text"}],"isError":true}}
+                        {"id":2,"jsonrpc":"2.0","result":{"content":[{"text":"An internal server error occurred while running the tool.", "type":"text"}],"isError":true}}
                         """;
         JSONAssert.assertEquals(expectedResponseString, response, true);
     }

--- a/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/tool/ToolErrorHandlingTest.java
+++ b/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/tool/ToolErrorHandlingTest.java
@@ -58,8 +58,7 @@ public class ToolErrorHandlingTest extends FATServletClient {
     @AfterClass
     public static void teardown() throws Exception {
         server.stopServer(
-                          "CWMCM0010E", //  Tool method threw an unexpected exception
-                          "CWMCM0011E" // An internal server error occurred
+                          "CWMCM0010E" //  Tool method threw an unexpected exception
         );
     }
 
@@ -126,7 +125,7 @@ public class ToolErrorHandlingTest extends FATServletClient {
                             "content": [
                               {
                                 "type": "text",
-                                "text": "CWMCM0011E: An internal server error occurred while running the tool."
+                                "text": "An internal server error occurred while running the tool."
                               }
                             ]
                           }
@@ -271,7 +270,7 @@ public class ToolErrorHandlingTest extends FATServletClient {
                                 "content": [
                                   {
                                     "type": "text",
-                                    "text": "CWMCM0011E: An internal server error occurred while running the tool."
+                                    "text": "An internal server error occurred while running the tool."
                                   }
                                 ]
                               }
@@ -343,7 +342,7 @@ public class ToolErrorHandlingTest extends FATServletClient {
                             "content": [
                               {
                                 "type": "text",
-                                "text": "CWMCM0011E: An internal server error occurred while running the tool."
+                                "text": "An internal server error occurred while running the tool."
                               }
                             ]
                           }

--- a/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/tool/ToolTest.java
+++ b/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/tool/ToolTest.java
@@ -104,12 +104,8 @@ public class ToolTest extends FATServletClient {
     public static void teardown() throws Exception {
         server.stopServer(
                           "CWMCM0010E", //The JSON-RPC request is not valid JSON.
-                          "CWMCM0011E", // The JSON-RPC request was invalid.
                           "CWMCM0012E", // The requested JSON-RPC method is not found.
-                          "CWMCM0013E", // JSON-RPC PC request contained invalid parameters.
-                          "CWMCM0014E", // An Internal Server Error occurred whilst processing the JSON-RPC request.
                           "CWMCM0010E", //  Tool method threw an unexpected exception
-                          "CWMCM0011E", // An internal server error occurred
                           "CWMCM0022E" // Invalid Cursor provided
         );
     }
@@ -921,7 +917,7 @@ public class ToolTest extends FATServletClient {
         String response = client.callMCP(request);
 
         String expectedResponseString = """
-                        {"id":2,"jsonrpc":"2.0","result":{"content":[{"type":"text","text":"CWMCM0011E: An internal server error occurred while running the tool."}], "isError": true}}
+                        {"id":2,"jsonrpc":"2.0","result":{"content":[{"type":"text","text":"An internal server error occurred while running the tool."}], "isError": true}}
                         """;
         JSONAssert.assertEquals(expectedResponseString, response, true);
         assertNotNull(server.waitForStringInLogUsingMark("Method call caused runtime exception", server.getDefaultLogFile()));


### PR DESCRIPTION
- [X] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [X] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [X] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #33901 .

This PR removes the liberty error codes for client facing error.