### PR TITLE
Use Cursor.get instead of elements to avoid elements list creation

### DIFF
--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/CursoredPageImpl.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/CursoredPageImpl.java
@@ -166,22 +166,23 @@ public class CursoredPageImpl<T> implements CursoredPage<T> {
      *                            are added due to repository special parameters.
      * @throws Exception if an error occurs
      */
-    @SuppressWarnings("unchecked")
     private void addParametersForCursor(Cursor cursor,
                                         @Sensitive Map<Object, Object> addedJPQLParams) //
                     throws Exception {
         final boolean trace = TraceComponent.isAnyTracingEnabled();
 
+        int cursorSize = cursor.size();
+
         // Expand ID(THIS) for composite IdClass into separate attributes
-        List<Object> cursorValues;
         SortedMap<String, Member> idClassAttributeAccessors = //
                         queryInfo.entityInfo.idClassAttributeAccessors;
-        if (idClassAttributeAccessors == null) {
-            cursorValues = (List<Object>) cursor.elements();
-        } else {
-            cursorValues = new ArrayList<>(cursor.size() + 3);
-            for (Object value : cursor.elements()) {
+        if (idClassAttributeAccessors != null) {
+            boolean foundIdClass = false;
+            ArrayList<Object> cursorValues = new ArrayList<>(cursorSize + 3);
+            for (int c = 0; c < cursorSize; c++) {
+                Object value = cursor.get(c);
                 if (queryInfo.entityInfo.idType.isInstance(value)) {
+                    foundIdClass = true;
                     for (Member accessor : idClassAttributeAccessors.values()) {
                         Object v = accessor instanceof Field //
                                         ? ((Field) accessor).get(value) //
@@ -192,9 +193,12 @@ public class CursoredPageImpl<T> implements CursoredPage<T> {
                     cursorValues.add(value);
                 }
             }
+            if (foundIdClass) {
+                cursor = Cursor.forKey(cursorValues.toArray());
+                cursorSize = cursor.size();
+            }
         }
 
-        int cursorSize = cursorValues.size();
         if (queryInfo.sorts.size() != cursorSize)
             cursorSizeMismatchError(cursor);
 
@@ -207,7 +211,7 @@ public class CursoredPageImpl<T> implements CursoredPage<T> {
             Object key = paramNames == null //
                             ? paramNum // positional parameters
                             : paramNames[paramNum - 1]; // named parameters
-            addedJPQLParams.put(key, cursorValues.get(c));
+            addedJPQLParams.put(key, cursor.get(c));
 
             if (trace && tc.isDebugEnabled())
                 Tr.debug(this, tc, "added parameter " + key + " for cursor");


### PR DESCRIPTION
Makes the normal path where there is not an IdClass more efficient.  And also the path where there is an IdClass on the entity but it is not used within the cursor.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
