### PR TITLE
Multi-hams: Warning and error message updates after ID review.

### DIFF
--- a/dev/io.openliberty.security.jakartasec.4.0.internal.cdi/resources/io/openliberty/security/jakartasec/cdi/internal/resources/JakartaSecurity40Messages.nlsprops
+++ b/dev/io.openliberty.security.jakartasec.4.0.internal.cdi/resources/io/openliberty/security/jakartasec/cdi/internal/resources/JakartaSecurity40Messages.nlsprops
@@ -17,18 +17,18 @@
 
 # Message prefix block: 2610-2620
 
-JAKARTA_SECURITY_CDI_ERROR_CUSTOM_QUALIFIERS_NO_HAM_HANDLER=CWWKS2610E: Missing a custom handler when using qualified HttpAuthenticationMechanisms.
+JAKARTA_SECURITY_CDI_ERROR_CUSTOM_QUALIFIERS_NO_HAM_HANDLER=CWWKS2610E: Missing a custom handler that uses qualified HttpAuthenticationMechanisms.
 JAKARTA_SECURITY_CDI_ERROR_CUSTOM_QUALIFIERS_NO_HAM_HANDLER.explanation=If qualified HttpAuthenticationMechanisms are specified, then the default HttpAuthenticationMechanismHandler cannot determine which HAM to use, therefore a custom implementation of the HttpAuthenticationMechanismHandler must be provided.
-JAKARTA_SECURITY_CDI_ERROR_CUSTOM_QUALIFIERS_NO_HAM_HANDLER.useraction=Implement an HttpAuthenticationMechanismHandler using customized logic to select a unique HttpAuthenticationMechanism.
+JAKARTA_SECURITY_CDI_ERROR_CUSTOM_QUALIFIERS_NO_HAM_HANDLER.useraction=Implement an HttpAuthenticationMechanismHandler that uses customized logic to select a unique HttpAuthenticationMechanism.
 
 JAKARTASEC_CDI_ERROR_PROCESSING_HAM_LIST=CWWKS2611E: Processing annotations for the {0} definition within a list failed.
-JAKARTASEC_CDI_ERROR_PROCESSING_HAM_LIST.explanation=Whilst processing a list of HttpAuthenticationMechanism definitions, an error occured whilst extracting annotation values.
+JAKARTASEC_CDI_ERROR_PROCESSING_HAM_LIST.explanation=While processing a list of HttpAuthenticationMechanism definitions, an error occurred when extracting annotation values.
 JAKARTASEC_CDI_ERROR_PROCESSING_HAM_LIST.useraction=Investigate the cause of the exception and correct the application configuration.
 
 JAKARTASEC_CDI_ERROR_EXTRACTING_HAM_PROPERTIES=CWWKS2612E: Processing properties the {0} type failed.
-JAKARTASEC_CDI_ERROR_EXTRACTING_HAM_PROPERTIES.explanation=Whilst processing a specific HttpAuthenticationMechanism annotation, an error occured whilst extracting property values.
+JAKARTASEC_CDI_ERROR_EXTRACTING_HAM_PROPERTIES.explanation=While processing a specific HttpAuthenticationMechanism annotation, an error occurred when extracting property values.
 JAKARTASEC_CDI_ERROR_EXTRACTING_HAM_PROPERTIES.useraction=Investigate the cause of the exception and correct the application configuration.
 
-JAKARTASEC_CDI_ERROR_CREATING_QUALIFIERS=CWWKS2613E: Could not create custom qualifier annotation {0} for qualifier class {1}.
-JAKARTASEC_CDI_ERROR_CREATING_QUALIFIERS.explanation=Whilst creating a qualified HttpAuthenticationMechanism, an error occured whilst creating a custom qualifier annotation.
+JAKARTASEC_CDI_ERROR_CREATING_QUALIFIERS=CWWKS2613E: Cannot create the {0} custom qualifier annotation for the {1} qualifier class.
+JAKARTASEC_CDI_ERROR_CREATING_QUALIFIERS.explanation=While creating a qualified HttpAuthenticationMechanism, an error occurred when creating a custom qualifier annotation.
 JAKARTASEC_CDI_ERROR_CREATING_QUALIFIERS.useraction=Investigate the cause of the exception and correct the application configuration.


### PR DESCRIPTION
- [X] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [X] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

Fixes [#32464](https://github.com/OpenLiberty/open-liberty/issues/32464)

This PR addresses review comments from ID regarding new translated messages for multiple HAMs.

The comments were originally made on [PR number 33110](https://github.com/OpenLiberty/open-liberty/pull/33110) which is now closed and merged, hence this new PR.