### PR TITLE
Fix async callback thread context propagation for ManagedExecutorService

### DIFF
--- a/dev/com.ibm.ws.jaxrs.2.0.common/src/org/apache/cxf/transport/http/HTTPConduit.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.common/src/org/apache/cxf/transport/http/HTTPConduit.java
@@ -1225,6 +1225,8 @@ public abstract class HTTPConduit
 
         @FFDCIgnore(RejectedExecutionException.class)
         protected void handleResponseOnWorkqueue(boolean allowCurrentThread, boolean forceWQ) throws IOException {
+            //Capture thread context before creating the runnable
+            AsyncClientRunnableWrapperManager.prepare(outMessage);
             Runnable runnable = new Runnable() {
                 @Override
                 @FFDCIgnore(Throwable.class)

--- a/dev/com.ibm.ws.jaxrs.2.0.common/src/org/apache/cxf/transport/http/HTTPConduit.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.common/src/org/apache/cxf/transport/http/HTTPConduit.java
@@ -92,6 +92,7 @@ import org.apache.cxf.ws.addressing.EndpointReferenceType;
 
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.ws.cxf.jaxrs20.client.component.AsyncClientRunnableWrapperManager;
 import com.ibm.ws.ffdc.annotation.FFDCIgnore;
 
 /*
@@ -1229,7 +1230,7 @@ public abstract class HTTPConduit
             // Capture thread context before creating the runnable
             AsyncClientRunnableWrapperManager.prepare(outMessage);
              // Liberty Change End
-            Runnable runnable = new Runnable() {
+            Runnable runnable = AsyncClientRunnableWrapperManager.wrap(outMessage, new Runnable() {
                 @Override
                 @FFDCIgnore(Throwable.class)
                 public void run() {
@@ -1246,7 +1247,7 @@ public abstract class HTTPConduit
                         mo.onMessage(outMessage);
                     }
                 }
-            };
+            });
             HTTPClientPolicy policy = getClient(outMessage);
             boolean exceptionSet = outMessage.getContent(Exception.class) != null;
             if (!exceptionSet) {

--- a/dev/com.ibm.ws.jaxrs.2.0.common/src/org/apache/cxf/transport/http/HTTPConduit.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.common/src/org/apache/cxf/transport/http/HTTPConduit.java
@@ -1225,8 +1225,10 @@ public abstract class HTTPConduit
 
         @FFDCIgnore(RejectedExecutionException.class)
         protected void handleResponseOnWorkqueue(boolean allowCurrentThread, boolean forceWQ) throws IOException {
-            //Capture thread context before creating the runnable
+            // Liberty change Begin
+            // Capture thread context before creating the runnable
             AsyncClientRunnableWrapperManager.prepare(outMessage);
+             // Liberty Change End
             Runnable runnable = new Runnable() {
                 @Override
                 @FFDCIgnore(Throwable.class)

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.transports.http.3.2/src/org/apache/cxf/transport/http/HTTPConduit.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.transports.http.3.2/src/org/apache/cxf/transport/http/HTTPConduit.java
@@ -1308,6 +1308,10 @@ public abstract class HTTPConduit
 
         @FFDCIgnore(RejectedExecutionException.class) // Liberty Change Start
         protected void handleResponseOnWorkqueue(boolean allowCurrentThread, boolean forceWQ) throws IOException {
+            // Liberty change Begin 
+            // Capture thread context before creating the runnable
+            AsyncClientRunnableWrapperManager.prepare(outMessage);
+            // Liberty Change End
             Runnable runnable = AsyncClientRunnableWrapperManager.wrap(outMessage, new Runnable() {
                 @Override
                 @FFDCIgnore(Throwable.class)


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

################################################################################################

Fixes https://github.com/OpenLiberty/open-liberty/issues/34149

Fixes defects 305613 - intermittent NamingException when JAX-RS InvocationCallback accesses java:comp/env on ManagedExecutorService threads.