### PR TITLE
Switch the default BlockingQueue implementation used for Liberty's thread pool

### DIFF
--- a/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/internal/ExecutorServiceImpl.java
+++ b/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/internal/ExecutorServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010, 2025 IBM Corporation and others.
+ * Copyright (c) 2010, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -217,7 +217,7 @@ public final class ExecutorServiceImpl implements WSExecutorService, ThreadQuies
     public static boolean isBeta = Boolean.valueOf(System.getProperty("com.ibm.ws.beta.edition"));
 
     // Default to use BoundedBuffer, but make it possible to easily switch to using ConcurrentPriorityBlockingQueue
-    public static final boolean useBoundedBuffer = Boolean.valueOf(System.getProperty("io.openliberty.threading.useBoundedBuffer", "true"));
+    public static final boolean useBoundedBuffer = Boolean.valueOf(System.getProperty("io.openliberty.threading.useBoundedBuffer", "false"));
 
     /**
      * Create a thread pool executor with the configured attributes from this

--- a/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/internal/ExecutorServiceImpl.java
+++ b/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/internal/ExecutorServiceImpl.java
@@ -216,7 +216,7 @@ public final class ExecutorServiceImpl implements WSExecutorService, ThreadQuies
 
     public static boolean isBeta = Boolean.valueOf(System.getProperty("com.ibm.ws.beta.edition"));
 
-    // Default to use BoundedBuffer, but make it possible to easily switch to using ConcurrentPriorityBlockingQueue
+    // Default to use ConcurrentPriorityBlockingQueue, but make it possible to easily switch to using BoundedBuffer
     public static final boolean useBoundedBuffer = Boolean.valueOf(System.getProperty("io.openliberty.threading.useBoundedBuffer", "false"));
 
     /**


### PR DESCRIPTION
- Re-enables ConcurrentPriorityBlockingQueue (CPBQ) as the default instead of BoundedBuffer.  Performance testing has shown that previous regressions are now resolved with CPBQ updates made in the last few months 