### PR TITLE
Made updates for fixing remaining H2 failures with Netty HTTP 2.0

### DIFF
--- a/dev/com.ibm.ws.transport.http2_fat/fat/src/test/server/transport/http2/H2FATApplicationHelper.java
+++ b/dev/com.ibm.ws.transport.http2_fat/fat/src/test/server/transport/http2/H2FATApplicationHelper.java
@@ -6,9 +6,6 @@
  * http://www.eclipse.org/legal/epl-2.0/
  * 
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package test.server.transport.http2;
 
@@ -127,26 +124,14 @@ public class H2FATApplicationHelper {
 
     }
 
-    public static void preTestNettyCheck(LibertyServer runtimeServer, LibertyServer server) throws Exception {
-        // Go through Logs and check if Netty is being used
-        boolean runningNetty = false;
-        // Wait for endpoints to finish loading and get the endpoint started messages
-        server.waitForStringInLog("CWWKO0219I.*");
+    public static void preTestNettyCheck(LibertyServer runtimeServer, LibertyServer serverUnderTest) throws Exception {
+        // Go through Logs and check if Netty is being used for the serverUnderTest
         runtimeServer.waitForStringInLog("CWWKO0219I.*");
-        List<String> test = server.findStringsInLogs("CWWKO0219I.*");
-        LOG.info("preTestNettyCheck : Got port list...... " + Arrays.toString(test.toArray()));
-        LOG.info("preTestNettyCheck : Looking for port: " + server.getHttpSecondaryPort());
-        for (String endpoint : test) {
-            LOG.info("preTestNettyCheck : Endpoint: " + endpoint);
-            if (!endpoint.contains("port " + Integer.toString(server.getHttpSecondaryPort())))
-                continue;
-            LOG.info("preTestNettyCheck : Netty? " + endpoint.contains("io.openliberty.netty.internal.tcp.TCPUtils"));
-            runningNetty = endpoint.contains("io.openliberty.netty.internal.tcp.TCPUtils");
-            break;
-        }
-        if (runningNetty)
+        String endpoint = serverUnderTest.waitForStringInLog("CWWKO0219I.*port " + serverUnderTest.getHttpSecondaryPort() + ".");
+        LOG.info("preTestNettyCheck : Netty enabled? " + ((endpoint == null) ? "false" : endpoint.contains("io.openliberty.netty.internal.tcp.TCPUtils")));
+        if(endpoint != null && endpoint.contains("io.openliberty.netty.internal.tcp.TCPUtils"))
             FATServletClient.runTest(runtimeServer,
-                                     Http2FullModeTests.defaultServletPath + server.getHostname() + "&port=" + server.getHttpSecondaryPort() + "&testdir=" + Utils.TEST_DIR,
+                                     Http2FullModeTests.defaultServletPath + serverUnderTest.getHostname() + "&port=" + serverUnderTest.getHttpSecondaryPort() + "&testdir=" + Utils.TEST_DIR,
                                      "setUsingNetty");
     }
 

--- a/dev/com.ibm.ws.transport.http2_fat/fat/src/test/server/transport/http2/H2FATApplicationHelper.java
+++ b/dev/com.ibm.ws.transport.http2_fat/fat/src/test/server/transport/http2/H2FATApplicationHelper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 IBM Corporation and others.
+ * Copyright (c) 2018, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -13,6 +13,8 @@
 package test.server.transport.http2;
 
 import java.io.File;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Set;
 import java.util.logging.Logger;
 
@@ -24,6 +26,8 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 import com.ibm.websphere.simplicity.ShrinkHelper;
 
 import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.utils.FATServletClient;
+
 
 /**
  * ShrinkWrap helper methods, modified from WCApplicationHelper.
@@ -122,4 +126,28 @@ public class H2FATApplicationHelper {
         }
 
     }
+
+    public static void preTestNettyCheck(LibertyServer runtimeServer, LibertyServer server) throws Exception {
+        // Go through Logs and check if Netty is being used
+        boolean runningNetty = false;
+        // Wait for endpoints to finish loading and get the endpoint started messages
+        server.waitForStringInLog("CWWKO0219I.*");
+        runtimeServer.waitForStringInLog("CWWKO0219I.*");
+        List<String> test = server.findStringsInLogs("CWWKO0219I.*");
+        LOG.info("preTestNettyCheck : Got port list...... " + Arrays.toString(test.toArray()));
+        LOG.info("preTestNettyCheck : Looking for port: " + server.getHttpSecondaryPort());
+        for (String endpoint : test) {
+            LOG.info("preTestNettyCheck : Endpoint: " + endpoint);
+            if (!endpoint.contains("port " + Integer.toString(server.getHttpSecondaryPort())))
+                continue;
+            LOG.info("preTestNettyCheck : Netty? " + endpoint.contains("io.openliberty.netty.internal.tcp.TCPUtils"));
+            runningNetty = endpoint.contains("io.openliberty.netty.internal.tcp.TCPUtils");
+            break;
+        }
+        if (runningNetty)
+            FATServletClient.runTest(runtimeServer,
+                                     Http2FullModeTests.defaultServletPath + server.getHostname() + "&port=" + server.getHttpSecondaryPort() + "&testdir=" + Utils.TEST_DIR,
+                                     "setUsingNetty");
+    }
+
 }

--- a/dev/com.ibm.ws.transport.http2_fat/fat/src/test/server/transport/http2/Http2CompressionTests.java
+++ b/dev/com.ibm.ws.transport.http2_fat/fat/src/test/server/transport/http2/Http2CompressionTests.java
@@ -10,8 +10,6 @@
 package test.server.transport.http2;
 
 import java.io.File;
-import java.util.Arrays;
-import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -57,32 +55,7 @@ public class Http2CompressionTests extends FATServletClient {
 
         server.startServer(true, true);
         runtimeServer.startServer(true, true);
-        // Go through Logs and check if Netty is being used
-        boolean runningNetty = false;
-        // Wait for endpoints to finish loading and get the endpoint started messages
-        server.waitForStringInLog("CWWKO0219I.*");
-        runtimeServer.waitForStringInLog("CWWKO0219I.*");
-        List<String> test = server.findStringsInLogs("CWWKO0219I.*");
-        if (LOGGER.isLoggable(Level.INFO)) {
-            LOGGER.logp(Level.INFO, CLASS_NAME, "test()", "Got port list...... " + Arrays.toString(test.toArray()));
-            LOGGER.logp(Level.INFO, CLASS_NAME, "test()", "Looking for port: " + server.getHttpSecondaryPort());
-        }
-        for (String endpoint : test) {
-            if (LOGGER.isLoggable(Level.INFO)) {
-                LOGGER.logp(Level.INFO, CLASS_NAME, "test()", "Endpoint: " + endpoint);
-            }
-            if (!endpoint.contains("port " + Integer.toString(server.getHttpSecondaryPort())))
-                continue;
-            if (LOGGER.isLoggable(Level.INFO)) {
-                LOGGER.logp(Level.INFO, CLASS_NAME, "test()", "Netty? " + endpoint.contains("io.openliberty.netty.internal.tcp.TCPUtils"));
-            }
-            runningNetty = endpoint.contains("io.openliberty.netty.internal.tcp.TCPUtils");
-            break;
-        }
-        if (runningNetty)
-            FATServletClient.runTest(runtimeServer,
-                                     Http2FullModeTests.defaultServletPath + server.getHostname() + "&port=" + server.getHttpSecondaryPort() + "&testdir=" + Utils.TEST_DIR,
-                                     "setUsingNetty");
+        H2FATApplicationHelper.preTestNettyCheck(runtimeServer, server);
     }
 
     @AfterClass

--- a/dev/com.ibm.ws.transport.http2_fat/fat/src/test/server/transport/http2/Http2Config31H2Off.java
+++ b/dev/com.ibm.ws.transport.http2_fat/fat/src/test/server/transport/http2/Http2Config31H2Off.java
@@ -10,8 +10,6 @@
 package test.server.transport.http2;
 
 import java.io.File;
-import java.util.Arrays;
-import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -59,32 +57,7 @@ public class Http2Config31H2Off extends FATServletClient {
 
         server.startServer(true, true);
         runtimeServer.startServer(true, true);
-        // Go through Logs and check if Netty is being used
-        boolean runningNetty = false;
-        // Wait for endpoints to finish loading and get the endpoint started messages
-        server.waitForStringInLog("CWWKO0219I.*");
-        runtimeServer.waitForStringInLog("CWWKO0219I.*");
-        List<String> test = server.findStringsInLogs("CWWKO0219I.*");
-        if (LOGGER.isLoggable(Level.INFO)) {
-            LOGGER.logp(Level.INFO, CLASS_NAME, "test()", "Got port list...... " + Arrays.toString(test.toArray()));
-            LOGGER.logp(Level.INFO, CLASS_NAME, "test()", "Looking for port: " + server.getHttpSecondaryPort());
-        }
-        for (String endpoint : test) {
-            if (LOGGER.isLoggable(Level.INFO)) {
-                LOGGER.logp(Level.INFO, CLASS_NAME, "test()", "Endpoint: " + endpoint);
-            }
-            if (!endpoint.contains("port " + Integer.toString(server.getHttpSecondaryPort())))
-                continue;
-            if (LOGGER.isLoggable(Level.INFO)) {
-                LOGGER.logp(Level.INFO, CLASS_NAME, "test()", "Netty? " + endpoint.contains("io.openliberty.netty.internal.tcp.TCPUtils"));
-            }
-            runningNetty = endpoint.contains("io.openliberty.netty.internal.tcp.TCPUtils");
-            break;
-        }
-        if (runningNetty)
-            FATServletClient.runTest(runtimeServer,
-                                     Http2FullModeTests.defaultServletPath + server.getHostname() + "&port=" + server.getHttpSecondaryPort() + "&testdir=" + Utils.TEST_DIR,
-                                     "setUsingNetty");
+        H2FATApplicationHelper.preTestNettyCheck(runtimeServer, server);
     }
 
     @AfterClass

--- a/dev/com.ibm.ws.transport.http2_fat/fat/src/test/server/transport/http2/Http2Config31H2On.java
+++ b/dev/com.ibm.ws.transport.http2_fat/fat/src/test/server/transport/http2/Http2Config31H2On.java
@@ -10,8 +10,6 @@
 package test.server.transport.http2;
 
 import java.io.File;
-import java.util.Arrays;
-import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -58,32 +56,7 @@ public class Http2Config31H2On extends FATServletClient {
 
         server.startServer(true, true);
         runtimeServer.startServer(true, true);
-        // Go through Logs and check if Netty is being used
-        boolean runningNetty = false;
-        // Wait for endpoints to finish loading and get the endpoint started messages
-        server.waitForStringInLog("CWWKO0219I.*");
-        runtimeServer.waitForStringInLog("CWWKO0219I.*");
-        List<String> test = server.findStringsInLogs("CWWKO0219I.*");
-        if (LOGGER.isLoggable(Level.INFO)) {
-            LOGGER.logp(Level.INFO, CLASS_NAME, "test()", "Got port list...... " + Arrays.toString(test.toArray()));
-            LOGGER.logp(Level.INFO, CLASS_NAME, "test()", "Looking for port: " + server.getHttpSecondaryPort());
-        }
-        for (String endpoint : test) {
-            if (LOGGER.isLoggable(Level.INFO)) {
-                LOGGER.logp(Level.INFO, CLASS_NAME, "test()", "Endpoint: " + endpoint);
-            }
-            if (!endpoint.contains("port " + Integer.toString(server.getHttpSecondaryPort())))
-                continue;
-            if (LOGGER.isLoggable(Level.INFO)) {
-                LOGGER.logp(Level.INFO, CLASS_NAME, "test()", "Netty? " + endpoint.contains("io.openliberty.netty.internal.tcp.TCPUtils"));
-            }
-            runningNetty = endpoint.contains("io.openliberty.netty.internal.tcp.TCPUtils");
-            break;
-        }
-        if (runningNetty)
-            FATServletClient.runTest(runtimeServer,
-                                     Http2FullModeTests.defaultServletPath + server.getHostname() + "&port=" + server.getHttpSecondaryPort() + "&testdir=" + Utils.TEST_DIR,
-                                     "setUsingNetty");
+        H2FATApplicationHelper.preTestNettyCheck(runtimeServer, server);
     }
 
     @AfterClass

--- a/dev/com.ibm.ws.transport.http2_fat/fat/src/test/server/transport/http2/Http2Config40H2Off.java
+++ b/dev/com.ibm.ws.transport.http2_fat/fat/src/test/server/transport/http2/Http2Config40H2Off.java
@@ -10,8 +10,6 @@
 package test.server.transport.http2;
 
 import java.io.File;
-import java.util.Arrays;
-import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -58,32 +56,7 @@ public class Http2Config40H2Off extends FATServletClient {
 
         server.startServer(true, true);
         runtimeServer.startServer(true, true);
-        // Go through Logs and check if Netty is being used
-        boolean runningNetty = false;
-        // Wait for endpoints to finish loading and get the endpoint started messages
-        server.waitForStringInLog("CWWKO0219I.*");
-        runtimeServer.waitForStringInLog("CWWKO0219I.*");
-        List<String> test = server.findStringsInLogs("CWWKO0219I.*");
-        if (LOGGER.isLoggable(Level.INFO)) {
-            LOGGER.logp(Level.INFO, CLASS_NAME, "test()", "Got port list...... " + Arrays.toString(test.toArray()));
-            LOGGER.logp(Level.INFO, CLASS_NAME, "test()", "Looking for port: " + server.getHttpSecondaryPort());
-        }
-        for (String endpoint : test) {
-            if (LOGGER.isLoggable(Level.INFO)) {
-                LOGGER.logp(Level.INFO, CLASS_NAME, "test()", "Endpoint: " + endpoint);
-            }
-            if (!endpoint.contains("port " + Integer.toString(server.getHttpSecondaryPort())))
-                continue;
-            if (LOGGER.isLoggable(Level.INFO)) {
-                LOGGER.logp(Level.INFO, CLASS_NAME, "test()", "Netty? " + endpoint.contains("io.openliberty.netty.internal.tcp.TCPUtils"));
-            }
-            runningNetty = endpoint.contains("io.openliberty.netty.internal.tcp.TCPUtils");
-            break;
-        }
-        if (runningNetty)
-            FATServletClient.runTest(runtimeServer,
-                                     Http2FullModeTests.defaultServletPath + server.getHostname() + "&port=" + server.getHttpSecondaryPort() + "&testdir=" + Utils.TEST_DIR,
-                                     "setUsingNetty");
+        H2FATApplicationHelper.preTestNettyCheck(runtimeServer, server);
     }
 
     @AfterClass

--- a/dev/com.ibm.ws.transport.http2_fat/fat/src/test/server/transport/http2/Http2FullModeTests.java
+++ b/dev/com.ibm.ws.transport.http2_fat/fat/src/test/server/transport/http2/Http2FullModeTests.java
@@ -10,8 +10,6 @@
 package test.server.transport.http2;
 
 import java.io.File;
-import java.util.Arrays;
-import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -68,32 +66,7 @@ public class Http2FullModeTests extends FATServletClient {
 
         server.startServer(true, true);
         runtimeServer.startServer(true, true);
-        // Go through Logs and check if Netty is being used
-        boolean runningNetty = false;
-        // Wait for endpoints to finish loading and get the endpoint started messages
-        server.waitForStringInLog("CWWKO0219I.*");
-        runtimeServer.waitForStringInLog("CWWKO0219I.*");
-        List<String> test = server.findStringsInLogs("CWWKO0219I.*");
-        if (LOGGER.isLoggable(Level.INFO)) {
-            LOGGER.logp(Level.INFO, CLASS_NAME, "test()", "Got port list...... " + Arrays.toString(test.toArray()));
-            LOGGER.logp(Level.INFO, CLASS_NAME, "test()", "Looking for port: " + server.getHttpSecondaryPort());
-        }
-        for (String endpoint : test) {
-            if (LOGGER.isLoggable(Level.INFO)) {
-                LOGGER.logp(Level.INFO, CLASS_NAME, "test()", "Endpoint: " + endpoint);
-            }
-            if (!endpoint.contains("port " + Integer.toString(server.getHttpSecondaryPort())))
-                continue;
-            if (LOGGER.isLoggable(Level.INFO)) {
-                LOGGER.logp(Level.INFO, CLASS_NAME, "test()", "Netty? " + endpoint.contains("io.openliberty.netty.internal.tcp.TCPUtils"));
-            }
-            runningNetty = endpoint.contains("io.openliberty.netty.internal.tcp.TCPUtils");
-            break;
-        }
-        if (runningNetty)
-            FATServletClient.runTest(runtimeServer,
-                                     defaultServletPath + server.getHostname() + "&port=" + server.getHttpSecondaryPort() + "&testdir=" + Utils.TEST_DIR,
-                                     "setUsingNetty");
+        H2FATApplicationHelper.preTestNettyCheck(runtimeServer, server);
     }
 
     @AfterClass

--- a/dev/com.ibm.ws.transport.http2_fat/fat/src/test/server/transport/http2/Http2FullTracingTests.java
+++ b/dev/com.ibm.ws.transport.http2_fat/fat/src/test/server/transport/http2/Http2FullTracingTests.java
@@ -10,8 +10,6 @@
 package test.server.transport.http2;
 
 import java.io.File;
-import java.util.Arrays;
-import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -57,32 +55,7 @@ public class Http2FullTracingTests extends FATServletClient {
 
         server.startServer(true, true);
         runtimeServer.startServer(true, true);
-        // Go through Logs and check if Netty is being used
-        boolean runningNetty = false;
-        // Wait for endpoints to finish loading and get the endpoint started messages
-        server.waitForStringInLog("CWWKO0219I.*");
-        runtimeServer.waitForStringInLog("CWWKO0219I.*");
-        List<String> test = server.findStringsInLogs("CWWKO0219I.*");
-        if (LOGGER.isLoggable(Level.INFO)) {
-            LOGGER.logp(Level.INFO, CLASS_NAME, "test()", "Got port list...... " + Arrays.toString(test.toArray()));
-            LOGGER.logp(Level.INFO, CLASS_NAME, "test()", "Looking for port: " + server.getHttpSecondaryPort());
-        }
-        for (String endpoint : test) {
-            if (LOGGER.isLoggable(Level.INFO)) {
-                LOGGER.logp(Level.INFO, CLASS_NAME, "test()", "Endpoint: " + endpoint);
-            }
-            if (!endpoint.contains("port " + Integer.toString(server.getHttpSecondaryPort())))
-                continue;
-            if (LOGGER.isLoggable(Level.INFO)) {
-                LOGGER.logp(Level.INFO, CLASS_NAME, "test()", "Netty? " + endpoint.contains("io.openliberty.netty.internal.tcp.TCPUtils"));
-            }
-            runningNetty = endpoint.contains("io.openliberty.netty.internal.tcp.TCPUtils");
-            break;
-        }
-        if (runningNetty)
-            FATServletClient.runTest(runtimeServer,
-                                     Http2FullModeTests.defaultServletPath + server.getHostname() + "&port=" + server.getHttpSecondaryPort() + "&testdir=" + Utils.TEST_DIR,
-                                     "setUsingNetty");
+        H2FATApplicationHelper.preTestNettyCheck(runtimeServer, server);
     }
 
     @AfterClass

--- a/dev/com.ibm.ws.transport.http2_fat/fat/src/test/server/transport/http2/Http2LiteModeTests.java
+++ b/dev/com.ibm.ws.transport.http2_fat/fat/src/test/server/transport/http2/Http2LiteModeTests.java
@@ -10,8 +10,6 @@
 package test.server.transport.http2;
 
 import java.io.File;
-import java.util.Arrays;
-import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -57,32 +55,7 @@ public class Http2LiteModeTests extends FATServletClient {
 
         server.startServer(true, true);
         runtimeServer.startServer(true, true);
-        // Go through Logs and check if Netty is being used
-        boolean runningNetty = false;
-        // Wait for endpoints to finish loading and get the endpoint started messages
-        server.waitForStringInLog("CWWKO0219I.*");
-        runtimeServer.waitForStringInLog("CWWKO0219I.*");
-        List<String> test = server.findStringsInLogs("CWWKO0219I.*");
-        if (LOGGER.isLoggable(Level.INFO)) {
-            LOGGER.logp(Level.INFO, CLASS_NAME, "test()", "Got port list...... " + Arrays.toString(test.toArray()));
-            LOGGER.logp(Level.INFO, CLASS_NAME, "test()", "Looking for port: " + server.getHttpSecondaryPort());
-        }
-        for (String endpoint : test) {
-            if (LOGGER.isLoggable(Level.INFO)) {
-                LOGGER.logp(Level.INFO, CLASS_NAME, "test()", "Endpoint: " + endpoint);
-            }
-            if (!endpoint.contains("port " + Integer.toString(server.getHttpSecondaryPort())))
-                continue;
-            if (LOGGER.isLoggable(Level.INFO)) {
-                LOGGER.logp(Level.INFO, CLASS_NAME, "test()", "Netty? " + endpoint.contains("io.openliberty.netty.internal.tcp.TCPUtils"));
-            }
-            runningNetty = endpoint.contains("io.openliberty.netty.internal.tcp.TCPUtils");
-            break;
-        }
-        if (runningNetty)
-            FATServletClient.runTest(runtimeServer,
-                                     Http2FullModeTests.defaultServletPath + server.getHostname() + "&port=" + server.getHttpSecondaryPort() + "&testdir=" + Utils.TEST_DIR,
-                                     "setUsingNetty");
+        H2FATApplicationHelper.preTestNettyCheck(runtimeServer, server);
     }
 
     @AfterClass

--- a/dev/com.ibm.ws.transport.http2_fat/fat/src/test/server/transport/http2/Http2RequestSocketTests.java
+++ b/dev/com.ibm.ws.transport.http2_fat/fat/src/test/server/transport/http2/Http2RequestSocketTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2025 IBM Corporation and others.
+ * Copyright (c) 2025, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -64,7 +64,7 @@ public class Http2RequestSocketTests extends FATServletClient {
         server.startServer(Http2SecureTests.class.getSimpleName() + ".log");
         assertNotNull("CWWKO0219I.*ssl not received", server.waitForStringInLog("CWWKO0219I.*ssl"));
         client = new SecureHttp2Client();
-
+        H2FATApplicationHelper.preTestNettyCheck(runtimeServer, server);
     }
 
     @AfterClass

--- a/dev/com.ibm.ws.transport.http2_fat/fat/src/test/server/transport/http2/Http2WindowUpdateTests.java
+++ b/dev/com.ibm.ws.transport.http2_fat/fat/src/test/server/transport/http2/Http2WindowUpdateTests.java
@@ -10,8 +10,6 @@
 package test.server.transport.http2;
 
 import java.io.File;
-import java.util.Arrays;
-import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -57,32 +55,7 @@ public class Http2WindowUpdateTests extends FATServletClient {
 
         server.startServer(true, true);
         runtimeServer.startServer(true, true);
-        // Go through Logs and check if Netty is being used
-        boolean runningNetty = false;
-        // Wait for endpoints to finish loading and get the endpoint started messages
-        server.waitForStringInLog("CWWKO0219I.*");
-        runtimeServer.waitForStringInLog("CWWKO0219I.*");
-        List<String> test = server.findStringsInLogs("CWWKO0219I.*");
-        if (LOGGER.isLoggable(Level.INFO)) {
-            LOGGER.logp(Level.INFO, CLASS_NAME, "test()", "Got port list...... " + Arrays.toString(test.toArray()));
-            LOGGER.logp(Level.INFO, CLASS_NAME, "test()", "Looking for port: " + server.getHttpSecondaryPort());
-        }
-        for (String endpoint : test) {
-            if (LOGGER.isLoggable(Level.INFO)) {
-                LOGGER.logp(Level.INFO, CLASS_NAME, "test()", "Endpoint: " + endpoint);
-            }
-            if (!endpoint.contains("port " + Integer.toString(server.getHttpSecondaryPort())))
-                continue;
-            if (LOGGER.isLoggable(Level.INFO)) {
-                LOGGER.logp(Level.INFO, CLASS_NAME, "test()", "Netty? " + endpoint.contains("io.openliberty.netty.internal.tcp.TCPUtils"));
-            }
-            runningNetty = endpoint.contains("io.openliberty.netty.internal.tcp.TCPUtils");
-            break;
-        }
-        if (runningNetty)
-            FATServletClient.runTest(runtimeServer,
-                                     Http2FullModeTests.defaultServletPath + server.getHostname() + "&port=" + server.getHttpSecondaryPort() + "&testdir=" + Utils.TEST_DIR,
-                                     "setUsingNetty");
+        H2FATApplicationHelper.preTestNettyCheck(runtimeServer, server);
     }
 
     @AfterClass

--- a/dev/com.ibm.ws.transport.http2_fat/fat/src/test/server/transport/http2/MultiSessionTests.java
+++ b/dev/com.ibm.ws.transport.http2_fat/fat/src/test/server/transport/http2/MultiSessionTests.java
@@ -12,9 +12,7 @@ package test.server.transport.http2;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
-import java.util.Arrays;
 import java.util.LinkedList;
-import java.util.List;
 import java.util.Queue;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
@@ -65,32 +63,7 @@ public class MultiSessionTests extends FATServletClient {
 
         server.startServer(true, true);
         runtimeServer.startServer(true);
-        // Go through Logs and check if Netty is being used
-        boolean runningNetty = false;
-        // Wait for endpoints to finish loading and get the endpoint started messages
-        server.waitForStringInLog("CWWKO0219I.*");
-        runtimeServer.waitForStringInLog("CWWKO0219I.*");
-        List<String> test = server.findStringsInLogs("CWWKO0219I.*");
-        if (LOGGER.isLoggable(Level.INFO)) {
-            LOGGER.logp(Level.INFO, CLASS_NAME, "test()", "Got port list...... " + Arrays.toString(test.toArray()));
-            LOGGER.logp(Level.INFO, CLASS_NAME, "test()", "Looking for port: " + server.getHttpSecondaryPort());
-        }
-        for (String endpoint : test) {
-            if (LOGGER.isLoggable(Level.INFO)) {
-                LOGGER.logp(Level.INFO, CLASS_NAME, "test()", "Endpoint: " + endpoint);
-            }
-            if (!endpoint.contains("port " + Integer.toString(server.getHttpSecondaryPort())))
-                continue;
-            if (LOGGER.isLoggable(Level.INFO)) {
-                LOGGER.logp(Level.INFO, CLASS_NAME, "test()", "Netty? " + endpoint.contains("io.openliberty.netty.internal.tcp.TCPUtils"));
-            }
-            runningNetty = endpoint.contains("io.openliberty.netty.internal.tcp.TCPUtils");
-            break;
-        }
-        if (runningNetty)
-            FATServletClient.runTest(runtimeServer,
-                                     Http2FullModeTests.defaultServletPath + server.getHostname() + "&port=" + server.getHttpSecondaryPort() + "&testdir=" + Utils.TEST_DIR,
-                                     "setUsingNetty");
+        H2FATApplicationHelper.preTestNettyCheck(runtimeServer, server);
     }
 
     @AfterClass

--- a/dev/com.ibm.ws.transport.http2_fat/test-applications/H2FATDriver.war/src/http2/test/driver/war/servlets/H2FATDriverServlet.java
+++ b/dev/com.ibm.ws.transport.http2_fat/test-applications/H2FATDriver.war/src/http2/test/driver/war/servlets/H2FATDriverServlet.java
@@ -5288,8 +5288,14 @@ public class H2FATDriverServlet extends FATServlet {
         CountDownLatch blockUntilConnectionIsDone = new CountDownLatch(1);
         Http2Client h2Client = getDefaultH2Client(request, response, blockUntilConnectionIsDone);
 
-        FrameGoAway errorFrame = new FrameGoAway(0, "too many reset frames processed".getBytes(),
-                ENHANCE_YOUR_CALM_ERROR, 1, false);
+        byte[] cfhwDebugData = "too many reset frames processed".getBytes();
+        byte[] nettyDebugData = "Maximum number 100 of RST frames frames reached within 30 seconds".getBytes();
+        FrameGoAway errorFrame;
+
+        if (USING_NETTY)
+            errorFrame = new FrameGoAway(0, nettyDebugData, ENHANCE_YOUR_CALM_ERROR, 2147483647, false);
+        else
+            errorFrame = new FrameGoAway(0, cfhwDebugData, ENHANCE_YOUR_CALM_ERROR, 1, false);
         h2Client.addExpectedFrame(errorFrame);
 
         setupDefaultUpgradedConnection(h2Client, HEADERS_ONLY_URI);


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [ ] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

This PR intends to fix the remaining set of failures that were yet to be addressed with Netty on HTTP 2.0. These were `testOutboundResetLimits` and `testGetRequestSocketInsecure`.
for https://github.com/OpenLiberty/open-liberty/issues/31988