### PR TITLE
Fix WAR deployment failure when servlet class defined in web-fragment

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/protected/com.ibm.websphere.appserver.containerServices-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/protected/com.ibm.websphere.appserver.containerServices-1.0.feature
@@ -20,7 +20,7 @@ IBM-Process-Types: server, \
  com.ibm.ws.javaee.version, \
  com.ibm.ws.serialization
 -jars=com.ibm.websphere.appserver.spi.containerServices; location:=dev/spi/ibm/
--files=dev/spi/ibm/javadoc/com.ibm.websphere.appserver.spi.containerServices_4.1-javadoc.zip
+-files=dev/spi/ibm/javadoc/com.ibm.websphere.appserver.spi.containerServices_4.2-javadoc.zip
 kind=ga
 edition=core
 WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.spi.containerServices/bnd.bnd
+++ b/dev/com.ibm.websphere.appserver.spi.containerServices/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017, 2025 IBM Corporation and others.
+# Copyright (c) 2017, 2026 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -11,7 +11,7 @@
 #     IBM Corporation - initial API and implementation
 #*******************************************************************************
 -include= ~../cnf/resources/bnd/bundle.props
-bVersion: 4.1
+bVersion: 4.2
 
 Bundle-Name: WebSphere Container Services SPI
 Bundle-Description: WebSphere Container Services SPI, version ${bVersion}

--- a/dev/com.ibm.ws.container.service/src/com/ibm/ws/container/service/config/ServletConfigurator.java
+++ b/dev/com.ibm.ws.container.service/src/com/ibm/ws/container/service/config/ServletConfigurator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2020 IBM Corporation and others.
+ * Copyright (c) 2012, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -105,7 +105,11 @@ public interface ServletConfigurator {
 
     public ConfigSource getConfigSource();
 
+    public void setConfigSource(ConfigSource source);
+
     public String getLibraryURI();
+
+    public void setLibraryURI(String libraryURI);
 
     boolean getMetadataCompleted();
 

--- a/dev/com.ibm.ws.container.service/src/com/ibm/ws/container/service/config/package-info.java
+++ b/dev/com.ibm.ws.container.service/src/com/ibm/ws/container/service/config/package-info.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2015 IBM Corporation and others.
+ * Copyright (c) 2011, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -10,6 +10,6 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-/** @version 2.1 */
-@org.osgi.annotation.versioning.Version("2.1")
+/** @version 2.2 */
+@org.osgi.annotation.versioning.Version("2.2")
 package com.ibm.ws.container.service.config;

--- a/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/osgi/container/config/WebAppConfigurator.java
+++ b/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/osgi/container/config/WebAppConfigurator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2021 IBM Corporation and others.
+ * Copyright (c) 2011, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -356,9 +356,17 @@ public class WebAppConfigurator implements ServletConfigurator {
         return this.currentSource;
     }
 
+    public void setConfigSource(ConfigSource source) {
+        this.currentSource = source;
+    }
+
     @Override
     public String getLibraryURI() {
         return this.currentLibraryURI;
+    }
+
+    public void setLibraryURI(String libraryURI) {
+        this.currentLibraryURI = libraryURI;
     }
 
     @Override

--- a/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/osgi/container/config/WebAppConfiguratorHelper.java
+++ b/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/osgi/container/config/WebAppConfiguratorHelper.java
@@ -2625,9 +2625,21 @@ public class WebAppConfiguratorHelper implements ServletConfiguratorHelper {
      * files before processing the mappings, which is necessary when a servlet-mapping in
      * web.xml references a servlet whose definition is provided in a web-fragment.xml.
      *
-     * @param servletMappings the list of servlet mappings to defer
+     * <p>We only defer mappings for servlets that don't have a definition yet.
+     * If the servlet is already defined (e.g., from an earlier source like annotations annotations or web.xml),
+     * we process the mapping immediately. This 
+     * <ul>
+     * <li>allows processServletMappingConfig() to apply the correct merge rules based on ConfigSource
+     *     (web.xml > web-fragment.xml > annotations)</li>
+     * <li>prevents duplicate mapping attempts that would occur if we deferred all mappings and then
+     *     tried to add them again after annotations have already added them</li>
+     * <li>maintains the existing precedence behavior where earlier sources override later ones</li>
+     * </ul>
+     *
+     * @param servletMappings the list of servlet mappings to process or defer
+     * @throws UnableToAdaptException if servlet mapping processing fails
      */
-    private void storeDeferredServletMappings(List<ServletMapping> servletMappings) {
+    private void storeDeferredServletMappings(List<ServletMapping> servletMappings) throws UnableToAdaptException {
         if (servletMappings == null || servletMappings.isEmpty()) {
             return;
         }
@@ -2636,7 +2648,21 @@ public class WebAppConfiguratorHelper implements ServletConfiguratorHelper {
         String currentLibraryURI = configurator.getLibraryURI();
         
         for (ServletMapping servletMapping : servletMappings) {
-            deferredServletMappings.add(new DeferredServletMapping(servletMapping, currentSource, currentLibraryURI));
+            String servletName = servletMapping.getServletName();
+            Map<String, ConfigItem<ServletConfig>> servletMap = configurator.getConfigItemMap("servlet");
+            
+            // Check if servlet definition exists
+            if (servletMap.get(servletName) == null) {
+                // Servlet not defined yet - defer mapping until all servlet definitions are collected
+                // This handles the case where web.xml has a servlet-mapping but the servlet definition
+                // is in a web-fragment.xml that hasn't been processed yet
+                deferredServletMappings.add(new DeferredServletMapping(servletMapping, currentSource, currentLibraryURI));
+            } else {
+                // Servlet already defined - process mapping immediately to maintain proper precedence
+                // This ensures processServletMappingConfig() can apply merge rules correctly and
+                // prevents duplicate mappings when annotations have already added mappings
+                processServletMappingConfig(servletMapping);
+            }
         }
     }
 

--- a/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/osgi/container/config/WebAppConfiguratorHelper.java
+++ b/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/osgi/container/config/WebAppConfiguratorHelper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 IBM Corporation and others.
+ * Copyright (c) 2011, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -16,6 +16,7 @@
 //      148426          10/06/14        bitonti                 Give extension default error page precedence in Servlet 3.0
 //      PI67942         10/21/16        zaroman                 encode URI after dispatch
 //      11909           12/11/20        jimblye                 Allow context-root to be overridden in server.xml
+//                      02/06/26.       jimblye                 Defer servlet mappings until webfragment servlet defs processed
 
 package com.ibm.ws.webcontainer.osgi.container.config;
 
@@ -156,6 +157,24 @@ import com.ibm.wsspi.webcontainer.webapp.WebAppConfig;
  * from web.xml, web-fragment.xml and annotations.  Configure them into the WebAppConfiguration.
  */
 public class WebAppConfiguratorHelper implements ServletConfiguratorHelper {
+    
+    /**
+     * Helper class to store servlet mappings for deferred processing.
+     * This allows all servlet definitions to be collected before processing mappings.
+     */
+    private static class DeferredServletMapping {
+        final ServletMapping servletMapping;
+        final ConfigSource source;
+        final String libraryURI;
+        
+        DeferredServletMapping(ServletMapping servletMapping, ConfigSource source, String libraryURI) {
+            this.servletMapping = servletMapping;
+            this.source = source;
+            this.libraryURI = libraryURI;
+        }
+    }
+    
+    private final List<DeferredServletMapping> deferredServletMappings = new ArrayList<>();
     private static final String CLASS_NAME = WebAppConfiguratorHelper.class.getSimpleName();
 
     private static final TraceComponent tc = Tr.register(WebAppConfiguratorHelper.class, WebContainerConstants.TR_GROUP, WebContainerConstants.NLS_PROPS);
@@ -818,7 +837,9 @@ public class WebAppConfiguratorHelper implements ServletConfiguratorHelper {
         
         configureSessionConfig(webApp.getSessionConfig());
         configureServlets(webApp, webApp.getServlets());
-        configureServletMappings(webApp.getServletMappings());
+        
+        // Defer servlet mapping processing until all servlet definitions are collected
+        storeDeferredServletMappings(webApp.getServletMappings());
         configureLocaleEncodingMap(webApp.getLocaleEncodingMappingList());
         configureListener(webApp.getListeners());
         configureEnvEntries(webApp.getEnvEntries());
@@ -856,7 +877,9 @@ public class WebAppConfiguratorHelper implements ServletConfiguratorHelper {
         configureDistributableFromFragment(webFragment.isSetDistributable());
         configureSessionConfig(webFragment.getSessionConfig());
         configureServlets(webFragment, webFragment.getServlets());
-        configureServletMappings(webFragment.getServletMappings());
+        
+        // Defer servlet mapping processing until all servlet definitions are collected
+        storeDeferredServletMappings(webFragment.getServletMappings());
         configureLocaleEncodingMap(webFragment.getLocaleEncodingMappingList());
         configureListener(webFragment.getListeners());
         configureEnvEntries(webFragment.getEnvEntries());
@@ -913,7 +936,11 @@ public class WebAppConfiguratorHelper implements ServletConfiguratorHelper {
     @Override
     public void configureDefaults() throws UnableToAdaptException {
 
-        //I think we need to process specifiedClasses first to find what servlets were defined 
+        // Process all deferred servlet mappings now that all servlet definitions have been collected
+        // from web.xml and all web-fragment.xml files
+        processDeferredServletMappings();
+        
+        //I think we need to process specifiedClasses first to find what servlets were defined
         //in case a filter is mapped to * (all servlets)
         configureSpecifiedClasses();
 
@@ -2564,9 +2591,52 @@ public class WebAppConfiguratorHelper implements ServletConfiguratorHelper {
         }
     }
 
-    private void configureServletMappings(List<ServletMapping> servletMappings) throws UnableToAdaptException {
+    /**
+     * Process all deferred servlet mappings after all servlet definitions have been collected.
+     * The deferred mappings retain their original source context for proper merging rules and error messages.
+     *
+     * @throws UnableToAdaptException if servlet mapping processing fails
+     */
+    private void processDeferredServletMappings() throws UnableToAdaptException {
+
+        // Save the current context
+	    ConfigSource savedSource = configurator.getConfigSource();
+        String savedLibraryURI = configurator.getLibraryURI();
+
+        for (DeferredServletMapping deferred : deferredServletMappings) {          
+            try {
+	            // Retrieve the context from for this servlet mapping
+                // Needed for proper merging rules in processServletMappingConfig(...)
+                configurator.setConfigSource(deferred.source);
+                configurator.setLibraryURI(deferred.libraryURI);
+                processServletMappingConfig(deferred.servletMapping);
+            } finally {
+                // Restore the saved context
+                configurator.setConfigSource(savedSource);
+                configurator.setLibraryURI(savedLibraryURI);
+            }
+        }
+        deferredServletMappings.clear();
+    }
+
+    /**
+     * Store servlet mappings for deferred processing.
+     * This allows all servlet definitions to be collected from web.xml and web-fragment.xml
+     * files before processing the mappings, which is necessary when a servlet-mapping in
+     * web.xml references a servlet whose definition is provided in a web-fragment.xml.
+     *
+     * @param servletMappings the list of servlet mappings to defer
+     */
+    private void storeDeferredServletMappings(List<ServletMapping> servletMappings) {
+        if (servletMappings == null || servletMappings.isEmpty()) {
+            return;
+        }
+        
+        ConfigSource currentSource = configurator.getConfigSource();
+        String currentLibraryURI = configurator.getLibraryURI();
+        
         for (ServletMapping servletMapping : servletMappings) {
-            processServletMappingConfig(servletMapping);
+            deferredServletMappings.add(new DeferredServletMapping(servletMapping, currentSource, currentLibraryURI));
         }
     }
 


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact
- [x] Fixes #34023
- [x] Fixes #34023

################################################################################################

Problem:
A web app fails to start on  with:

MetaDataException: SRVE0303E: Servlet name not found adding servlet mapping

Cause:  Liberty processed servlet mappings from web.xml before reading servlet definitions from web-fragment.xml in JARs. 

Solution:  Defer servlet mapping processing until all servlet definitions are known.

fixes https://github.com/OpenLiberty/open-liberty/issues/34023


