### PR TITLE
Add trace and enable unit test for MemoryInformation on Windows

### DIFF
--- a/dev/com.ibm.ws.kernel.service/src/com/ibm/ws/kernel/service/util/MemoryInformation.java
+++ b/dev/com.ibm.ws.kernel.service/src/com/ibm/ws/kernel/service/util/MemoryInformation.java
@@ -682,10 +682,20 @@ public class MemoryInformation {
                 "$mem = Get-CimInstance Win32_PerfFormattedData_PerfOS_Memory; " +
                 "Write-Output ($mem.AvailableBytes + $mem.CacheBytes)");
         
+        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+            Tr.debug(tc, "PowerShell returned " + lines.size() + " line(s): " + lines);
+        }
+
         for (String line : lines) {
             line = line.trim();
+            if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                 Tr.debug(tc, "Processing line: '" + line + "'");
+            }
             if (!line.isEmpty() && line.matches("\\d+")) {
                 long available = Long.parseLong(line);
+                if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                     Tr.debug(tc, "Parsed available memory: " + available + " bytes");
+                }
                 if (available > 0) {
                     return available;
                 }

--- a/dev/com.ibm.ws.kernel.service/test/com/ibm/ws/kernel/service/test/MemoryInformationTests.java
+++ b/dev/com.ibm.ws.kernel.service/test/com/ibm/ws/kernel/service/test/MemoryInformationTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 IBM Corporation and others.
+ * Copyright (c) 2018,2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -27,7 +27,10 @@ public class MemoryInformationTests {
     public void testOSMemoryStatistics() throws Exception {
         // Since unit tests are part of builds, we're conservative in which
         // ones we always test
-        if (OperatingSystem.instance().getOperatingSystemType() == OperatingSystemType.Linux) {
+        OperatingSystemType osType = OperatingSystem.instance().getOperatingSystemType();
+        if (osType == OperatingSystemType.Linux || osType == OperatingSystemType.Windows) {
+            System.out.println("Testing on OS: " + osType);
+            
             long totalMemory = MemoryInformation.instance().getTotalMemory();
             System.out.println("Total memory: " + totalMemory);
             Assert.assertTrue("getTotalMemory invalid",
@@ -42,6 +45,8 @@ public class MemoryInformationTests {
             System.out.println("Available memory %: " + (availableMemoryRatio * 100.0));
             Assert.assertTrue("getAvailableMemoryRatio invalid",
                               availableMemoryRatio > 0);
+        } else {
+            System.out.println("Skipping test on OS: " + osType);
         }
     }
 }


### PR DESCRIPTION
enable unit test and add trace for MemoryInformation.java

Wait for #33997 to be merged, then run build and SOE Windows builds.