### PR TITLE
Resteasy ClientBuilder issue fix

### DIFF
--- a/dev/io.openliberty.jakarta.restfulWS.3.0/bnd.bnd
+++ b/dev/io.openliberty.jakarta.restfulWS.3.0/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2020, 2025 IBM Corporation and others.
+# Copyright (c) 2020, 2026 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at

--- a/dev/io.openliberty.jakarta.restfulWS.3.0/bnd.bnd
+++ b/dev/io.openliberty.jakarta.restfulWS.3.0/bnd.bnd
@@ -18,6 +18,10 @@ Bundle-SymbolicName: io.openliberty.jakarta.restfulWS.3.0; singleton:=true
 
 Export-Package: jakarta.ws.rs.*; version="3.0.0"
 
+Import-Package: \
+  io.openliberty.org.jboss.resteasy.common.client; resolution:=optional, \
+  *
+
 instrument.disabled: true
 
 publish.wlp.jar.suffix: dev/api/spec

--- a/dev/io.openliberty.jakarta/restfulWS.3.1.bnd
+++ b/dev/io.openliberty.jakarta/restfulWS.3.1.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2022, 2025 IBM Corporation and others.
+# Copyright (c) 2022, 2026 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at

--- a/dev/io.openliberty.jakarta/restfulWS.3.1.bnd
+++ b/dev/io.openliberty.jakarta/restfulWS.3.1.bnd
@@ -22,6 +22,10 @@ Bundle-SymbolicName: io.openliberty.jakarta.restfulWS.3.1; singleton:=true
 
 Export-Package: jakarta.ws.rs.*; version="3.1.0"
 
+Import-Package: \
+  io.openliberty.org.jboss.resteasy.common.client; resolution:=optional, \
+  *
+
 -includeresource: \
    @\${repo;jakarta.ws.rs:jakarta.ws.rs-api;3.1.0;EXACT}!/!(META-INF/maven/*|module-info.class)
 

--- a/dev/io.openliberty.jakarta/restfulWS.4.0.bnd
+++ b/dev/io.openliberty.jakarta/restfulWS.4.0.bnd
@@ -19,6 +19,10 @@ Bundle-SymbolicName: io.openliberty.jakarta.restfulWS.4.0; singleton:=true
 
 Export-Package: jakarta.ws.rs.*; version="4.0.0"
 
+Import-Package: \
+  io.openliberty.org.jboss.resteasy.common.client; resolution:=optional, \
+  *
+
 -includeresource: \
    @\${repo;jakarta.ws.rs:jakarta.ws.rs-api;4.0.0;EXACT}!/!(META-INF/maven/*|module-info.class)
 

--- a/dev/io.openliberty.jakarta/restfulWS.4.0.bnd
+++ b/dev/io.openliberty.jakarta/restfulWS.4.0.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2024, 2025 IBM Corporation and others.
+# Copyright (c) 2024, 2026 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at

--- a/dev/io.openliberty.jaxrs.global.handler.internal_fat/publish/servers/SimpleGlobalHandlerServer/jvm.options
+++ b/dev/io.openliberty.jaxrs.global.handler.internal_fat/publish/servers/SimpleGlobalHandlerServer/jvm.options
@@ -1,0 +1,2 @@
+-Djavax.ws.rs.client.ClientBuilder=com.ibm.ws.jaxrs20.client.JAXRSClientBuilderImpl
+-Djakarta.ws.rs.client.ClientBuilder=io.openliberty.org.jboss.resteasy.common.client.LibertyResteasyClientBuilderImpl

--- a/dev/io.openliberty.jaxrs.global.handler.internal_fat/test-applications/MySimpleGlobalHandler/resources/META-INF/MANIFEST.MF
+++ b/dev/io.openliberty.jaxrs.global.handler.internal_fat/test-applications/MySimpleGlobalHandler/resources/META-INF/MANIFEST.MF
@@ -5,4 +5,4 @@ Bundle-SymbolicName: MySimpleGlobalHandler
 Bundle-Version: 1.0.0
 Manifest-Version: 1.0
 Export-Package: io.openliberty.jaxrs.fat.globalhandler.simple.userbundle
-Import-Package: com.ibm.wsspi.webservices.handler,org.osgi.framework
+Import-Package: com.ibm.wsspi.webservices.handler,org.osgi.framework,javax.ws.rs.client

--- a/dev/io.openliberty.jaxrs.global.handler.internal_fat/test-applications/MySimpleGlobalHandler/src/io/openliberty/jaxrs/fat/globalhandler/simple/userbundle/MySimpleHandlerActivitor.java
+++ b/dev/io.openliberty.jaxrs.global.handler.internal_fat/test-applications/MySimpleGlobalHandler/src/io/openliberty/jaxrs/fat/globalhandler/simple/userbundle/MySimpleHandlerActivitor.java
@@ -25,6 +25,7 @@ public class MySimpleHandlerActivitor implements BundleActivator {
 
     @Override
     public void start(BundleContext context) throws Exception {
+        System.out.println("in start method in bundle activator");
         // Test ClientBuilder.newBuilder() - will throw exception if it doesn't work
         ClientBuilder builder = ClientBuilder.newBuilder();
         

--- a/dev/io.openliberty.jaxrs.global.handler.internal_fat/test-applications/MySimpleGlobalHandler/src/io/openliberty/jaxrs/fat/globalhandler/simple/userbundle/MySimpleHandlerActivitor.java
+++ b/dev/io.openliberty.jaxrs.global.handler.internal_fat/test-applications/MySimpleGlobalHandler/src/io/openliberty/jaxrs/fat/globalhandler/simple/userbundle/MySimpleHandlerActivitor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022, 2023 IBM Corporation and others.
+ * Copyright (c) 2022, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/dev/io.openliberty.jaxrs.global.handler.internal_fat/test-applications/MySimpleGlobalHandler/src/io/openliberty/jaxrs/fat/globalhandler/simple/userbundle/MySimpleHandlerActivitor.java
+++ b/dev/io.openliberty.jaxrs.global.handler.internal_fat/test-applications/MySimpleGlobalHandler/src/io/openliberty/jaxrs/fat/globalhandler/simple/userbundle/MySimpleHandlerActivitor.java
@@ -26,7 +26,7 @@ public class MySimpleHandlerActivitor implements BundleActivator {
     @Override
     public void start(BundleContext context) throws Exception {
         System.out.println("in start method in bundle activator");
-        // Test ClientBuilder.newBuilder() - will throw exception if it doesn't work
+        // Test ClientBuilder.newBuilder() - Added to test for problem documented in #34019 
         ClientBuilder builder = ClientBuilder.newBuilder();
         
         final Hashtable<String, Object> handlerProps = new Hashtable<String, Object>();

--- a/dev/io.openliberty.jaxrs.global.handler.internal_fat/test-applications/MySimpleGlobalHandler/src/io/openliberty/jaxrs/fat/globalhandler/simple/userbundle/MySimpleHandlerActivitor.java
+++ b/dev/io.openliberty.jaxrs.global.handler.internal_fat/test-applications/MySimpleGlobalHandler/src/io/openliberty/jaxrs/fat/globalhandler/simple/userbundle/MySimpleHandlerActivitor.java
@@ -4,12 +4,14 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *******************************************************************************/
 package io.openliberty.jaxrs.fat.globalhandler.simple.userbundle;
 
 import java.util.Hashtable;
+
+import javax.ws.rs.client.ClientBuilder;
 
 import org.osgi.framework.BundleActivator;
 import org.osgi.framework.BundleContext;
@@ -23,8 +25,9 @@ public class MySimpleHandlerActivitor implements BundleActivator {
 
     @Override
     public void start(BundleContext context) throws Exception {
-
-        System.out.println("in start method in bundle activator");
+        // Test ClientBuilder.newBuilder() - will throw exception if it doesn't work
+        ClientBuilder builder = ClientBuilder.newBuilder();
+        
         final Hashtable<String, Object> handlerProps = new Hashtable<String, Object>();
 
         handlerProps.put(HandlerConstants.ENGINE_TYPE, HandlerConstants.ENGINE_TYPE_JAXRS);


### PR DESCRIPTION
Fixes #34019 

bnd files in 3.0, 3.1 and 4.0 versions of restful WS are updated to make sure resteasy is available during feature bundle activation

- [X] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [X] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [X] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

