### PR TITLE
Update in memory authen cache for performance issues

### DIFF
--- a/dev/com.ibm.ws.security.authentication.builtin/src/com/ibm/ws/security/authentication/internal/cache/AuthCache.java
+++ b/dev/com.ibm.ws.security.authentication.builtin/src/com/ibm/ws/security/authentication/internal/cache/AuthCache.java
@@ -1,16 +1,18 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2022 IBM Corporation and others.
+ * Copyright (c) 2021, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package com.ibm.ws.security.authentication.internal.cache;
+
+import javax.security.auth.Subject;
 
 import com.ibm.ws.security.authentication.cache.CacheObject;
 
@@ -53,4 +55,9 @@ public interface AuthCache {
      * Stop the eviction task, if any.
      */
     public void stopEvictionTask();
+
+    /**
+     * Creates a cache implementation specific CacheObject or the provided Subject
+     */
+    public CacheObject createCacheObject(Subject subject);
 }

--- a/dev/com.ibm.ws.security.authentication.builtin/src/com/ibm/ws/security/authentication/internal/cache/AuthCache.java
+++ b/dev/com.ibm.ws.security.authentication.builtin/src/com/ibm/ws/security/authentication/internal/cache/AuthCache.java
@@ -57,7 +57,7 @@ public interface AuthCache {
     public void stopEvictionTask();
 
     /**
-     * Creates a cache implementation specific CacheObject or the provided Subject
+     * Creates a cache implementation specific CacheObject for the provided Subject
      */
     public CacheObject createCacheObject(Subject subject);
 }

--- a/dev/com.ibm.ws.security.authentication.builtin/src/com/ibm/ws/security/authentication/internal/cache/AuthCacheServiceImpl.java
+++ b/dev/com.ibm.ws.security.authentication.builtin/src/com/ibm/ws/security/authentication/internal/cache/AuthCacheServiceImpl.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2022 IBM Corporation and others.
+ * Copyright (c) 2011, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -71,7 +71,7 @@ public class AuthCacheServiceImpl implements AuthCacheService, UserRegistryChang
     @Override
     public void insert(Subject subject, String userid, @Sensitive String password) {
         try {
-            CacheObject cacheObject = new CacheObject(subject);
+            CacheObject cacheObject = cache.createCacheObject(subject);
             CacheContext cacheContext = new CacheContext(authCacheConfig, cacheObject, userid, password);
             commonInsert(cacheContext, cacheObject);
         } catch (Exception e) {
@@ -86,7 +86,7 @@ public class AuthCacheServiceImpl implements AuthCacheService, UserRegistryChang
     @Override
     public void insert(Subject subject, X509Certificate[] certChain) {
         try {
-            CacheObject cacheObject = new CacheObject(subject);
+            CacheObject cacheObject = cache.createCacheObject(subject);
             CacheContext cacheContext = new CacheContext(authCacheConfig, cacheObject, certChain);
             commonInsert(cacheContext, cacheObject);
         } catch (Exception e) {
@@ -103,7 +103,7 @@ public class AuthCacheServiceImpl implements AuthCacheService, UserRegistryChang
     @Override
     public void insert(Subject subject) {
         try {
-            CacheObject cacheObject = new CacheObject(subject);
+            CacheObject cacheObject = cache.createCacheObject(subject);
             CacheContext cacheContext = new CacheContext(authCacheConfig, cacheObject);
             commonInsert(cacheContext, cacheObject);
         } catch (Exception e) {

--- a/dev/com.ibm.ws.security.authentication.builtin/src/com/ibm/ws/security/authentication/internal/cache/InMemoryAuthCache.java
+++ b/dev/com.ibm.ws.security.authentication.builtin/src/com/ibm/ws/security/authentication/internal/cache/InMemoryAuthCache.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 1997, 2022 IBM Corporation and others.
+ * Copyright (c) 1997, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -19,6 +19,8 @@ import java.util.Set;
 import java.util.Timer;
 import java.util.TimerTask;
 import java.util.concurrent.ConcurrentHashMap;
+
+import javax.security.auth.Subject;
 
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
@@ -304,5 +306,10 @@ public class InMemoryAuthCache implements AuthCache, FFDCSelfIntrospectable {
                               "entryLimit = " + entryLimit,
                               "cacheEvictionListenerSet = " + cacheEvictionListenerSet,
                               "timer = " + timer };
+    }
+
+    @Override
+    public CacheObject createCacheObject(Subject subject) {
+        return new InMemoryCacheObject(subject);
     }
 }

--- a/dev/com.ibm.ws.security.authentication.builtin/src/com/ibm/ws/security/authentication/internal/cache/InMemoryCacheObject.java
+++ b/dev/com.ibm.ws.security.authentication.builtin/src/com/ibm/ws/security/authentication/internal/cache/InMemoryCacheObject.java
@@ -1,0 +1,59 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package com.ibm.ws.security.authentication.internal.cache;
+
+import java.security.Principal;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+import javax.security.auth.Subject;
+
+import com.ibm.ws.security.authentication.cache.CacheObject;
+
+/**
+ * This subclass doesn't return the same Subject object each time, but instead makes a new Subject each time
+ * so that threads do not block getting information from the Subject since the Subject class is heavily synchronized
+ */
+public final class InMemoryCacheObject extends CacheObject {
+
+    private static final long serialVersionUID = 1L;
+
+    private transient final Set<Principal> principals;
+
+    private transient final Set<Object> publicCredentials;
+
+    private transient final Set<Object> privateCredentials;
+
+    /**
+     * @param subject
+     */
+    InMemoryCacheObject(Subject subject) {
+        super(subject);
+        // save off the principals and credentials so that we are not doing synchronization logic when returning
+        // the Subject with the overridden getSubject() method
+        if (subject == null) {
+            principals = null;
+            publicCredentials = null;
+            privateCredentials = null;
+        } else {
+            principals = Collections.unmodifiableSet(new HashSet<Principal>(subject.getPrincipals()));
+            publicCredentials = Collections.unmodifiableSet(new HashSet<Object>(subject.getPublicCredentials()));
+            privateCredentials = Collections.unmodifiableSet(new HashSet<Object>(subject.getPrivateCredentials()));
+        }
+    }
+
+    @Override
+    public Subject getSubject() {
+        Subject cachedSubject = super.getSubject();
+        // Need to return a new Subject instance so that multiple threads are not trying to access the same Subject instance
+        return cachedSubject == null ? null : new Subject(cachedSubject.isReadOnly(), principals, publicCredentials, privateCredentials);
+    }
+}

--- a/dev/com.ibm.ws.security.authentication.builtin/src/com/ibm/ws/security/authentication/internal/cache/JCacheAuthCache.java
+++ b/dev/com.ibm.ws.security.authentication.builtin/src/com/ibm/ws/security/authentication/internal/cache/JCacheAuthCache.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2022 IBM Corporation and others.
+ * Copyright (c) 2021, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -16,6 +16,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 import javax.cache.Cache;
+import javax.security.auth.Subject;
 
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
@@ -284,5 +285,10 @@ public class JCacheAuthCache implements AuthCache {
         if (inMemoryCache != null) {
             inMemoryCache.stopEvictionTask();
         }
+    }
+
+    @Override
+    public CacheObject createCacheObject(Subject subject) {
+        return new CacheObject(subject);
     }
 }

--- a/dev/com.ibm.ws.security.authentication.builtin/test/com/ibm/ws/security/authentication/internal/cache/AuthCacheServiceTest.java
+++ b/dev/com.ibm.ws.security.authentication.builtin/test/com/ibm/ws/security/authentication/internal/cache/AuthCacheServiceTest.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2022 IBM Corporation and others.
+ * Copyright (c) 2011, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -12,9 +12,10 @@
  *******************************************************************************/
 package com.ibm.ws.security.authentication.internal.cache;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -173,7 +174,8 @@ public class AuthCacheServiceTest {
 
             Subject actualSubject = authCacheService.getSubject(getSSOTokenCacheKey(testSubject));
 
-            assertSame("The subject must be found in the cache by its SSO token.", testSubject, actualSubject);
+            assertEquals("The subject must be found in the cache by its SSO token.", testSubject, actualSubject);
+            assertNotSame("The subject must be a new instance when returned from the cache.", testSubject, actualSubject);
         } catch (Throwable t) {
             outputMgr.failWithThrowable(methodName, t);
         }
@@ -220,7 +222,8 @@ public class AuthCacheServiceTest {
 
             Subject actualSubject = authCacheService.getSubject(basicAuthCacheKey);
 
-            assertSame("The subject must be found in the cache by its <realm>:<userid>:<hashedPassword>", testSubject, actualSubject);
+            assertEquals("The subject must be found in the cache by its <realm>:<userid>:<hashedPassword>.", testSubject, actualSubject);
+            assertNotSame("The subject must be a new instance when returned from the cache.", testSubject, actualSubject);
         } catch (Throwable t) {
             outputMgr.failWithThrowable(methodName, t);
         }
@@ -251,8 +254,8 @@ public class AuthCacheServiceTest {
             Subject actualSubject = null;
             for (Object lookupKey : lookupKeys) {
                 actualSubject = authCacheService.getSubject(lookupKey);
-                assertSame("The subject must be found in the cache when using the " + lookupKey + " key.",
-                           testSubject, actualSubject);
+                assertEquals("The subject must be found in the cache when using the " + lookupKey + " key.", testSubject, actualSubject);
+                assertNotSame("The subject must be a new instance when returned from the cache.", testSubject, actualSubject);
             }
         } catch (Throwable t) {
             outputMgr.failWithThrowable(methodName, t);
@@ -289,7 +292,8 @@ public class AuthCacheServiceTest {
             authCacheService.insert(testSubject, testUser, testPassword);
             actualSubject = authCacheService.getSubject(basicAuthCacheKey);
 
-            assertSame("The subject must be found in the cache.", testSubject, actualSubject);
+            assertEquals("The subject must be found in the cache.", testSubject, actualSubject);
+            assertNotSame("The subject must be a new instance when returned from the cache.", testSubject, actualSubject);
         } catch (Throwable t) {
             outputMgr.failWithThrowable(methodName, t);
         }
@@ -330,7 +334,8 @@ public class AuthCacheServiceTest {
 
             SingleSignonToken ssoToken = getSSOToken(testSubject);
             Subject actualSubject = authCacheService.getSubject(getSSOTokenCacheKey(ssoToken));
-            assertSame("The subject must still be found in the cache.", testSubject, actualSubject);
+            assertEquals("The subject must still be found in the cache.", testSubject, actualSubject);
+            assertNotSame("The subject must be a new instance when returned from the cache.", testSubject, actualSubject);
         } catch (Throwable t) {
             outputMgr.failWithThrowable(methodName, t);
         }
@@ -405,7 +410,8 @@ public class AuthCacheServiceTest {
 
             Subject actualSubject = authCacheService.getSubject(invalidSubjectLookupKey);
 
-            assertSame("The subject must still be found in the cache.", invalidSubject, actualSubject);
+            assertEquals("The subject must still be found in the cache.", invalidSubject, actualSubject);
+            assertNotSame("The subject must be a new instance when returned from the cache.", invalidSubject, actualSubject);
         } catch (Throwable t) {
             outputMgr.failWithThrowable(methodName, t);
         }

--- a/dev/com.ibm.ws.security.authentication.builtin/test/com/ibm/ws/security/authentication/internal/cache/InMemoryCacheTest.java
+++ b/dev/com.ibm.ws.security.authentication.builtin/test/com/ibm/ws/security/authentication/internal/cache/InMemoryCacheTest.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2010, 2022 IBM Corporation and others.
+ * Copyright (c) 2010, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -82,7 +82,7 @@ public class InMemoryCacheTest {
         });
         InMemoryAuthCache cache = new InMemoryAuthCache(0, 0, defaultTimeoutInMilliSeconds, mockCacheEvictionListenerSet);
         registeredCachesForStoppingEvictionTasks.add(cache);
-        cache.insert("1", new CacheObject(null));
+        cache.insert("1", cache.createCacheObject(null));
     }
 
     /**
@@ -101,7 +101,7 @@ public class InMemoryCacheTest {
         });
         InMemoryAuthCache cache = new InMemoryAuthCache(0, 0, 5, mockCacheEvictionListenerSet);
         registeredCachesForStoppingEvictionTasks.add(cache);
-        cache.insert("1", new CacheObject(null));
+        cache.insert("1", cache.createCacheObject(null));
     }
 
     /**
@@ -122,10 +122,10 @@ public class InMemoryCacheTest {
         });
         InMemoryAuthCache cache = new InMemoryAuthCache(0, 1, defaultTimeoutInMilliSeconds, mockCacheEvictionListenerSet);
         registeredCachesForStoppingEvictionTasks.add(cache);
-        cache.insert("1", new CacheObject(null));
-        cache.insert("2", new CacheObject(null));
-        cache.insert("3", new CacheObject(null));
-        cache.insert("4", new CacheObject(null));
+        cache.insert("1", cache.createCacheObject(null));
+        cache.insert("2", cache.createCacheObject(null));
+        cache.insert("3", cache.createCacheObject(null));
+        cache.insert("4", cache.createCacheObject(null));
     }
 
     /**
@@ -165,7 +165,7 @@ public class InMemoryCacheTest {
     @Test
     public void isEvictionRequired_underByOne() {
         InMemoryAuthCache cache = new InMemoryAuthCache(10, 2, 0);
-        cache.insert("1", new CacheObject(null));
+        cache.insert("1", cache.createCacheObject(null));
         assertFalse(cache.isEvictionRequired());
     }
 
@@ -176,8 +176,8 @@ public class InMemoryCacheTest {
     @Test
     public void isEvictionRequired_equals() {
         InMemoryAuthCache cache = new InMemoryAuthCache(10, 2, 0);
-        cache.insert("1", new CacheObject(null));
-        cache.insert("2", new CacheObject(null));
+        cache.insert("1", cache.createCacheObject(null));
+        cache.insert("2", cache.createCacheObject(null));
         assertFalse(cache.isEvictionRequired());
     }
 
@@ -188,9 +188,9 @@ public class InMemoryCacheTest {
     @Test
     public void isEvictionRequired_overByOne() {
         InMemoryAuthCache cache = new InMemoryAuthCache(10, 2, 0);
-        cache.insert("1", new CacheObject(null));
-        cache.insert("2", new CacheObject(null));
-        cache.insert("3", new CacheObject(null));
+        cache.insert("1", cache.createCacheObject(null));
+        cache.insert("2", cache.createCacheObject(null));
+        cache.insert("3", cache.createCacheObject(null));
         assertTrue(cache.isEvictionRequired());
     }
 
@@ -217,7 +217,7 @@ public class InMemoryCacheTest {
         evictionListeners.add(cacheEvictionListener);
 
         InMemoryAuthCache cache = new InMemoryAuthCache(10, Integer.MAX_VALUE, 0, evictionListeners);
-        cache.insert("1", new CacheObject(new Subject()));
+        cache.insert("1", cache.createCacheObject(new Subject()));
         cache.evictStaleEntries();
         cache.evictStaleEntries();
         cache.evictStaleEntries();


### PR DESCRIPTION
- The in memory authentication cache today caches Subject objects to avoid having to authenticate the same user over and over.
- Before this change, the same cached Subject was returned which can cause concurrency issues if multiple requests are using the same user to authenticate.  The problem occurs if the Subject object is used to get information about the principal or credentials in the Subject because those operations are synchronized.
- With this change the in memory authentication cache now returns a copy of the Subject instead of the same exact instance so that threads can operate independently even if they are processing requires for the same user.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
