### PR TITLE
Fix NPE in WebAppSecurityCollaboratorImpl during servlet destruction

### DIFF
--- a/dev/com.ibm.ws.webcontainer.security/src/com/ibm/ws/webcontainer/security/WebAppSecurityCollaboratorImpl.java
+++ b/dev/com.ibm.ws.webcontainer.security/src/com/ibm/ws/webcontainer/security/WebAppSecurityCollaboratorImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 IBM Corporation and others.
+ * Copyright (c) 2011, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -1218,10 +1218,15 @@ public class WebAppSecurityCollaboratorImpl implements IWebAppSecurityCollaborat
      */
     private boolean setUnauthenticatedSubjectIfNeeded(Subject invokedSubject, Subject receivedSubject) {
         if ((invokedSubject == null) && (receivedSubject == null)) {
-            // create the unauthenticated subject and set as the invocation subject
-            SubjectManager sm = new SubjectManager();
-            sm.setInvocationSubject(unauthenticatedSubjectService.getUnauthenticatedSubject());
-            return true;
+            // Check if service is available before using it (may be null during shutdown)
+            if (unauthenticatedSubjectService != null) {
+                SubjectManager sm = new SubjectManager();
+                sm.setInvocationSubject(unauthenticatedSubjectService.getUnauthenticatedSubject());
+                return true;
+            }
+            if (tc.isDebugEnabled()) {
+                Tr.debug(tc, "UnauthenticatedSubjectService unavailable, skipping unauthenticated subject setup");
+            }
         }
         return false;
     }


### PR DESCRIPTION
During application shutdown, a race condition can occur where the UnauthenticatedSubjectService is unset via OSGi service deactivation while servlets are being destroyed. This causes a NullPointerException in setUnauthenticatedSubjectIfNeeded() when it attempts to dereference the null service reference.

The service is marked as OPTIONAL/DYNAMIC in the OSGi configuration, meaning it can be unset at any time during the component lifecycle. During shutdown, OSGi deactivates services in parallel without strict ordering guarantees, creating an 8ms race window where the service becomes null while servlet destruction is still in progress.

This fix adds a defensive null check before dereferencing the service, consistent with how Liberty handles optional services elsewhere in the codebase (see AuthenticateApi.java line 213, TAIAuthenticator.java line 205). The null check is safe because:

1. The NPE only occurs during servlet destruction (shutdown/uninstall), not during active request processing
2. No security decisions are being made during servlet cleanup
3. The unauthenticated subject is only needed for thread context setup during normal operations, not during destruction
4. Skipping the subject setup during shutdown has no security impact

The fix allows servlet destruction to complete gracefully when the service is unavailable, preventing intermittent test failures and potential production NPEs during application shutdown.


- [X] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [X] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
