### PR TITLE
Enable when using hibernate

### DIFF
--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
@@ -5192,7 +5192,7 @@ public class QueryInfo {
                     if (c != null)
                         c.append("FROM ").append(entityInfo.name);
 
-                    if (entityVar_.length() > 0) {
+                    if (entityVar != THIS) {
                         q.append(' ').append(entityVar);
                         if (c != null)
                             c.append(' ').append(entityVar);
@@ -5628,7 +5628,14 @@ public class QueryInfo {
             // In this case, Constraint typed parameters will not be allowed.
             Iterator<String> paramNames = jpqlParamNames.iterator();
             for (int a = 0; a < specialParamsStartAt; a++) {
-                paramNames.hasNext(); // TODO
+                if (!paramNames.hasNext())
+                    throw exc(UnsupportedOperationException.class,
+                              "CWWKD1022.too.many.params",
+                              method.getName(),
+                              repositoryInterface.getName(),
+                              a + 1,
+                              specialParamsStartAt + 1,
+                              jpql);
                 String paramName = paramNames.next();
                 if (trace && tc.isDebugEnabled())
                     Tr.debug(this, tc, "[m] set :" + paramName + ' ' + loggable(args[a]));

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
@@ -4856,9 +4856,13 @@ public class QueryInfo {
         boolean insertRecordConstructors = producer.compat().atLeast(1, 1) &&
                                            singleType.isRecord();
         boolean needsParenthesesEnd = false;
-        boolean needsConstructorEnd = hasTopLevelSelectClause &&
-                                      insertRecordConstructors &&
-                                      parseSelectForConstructor(ql, startAt, modifyAt);
+        int insertConstructorBeginAt = hasTopLevelSelectClause && insertRecordConstructors //
+                        ? parseSelectForConstructor(ql, startAt, modifyAt) //
+                        : -1;
+        // Conversion to a record requires at least 2 constructor args. Per the
+        // Jakarta Data spec, "when the select list contains only one path expression,
+        // the query directly returns the values of the path expression."
+        int numPossibleConstructorArgs = insertConstructorBeginAt == -1 ? 0 : 1;
 
         Integer addFromAt = findQueryStartsWithSelect == null //
                         ? -1 // never, it's a DELETE or UPDATE so it always has FROM
@@ -4903,10 +4907,13 @@ public class QueryInfo {
                                 countReplacesFirstSelectEndingAt < 0) {
                                 countReplacesFirstSelectEndingAt = i;
                             }
-                            if (needsConstructorEnd) {
-                                needsConstructorEnd = false;
-                                modifyAt.put(i - 1,
-                                             QueryEdit.ADD_CONSTRUCTOR_END);
+                            if (numPossibleConstructorArgs > 0) {
+                                if (numPossibleConstructorArgs == 1)
+                                    modifyAt.remove(insertConstructorBeginAt);
+                                else
+                                    modifyAt.put(i - 1,
+                                                 QueryEdit.ADD_CONSTRUCTOR_END);
+                                numPossibleConstructorArgs = 0;
                             }
                         }
 
@@ -4975,10 +4982,13 @@ public class QueryInfo {
                                 countReplacesFirstSelectEndingAt < 0) {
                                 countReplacesFirstSelectEndingAt = i;
                             }
-                            if (needsConstructorEnd) {
-                                needsConstructorEnd = false;
-                                modifyAt.put(i - 1, // avoid possible collision with ADD_FROM
-                                             QueryEdit.ADD_CONSTRUCTOR_END);
+                            if (numPossibleConstructorArgs > 0) {
+                                if (numPossibleConstructorArgs == 1)
+                                    modifyAt.remove(insertConstructorBeginAt);
+                                else
+                                    modifyAt.put(i - 1, // avoid possible collision with ADD_FROM
+                                                 QueryEdit.ADD_CONSTRUCTOR_END);
+                                numPossibleConstructorArgs = 0;
                             }
                             if (needsParenthesesEnd) {
                                 needsParenthesesEnd = false;
@@ -4998,8 +5008,13 @@ public class QueryInfo {
                             } else if (isSelect) {
                                 hasTopLevelSelectClause = true;
 
-                                if (insertRecordConstructors)
-                                    needsConstructorEnd = parseSelectForConstructor(ql, i, modifyAt);
+                                if (insertRecordConstructors) {
+                                    insertConstructorBeginAt = hasTopLevelSelectClause && insertRecordConstructors //
+                                                    ? parseSelectForConstructor(ql, i, modifyAt) //
+                                                    : -1;
+                                    numPossibleConstructorArgs = //
+                                                    insertConstructorBeginAt == -1 ? 0 : 1;
+                                }
 
                                 if (countReplacesFirstSelectAt < 0)
                                     countReplacesFirstSelectAt = i;
@@ -5023,9 +5038,13 @@ public class QueryInfo {
                         i++;
                     }
                 }
-            } else if (paramName != null) {
-                qlParamNames.add(paramName.toString());
-                paramName = null;
+            } else {
+                if (depth == 0 && !isLiteral && ch == ',' && numPossibleConstructorArgs > 0)
+                    numPossibleConstructorArgs++;
+                if (paramName != null) {
+                    qlParamNames.add(paramName.toString());
+                    paramName = null;
+                }
             }
         }
 
@@ -5062,9 +5081,13 @@ public class QueryInfo {
             modifyAt.put(addFromAt,
                          QueryEdit.ADD_FROM);
 
-        if (needsConstructorEnd)
-            modifyAt.put(length - 1, // avoid possible collision with ADD_FROM
-                         QueryEdit.ADD_CONSTRUCTOR_END);
+        if (numPossibleConstructorArgs > 0) {
+            if (numPossibleConstructorArgs == 1)
+                modifyAt.remove(insertConstructorBeginAt);
+            else
+                modifyAt.put(length - 1, // avoid possible collision with ADD_FROM
+                             QueryEdit.ADD_CONSTRUCTOR_END);
+        }
 
         if (needsParenthesesEnd)
             modifyAt.put(length,
@@ -5080,14 +5103,14 @@ public class QueryInfo {
      * @param ql       the query.
      * @param i        position in the query after SELECT.
      * @param modifyAt indices at which to perform modifications.
-     * @return true if this method added the ADD_CONSTRUCTOR_BEGIN instruction
-     *         which needs to be paired with ADD_CONSTRUCTOR_END.
+     * @return position in the query at which to insert constructor syntax.
+     *         -1 if the constructor syntax should not be inserted.
      */
     @Trivial
-    private boolean parseSelectForConstructor(String ql,
-                                              int i,
-                                              Map<Integer, QueryEdit> modifyAt) {
-        boolean needsConstructorEnd = false;
+    private int parseSelectForConstructor(String ql,
+                                          int i,
+                                          Map<Integer, QueryEdit> modifyAt) {
+        int insertConstructorBeginAt = -1;
         int length = ql.length();
 
         while (i < length && Character.isWhitespace(ql.charAt(i)))
@@ -5100,10 +5123,10 @@ public class QueryInfo {
             i += 3;
         } else {
             modifyAt.put(i, QueryEdit.ADD_CONSTRUCTOR_BEGIN);
-            needsConstructorEnd = true;
+            insertConstructorBeginAt = i;
         }
 
-        return needsConstructorEnd;
+        return insertConstructorBeginAt;
     }
 
     /**

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
@@ -3182,19 +3182,21 @@ public class QueryInfo {
             } else if (entityInfo.idClassAttributeAccessors != null &&
                        singleType.equals(entityInfo.idType)) {
                 // IdClass
-                // TODO remove once #29073 is fixed
-                // The following guess of alphabetic order is not valid in most cases, but this
-                // whole code block will be removed before GA, so there is no reason to correct it.
-                q.append("SELECT NEW ").append(singleType.getName()).append('(');
-                boolean first = true;
-                for (String idClassAttributeName : entityInfo.idClassAttributeAccessors.keySet()) {
-                    String name = getAttributeName(idClassAttributeName, true);
-                    q.append(first ? "" : ", ").append(o_).append(name);
-                    first = false;
+                if (entityInfo.isHibernate) {
+                    q.append("SELECT ID(").append(entityVar).append(')');
+                } else {
+                    // TODO remove once #29073 is fixed and use above code instead.
+                    // The following guess of alphabetic order is not valid in most cases, but this
+                    // whole code block will be removed before GA, so there is no reason to correct it.
+                    q.append("SELECT NEW ").append(singleType.getName()).append('(');
+                    boolean first = true;
+                    for (String idClassAttributeName : entityInfo.idClassAttributeAccessors.keySet()) {
+                        String name = getAttributeName(idClassAttributeName, true);
+                        q.append(first ? "" : ", ").append(o_).append(name);
+                        first = false;
+                    }
+                    q.append(')');
                 }
-                q.append(')');
-                // TODO enable this once #29073 is fixed
-                // q.append("SELECT ID(").append(entityVar).append(')');
             } else {
                 // Is the result type a record?
                 RecordComponent[] recordComponents = singleType.getRecordComponents();

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/RepositoryImpl.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/RepositoryImpl.java
@@ -588,14 +588,6 @@ public class RepositoryImpl<R> implements InvocationHandler {
                                          Util.txStatusToString(status));
                             provider.tranMgr.commit();
                         }
-
-                        // TODO Is this necessary after a transaction?
-                        if (em != null && queryType.detachEntities) {
-                            // TODO 1.1 only detach if a stateless repository
-                            if (trace && tc.isDebugEnabled())
-                                Tr.debug(this, tc, "clear");
-                            em.clear();
-                        }
                     } else {
                         if (Status.STATUS_ACTIVE == provider.tranMgr.getStatus()) {
                             if (failed) {

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
@@ -292,7 +292,8 @@ public class DataJPATestServlet extends FATServlet {
         demographics.write(new DemographicInfo(2002, 4, 30, 112700000, 2582340471146.16, 3402336886067.70));
 
         // TODO remove this workaround for intermittent issue triggered by test ordering once 28078 is fixed
-        testLiteralDouble();
+        if (!isHibernate())
+            testLiteralDouble();
         // To quickly try reproducing the issue, remove the above line and add the following line to tearDown,
         // runTest(server, "DataJPATestApp", "testLiteralDouble");
     }
@@ -1469,7 +1470,7 @@ public class DataJPATestServlet extends FATServlet {
         }
 
         // TODO enable once issue #32204 is fixed in EclipseLink
-        if (false)
+        if (isHibernate())
             assertEquals(List.of(345003450L, 678006780L),
                          taxpayers.findByBankAccountsContains(AccountId.of(26122300, 410224))
                                          .map(t -> t.ssn)
@@ -3386,8 +3387,12 @@ public class DataJPATestServlet extends FATServlet {
      * Use a repository method with a Query that hard codes a literal for a double value in E notation,
      * as is done in an example within the spec.
      */
-    // enable once 28078 is fixed @Test
+    @Test
     public void testLiteralDouble() {
+        // TODO enable for EclipseLink once 28078 is fixed
+        if (!isHibernate())
+            return;
+
         // Clear out data before test
         accounts.deleteByOwnerEndsWith("TestLiteralDouble");
 


### PR DESCRIPTION
Enable tests and code path (that does not work with EcilpseLink) when using Hibernate as the Persistence provider.
Resolve a couple of TODOs.
Fix a bug comparing against the wrong field.
Comply with a Jakarta Data specification requirement for SELECT of single entity attribute to return value rather than constructing a record, the latter of which requires selecting multiple values.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
