### PR TITLE
Use new JarEntry when modifying test applications

### DIFF
--- a/dev/com.ibm.ws.springboot.fat20_fat/fat/src/com/ibm/ws/springboot/support/fat/JPAEclipseLinkAppTests20War.java
+++ b/dev/com.ibm.ws.springboot.fat20_fat/fat/src/com/ibm/ws/springboot/support/fat/JPAEclipseLinkAppTests20War.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2025 IBM Corporation and others.
+ * Copyright (c) 2025, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -64,7 +64,6 @@ public class JPAEclipseLinkAppTests20War extends JPAAppAbstractTests {
             Enumeration<JarEntry> entries = jarFile.entries();
             while (entries.hasMoreElements()) {
                 JarEntry originalEntry = entries.nextElement();
-                JarEntry newEntry = originalEntry;
                 String entryName = originalEntry.getName();
                 if (entryName.equals("WEB-INF/classes/META-INF/persistence.xml")) {
                     // Remove the default persistence.xml processed by Liberty
@@ -74,7 +73,7 @@ public class JPAEclipseLinkAppTests20War extends JPAAppAbstractTests {
                     // Remove the web.xml
                     continue;
                 }
-                jarOutputStream.putNextEntry(newEntry);
+                jarOutputStream.putNextEntry(new JarEntry(entryName));
                 byte[] buffer = new byte[1024];
                 int bytesRead;
                 try (InputStream entryIn = jarFile.getInputStream(originalEntry)) {

--- a/dev/com.ibm.ws.springboot.fat20_fat/fat/src/com/ibm/ws/springboot/support/fat/JPAEclipseLinkWeavingAppTests20War.java
+++ b/dev/com.ibm.ws.springboot.fat20_fat/fat/src/com/ibm/ws/springboot/support/fat/JPAEclipseLinkWeavingAppTests20War.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2025 IBM Corporation and others.
+ * Copyright (c) 2025, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -64,7 +64,6 @@ public class JPAEclipseLinkWeavingAppTests20War extends JPAAppAbstractTests {
             Enumeration<JarEntry> entries = jarFile.entries();
             while (entries.hasMoreElements()) {
                 JarEntry originalEntry = entries.nextElement();
-                JarEntry newEntry = originalEntry;
                 String entryName = originalEntry.getName();
                 if (entryName.equals("WEB-INF/classes/META-INF/persistence.xml")) {
                     // Remove the default persistence.xml processed by Liberty
@@ -74,7 +73,7 @@ public class JPAEclipseLinkWeavingAppTests20War extends JPAAppAbstractTests {
                     // Remove the web.xml
                     continue;
                 }
-                jarOutputStream.putNextEntry(newEntry);
+                jarOutputStream.putNextEntry(new JarEntry(entryName));
                 byte[] buffer = new byte[1024];
                 int bytesRead;
                 try (InputStream entryIn = jarFile.getInputStream(originalEntry)) {

--- a/dev/com.ibm.ws.springboot.fat20_fat/fat/src/com/ibm/ws/springboot/support/fat/JPAHibernateAppTests20War.java
+++ b/dev/com.ibm.ws.springboot.fat20_fat/fat/src/com/ibm/ws/springboot/support/fat/JPAHibernateAppTests20War.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2025 IBM Corporation and others.
+ * Copyright (c) 2025, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -62,8 +62,8 @@ public class JPAHibernateAppTests20War extends JPAAppAbstractTests {
             Enumeration<JarEntry> entries = jarFile.entries();
             while (entries.hasMoreElements()) {
                 JarEntry originalEntry = entries.nextElement();
-                JarEntry newEntry = originalEntry;
                 String entryName = originalEntry.getName();
+                JarEntry newEntry = new JarEntry(originalEntry.getName());
                 if (entryName.startsWith("WEB-INF/lib-provided/") && !entryName.endsWith("/")) {
                     if (!tomcatStarter(entryName)) {
                         newEntry = new JarEntry(entryName.replace("lib-provided", "lib"));

--- a/dev/com.ibm.ws.springboot.fat20_fat/fat/src/com/ibm/ws/springboot/support/fat/NonZipExtensionFilesInBootInfLibTests20.java
+++ b/dev/com.ibm.ws.springboot.fat20_fat/fat/src/com/ibm/ws/springboot/support/fat/NonZipExtensionFilesInBootInfLibTests20.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2018 IBM Corporation and others.
+ * Copyright (c) 2018, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -145,7 +145,7 @@ public class NonZipExtensionFilesInBootInfLibTests20 extends AbstractSpringTests
                     String entryName = entry.getName();
                     if (!entryName.equals(newEntry) && !zipEntries.contains(entryName)) {
                         zipEntries.add(entryName);
-                        jos.putNextEntry(entry);
+                        jos.putNextEntry(new JarEntry(entryName));
                         try (InputStream entryStream = appJar.getInputStream(entry)) {
                             while ((len = entryStream.read(buffer)) != -1) {
                                 jos.write(buffer, 0, len);
@@ -185,12 +185,12 @@ public class NonZipExtensionFilesInBootInfLibTests20 extends AbstractSpringTests
 
                     if (!zipEntries.contains(entryName)) {
                         zipEntries.add(entryName);
-                        if (entryName.equals("BOOT-INF/lib/spring-boot-starter-web-2.0.0.RELEASE.jar")) {
+                        if (entryName.startsWith("BOOT-INF/lib/spring-boot-starter-web-")) {
                             //change the extension of the library jar
                             JarEntry entryWithDiffExt = new JarEntry("BOOT-INF/lib/" + entryName + ".xyz");
                             jos.putNextEntry(entryWithDiffExt);
                         } else {
-                            jos.putNextEntry(entry);
+                            jos.putNextEntry(new JarEntry(entryName));
                         }
 
                         try (InputStream entryStream = appJar.getInputStream(entry)) {

--- a/dev/com.ibm.ws.springboot.fat20_fat/fat/src/com/ibm/ws/springboot/support/fat/ValidationAbstractTests.java
+++ b/dev/com.ibm.ws.springboot.fat20_fat/fat/src/com/ibm/ws/springboot/support/fat/ValidationAbstractTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2025 IBM Corporation and others.
+ * Copyright (c) 2025, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -49,13 +49,12 @@ public abstract class ValidationAbstractTests extends AbstractSpringTests {
             Enumeration<JarEntry> entries = jarFile.entries();
             while (entries.hasMoreElements()) {
                 JarEntry originalEntry = entries.nextElement();
-                JarEntry newEntry = originalEntry;
                 String entryName = originalEntry.getName();
                 if (entryName.startsWith("WEB-INF/lib-provided/")) {
                     // remove all content of lib-provided
                     continue;
                 }
-                jarOutputStream.putNextEntry(newEntry);
+                jarOutputStream.putNextEntry(new JarEntry(entryName));
                 byte[] buffer = new byte[1024];
                 int bytesRead;
                 try (InputStream entryIn = jarFile.getInputStream(originalEntry)) {

--- a/dev/io.openliberty.springboot.fat30_fat/fat/src/com/ibm/ws/springboot/support/fat/JPAEclipseLinkAppTests30.java
+++ b/dev/io.openliberty.springboot.fat30_fat/fat/src/com/ibm/ws/springboot/support/fat/JPAEclipseLinkAppTests30.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2025 IBM Corporation and others.
+ * Copyright (c) 2025, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -65,7 +65,6 @@ public class JPAEclipseLinkAppTests30 extends JPAAppAbstractTests {
             Enumeration<JarEntry> entries = jarFile.entries();
             while (entries.hasMoreElements()) {
                 JarEntry originalEntry = entries.nextElement();
-                JarEntry newEntry = originalEntry;
                 String entryName = originalEntry.getName();
                 if (entryName.equals("WEB-INF/classes/META-INF/persistence.xml")) {
                     // Remove the default persistence.xml processed by Liberty
@@ -75,7 +74,7 @@ public class JPAEclipseLinkAppTests30 extends JPAAppAbstractTests {
                     // Remove the web.xml
                     continue;
                 }
-                jarOutputStream.putNextEntry(newEntry);
+                jarOutputStream.putNextEntry(new JarEntry(entryName));
                 byte[] buffer = new byte[1024];
                 int bytesRead;
                 try (InputStream entryIn = jarFile.getInputStream(originalEntry)) {

--- a/dev/io.openliberty.springboot.fat30_fat/fat/src/com/ibm/ws/springboot/support/fat/JPAEclipseLinkAppTests30War.java
+++ b/dev/io.openliberty.springboot.fat30_fat/fat/src/com/ibm/ws/springboot/support/fat/JPAEclipseLinkAppTests30War.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2025 IBM Corporation and others.
+ * Copyright (c) 2025, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -65,7 +65,6 @@ public class JPAEclipseLinkAppTests30War extends JPAAppAbstractTests {
             Enumeration<JarEntry> entries = jarFile.entries();
             while (entries.hasMoreElements()) {
                 JarEntry originalEntry = entries.nextElement();
-                JarEntry newEntry = originalEntry;
                 String entryName = originalEntry.getName();
                 if (entryName.equals("WEB-INF/classes/META-INF/persistence.xml")) {
                     // Remove the default persistence.xml processed by Liberty
@@ -75,7 +74,7 @@ public class JPAEclipseLinkAppTests30War extends JPAAppAbstractTests {
                     // Remove the web.xml
                     continue;
                 }
-                jarOutputStream.putNextEntry(newEntry);
+                jarOutputStream.putNextEntry(new JarEntry(entryName));
                 byte[] buffer = new byte[1024];
                 int bytesRead;
                 try (InputStream entryIn = jarFile.getInputStream(originalEntry)) {

--- a/dev/io.openliberty.springboot.fat30_fat/fat/src/com/ibm/ws/springboot/support/fat/JPAEclipseLinkWeavingAppTests30.java
+++ b/dev/io.openliberty.springboot.fat30_fat/fat/src/com/ibm/ws/springboot/support/fat/JPAEclipseLinkWeavingAppTests30.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2025 IBM Corporation and others.
+ * Copyright (c) 2025, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -65,7 +65,6 @@ public class JPAEclipseLinkWeavingAppTests30 extends JPAAppAbstractTests {
             Enumeration<JarEntry> entries = jarFile.entries();
             while (entries.hasMoreElements()) {
                 JarEntry originalEntry = entries.nextElement();
-                JarEntry newEntry = originalEntry;
                 String entryName = originalEntry.getName();
                 if (entryName.equals("WEB-INF/classes/META-INF/persistence.xml")) {
                     // Remove the default persistence.xml processed by Liberty
@@ -75,7 +74,7 @@ public class JPAEclipseLinkWeavingAppTests30 extends JPAAppAbstractTests {
                     // Remove the web.xml
                     continue;
                 }
-                jarOutputStream.putNextEntry(newEntry);
+                jarOutputStream.putNextEntry(new JarEntry(entryName));
                 byte[] buffer = new byte[1024];
                 int bytesRead;
                 try (InputStream entryIn = jarFile.getInputStream(originalEntry)) {

--- a/dev/io.openliberty.springboot.fat30_fat/fat/src/com/ibm/ws/springboot/support/fat/JPAEclipseLinkWeavingAppTests30War.java
+++ b/dev/io.openliberty.springboot.fat30_fat/fat/src/com/ibm/ws/springboot/support/fat/JPAEclipseLinkWeavingAppTests30War.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2025 IBM Corporation and others.
+ * Copyright (c) 2025, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -65,7 +65,6 @@ public class JPAEclipseLinkWeavingAppTests30War extends JPAAppAbstractTests {
             Enumeration<JarEntry> entries = jarFile.entries();
             while (entries.hasMoreElements()) {
                 JarEntry originalEntry = entries.nextElement();
-                JarEntry newEntry = originalEntry;
                 String entryName = originalEntry.getName();
                 if (entryName.equals("WEB-INF/classes/META-INF/persistence.xml")) {
                     // Remove the default persistence.xml processed by Liberty
@@ -75,7 +74,7 @@ public class JPAEclipseLinkWeavingAppTests30War extends JPAAppAbstractTests {
                     // Remove the web.xml
                     continue;
                 }
-                jarOutputStream.putNextEntry(newEntry);
+                jarOutputStream.putNextEntry(new JarEntry(entryName));
                 byte[] buffer = new byte[1024];
                 int bytesRead;
                 try (InputStream entryIn = jarFile.getInputStream(originalEntry)) {

--- a/dev/io.openliberty.springboot.fat30_fat/fat/src/com/ibm/ws/springboot/support/fat/JPAHibernateAppTests30.java
+++ b/dev/io.openliberty.springboot.fat30_fat/fat/src/com/ibm/ws/springboot/support/fat/JPAHibernateAppTests30.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2025 IBM Corporation and others.
+ * Copyright (c) 2025, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -63,8 +63,8 @@ public class JPAHibernateAppTests30 extends JPAAppAbstractTests {
             Enumeration<JarEntry> entries = jarFile.entries();
             while (entries.hasMoreElements()) {
                 JarEntry originalEntry = entries.nextElement();
-                JarEntry newEntry = originalEntry;
                 String entryName = originalEntry.getName();
+                JarEntry newEntry = new JarEntry(entryName);
                 if (entryName.startsWith("WEB-INF/lib-provided/") && !entryName.endsWith("/")) {
                     if (!tomcatStarter(entryName)) {
                         newEntry = new JarEntry(entryName.replace("lib-provided", "lib"));

--- a/dev/io.openliberty.springboot.fat30_fat/fat/src/com/ibm/ws/springboot/support/fat/JPAHibernateAppTests30War.java
+++ b/dev/io.openliberty.springboot.fat30_fat/fat/src/com/ibm/ws/springboot/support/fat/JPAHibernateAppTests30War.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2025 IBM Corporation and others.
+ * Copyright (c) 2025, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -63,8 +63,8 @@ public class JPAHibernateAppTests30War extends JPAAppAbstractTests {
             Enumeration<JarEntry> entries = jarFile.entries();
             while (entries.hasMoreElements()) {
                 JarEntry originalEntry = entries.nextElement();
-                JarEntry newEntry = originalEntry;
                 String entryName = originalEntry.getName();
+                JarEntry newEntry = new JarEntry(entryName);
                 if (entryName.startsWith("WEB-INF/lib-provided/") && !entryName.endsWith("/")) {
                     if (!tomcatStarter(entryName)) {
                         newEntry = new JarEntry(entryName.replace("lib-provided", "lib"));

--- a/dev/io.openliberty.springboot.fat30_fat/fat/src/com/ibm/ws/springboot/support/fat/NonZipExtensionFilesInBootInfLibTests30.java
+++ b/dev/io.openliberty.springboot.fat30_fat/fat/src/com/ibm/ws/springboot/support/fat/NonZipExtensionFilesInBootInfLibTests30.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018,2023 IBM Corporation and others.
+ * Copyright (c) 2018, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -147,7 +147,7 @@ public class NonZipExtensionFilesInBootInfLibTests30 extends AbstractSpringTests
                     String entryName = entry.getName();
                     if (!entryName.equals(newEntry) && !zipEntries.contains(entryName)) {
                         zipEntries.add(entryName);
-                        jos.putNextEntry(entry);
+                        jos.putNextEntry(new JarEntry(entryName));
                         try (InputStream entryStream = appJar.getInputStream(entry)) {
                             while ((len = entryStream.read(buffer)) != -1) {
                                 jos.write(buffer, 0, len);
@@ -187,12 +187,12 @@ public class NonZipExtensionFilesInBootInfLibTests30 extends AbstractSpringTests
 
                     if (!zipEntries.contains(entryName)) {
                         zipEntries.add(entryName);
-                        if (entryName.equals("BOOT-INF/lib/spring-boot-starter-web-2.0.0.RELEASE.jar")) {
+                        if (entryName.startsWith("BOOT-INF/lib/spring-boot-starter-web")) {
                             //change the extension of the library jar
                             JarEntry entryWithDiffExt = new JarEntry("BOOT-INF/lib/" + entryName + ".xyz");
                             jos.putNextEntry(entryWithDiffExt);
                         } else {
-                            jos.putNextEntry(entry);
+                            jos.putNextEntry(new JarEntry(entryName));
                         }
 
                         try (InputStream entryStream = appJar.getInputStream(entry)) {

--- a/dev/io.openliberty.springboot.fat30_fat/fat/src/com/ibm/ws/springboot/support/fat/ValidationAbstractTests.java
+++ b/dev/io.openliberty.springboot.fat30_fat/fat/src/com/ibm/ws/springboot/support/fat/ValidationAbstractTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2025 IBM Corporation and others.
+ * Copyright (c) 2025, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -49,13 +49,12 @@ public abstract class ValidationAbstractTests extends AbstractSpringTests {
             Enumeration<JarEntry> entries = jarFile.entries();
             while (entries.hasMoreElements()) {
                 JarEntry originalEntry = entries.nextElement();
-                JarEntry newEntry = originalEntry;
                 String entryName = originalEntry.getName();
                 if (entryName.startsWith("WEB-INF/lib-provided/")) {
                     // remove all content of lib-provided
                     continue;
                 }
-                jarOutputStream.putNextEntry(newEntry);
+                jarOutputStream.putNextEntry(new JarEntry(entryName));
                 byte[] buffer = new byte[1024];
                 int bytesRead;
                 try (InputStream entryIn = jarFile.getInputStream(originalEntry)) {

--- a/dev/io.openliberty.springboot.fat40_fat/fat/src/com/ibm/ws/springboot/support/fat/JPAEclipseLinkAppTests40.java
+++ b/dev/io.openliberty.springboot.fat40_fat/fat/src/com/ibm/ws/springboot/support/fat/JPAEclipseLinkAppTests40.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2025 IBM Corporation and others.
+ * Copyright (c) 2025, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -65,7 +65,6 @@ public class JPAEclipseLinkAppTests40 extends JPAAppAbstractTests {
             Enumeration<JarEntry> entries = jarFile.entries();
             while (entries.hasMoreElements()) {
                 JarEntry originalEntry = entries.nextElement();
-                JarEntry newEntry = originalEntry;
                 String entryName = originalEntry.getName();
                 if (entryName.equals("WEB-INF/classes/META-INF/persistence.xml")) {
                     // Remove the default persistence.xml processed by Liberty
@@ -75,7 +74,7 @@ public class JPAEclipseLinkAppTests40 extends JPAAppAbstractTests {
                     // Remove the web.xml
                     continue;
                 }
-                jarOutputStream.putNextEntry(newEntry);
+                jarOutputStream.putNextEntry(new JarEntry(entryName));
                 byte[] buffer = new byte[1024];
                 int bytesRead;
                 try (InputStream entryIn = jarFile.getInputStream(originalEntry)) {

--- a/dev/io.openliberty.springboot.fat40_fat/fat/src/com/ibm/ws/springboot/support/fat/JPAEclipseLinkAppTests40War.java
+++ b/dev/io.openliberty.springboot.fat40_fat/fat/src/com/ibm/ws/springboot/support/fat/JPAEclipseLinkAppTests40War.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2025 IBM Corporation and others.
+ * Copyright (c) 2025, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -65,7 +65,6 @@ public class JPAEclipseLinkAppTests40War extends JPAAppAbstractTests {
             Enumeration<JarEntry> entries = jarFile.entries();
             while (entries.hasMoreElements()) {
                 JarEntry originalEntry = entries.nextElement();
-                JarEntry newEntry = originalEntry;
                 String entryName = originalEntry.getName();
                 if (entryName.equals("WEB-INF/classes/META-INF/persistence.xml")) {
                     // Remove the default persistence.xml processed by Liberty
@@ -75,7 +74,7 @@ public class JPAEclipseLinkAppTests40War extends JPAAppAbstractTests {
                     // Remove the web.xml
                     continue;
                 }
-                jarOutputStream.putNextEntry(newEntry);
+                jarOutputStream.putNextEntry(new JarEntry(entryName));
                 byte[] buffer = new byte[1024];
                 int bytesRead;
                 try (InputStream entryIn = jarFile.getInputStream(originalEntry)) {

--- a/dev/io.openliberty.springboot.fat40_fat/fat/src/com/ibm/ws/springboot/support/fat/JPAEclipseLinkWeavingAppTests40.java
+++ b/dev/io.openliberty.springboot.fat40_fat/fat/src/com/ibm/ws/springboot/support/fat/JPAEclipseLinkWeavingAppTests40.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2025 IBM Corporation and others.
+ * Copyright (c) 2025, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -65,7 +65,6 @@ public class JPAEclipseLinkWeavingAppTests40 extends JPAAppAbstractTests {
             Enumeration<JarEntry> entries = jarFile.entries();
             while (entries.hasMoreElements()) {
                 JarEntry originalEntry = entries.nextElement();
-                JarEntry newEntry = originalEntry;
                 String entryName = originalEntry.getName();
                 if (entryName.equals("WEB-INF/classes/META-INF/persistence.xml")) {
                     // Remove the default persistence.xml processed by Liberty
@@ -75,7 +74,7 @@ public class JPAEclipseLinkWeavingAppTests40 extends JPAAppAbstractTests {
                     // Remove the web.xml
                     continue;
                 }
-                jarOutputStream.putNextEntry(newEntry);
+                jarOutputStream.putNextEntry(new JarEntry(entryName));
                 byte[] buffer = new byte[1024];
                 int bytesRead;
                 try (InputStream entryIn = jarFile.getInputStream(originalEntry)) {

--- a/dev/io.openliberty.springboot.fat40_fat/fat/src/com/ibm/ws/springboot/support/fat/JPAEclipseLinkWeavingAppTests40War.java
+++ b/dev/io.openliberty.springboot.fat40_fat/fat/src/com/ibm/ws/springboot/support/fat/JPAEclipseLinkWeavingAppTests40War.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2025 IBM Corporation and others.
+ * Copyright (c) 2025, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -65,7 +65,6 @@ public class JPAEclipseLinkWeavingAppTests40War extends JPAAppAbstractTests {
             Enumeration<JarEntry> entries = jarFile.entries();
             while (entries.hasMoreElements()) {
                 JarEntry originalEntry = entries.nextElement();
-                JarEntry newEntry = originalEntry;
                 String entryName = originalEntry.getName();
                 if (entryName.equals("WEB-INF/classes/META-INF/persistence.xml")) {
                     // Remove the default persistence.xml processed by Liberty
@@ -75,7 +74,7 @@ public class JPAEclipseLinkWeavingAppTests40War extends JPAAppAbstractTests {
                     // Remove the web.xml
                     continue;
                 }
-                jarOutputStream.putNextEntry(newEntry);
+                jarOutputStream.putNextEntry(new JarEntry(entryName));
                 byte[] buffer = new byte[1024];
                 int bytesRead;
                 try (InputStream entryIn = jarFile.getInputStream(originalEntry)) {

--- a/dev/io.openliberty.springboot.fat40_fat/fat/src/com/ibm/ws/springboot/support/fat/JPAHibernateAppTests40.java
+++ b/dev/io.openliberty.springboot.fat40_fat/fat/src/com/ibm/ws/springboot/support/fat/JPAHibernateAppTests40.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2025 IBM Corporation and others.
+ * Copyright (c) 2025, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -63,8 +63,8 @@ public class JPAHibernateAppTests40 extends JPAAppAbstractTests {
             Enumeration<JarEntry> entries = jarFile.entries();
             while (entries.hasMoreElements()) {
                 JarEntry originalEntry = entries.nextElement();
-                JarEntry newEntry = originalEntry;
                 String entryName = originalEntry.getName();
+                JarEntry newEntry = new JarEntry(entryName);
                 if (entryName.startsWith("WEB-INF/lib-provided/") && !entryName.endsWith("/")) {
                     if (!tomcatStarter(entryName)) {
                         newEntry = new JarEntry(entryName.replace("lib-provided", "lib"));

--- a/dev/io.openliberty.springboot.fat40_fat/fat/src/com/ibm/ws/springboot/support/fat/JPAHibernateAppTests40War.java
+++ b/dev/io.openliberty.springboot.fat40_fat/fat/src/com/ibm/ws/springboot/support/fat/JPAHibernateAppTests40War.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2025 IBM Corporation and others.
+ * Copyright (c) 2025, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -63,8 +63,8 @@ public class JPAHibernateAppTests40War extends JPAAppAbstractTests {
             Enumeration<JarEntry> entries = jarFile.entries();
             while (entries.hasMoreElements()) {
                 JarEntry originalEntry = entries.nextElement();
-                JarEntry newEntry = originalEntry;
                 String entryName = originalEntry.getName();
+                JarEntry newEntry = new JarEntry(entryName);
                 if (entryName.startsWith("WEB-INF/lib-provided/") && !entryName.endsWith("/")) {
                     if (!tomcatStarter(entryName)) {
                         newEntry = new JarEntry(entryName.replace("lib-provided", "lib"));

--- a/dev/io.openliberty.springboot.fat40_fat/fat/src/com/ibm/ws/springboot/support/fat/NonZipExtensionFilesInBootInfLibTests40.java
+++ b/dev/io.openliberty.springboot.fat40_fat/fat/src/com/ibm/ws/springboot/support/fat/NonZipExtensionFilesInBootInfLibTests40.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018,2025 IBM Corporation and others.
+ * Copyright (c) 2018, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -146,7 +146,7 @@ public class NonZipExtensionFilesInBootInfLibTests40 extends AbstractSpringTests
                     String entryName = entry.getName();
                     if (!entryName.equals(newEntry) && !zipEntries.contains(entryName)) {
                         zipEntries.add(entryName);
-                        jos.putNextEntry(entry);
+                        jos.putNextEntry(new JarEntry(entryName));
                         try (InputStream entryStream = appJar.getInputStream(entry)) {
                             while ((len = entryStream.read(buffer)) != -1) {
                                 jos.write(buffer, 0, len);
@@ -186,12 +186,12 @@ public class NonZipExtensionFilesInBootInfLibTests40 extends AbstractSpringTests
 
                     if (!zipEntries.contains(entryName)) {
                         zipEntries.add(entryName);
-                        if (entryName.equals("BOOT-INF/lib/spring-boot-starter-web-2.0.0.RELEASE.jar")) {
+                        if (entryName.startsWith("BOOT-INF/lib/spring-boot-starter-web-")) {
                             //change the extension of the library jar
                             JarEntry entryWithDiffExt = new JarEntry("BOOT-INF/lib/" + entryName + ".xyz");
                             jos.putNextEntry(entryWithDiffExt);
                         } else {
-                            jos.putNextEntry(entry);
+                            jos.putNextEntry(new JarEntry(entryName));
                         }
 
                         try (InputStream entryStream = appJar.getInputStream(entry)) {


### PR DESCRIPTION
Using existing JarEntry objects from one JarFile to create a new JAR seems to cause random failures in the tests when trying to write to the JarOutputStream.


- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

