### PR TITLE
Explicitly enable the use of an in memory identity store via external

### DIFF
--- a/dev/com.ibm.ws.webcontainer.security.admin/src/com/ibm/ws/webcontainer/security/admin/internal/WebAdminSecurityConfigImpl.java
+++ b/dev/com.ibm.ws.webcontainer.security.admin/src/com/ibm/ws/webcontainer/security/admin/internal/WebAdminSecurityConfigImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 IBM Corporation and others.
+ * Copyright (c) 2011, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -342,4 +342,15 @@ class WebAdminSecurityConfigImpl implements WebAppSecurityConfig {
         else
             return postParamMaxRequestBodySize;
     }
+	
+    /** {@inheritDoc} */
+    @Override
+    public boolean getAllowInMemoryIdentityStores() { 
+        WebAppSecurityConfig globalConfig = WebAppSecurityCollaboratorImpl.getGlobalWebAppSecurityConfig();
+        if (globalConfig != null) {
+            return globalConfig.getAllowInMemoryIdentityStores();
+        } else {
+            return false;
+        }
+    }	
 }

--- a/dev/com.ibm.ws.webcontainer.security.app/resources/OSGI-INF/l10n/metatype.properties
+++ b/dev/com.ibm.ws.webcontainer.security.app/resources/OSGI-INF/l10n/metatype.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2011, 2024 IBM Corporation and others.
+# Copyright (c) 2011, 2026 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -126,3 +126,7 @@ partitionedCookie.desc=Specifies whether to partition SSO cookies with SameSite 
 partitionedCookieTrue=Always partition SSO cookies that have SameSite set to None.
 partitionedCookieFalse=Do not partition SSO cookies.
 partitionedCookieDefer=Allow the HTTP transport settings to determine whether to partition SSO cookies.
+
+allowInMemoryIdentityStores=Allow the usage of an in-memory identity store
+allowInMemoryIdentityStores.desc=When explicitly set to true and an in-memory identity store is defined within an application, the in-memory identity store is used during the authentication process.
+

--- a/dev/com.ibm.ws.webcontainer.security.app/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.webcontainer.security.app/resources/OSGI-INF/metatype/metatype.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2011, 2024 IBM Corporation and others.
+    Copyright (c) 2011, 2026 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -159,6 +159,9 @@
             ibm:final="true" name="internal" description="internal use only" />
         <AD id="loggedOutCookieCacheService.cardinality.minimum" type="String"  default="${count(loggedOutCookieCacheRef)}" 
             ibm:final="true" name="internal" description="internal use only"/>
+
+        <AD id="allowInMemoryIdentityStores" name="%allowInMemoryIdentityStores" description="%allowInMemoryIdentityStores.desc"
+            required="false" type="Boolean" default="false" ibm:beta="true"/>
             
     </OCD>
     <Designate pid="com.ibm.ws.webcontainer.security.WebAppSecurityCollaboratorImpl">

--- a/dev/com.ibm.ws.webcontainer.security.feature/src/com/ibm/ws/webcontainer/security/feature/internal/FeatureWebSecurityConfigImpl.java
+++ b/dev/com.ibm.ws.webcontainer.security.feature/src/com/ibm/ws/webcontainer/security/feature/internal/FeatureWebSecurityConfigImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 IBM Corporation and others.
+ * Copyright (c) 2011, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -450,4 +450,15 @@ class FeatureWebSecurityConfigImpl implements WebAppSecurityConfig {
         else
             return postParamMaxRequestBodySize;
     }
+    
+    /** {@inheritDoc} */
+    @Override
+    public boolean getAllowInMemoryIdentityStores() { 
+        WebAppSecurityConfig globalConfig = WebAppSecurityCollaboratorImpl.getGlobalWebAppSecurityConfig();
+        if (globalConfig != null) {
+            return globalConfig.getAllowInMemoryIdentityStores();
+        } else {
+            return false;
+        }
+    }	
 }

--- a/dev/com.ibm.ws.webcontainer.security/src/com/ibm/ws/webcontainer/security/WebAppSecurityConfig.java
+++ b/dev/com.ibm.ws.webcontainer.security/src/com/ibm/ws/webcontainer/security/WebAppSecurityConfig.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 IBM Corporation and others.
+ * Copyright (c) 2011, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -162,4 +162,11 @@ public interface WebAppSecurityConfig {
     boolean isUseContextRootForSSOCookiePath();
 
     long postParamMaxRequestBodySize();
+
+    /**
+     * Check if in memory identity stores have been explicitly enabled.
+     *
+     * @return true if in memory identity stores have been explicitly enabled, false else.
+     */
+    boolean getAllowInMemoryIdentityStores();
 }

--- a/dev/com.ibm.ws.webcontainer.security/src/com/ibm/ws/webcontainer/security/internal/WebAppSecurityConfigImpl.java
+++ b/dev/com.ibm.ws.webcontainer.security/src/com/ibm/ws/webcontainer/security/internal/WebAppSecurityConfigImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 IBM Corporation and others.
+ * Copyright (c) 2011, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -73,6 +73,7 @@ public class WebAppSecurityConfigImpl implements WebAppSecurityConfig {
     public static final String CFG_KEY_PARTITIONED_COOKIE = "partitionedCookie";
     public static final String CFG_KEY_USE_CONTEXT_ROOT_FOR_SSO_COOKIE_PATH = "useContextRootForSSOCookiePath";
     public static final String CFG_KEY_MAX_CONTENT_LENGTH_TO_SAVE_POST_PARAMETERS = "postParamMaxRequestBodySize";
+    public static final String CFG_KEY_ALLOW_IN_MEMORY_IDENTITY_STORES = "allowInMemoryIdentityStores";
 
     // New attributes must update getChangedProperties method
     private final Boolean logoutOnHttpSessionExpire;
@@ -107,6 +108,7 @@ public class WebAppSecurityConfigImpl implements WebAppSecurityConfig {
     private Boolean partitionedCookie = null; // in BETA, mark as final once GA'ed
     private final Boolean useContextRootForSSOCookiePath;
     private final Long postParamMaxRequestBodySize;
+    private final Boolean allowInMemoryIdentityStores;
 
     protected final AtomicServiceReference<WsLocationAdmin> locationAdminRef;
     protected final AtomicServiceReference<SecurityService> securityServiceRef;
@@ -149,6 +151,7 @@ public class WebAppSecurityConfigImpl implements WebAppSecurityConfig {
             put(CFG_KEY_PARTITIONED_COOKIE, "partitionedCookie");
             put(CFG_KEY_USE_CONTEXT_ROOT_FOR_SSO_COOKIE_PATH, "useContextRootForSSOCookiePath");
             put(CFG_KEY_MAX_CONTENT_LENGTH_TO_SAVE_POST_PARAMETERS, "postParamMaxRequestBodySize");
+            put(CFG_KEY_ALLOW_IN_MEMORY_IDENTITY_STORES, "allowInMemoryIdentityStores");
         }
     };
 
@@ -194,9 +197,10 @@ public class WebAppSecurityConfigImpl implements WebAppSecurityConfig {
         sameSiteCookie = (String) newProperties.get(CFG_KEY_SAME_SITE_COOKIE);
         useContextRootForSSOCookiePath = (Boolean) newProperties.get(CFG_KEY_USE_CONTEXT_ROOT_FOR_SSO_COOKIE_PATH);
         postParamMaxRequestBodySize = (Long) newProperties.get(CFG_KEY_MAX_CONTENT_LENGTH_TO_SAVE_POST_PARAMETERS);
+        allowInMemoryIdentityStores = (Boolean) newProperties.get(CFG_KEY_ALLOW_IN_MEMORY_IDENTITY_STORES);
 
         String partValue = (String) newProperties.get(CFG_KEY_PARTITIONED_COOKIE);
-        if ("true".equalsIgnoreCase(partValue)||"false".equalsIgnoreCase(partValue)) {
+        if ("true".equalsIgnoreCase(partValue) || "false".equalsIgnoreCase(partValue)) {
             // we want partitionedCookie to be null unless the value is true or false
             // defer is the default value which mean that the channel config determines the partitioned value
             // if the value is true / false then this config was explicltly set by the user
@@ -615,8 +619,8 @@ public class WebAppSecurityConfigImpl implements WebAppSecurityConfig {
 
     @Override
     public boolean isPartitionedCookie() {
-        if (partitionedCookie!=null && partitionedCookie==Boolean.TRUE) {
-          return true;
+        if (partitionedCookie != null && partitionedCookie == Boolean.TRUE) {
+            return true;
         }
         return false;
     }
@@ -631,17 +635,22 @@ public class WebAppSecurityConfigImpl implements WebAppSecurityConfig {
         return postParamMaxRequestBodySize.longValue();
     }
 
+    @Override
+    public boolean getAllowInMemoryIdentityStores() {
+        return allowInMemoryIdentityStores != null ? allowInMemoryIdentityStores.booleanValue() : false;
+    }
+
     // This method is for config users that need to know if an admin has provided a true/false or no value for a
     // boolean config attribute.  The current infrastructure does not properly support this
     public static Boolean getBooleanValue(String attribute, String strValue) {
-      Boolean retVal = null;
-      if (strValue!=null && strValue.length()>0) {
-        //only values that config gives us are true/false/defer
-        if ("true".equalsIgnoreCase(strValue) || "false".equalsIgnoreCase(strValue)) {
-          retVal = Boolean.valueOf(strValue);
-        } 
-      }
-      return(retVal);
+        Boolean retVal = null;
+        if (strValue != null && strValue.length() > 0) {
+            //only values that config gives us are true/false/defer
+            if ("true".equalsIgnoreCase(strValue) || "false".equalsIgnoreCase(strValue)) {
+                retVal = Boolean.valueOf(strValue);
+            }
+        }
+        return (retVal);
     }
 
 }

--- a/dev/com.ibm.ws.webcontainer.security/test/com/ibm/ws/webcontainer/security/internal/WebAppSecurityConfigImplTest.java
+++ b/dev/com.ibm.ws.webcontainer.security/test/com/ibm/ws/webcontainer/security/internal/WebAppSecurityConfigImplTest.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 IBM Corporation and others.
+ * Copyright (c) 2017, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -193,7 +193,7 @@ public class WebAppSecurityConfigImplTest {
         WebAppSecurityConfig webCfg = new WebAppSecurityConfigImpl(createMapChanged(), locationAdminRef, securityServiceRef, null, null);
 
         assertEquals("When all settings have changed, all should be listed",
-                     "allowFailOverToBasicAuth=false,autoGenSsoCookieName=true,basicAuthenticationMechanismRealmName=newRealm,contextRootForFormAuthenticationMechanism=/modified,displayAuthenticationRealm=true,loginErrorURL=modifiedLoginError,overrideHttpAuthMethod=modified,ssoCookieName=mySSOCookie,ssoDomainNames=,webAlwaysLogin=false",
+                     "allowFailOverToBasicAuth=false,allowInMemoryIdentityStores=true,autoGenSsoCookieName=true,basicAuthenticationMechanismRealmName=newRealm,contextRootForFormAuthenticationMechanism=/modified,displayAuthenticationRealm=true,loginErrorURL=modifiedLoginError,overrideHttpAuthMethod=modified,ssoCookieName=mySSOCookie,ssoDomainNames=,webAlwaysLogin=false",
                      webCfg.getChangedProperties(webCfgOld));
     }
 
@@ -220,6 +220,7 @@ public class WebAppSecurityConfigImplTest {
                 put("contextRootForFormAuthenticationMechanism", "/original");
                 put("basicAuthenticationMechanismRealmName", "realm");
                 put("overrideHttpAuthMethod", "original");
+                put("allowInMemoryIdentityStores", Boolean.FALSE);
             }
         };
         return cfg;
@@ -238,6 +239,7 @@ public class WebAppSecurityConfigImplTest {
                 put("contextRootForFormAuthenticationMechanism", "/modified");
                 put("basicAuthenticationMechanismRealmName", "newRealm");
                 put("overrideHttpAuthMethod", "modified");
+                put("allowInMemoryIdentityStores", Boolean.TRUE);
             }
         };
         return cfg;
@@ -473,8 +475,8 @@ public class WebAppSecurityConfigImplTest {
     public void testPartitioned_notSet() {
         Map<String, Object> cfg = new HashMap<String, Object>();
         WebAppSecurityConfig webCfg = new WebAppSecurityConfigImpl(cfg, locationAdminRef, securityServiceRef, null, null);
-        assertNull("Partitioned value should be null, but is ["+webCfg.getPartitionedCookie()+"]", webCfg.getPartitionedCookie());
-        assertEquals("isPartitioned value should be false, but is ["+webCfg.isPartitionedCookie()+"]", false, webCfg.isPartitionedCookie());
+        assertNull("Partitioned value should be null, but is [" + webCfg.getPartitionedCookie() + "]", webCfg.getPartitionedCookie());
+        assertEquals("isPartitioned value should be false, but is [" + webCfg.isPartitionedCookie() + "]", false, webCfg.isPartitionedCookie());
     }
 
     //defer is same as not set
@@ -483,10 +485,10 @@ public class WebAppSecurityConfigImplTest {
         final String PART_NAME = "partitionedCookie";
         final String PART_VALUE = "Defer";
         Map<String, Object> cfg = new HashMap<String, Object>();
-        cfg.put(PART_NAME,PART_VALUE);
+        cfg.put(PART_NAME, PART_VALUE);
         WebAppSecurityConfig webCfg = new WebAppSecurityConfigImpl(cfg, locationAdminRef, securityServiceRef, null, null);
-        assertNull("Partitioned value should be null, but is ["+webCfg.getPartitionedCookie()+"]", webCfg.getPartitionedCookie());
-        assertEquals("isPartitioned value should be false, but is ["+webCfg.isPartitionedCookie()+"]", false, webCfg.isPartitionedCookie());
+        assertNull("Partitioned value should be null, but is [" + webCfg.getPartitionedCookie() + "]", webCfg.getPartitionedCookie());
+        assertEquals("isPartitioned value should be false, but is [" + webCfg.isPartitionedCookie() + "]", false, webCfg.isPartitionedCookie());
     }
 
     @Test
@@ -494,10 +496,10 @@ public class WebAppSecurityConfigImplTest {
         final String PART_NAME = "partitionedCookie";
         final String PART_VALUE = "true";
         Map<String, Object> cfg = new HashMap<String, Object>();
-        cfg.put(PART_NAME,PART_VALUE);
+        cfg.put(PART_NAME, PART_VALUE);
         WebAppSecurityConfig webCfg = new WebAppSecurityConfigImpl(cfg, locationAdminRef, securityServiceRef, null, null);
-        assertEquals("Partitioned value should be TRUE, but is ["+webCfg.getPartitionedCookie()+"]", Boolean.TRUE, webCfg.getPartitionedCookie());
-        assertTrue("isPartitioned value should be true, but is ["+webCfg.isPartitionedCookie()+"]", webCfg.isPartitionedCookie());
+        assertEquals("Partitioned value should be TRUE, but is [" + webCfg.getPartitionedCookie() + "]", Boolean.TRUE, webCfg.getPartitionedCookie());
+        assertTrue("isPartitioned value should be true, but is [" + webCfg.isPartitionedCookie() + "]", webCfg.isPartitionedCookie());
     }
 
     @Test
@@ -505,10 +507,39 @@ public class WebAppSecurityConfigImplTest {
         final String PART_NAME = "partitionedCookie";
         final String PART_VALUE = "false";
         Map<String, Object> cfg = new HashMap<String, Object>();
-        cfg.put(PART_NAME,PART_VALUE);
+        cfg.put(PART_NAME, PART_VALUE);
         WebAppSecurityConfig webCfg = new WebAppSecurityConfigImpl(cfg, locationAdminRef, securityServiceRef, null, null);
-        assertEquals("Partitioned value should be FALSE, but is ["+webCfg.getPartitionedCookie()+"]", Boolean.FALSE, webCfg.getPartitionedCookie());
-        assertEquals("isPartitioned value should be false, but is ["+webCfg.isPartitionedCookie()+"]", false, webCfg.isPartitionedCookie());
+        assertEquals("Partitioned value should be FALSE, but is [" + webCfg.getPartitionedCookie() + "]", Boolean.FALSE, webCfg.getPartitionedCookie());
+        assertEquals("isPartitioned value should be false, but is [" + webCfg.isPartitionedCookie() + "]", false, webCfg.isPartitionedCookie());
+    }
+
+    @Test
+    public void getChangedProperties_allowInMemoryIdentityStores() {
+        driveSingleAttributeTest("allowInMemoryIdentityStores",
+                                 Boolean.TRUE, Boolean.FALSE);
+    }
+
+    @Test
+    public void testGetAllowInMemoryIdentityStores_NotSet() {
+        Map<String, Object> cfg = new HashMap<String, Object>();
+        WebAppSecurityConfig webCfg = new WebAppSecurityConfigImpl(cfg, locationAdminRef, securityServiceRef, null, null);
+        assertEquals("False should be returned since the value is not set.", false, webCfg.getAllowInMemoryIdentityStores());
+    }
+
+    @Test
+    public void testGetAllowInMemoryIdentityStores_True() {
+        Map<String, Object> cfg = new HashMap<String, Object>();
+        cfg.put("allowInMemoryIdentityStores", Boolean.TRUE);
+        WebAppSecurityConfig webCfg = new WebAppSecurityConfigImpl(cfg, locationAdminRef, securityServiceRef, null, null);
+        assertEquals("True should be returned.", true, webCfg.getAllowInMemoryIdentityStores());
+    }
+
+    @Test
+    public void testGetAllowInMemoryIdentityStores_False() {
+        Map<String, Object> cfg = new HashMap<String, Object>();
+        cfg.put("allowInMemoryIdentityStores", Boolean.FALSE);
+        WebAppSecurityConfig webCfg = new WebAppSecurityConfigImpl(cfg, locationAdminRef, securityServiceRef, null, null);
+        assertEquals("False should be returned.", false, webCfg.getAllowInMemoryIdentityStores());
     }
 
     /**

--- a/dev/io.openliberty.security.jakartasec.4.0.internal.cdi/src/io/openliberty/security/jakartasec/cdi/extensions/JakartaSecurity40CDIExtension.java
+++ b/dev/io.openliberty.security.jakartasec.4.0.internal.cdi/src/io/openliberty/security/jakartasec/cdi/extensions/JakartaSecurity40CDIExtension.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2025 IBM Corporation and others.
+ * Copyright (c) 2025, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -54,13 +54,44 @@ public class JakartaSecurity40CDIExtension implements Extension {
         // empty
     }
 
+    /**
+     * Check if in memory identity stores are enabled via webAppSecurity configuration.
+     *
+     * @return true if enabled, false else.
+     */
+    private boolean areInMemoryIdentityStoresEnabled() {
+        try {
+            com.ibm.ws.webcontainer.security.WebAppSecurityConfig config = com.ibm.ws.webcontainer.security.util.WebConfigUtils.getWebAppSecurityConfig();
+            if (config != null) {
+                return config.getAllowInMemoryIdentityStores();
+            }
+        } catch (Exception e) {
+            if (tc.isDebugEnabled()) {
+                Tr.debug(tc, "Error checking allowInMemoryIdentityStores config - defaulting to false.", e);
+            }
+        }
+        return false;
+    }
+
     /*
      * Process an @InMemoryIdentityStoreDefinition if found within the application.
      */
     public <T> void processAnnotatedInMemory(@WithAnnotations({ InMemoryIdentityStoreDefinition.class }) @Observes ProcessAnnotatedType<T> event, BeanManager beanManager) {
         AnnotatedType<T> annotatedType = event.getAnnotatedType();
-        Annotation inMemoryAnnotation = annotatedType.getAnnotation(InMemoryIdentityStoreDefinition.class);
-        addInMemoryIdentityStoreBean(inMemoryAnnotation, beanManager);
+
+        // add the in memory identity store only if it has been explicitly enabled
+        boolean areInMemoryIdentityStoresEnabled = areInMemoryIdentityStoresEnabled();
+
+        if (areInMemoryIdentityStoresEnabled) {
+            Annotation inMemoryAnnotation = annotatedType.getAnnotation(InMemoryIdentityStoreDefinition.class);
+            addInMemoryIdentityStoreBean(inMemoryAnnotation, beanManager);
+        } else {
+            if (tc.isDebugEnabled()) {
+                Tr.debug(tc, "An identity store that is configured by using an @InMemoryIdentityStoreDefinition " +
+                             "annotation was detected within this application, but it will not be used because " +
+                             "it was not explicitly enabled.");
+            }
+        }
     }
 
     /**
@@ -89,9 +120,9 @@ public class JakartaSecurity40CDIExtension implements Extension {
             if (tc.isDebugEnabled()) {
                 Tr.debug(tc, "fetching in memory identity store properties");
             }
-            
+
             Class<? extends Annotation> annotationType = inMemoryAnnotation.annotationType();
-            
+
             // these are the methods from the annotation
             Method[] methods = annotationType.getMethods();
             for (Method m : methods) {
@@ -119,7 +150,7 @@ public class JakartaSecurity40CDIExtension implements Extension {
             Tr.debug(tc, "afterBeanDiscovery : instance : " + Integer.toHexString(this.hashCode()) + " BeanManager : " + Integer.toHexString(beanManager.hashCode()));
         }
 
-        // Verification of mechanisms and registration of ModulePropertiesProviderBean performed in JavaEESecCDIExtension's afterBeanDiscovery()
+        // add all beans gathered in the previous annotation parsing phase
         for (Bean<IdentityStore> bean : beansToAdd) {
             afterBeanDiscovery.addBean(bean);
         }

--- a/dev/io.openliberty.security.jakartasec.4.0.internal_fat/publish/servers/jakartaSec40Server/server.xml
+++ b/dev/io.openliberty.security.jakartasec.4.0.internal_fat/publish/servers/jakartaSec40Server/server.xml
@@ -8,5 +8,7 @@
         <feature>restfulWS-4.0</feature>
     </featureManager>
 
+  <webAppSecurity allowInMemoryIdentityStores="true"/>
+
     <include location="../fatTestPorts.xml" />
 </server>


### PR DESCRIPTION
configuration.


- [X] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [X] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

Fixes [#33536](https://github.com/OpenLiberty/open-liberty/issues/33536 (GitHub Issue with acceptance criteria))

Explicitly enable the usage of in-memory identity stores via server.xml configuration, server wide. By default, the usage of an in-memory identity store defined within an application is disabled, therefore there is zero-migration concerns. This cannot be overridden with a custom identity store handler.

If explicitly enabled, the in-memory identity store will be created and involved within the authentication work flow.

The server.xml to configure and enable the in memory identity store is (and remember, if not set, it defaults to "false"):

```
<server>
. . .
<webAppSecurity allowInMemoryIdentityStores="true"/>
. . .
</server>
```
