### PR TITLE
Generated queries should use implicit entity identification variable

### DIFF
--- a/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
+++ b/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
@@ -1246,10 +1246,10 @@ CWWKD1123.sort.incompat.with.cursor=CWWKD1123E: A cursor cannot be inferred \
  for a requested page of results because one of the sort criteria supplied \
  to the {0} method of the {1} repository is not an entity attribute: {2}. \
  Use the {3} method to construct a cursor that matches the sort criteria, and \
- supply the cursor to the afterCursor or beforeCursor method of a PageRequest. \
+ supply the cursor to the afterCursor or beforeCursor method of a PageRequest class. \
  Alternatively, change the sort criteria to include only the names of entity \
- attributes. Valid attribute names for the {4} entity class are: {5}.
-CWWKD1123.sort.incompat.with.cursor.explanation=In order to automatically \
+ attributes. Valid attribute names for the {4} entity class are {5}.
+CWWKD1123.sort.incompat.with.cursor.explanation=To automatically \
  create a cursor based on the sort criteria, each of the sort criteria must \
  sort by a single entity attribute name.
 CWWKD1123.sort.incompat.with.cursor.useraction=Supply a cursor that is consistent \

--- a/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
+++ b/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
@@ -1253,5 +1253,5 @@ CWWKD1123.sort.incompat.with.cursor.explanation=In order to automatically \
  create a cursor based on the sort criteria, each of the sort criteria must \
  sort by a single entity attribute name.
 CWWKD1123.sort.incompat.with.cursor.useraction=Supply a cursor that is consistent \
- with the sort criteria. Alernatively, switch to offset-based pagination or \
+ with the sort criteria. Alternatively, switch to offset-based pagination or \
  modify the sort criteria to only sort by entity attributes.

--- a/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
+++ b/dev/io.openliberty.data.internal.persistence/resources/io/openliberty/data/internal/persistence/resources/CWWKDMessages.nlsprops
@@ -1241,3 +1241,17 @@ CWWKD1122.entity.lacks.id.explanation=Entities are required to have a unique \
  identifier attribute.
 CWWKD1122.entity.lacks.id.useraction=Enable the Jakarta Persistence feature \
  and follow the Jakarta Persistence entity model to assign a unique identifier.
+
+CWWKD1123.sort.incompat.with.cursor=CWWKD1123E: A cursor cannot be inferred \
+ for a requested page of results because one of the sort criteria supplied \
+ to the {0} method of the {1} repository is not an entity attribute: {2}. \
+ Use the {3} method to construct a cursor that matches the sort criteria, and \
+ supply the cursor to the afterCursor or beforeCursor method of a PageRequest. \
+ Alternatively, change the sort criteria to include only the names of entity \
+ attributes. Valid attribute names for the {4} entity class are: {5}.
+CWWKD1123.sort.incompat.with.cursor.explanation=In order to automatically \
+ create a cursor based on the sort criteria, each of the sort criteria must \
+ sort by a single entity attribute name.
+CWWKD1123.sort.incompat.with.cursor.useraction=Supply a cursor that is consistent \
+ with the sort criteria. Alernatively, switch to offset-based pagination or \
+ modify the sort criteria to only sort by entity attributes.

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
@@ -133,6 +133,11 @@ public class QueryInfo {
     private static final int[] NONE_STATIC_SORT_ONLY = new int[0];
 
     /**
+     * The implicit entity identifier variable defined by Jakarta Persistence.
+     */
+    private static final String THIS = "this";
+
+    /**
      * Information about the type of entity to which the query pertains.
      */
     EntityInfo entityInfo;
@@ -146,13 +151,13 @@ public class QueryInfo {
      * Entity identifier variable name if an identifier variable is used.
      * Otherwise "this". "o" is used as the default in generated queries.
      */
-    private String entityVar = "o";
+    private String entityVar = THIS;
 
     /**
      * Entity identifier variable name and . character if an identifier variable is used.
      * Otherwise the empty string. "o." is used as the default in generated queries.
      */
-    private String entityVar_ = "o.";
+    private String entityVar_ = THIS + '.';
 
     /**
      * Indicates if the query has a WHERE clause.
@@ -2598,9 +2603,13 @@ public class QueryInfo {
      */
     private void generateCount(String where) {
         String o = entityVar;
-        StringBuilder q = new StringBuilder(21 + 2 * o.length() + entityInfo.name.length() + (where == null ? 0 : where.length())) //
-                        .append("SELECT COUNT(").append(o).append(") FROM ") //
-                        .append(entityInfo.name).append(' ').append(o);
+        StringBuilder q = new StringBuilder(21 + 2 * o.length() +
+                                            entityInfo.name.length() +
+                                            (where == null ? 0 : where.length())) //
+                                                            .append("SELECT COUNT(").append(o).append(") FROM ") //
+                                                            .append(entityInfo.name);
+        if (o != THIS)
+            q.append(' ').append(o);
 
         if (where != null)
             q.append(where);
@@ -2713,12 +2722,19 @@ public class QueryInfo {
         StringBuilder q;
         if (entityInfo.idClassAttributeAccessors == null) {
             String idAttrName = entityInfo.attributeNames.get(ID);
-            q = new StringBuilder(24 + entityInfo.name.length() + o.length() * 2 + idAttrName.length()) //
-                            .append("DELETE FROM ").append(entityInfo.name).append(' ').append(o).append(" WHERE ") //
-                            .append(o_).append(idAttrName).append("=?1");
+            q = new StringBuilder(24 + entityInfo.name.length() +
+                                  o.length() * 2 +
+                                  idAttrName.length()) //
+                                                  .append("DELETE FROM ").append(entityInfo.name);
+            if (o != THIS)
+                q.append(' ').append(o);
+            q.append(" WHERE ").append(o_).append(idAttrName).append("=?1");
         } else {
             q = new StringBuilder(200) //
-                            .append("DELETE FROM ").append(entityInfo.name).append(' ').append(o).append(" WHERE ");
+                            .append("DELETE FROM ").append(entityInfo.name);
+            if (o != THIS)
+                q.append(' ').append(o);
+            q.append(" WHERE ");
             int count = 0;
             for (String idClassAttrName : entityInfo.idClassAttributeAccessors.keySet()) {
                 if (++count != 1)
@@ -2737,7 +2753,9 @@ public class QueryInfo {
         String o_ = entityVar_;
 
         StringBuilder q = new StringBuilder(100) //
-                        .append("DELETE FROM ").append(entityInfo.name).append(' ').append(o);
+                        .append("DELETE FROM ").append(entityInfo.name);
+        if (o != THIS)
+            q.append(' ').append(o);
 
         if (method.getParameterCount() == 0) {
             type = QM_DELETE;
@@ -2962,11 +2980,15 @@ public class QueryInfo {
         if (q == null && type == FIND) { // SELECT
             q = generateSelectClause() //
                             .append(" FROM ") //
-                            .append(entityInfo.name).append(' ').append(o);
+                            .append(entityInfo.name);
+            if (o != THIS)
+                q.append(' ').append(o);
         } else if (q == null) { // UPDATE
             q = new StringBuilder(250).append("UPDATE ") //
-                            .append(entityInfo.name).append(' ').append(o) //
-                            .append(" SET");
+                            .append(entityInfo.name);
+            if (o != THIS)
+                q.append(' ').append(o);
+            q.append(" SET");
 
             boolean needsVersionUpdate = entityInfo.versionAttributeName != null;
             boolean first = true;
@@ -3155,7 +3177,7 @@ public class QueryInfo {
                 // Omission of the optional SELECT clause means "SELECT this" per
                 // the Jakarta Persistence spec. Given that, a SELECT clause ends up
                 // being required if the entity identification variable is not "this"
-                if (!"this".equals(o))
+                if (o != THIS)
                     q.append("SELECT ").append(o);
             } else if (entityInfo.idClassAttributeAccessors != null &&
                        singleType.equals(entityInfo.idType)) {
@@ -3309,9 +3331,10 @@ public class QueryInfo {
             setType(Update.class, LC_UPDATE);
 
             q = new StringBuilder(100) //
-                            .append("UPDATE ").append(entityInfo.name) //
-                            .append(' ').append(o) //
-                            .append(" SET ");
+                            .append("UPDATE ").append(entityInfo.name);
+            if (o != THIS)
+                q.append(' ').append(o);
+            q.append(" SET ");
 
             boolean first = true;
             for (String name : entityInfo.attributeNamesForEntityUpdate) {
@@ -3330,8 +3353,9 @@ public class QueryInfo {
 
             q = new StringBuilder(100) //
                             .append("SELECT ").append(o) //
-                            .append(" FROM ").append(entityInfo.name) //
-                            .append(' ').append(o);
+                            .append(" FROM ").append(entityInfo.name);
+            if (o != THIS)
+                q.append(' ').append(o);
         }
 
         hasWhere = true;
@@ -3442,7 +3466,7 @@ public class QueryInfo {
     }
 
     @Trivial
-    private String getAttributeName(String name, boolean failIfNotFound) {
+    private String getAttributeName(final String name, final boolean failIfNotFound) {
         String attributeName;
         int len = name.length();
         if (len > 6 && name.charAt(len - 1) == ')') {
@@ -3503,24 +3527,34 @@ public class QueryInfo {
                     // tolerate possible mixture of . and _ separators with lack of separators:
                     lowerName = lowerName.replace("_", "");
                     attributeName = entityInfo.attributeNames.get(lowerName);
-                    if (attributeName == null && failIfNotFound) {
-                        if (Util.hasOperationAnno(method, producer))
-                            throw exc(MappingException.class,
-                                      "CWWKD1010.unknown.entity.attr",
-                                      name,
-                                      entityInfo.getType().getName(),
-                                      method.getName(),
-                                      repositoryInterface.getName(),
-                                      entityInfo.attributeTypes.keySet());
-                        else
-                            throw exc(MappingException.class,
-                                      "CWWKD1091.method.name.parse.err",
-                                      name,
-                                      entityInfo.getType().getName(),
-                                      method.getName(),
-                                      repositoryInterface.getName(),
-                                      Util.operationAnnoNames(producer),
-                                      entityInfo.attributeTypes.keySet());
+                    if (attributeName == null) {
+                        boolean nameCharsOnly = true;
+                        for (int i = 0; nameCharsOnly && i < lowerName.length(); i++)
+                            nameCharsOnly &= Character //
+                                            .isJavaIdentifierPart(lowerName.charAt(i));
+                        if (!nameCharsOnly)
+                            // allow functions, such as: length * width
+                            attributeName = name;
+
+                        if (nameCharsOnly && failIfNotFound) {
+                            if (Util.hasOperationAnno(method, producer))
+                                throw exc(MappingException.class,
+                                          "CWWKD1010.unknown.entity.attr",
+                                          name,
+                                          entityInfo.getType().getName(),
+                                          method.getName(),
+                                          repositoryInterface.getName(),
+                                          entityInfo.attributeTypes.keySet());
+                            else
+                                throw exc(MappingException.class,
+                                          "CWWKD1091.method.name.parse.err",
+                                          name,
+                                          entityInfo.getType().getName(),
+                                          method.getName(),
+                                          repositoryInterface.getName(),
+                                          Util.operationAnnoNames(producer),
+                                          entityInfo.attributeTypes.keySet());
+                        }
                     }
                 }
             }
@@ -3546,6 +3580,15 @@ public class QueryInfo {
                 if (trace && tc.isDebugEnabled())
                     Tr.debug(this, tc, "getCursorValues for " + loggable(entity),
                              accessors);
+                if (accessors == null)
+                    throw exc(MappingException.class,
+                              "CWWKD1123.sort.incompat.with.cursor",
+                              method.getName(),
+                              repositoryInterface.getName(),
+                              sort.property(),
+                              "Cursor.forKey",
+                              entityInfo.getType().getName(),
+                              entityInfo.attributeTypes.keySet());
                 Object value = entity;
                 for (Member accessor : accessors)
                     if (accessor instanceof Method)
@@ -3784,7 +3827,9 @@ public class QueryInfo {
                 if (q == null)
                     if (jpql == null) {
                         q = generateSelectClause();
-                        q.append(" FROM ").append(entityInfo.name).append(' ').append(entityVar);
+                        q.append(" FROM ").append(entityInfo.name);
+                        if (entityVar != THIS)
+                            q.append(' ').append(entityVar);
                         if (countPages)
                             generateCount(null);
                     } else {
@@ -3958,7 +4003,7 @@ public class QueryInfo {
                               "UPDATE [entity_name] SET [update_items] WHERE [conditional_expression]");
 
                 entityVar = parseIdentificationVariable(startAt, length, ql);
-                entityVar_ = entityVar == "this" ? "" : (entityVar + '.');
+                entityVar_ = entityVar + '.';
             }
 
             modifyAt = parseQuery(ql, startAt, null, false, entityInfos, qlParamNames);
@@ -4082,7 +4127,9 @@ public class QueryInfo {
                 orderBy = methodName.indexOf("OrderBy", by + 2);
             }
             parseFindClause(by > 0 ? by : orderBy > 0 ? orderBy : -1);
-            q = generateSelectClause().append(" FROM ").append(entityInfo.name).append(' ').append(o);
+            q = generateSelectClause().append(" FROM ").append(entityInfo.name);
+            if (o != THIS)
+                q.append(' ').append(o);
             if (by > 0) {
                 int where = q.length();
                 generateWhereClause(methodName, by + 2, orderBy > 0 ? orderBy : methodName.length(), q);
@@ -4107,11 +4154,15 @@ public class QueryInfo {
                     orderBy = methodName.indexOf("OrderBy", by + 2);
                 }
                 type = FIND_AND_DELETE;
-                q = generateSelectClause().append(" FROM ").append(entityInfo.name).append(' ').append(o);
+                q = generateSelectClause().append(" FROM ").append(entityInfo.name);
+                if (o != THIS)
+                    q.append(' ').append(o);
                 jpqlDelete = generateDeleteById();
             } else { // DELETE
                 type = QM_DELETE;
-                q = new StringBuilder(150).append("DELETE FROM ").append(entityInfo.name).append(' ').append(o);
+                q = new StringBuilder(150).append("DELETE FROM ").append(entityInfo.name);
+                if (o != THIS)
+                    q.append(' ').append(o);
             }
 
             if (by > 0)
@@ -4126,14 +4177,18 @@ public class QueryInfo {
         } else if (methodName.startsWith("count")) {
             q = new StringBuilder(150) //
                             .append("SELECT COUNT(").append(o).append(") FROM ") //
-                            .append(entityInfo.name).append(' ').append(o);
+                            .append(entityInfo.name);
+            if (o != THIS)
+                q.append(' ').append(o);
             if (by > 0 && methodName.length() > by + 2)
                 generateWhereClause(methodName, by + 2, methodName.length(), q);
             type = COUNT;
         } else if (methodName.startsWith("exists")) {
             q = new StringBuilder(200) //
                             .append("SELECT ID(").append(o).append(") FROM ") //
-                            .append(entityInfo.name).append(' ').append(o);
+                            .append(entityInfo.name);
+            if (o != THIS)
+                q.append(' ').append(o);
             if (by > 0 && methodName.length() > by + 2)
                 generateWhereClause(methodName, by + 2, methodName.length(), q);
             type = EXISTS;
@@ -4178,17 +4233,23 @@ public class QueryInfo {
         } else if (methodTypeAnno instanceof Delete) {
             if (isFindAndDelete()) {
                 type = FIND_AND_DELETE;
-                q = generateSelectClause().append(" FROM ").append(entityInfo.name).append(' ').append(o);
+                q = generateSelectClause().append(" FROM ").append(entityInfo.name);
+                if (o != THIS)
+                    q.append(' ').append(o);
                 jpqlDelete = generateDeleteById();
             } else { // DELETE
                 type = QM_DELETE;
-                q = new StringBuilder(150).append("DELETE FROM ").append(entityInfo.name).append(' ').append(o);
+                q = new StringBuilder(150).append("DELETE FROM ").append(entityInfo.name);
+                if (o != THIS)
+                    q.append(' ').append(o);
             }
             if (method.getParameterCount() > 0)
                 generateParamBasedQuery(q, methodTypeAnno, countPages);
         } else if ("Count".equals(methodTypeAnno.annotationType().getSimpleName())) {
             type = COUNT;
-            q = new StringBuilder(150).append("SELECT COUNT(").append(o).append(") FROM ").append(entityInfo.name).append(' ').append(o);
+            q = new StringBuilder(150).append("SELECT COUNT(").append(o).append(") FROM ").append(entityInfo.name);
+            if (o != THIS)
+                q.append(' ').append(o);
             if (method.getParameterCount() > 0)
                 generateParamBasedQuery(q, methodTypeAnno, countPages);
         } else if ("Exists".equals(methodTypeAnno.annotationType().getSimpleName())) {
@@ -4196,7 +4257,9 @@ public class QueryInfo {
             validateReturnForExists();
             q = new StringBuilder(200) //
                             .append("SELECT ID(").append(o).append(") FROM ") //
-                            .append(entityInfo.name).append(' ').append(o);
+                            .append(entityInfo.name);
+            if (o != THIS)
+                q.append(' ').append(o);
             if (method.getParameterCount() > 0)
                 generateParamBasedQuery(q, methodTypeAnno, countPages);
         } else {
@@ -4869,7 +4932,7 @@ public class QueryInfo {
                                           "DELETE FROM [entity_name] WHERE [conditional_expression]");
 
                             entityVar = parseIdentificationVariable(i, length, ql);
-                            entityVar_ = entityVar == "this" ? "" : (entityVar + '.');
+                            entityVar_ = entityVar + '.';
                             initEntityVar = false;
                         }
                         i--; // balances loop increment when already positioned correctly
@@ -4965,8 +5028,8 @@ public class QueryInfo {
         }
 
         if (initEntityVar) {
-            entityVar = "this";
-            entityVar_ = "";
+            entityVar = THIS;
+            entityVar_ = THIS + ".";
         }
 
         if (paramName != null)

--- a/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat/test-applications/DataTestApp/src/test/jakarta/data/web/DataTestServlet.java
@@ -652,6 +652,217 @@ public class DataTestServlet extends FATServlet {
     }
 
     /**
+     * To a Query by Method Name repository method that returns CursoredPages
+     * of results, supply sort criteria that includes a computation rather than
+     * sorting by a single entity attribute.
+     */
+    @Test
+    public void testComputationInOrderArgOfMethodThatReturnsCursoredPage() {
+
+        // prime  bits   sumOfbits numeral  p/s  p-2s
+        // ------ ------ --------- -------- ---- ----
+        //  3     000011     2     iii        1   -1
+        //  5     000101     2     v          2    1
+        //  7     000111     3     vii        2    1
+        // 11     001011     3     XI         3    5
+        // 13     001101     3     XIII       4    7
+        // 23     010111     4     XXIII      5   15
+        // 19     010011     3     XIX        6   13
+        // 31     011111     5     XXXI       6   21
+        // 29     011101     4     XXIX       7   21
+        // 17     010001     2     XVII       8   13
+        // 47     101111     5     XLVII      9   37
+        // 43     101011     4     XLIII     10   35
+        // 37     100101     3     XXXVII    12   31
+        // 41     101001     3     XLI       13   35
+
+        Order<Prime> order = Order.by(Sort.asc("numberId / sumOfBits"),
+                                      Sort.asc("numberId - 2 * sumOfBits"),
+                                      Sort.asc(ID));
+
+        PageRequest page1Req = PageRequest.ofSize(7);
+
+        CursoredPage<Prime> page1 = primes //
+                        .findByNumberIdBetweenAndEvenFalse(1,
+                                                           50,
+                                                           page1Req,
+                                                           order);
+
+        assertEquals(2, page1.totalPages());
+
+        assertEquals(List.of(3L, 5L, 7L, 11L, 13L, 23L, 19L),
+                     page1.stream()
+                                     .map(p -> p.numberId)
+                                     .toList());
+
+        Prime last = page1.content().get(page1.numberOfElements() - 1);
+
+        Cursor cursorNext = Cursor.forKey(last.numberId / last.sumOfBits,
+                                          last.numberId - 2 * last.sumOfBits,
+                                          last.numberId);
+
+        PageRequest page2Req = PageRequest.ofPage(2).size(7).afterCursor(cursorNext);
+
+        Page<Prime> page2 = primes //
+                        .findByNumberIdBetweenAndEvenFalse(1,
+                                                           50,
+                                                           page2Req,
+                                                           order);
+
+        assertEquals(14, page2.totalElements());
+
+        assertEquals(List.of(31L, 29L, 17L, 47L, 43L, 37L, 41L),
+                     page2.stream()
+                                     .map(p -> p.numberId)
+                                     .toList());
+
+        assertEquals(false, page2.hasNext());
+
+        Prime prime29 = page2.content().get(1);
+        assertEquals(29L, prime29.numberId);
+        Cursor cursor29 = Cursor.forKey(prime29.numberId / prime29.sumOfBits,
+                                        prime29.numberId - 2 * prime29.sumOfBits,
+                                        prime29.numberId);
+
+        PageRequest before29Req = PageRequest.ofPage(2).size(7).beforeCursor(cursor29);
+
+        Page<Prime> page = primes //
+                        .findByNumberIdBetweenAndEvenFalse(1,
+                                                           50,
+                                                           before29Req,
+                                                           order);
+
+        assertEquals(14, page.totalElements());
+
+        assertEquals(List.of(5L, 7L, 11L, 13L, 23L, 19L, 31L),
+                     page.stream()
+                                     .map(p -> p.numberId)
+                                     .toList());
+
+        assertEquals(true, page.hasPrevious());
+    }
+
+    /**
+     * To a Query by Method Name repository method that returns Pages of results,
+     * supply sort criteria that includes a computation rather than sorting by a
+     * single entity attribute.
+     */
+    @Test
+    public void testComputationInOrderArgOfMethodThatReturnsPage() {
+
+        // prime  bits   sumOfbits numeral  p-2s  p/s
+        // ------ ------ --------- -------- ---- ----
+        // 47     101111     5     XLVII     37    9
+        // 41     101001     3     XLI       35   13
+        // 43     101011     4     XLIII     35   10
+        // 37     100101     3     XXXVII    31   12
+        // 29     011101     4     XXIX      21    7
+        // 31     011111     5     XXXI      21    6
+        // 23     010111     4     XXIII     15    5
+        // 17     010001     2     XVII      13    8
+        // 19     010011     3     XIX       13    6
+        // 13     001101     3     XIII       7    4
+        // 11     001011     3     XI         5    3
+
+        Sort<Prime> descByPMinus2S = Sort.desc("numberId-2*sumOfBits");
+        Sort<Prime> descByPDividedByS = Sort.desc("numberId/sumOfBits");
+
+        PageRequest page1req = PageRequest.ofSize(5);
+
+        Order<Prime> order = Order.by(descByPMinus2S,
+                                      descByPDividedByS);
+
+        Page<Prime> page1;
+        page1 = primes.findByRomanNumeralEndsWithAndNumberIdLessThan("X%I%",
+                                                                     50,
+                                                                     page1req,
+                                                                     order);
+
+        assertEquals(11, page1.totalElements());
+
+        assertEquals(List.of(47L, 41L, 43L, 37L, 29L),
+                     page1.stream()
+                                     .map(p -> p.numberId)
+                                     .toList());
+
+        // Request page 2 with separate Order and Sort that achieve an equivalent order
+        order = Order.by(descByPMinus2S);
+        PageRequest page2req = page1.nextPageRequest();
+        Page<Prime> page2;
+        page2 = primes.findByRomanNumeralEndsWithAndNumberIdLessThan("X%I%",
+                                                                     50,
+                                                                     page2req,
+                                                                     order,
+                                                                     descByPDividedByS);
+
+        assertEquals(3, page2.totalPages());
+
+        assertEquals(List.of(31L, 23L, 17L, 19L, 13L),
+                     page2.stream()
+                                     .map(p -> p.numberId)
+                                     .toList());
+
+        PageRequest page3req = page2.nextPageRequest();
+        Page<Prime> page3;
+        page3 = primes.findByRomanNumeralEndsWithAndNumberIdLessThan("X%I%",
+                                                                     50,
+                                                                     page3req,
+                                                                     order,
+                                                                     descByPDividedByS);
+
+        assertEquals(List.of(11L),
+                     page3.stream()
+                                     .map(p -> p.numberId)
+                                     .toList());
+    }
+
+    /**
+     * To a Query by Method Name repository method, supply sort criteria that
+     * includes a computation rather than sorting by a single entity attribute.
+     */
+    @Test
+    public void testComputationInSortArgOfMethodNameQuery() {
+
+        Sort<Prime> sortByFunction = Sort.asc("(numberId - 8) * (numberId - 8)");
+
+        assertEquals(List.of(7L, // computes to 1
+                             5L, // computes to 9
+                             11L, // computes to 9
+                             3L, // computes to 25
+                             13L, // computes to 25
+                             17L), // computes to 81
+                     primes.findByNumberIdBetween(3,
+                                                  18,
+                                                  sortByFunction,
+                                                  Sort.asc("numberId"))
+                                     .stream()
+                                     .map(p -> p.numberId)
+                                     .toList());
+    }
+
+    /**
+     * To a Parameter-based Find repository method, supply sort criteria that
+     * includes a computation rather than sorting by a single entity attribute.
+     */
+    @Test
+    public void testComputationInSortArgOfParameterBasedFind() {
+
+        Sort<Prime> sortByFunction = Sort.asc("numberId*numberId-29*numberId+210");
+
+        assertEquals(List.of(13L, // computes to 2
+                             11L, // computes to 12
+                             19L, // computes to 20
+                             7L, // computes to 56
+                             37L), // computes to 506
+                     primes.find(false,
+                                 3,
+                                 Limit.of(5),
+                                 sortByFunction)
+                                     .map(p -> p.numberId)
+                                     .toList());
+    }
+
+    /**
      * Use a repository method that performs a JDQL query using the String
      * concatenation operator ||.
      */

--- a/dev/io.openliberty.data.internal_fat_errorpaths/fat/src/test/jakarta/data/errpaths/DataIntrospectorTest.java
+++ b/dev/io.openliberty.data.internal_fat_errorpaths/fat/src/test/jakarta/data/errpaths/DataIntrospectorTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2025 IBM Corporation and others.
+ * Copyright (c) 2025,2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -106,7 +106,7 @@ public class DataIntrospectorTest extends FATServletClient {
     @Test
     public void testOutputContainsCountQueryForPages() {
         assertLineFound("    JPQL count query: " +
-                        "SELECT COUNT(o) FROM Voter o WHERE (o.address=?1)");
+                        "SELECT COUNT(this) FROM Voter WHERE (this.address=?1)");
     }
 
     /**


### PR DESCRIPTION
Adds tests cases to cover more complex sort criteria (other than only the entity attribute name).
Adds an error message for the case where a cursor for cursor-based pagination cannot be inferred.
Switches generated queries to use the implicit entity identifier `this` rather than making up an identifier of our own now that implicit entity identifiers are behaving correct in both Persistence providers.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
