### PR TITLE
Create useNativeIO config for Netty

### DIFF
--- a/dev/io.openliberty.netty.internal.impl/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/io.openliberty.netty.internal.impl/resources/OSGI-INF/metatype/metatype.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2025 IBM Corporation and others.
+    Copyright (c) 2025, 2026 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -42,6 +42,9 @@
 
          <AD name="internal" description="internal use only"
             id="scalerMetricsWindowSize" required="false" type="String" ibm:type="duration" default="0s" min="0"/>
+
+         <AD name="internal" description="internal use only"
+            id="useNativeIO" required="false" type="Boolean" default="false" />
    </OCD>
 
    <Designate pid="io.openliberty.netty.internal">

--- a/dev/io.openliberty.netty.internal.impl/src/io/openliberty/netty/internal/impl/NettyConstants.java
+++ b/dev/io.openliberty.netty.internal.impl/src/io/openliberty/netty/internal/impl/NettyConstants.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2025 IBM Corporation and others.
+ * Copyright (c) 2021, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -51,4 +51,6 @@ public interface NettyConstants {
     public static final int SCALER_UP_STEP = 1;
     public static final int SCALER_CYCLES = 3;
     public static final long SCALER_METRICS_WINDOW = 0;
+    /** Enable Native Transport (EPoll on Linux, Kqueue on MacOS). Otherwise, NIO is the default */
+    public static final String USE_NATIVE_TRANSPORT = "useNativeIO";
 }

--- a/dev/io.openliberty.netty.internal.impl/src/io/openliberty/netty/internal/impl/NettyFrameworkImpl.java
+++ b/dev/io.openliberty.netty.internal.impl/src/io/openliberty/netty/internal/impl/NettyFrameworkImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2025 IBM Corporation and others.
+ * Copyright (c) 2021, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -116,6 +116,8 @@ public class NettyFrameworkImpl implements ServerQuiesceListener, NettyFramework
 
     private ChannelFrameworkConfig channelConfig;
 
+    private boolean useNativeIO;
+
     @Activate
     protected void activate(ComponentContext context, Map<String, Object> config) {
         if (!ProductInfo.getBetaEdition()) {
@@ -135,26 +137,7 @@ public class NettyFrameworkImpl implements ServerQuiesceListener, NettyFramework
                 }
             });
         }
-        IoHandlerFactory parentFactory;
-        IoHandlerFactory childFactory;
-        if (Epoll.isAvailable()) {
-            parentFactory = EpollIoHandler.newFactory();
-            childFactory = EpollIoHandler.newFactory();
-        } else if (KQueue.isAvailable()) {
-            parentFactory = KQueueIoHandler.newFactory();
-            childFactory = KQueueIoHandler.newFactory();
-        } else {
-            parentFactory = NioIoHandler.newFactory();
-            childFactory = NioIoHandler.newFactory();
-        }
 
-        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-            Tr.debug(tc, "Created IoHandlerFactories -> parent: " + parentFactory + ", child: " + childFactory);
-        }
-
-        // Compared to channelfw, quiesce is hit every time because
-        // connections are lazy cleaned on deactivate
-        parentGroup = new MultiThreadIoEventLoopGroup(1, parentFactory);
         // Attempt to get the properties from the passed configuration but give priority to
         // the system properties if set
         int maxThreads;
@@ -162,6 +145,7 @@ public class NettyFrameworkImpl implements ServerQuiesceListener, NettyFramework
         if (System.getSecurityManager() == null) {
             maxThreads = Integer.getInteger(NettyConstants.SCALER_MAX_THREADS_PROPERTY, (Integer)config.getOrDefault(NettyConstants.SCALER_MAX_THREADS_PROPERTY, NettyConstants.SCALER_MAX_THREADS));
             metricsWindow = Long.getLong(NettyConstants.SCALER_METRICS_WINDOW_PROPERTY, (Long)config.getOrDefault(NettyConstants.SCALER_METRICS_WINDOW_PROPERTY, NettyConstants.SCALER_METRICS_WINDOW));
+            useNativeIO = Boolean.getBoolean(NettyConstants.USE_NATIVE_TRANSPORT) || (Boolean)config.getOrDefault(NettyConstants.USE_NATIVE_TRANSPORT, true);
         }
         else {
             maxThreads = AccessController.doPrivileged(new PrivilegedAction<Integer>() {
@@ -176,7 +160,47 @@ public class NettyFrameworkImpl implements ServerQuiesceListener, NettyFramework
                     return Long.getLong(NettyConstants.SCALER_METRICS_WINDOW_PROPERTY, (Long)config.getOrDefault(NettyConstants.SCALER_METRICS_WINDOW_PROPERTY, NettyConstants.SCALER_METRICS_WINDOW));
                 }
             });
+            useNativeIO = AccessController.doPrivileged(new PrivilegedAction<Boolean>() {
+                @Override
+                public Boolean run() {
+                    return Boolean.getBoolean(NettyConstants.USE_NATIVE_TRANSPORT) || (Boolean)config.getOrDefault(NettyConstants.USE_NATIVE_TRANSPORT, true);
+                }
+            });
         }
+
+        String systemProperty_useNativeIO = System.getProperty("io.openliberty.netty.internal.useNativeIO", "true");
+        if(systemProperty_useNativeIO.equalsIgnoreCase("false")) {
+            useNativeIO = false;
+                if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                    Tr.debug(tc, "io.openliberty.netty.internal.useNativeIO system property is set to false, enabling native transport.");
+                }
+        }
+
+        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+            Tr.debug(tc, "useNativeIO set to: " + useNativeIO);
+        }
+
+        IoHandlerFactory parentFactory;
+        IoHandlerFactory childFactory;
+        if (Epoll.isAvailable() && useNativeIO) {
+            parentFactory = EpollIoHandler.newFactory();
+            childFactory = EpollIoHandler.newFactory();
+        } else if (KQueue.isAvailable() && useNativeIO) {
+            parentFactory = KQueueIoHandler.newFactory();
+            childFactory = KQueueIoHandler.newFactory();
+        } else {
+            parentFactory = NioIoHandler.newFactory();
+            childFactory = NioIoHandler.newFactory();
+        }
+
+        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+            Tr.debug(tc, "Created IoHandlerFactories -> parent: " + parentFactory + ", child: " + childFactory);
+        }
+
+        // Compared to channelfw, quiesce is hit every time because
+        // connections are lazy cleaned on deactivate
+        parentGroup = new MultiThreadIoEventLoopGroup(1, parentFactory);
+
         AutoScalingEventExecutorChooserFactory scaler = createThreadScaler();
         childGroup = new MultiThreadIoEventLoopGroup(maxThreads, null, scaler, childFactory);
         outboundConnections = new DefaultChannelGroup(childGroup.next());
@@ -326,9 +350,9 @@ public class NettyFrameworkImpl implements ServerQuiesceListener, NettyFramework
      * Used for server sockets - based on platform.
      */
     public Class getServerSocketChannelClass() {
-        if(Epoll.isAvailable()){
+        if(Epoll.isAvailable() && useNativeIO){
             return EpollServerSocketChannel.class;
-        } else if (KQueue.isAvailable()) {
+        } else if (KQueue.isAvailable() && useNativeIO){
             return KQueueServerSocketChannel.class;
         } else {
             return NioServerSocketChannel.class;
@@ -339,9 +363,9 @@ public class NettyFrameworkImpl implements ServerQuiesceListener, NettyFramework
      * Used for client sockets - based on platform.
      */
     public Class getSocketChannelClass() {
-        if(Epoll.isAvailable()){
+        if(Epoll.isAvailable() && useNativeIO){
             return EpollSocketChannel.class;
-        } else if (KQueue.isAvailable()) {
+        } else if (KQueue.isAvailable() && useNativeIO){
             return KQueueSocketChannel.class;
         } else {
             return NioSocketChannel.class;
@@ -352,9 +376,9 @@ public class NettyFrameworkImpl implements ServerQuiesceListener, NettyFramework
      * Used in UDP channels - based on platform.
      */
     public Class getDatagramClass() {
-        if (Epoll.isAvailable()) {
+        if (Epoll.isAvailable() && useNativeIO) {
             return EpollDatagramChannel.class;
-        } else if (KQueue.isAvailable()) {
+        } else if (KQueue.isAvailable() && useNativeIO) {
             return KQueueDatagramChannel.class;
         } else {
             return NioDatagramChannel.class;

--- a/dev/io.openliberty.netty.internal.impl/src/io/openliberty/netty/internal/impl/NettyFrameworkImpl.java
+++ b/dev/io.openliberty.netty.internal.impl/src/io/openliberty/netty/internal/impl/NettyFrameworkImpl.java
@@ -9,8 +9,6 @@
  *******************************************************************************/
 package io.openliberty.netty.internal.impl;
 
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.util.Map;
 import java.util.Queue;
 import java.util.Set;
@@ -87,7 +85,7 @@ import io.openliberty.netty.internal.udp.UDPUtils;
  * Liberty NettyFramework implementation bundle
  */
 @Component(immediate = true, service = { NettyFramework.class, ServerQuiesceListener.class },
-           configurationPolicy = ConfigurationPolicy.OPTIONAL,
+           configurationPolicy = ConfigurationPolicy.REQUIRE,
            configurationPid = "io.openliberty.netty.internal",
            property = { "service.vendor=IBM" })
 public class NettyFrameworkImpl implements ServerQuiesceListener, NettyFramework {
@@ -117,7 +115,7 @@ public class NettyFrameworkImpl implements ServerQuiesceListener, NettyFramework
 
     private ChannelFrameworkConfig channelConfig;
 
-    private boolean useNativeIO;
+    private boolean useNativeIO = true;
 
     @Activate
     protected void activate(ComponentContext context, Map<String, Object> config) {
@@ -126,55 +124,20 @@ public class NettyFrameworkImpl implements ServerQuiesceListener, NettyFramework
             return;
         }
         // Netty specific configurations for performance
-        if (System.getSecurityManager() == null) {
-            setNettySystemProperties();
-        }
-        else {
-            AccessController.doPrivileged(new PrivilegedAction<Void>() {
-                @Override
-                public Void run() {
-                    setNettySystemProperties();
-                    return null;
-                }
-            });
-        }
+        setNettySystemProperties();
 
         // Attempt to get the properties from the passed configuration but give priority to
         // the system properties if set
-        int maxThreads;
-        long metricsWindow;
-        if (System.getSecurityManager() == null) {
-            maxThreads = Integer.getInteger(NettyConstants.SCALER_MAX_THREADS_PROPERTY, (Integer)config.getOrDefault(NettyConstants.SCALER_MAX_THREADS_PROPERTY, NettyConstants.SCALER_MAX_THREADS));
-            metricsWindow = Long.getLong(NettyConstants.SCALER_METRICS_WINDOW_PROPERTY, (Long)config.getOrDefault(NettyConstants.SCALER_METRICS_WINDOW_PROPERTY, NettyConstants.SCALER_METRICS_WINDOW));
-            useNativeIO = Boolean.getBoolean(NettyConstants.USE_NATIVE_TRANSPORT) || (Boolean)config.getOrDefault(NettyConstants.USE_NATIVE_TRANSPORT, true);
-        }
-        else {
-            maxThreads = AccessController.doPrivileged(new PrivilegedAction<Integer>() {
-                @Override
-                public Integer run() {
-                    return Integer.getInteger(NettyConstants.SCALER_MAX_THREADS_PROPERTY, (Integer)config.getOrDefault(NettyConstants.SCALER_MAX_THREADS_PROPERTY, NettyConstants.SCALER_MAX_THREADS));
-                }
-            });
-            metricsWindow = AccessController.doPrivileged(new PrivilegedAction<Long>() {
-                @Override
-                public Long run() {
-                    return Long.getLong(NettyConstants.SCALER_METRICS_WINDOW_PROPERTY, (Long)config.getOrDefault(NettyConstants.SCALER_METRICS_WINDOW_PROPERTY, NettyConstants.SCALER_METRICS_WINDOW));
-                }
-            });
-            useNativeIO = AccessController.doPrivileged(new PrivilegedAction<Boolean>() {
-                @Override
-                public Boolean run() {
-                    return Boolean.getBoolean(NettyConstants.USE_NATIVE_TRANSPORT) || (Boolean)config.getOrDefault(NettyConstants.USE_NATIVE_TRANSPORT, true);
-                }
-            });
-        }
+        int maxThreads = Integer.getInteger(NettyConstants.SCALER_MAX_THREADS_PROPERTY, (Integer) config.get(NettyConstants.SCALER_MAX_THREADS_PROPERTY));
+        long metricsWindow = Long.getLong(NettyConstants.SCALER_METRICS_WINDOW_PROPERTY, (Long) config.get(NettyConstants.SCALER_METRICS_WINDOW_PROPERTY));
+        useNativeIO = (Boolean)config.get(NettyConstants.USE_NATIVE_TRANSPORT);
 
         String systemProperty_useNativeIO = System.getProperty("io.openliberty.netty.internal.useNativeIO", "true");
         if(systemProperty_useNativeIO.equalsIgnoreCase("false")) {
             useNativeIO = false;
-                if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-                    Tr.debug(tc, "io.openliberty.netty.internal.useNativeIO system property is set to false, NOT enabling native transport.");
-                }
+            if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                Tr.debug(tc, "io.openliberty.netty.internal.useNativeIO system property is set to false, NOT enabling native transport.");
+            }
         }
 
         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
@@ -202,7 +165,7 @@ public class NettyFrameworkImpl implements ServerQuiesceListener, NettyFramework
         // connections are lazy cleaned on deactivate
         parentGroup = new MultiThreadIoEventLoopGroup(1, parentFactory);
 
-        AutoScalingEventExecutorChooserFactory scaler = createThreadScaler();
+        AutoScalingEventExecutorChooserFactory scaler = createThreadScaler(config);
         childGroup = new MultiThreadIoEventLoopGroup(maxThreads, null, scaler, childFactory);
         outboundConnections = new DefaultChannelGroup(childGroup.next());
         
@@ -219,70 +182,21 @@ public class NettyFrameworkImpl implements ServerQuiesceListener, NettyFramework
         }
     }
 
-    private AutoScalingEventExecutorChooserFactory createThreadScaler() {
-        int minThreads, maxThreads, upStep, downStep, cycles;
-        long windowSize;
-        double downThreshold, upThreshold;
-        if (System.getSecurityManager() == null) {
-            minThreads = Integer.getInteger(NettyConstants.SCALER_MIN_THREADS_PROPERTY, NettyConstants.SCALER_MIN_THREADS);
-            maxThreads = Integer.getInteger(NettyConstants.SCALER_MAX_THREADS_PROPERTY, NettyConstants.SCALER_MAX_THREADS);
-            windowSize = Long.getLong(NettyConstants.SCALER_WINDOW_PROPERTY, NettyConstants.SCALER_WINDOW);
-            downThreshold = parseDouble(NettyConstants.SCALER_DOWN_THRESHOLD_PROPERTY, NettyConstants.SCALER_DOWN_THRESHOLD);
-            upThreshold = parseDouble(NettyConstants.SCALER_UP_THRESHOLD_PROPERTY, NettyConstants.SCALER_UP_THRESHOLD);
-            upStep = Integer.getInteger(NettyConstants.SCALER_UP_STEP_PROPERTY, NettyConstants.SCALER_UP_STEP);
-            downStep = Integer.getInteger(NettyConstants.SCALER_DOWN_STEP_PROPERTY, NettyConstants.SCALER_DOWN_STEP);
-            cycles = Integer.getInteger(NettyConstants.SCALER_CYCLES_PROPERTY, NettyConstants.SCALER_CYCLES);
-        }
-        else {
-            minThreads = AccessController.doPrivileged(new PrivilegedAction<Integer>() {
-                @Override
-                public Integer run() {
-                    return Integer.getInteger(NettyConstants.SCALER_MIN_THREADS_PROPERTY, NettyConstants.SCALER_MIN_THREADS);
-                }
-            });
-            maxThreads = AccessController.doPrivileged(new PrivilegedAction<Integer>() {
-                @Override
-                public Integer run() {
-                    return Integer.getInteger(NettyConstants.SCALER_MAX_THREADS_PROPERTY, NettyConstants.SCALER_MAX_THREADS);
-                }
-            });
-            windowSize = AccessController.doPrivileged(new PrivilegedAction<Long>() {
-                @Override
-                public Long run() {
-                    return Long.getLong(NettyConstants.SCALER_WINDOW_PROPERTY, NettyConstants.SCALER_WINDOW);
-                }
-            });
-            downThreshold = AccessController.doPrivileged(new PrivilegedAction<Double>() {
-                @Override
-                public Double run() {
-                    return parseDouble(NettyConstants.SCALER_DOWN_THRESHOLD_PROPERTY, NettyConstants.SCALER_DOWN_THRESHOLD);
-                }
-            });
-            upThreshold = AccessController.doPrivileged(new PrivilegedAction<Double>() {
-                @Override
-                public Double run() {
-                    return parseDouble(NettyConstants.SCALER_UP_THRESHOLD_PROPERTY, NettyConstants.SCALER_UP_THRESHOLD);
-                }
-            });
-            upStep = AccessController.doPrivileged(new PrivilegedAction<Integer>() {
-                @Override
-                public Integer run() {
-                    return Integer.getInteger(NettyConstants.SCALER_UP_STEP_PROPERTY, NettyConstants.SCALER_UP_STEP);
-                }
-            });
-            downStep = AccessController.doPrivileged(new PrivilegedAction<Integer>() {
-                @Override
-                public Integer run() {
-                    return Integer.getInteger(NettyConstants.SCALER_DOWN_STEP_PROPERTY, NettyConstants.SCALER_DOWN_STEP);
-                }
-            });
-            cycles = AccessController.doPrivileged(new PrivilegedAction<Integer>() {
-                @Override
-                public Integer run() {
-                    return Integer.getInteger(NettyConstants.SCALER_CYCLES_PROPERTY, NettyConstants.SCALER_CYCLES);
-                }
-            });
-        }
+    /**
+     * Creates a Netty Dynamic Autoscaler based off the values in the passed config map.
+     *
+     * @param config Bundle config containing the necessary items for the Auto Scaler
+     */
+    private AutoScalingEventExecutorChooserFactory createThreadScaler(Map<String, Object> config) {
+        int minThreads = Integer.getInteger(NettyConstants.SCALER_MIN_THREADS_PROPERTY, (Integer) config.get(NettyConstants.SCALER_MIN_THREADS_PROPERTY));
+        int maxThreads = Integer.getInteger(NettyConstants.SCALER_MAX_THREADS_PROPERTY, (Integer) config.get(NettyConstants.SCALER_MAX_THREADS_PROPERTY));
+        long windowSize = Long.getLong(NettyConstants.SCALER_WINDOW_PROPERTY, (Long) config.get(NettyConstants.SCALER_WINDOW_PROPERTY));
+        double downThreshold = parseDouble(NettyConstants.SCALER_DOWN_THRESHOLD_PROPERTY,(Double) config.get(NettyConstants.SCALER_DOWN_THRESHOLD_PROPERTY));
+        double upThreshold = parseDouble(NettyConstants.SCALER_UP_THRESHOLD_PROPERTY, (Double) config.get(NettyConstants.SCALER_UP_THRESHOLD_PROPERTY));
+        int upStep = Integer.getInteger(NettyConstants.SCALER_UP_STEP_PROPERTY, (Integer) config.get(NettyConstants.SCALER_UP_STEP_PROPERTY));
+        int downStep = Integer.getInteger(NettyConstants.SCALER_DOWN_STEP_PROPERTY, (Integer) config.get(NettyConstants.SCALER_DOWN_STEP_PROPERTY));
+        int cycles = Integer.getInteger(NettyConstants.SCALER_CYCLES_PROPERTY, (Integer) config.get(NettyConstants.SCALER_CYCLES_PROPERTY));
+        
         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
             Tr.debug(tc, "Creating AutoScaler with minThreads: " + minThreads + ", maxThreads: " + maxThreads + ", windowSize: " + windowSize + ", downThreshold: " + downThreshold + ", upThreshold: " + upThreshold + ", upStep: " + upStep + ", downStep: " + downStep + ", cycles: " + cycles);
         }
@@ -299,32 +213,6 @@ public class NettyFrameworkImpl implements ServerQuiesceListener, NettyFramework
         } catch(NumberFormatException e) {
             return defaultValue;
         }
-    }
-
-    /**
-     * Creates a Netty Dynamic Autoscaler based off the values in the passed config map.
-     *
-     * @param config Bundle config containing the necessary items for the Auto Scaler
-     */
-    private AutoScalingEventExecutorChooserFactory createThreadScaler(Map<String, Object> config) {
-        if(config == null) {
-            throw new IllegalArgumentException("Passed config object that was null!!");
-        }
-        int minThreads, maxThreads, upStep, downStep, cycles;
-        long windowSize;
-        double downThreshold, upThreshold;
-        minThreads = (Integer)config.getOrDefault(NettyConstants.SCALER_MIN_THREADS_PROPERTY, NettyConstants.SCALER_MIN_THREADS);
-        maxThreads = (Integer)config.getOrDefault(NettyConstants.SCALER_MAX_THREADS_PROPERTY, NettyConstants.SCALER_MAX_THREADS);
-        upStep = (Integer)config.getOrDefault(NettyConstants.SCALER_UP_STEP_PROPERTY, NettyConstants.SCALER_UP_STEP);
-        downStep = (Integer)config.getOrDefault(NettyConstants.SCALER_DOWN_STEP_PROPERTY, NettyConstants.SCALER_DOWN_STEP);
-        cycles = (Integer)config.getOrDefault(NettyConstants.SCALER_CYCLES_PROPERTY, NettyConstants.SCALER_CYCLES);
-        windowSize = (Long)config.getOrDefault(NettyConstants.SCALER_WINDOW_PROPERTY, NettyConstants.SCALER_WINDOW);
-        downThreshold = (Double)config.getOrDefault(NettyConstants.SCALER_DOWN_THRESHOLD_PROPERTY, NettyConstants.SCALER_DOWN_THRESHOLD);
-        upThreshold = (Double)config.getOrDefault(NettyConstants.SCALER_UP_THRESHOLD_PROPERTY, NettyConstants.SCALER_UP_THRESHOLD);
-        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-            Tr.debug(tc, "Creating AutoScaler from config with minThreads: " + minThreads + ", maxThreads: " + maxThreads + ", windowSize: " + windowSize + ", downThreshold: " + downThreshold + ", upThreshold: " + upThreshold + ", upStep: " + upStep + ", downStep: " + downStep + ", cycles: " + cycles);
-        }
-        return new AutoScalingEventExecutorChooserFactory(minThreads, maxThreads, windowSize, TimeUnit.MILLISECONDS, downThreshold, upThreshold, upStep, downStep, cycles);
     }
 
     /**

--- a/dev/io.openliberty.netty.internal.impl/src/io/openliberty/netty/internal/impl/NettyFrameworkImpl.java
+++ b/dev/io.openliberty.netty.internal.impl/src/io/openliberty/netty/internal/impl/NettyFrameworkImpl.java
@@ -87,7 +87,8 @@ import io.openliberty.netty.internal.udp.UDPUtils;
  * Liberty NettyFramework implementation bundle
  */
 @Component(immediate = true, service = { NettyFramework.class, ServerQuiesceListener.class },
-           configurationPolicy = ConfigurationPolicy.IGNORE,
+           configurationPolicy = ConfigurationPolicy.OPTIONAL,
+           configurationPid = "io.openliberty.netty.internal",
            property = { "service.vendor=IBM" })
 public class NettyFrameworkImpl implements ServerQuiesceListener, NettyFramework {
 

--- a/dev/io.openliberty.netty.internal.impl/src/io/openliberty/netty/internal/impl/NettyFrameworkImpl.java
+++ b/dev/io.openliberty.netty.internal.impl/src/io/openliberty/netty/internal/impl/NettyFrameworkImpl.java
@@ -173,7 +173,7 @@ public class NettyFrameworkImpl implements ServerQuiesceListener, NettyFramework
         if(systemProperty_useNativeIO.equalsIgnoreCase("false")) {
             useNativeIO = false;
                 if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-                    Tr.debug(tc, "io.openliberty.netty.internal.useNativeIO system property is set to false, enabling native transport.");
+                    Tr.debug(tc, "io.openliberty.netty.internal.useNativeIO system property is set to false, NOT enabling native transport.");
                 }
         }
 
@@ -183,10 +183,10 @@ public class NettyFrameworkImpl implements ServerQuiesceListener, NettyFramework
 
         IoHandlerFactory parentFactory;
         IoHandlerFactory childFactory;
-        if (Epoll.isAvailable() && useNativeIO) {
+        if (useNativeIO && Epoll.isAvailable()) {
             parentFactory = EpollIoHandler.newFactory();
             childFactory = EpollIoHandler.newFactory();
-        } else if (KQueue.isAvailable() && useNativeIO) {
+        } else if (useNativeIO && KQueue.isAvailable()) {
             parentFactory = KQueueIoHandler.newFactory();
             childFactory = KQueueIoHandler.newFactory();
         } else {
@@ -351,9 +351,9 @@ public class NettyFrameworkImpl implements ServerQuiesceListener, NettyFramework
      * Used for server sockets - based on platform.
      */
     public Class getServerSocketChannelClass() {
-        if(Epoll.isAvailable() && useNativeIO){
+        if(useNativeIO && Epoll.isAvailable()){
             return EpollServerSocketChannel.class;
-        } else if (KQueue.isAvailable() && useNativeIO){
+        } else if (useNativeIO && KQueue.isAvailable()){
             return KQueueServerSocketChannel.class;
         } else {
             return NioServerSocketChannel.class;
@@ -364,9 +364,9 @@ public class NettyFrameworkImpl implements ServerQuiesceListener, NettyFramework
      * Used for client sockets - based on platform.
      */
     public Class getSocketChannelClass() {
-        if(Epoll.isAvailable() && useNativeIO){
+        if(useNativeIO && Epoll.isAvailable()){
             return EpollSocketChannel.class;
-        } else if (KQueue.isAvailable() && useNativeIO){
+        } else if (useNativeIO && KQueue.isAvailable()){
             return KQueueSocketChannel.class;
         } else {
             return NioSocketChannel.class;
@@ -377,9 +377,9 @@ public class NettyFrameworkImpl implements ServerQuiesceListener, NettyFramework
      * Used in UDP channels - based on platform.
      */
     public Class getDatagramClass() {
-        if (Epoll.isAvailable() && useNativeIO) {
+        if (useNativeIO && Epoll.isAvailable()) {
             return EpollDatagramChannel.class;
-        } else if (KQueue.isAvailable() && useNativeIO) {
+        } else if (useNativeIO && KQueue.isAvailable()) {
             return KQueueDatagramChannel.class;
         } else {
             return NioDatagramChannel.class;

--- a/dev/io.openliberty.transport.http_fat/fat/src/io/openliberty/transport/http_fat/FATSuite.java
+++ b/dev/io.openliberty.transport.http_fat/fat/src/io/openliberty/transport/http_fat/FATSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2025 IBM Corporation and others.
+ * Copyright (c) 2021, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -32,7 +32,8 @@ import io.openliberty.transport.http_fat.accesslists.AccessListsTests;
                 ContentTypeResponseHeaderTests.class,
                 AccessLogRolloverTest.class,
                 MaxMessageSizeLimitTests.class,
-                Expect100ContinueTest.class
+                Expect100ContinueTest.class,
+                NettyConfigurationTests.class
 })
 
 public class FATSuite {

--- a/dev/io.openliberty.transport.http_fat/fat/src/io/openliberty/transport/http_fat/MaxOpenConnectionsTests.java
+++ b/dev/io.openliberty.transport.http_fat/fat/src/io/openliberty/transport/http_fat/MaxOpenConnectionsTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2025, 2026 IBM Corporation and others.
+ * Copyright (c) 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/dev/io.openliberty.transport.http_fat/fat/src/io/openliberty/transport/http_fat/MaxOpenConnectionsTests.java
+++ b/dev/io.openliberty.transport.http_fat/fat/src/io/openliberty/transport/http_fat/MaxOpenConnectionsTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2026 IBM Corporation and others.
+ * Copyright (c) 2025, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/dev/io.openliberty.transport.http_fat/fat/src/io/openliberty/transport/http_fat/NettyConfigurationTests.java
+++ b/dev/io.openliberty.transport.http_fat/fat/src/io/openliberty/transport/http_fat/NettyConfigurationTests.java
@@ -10,35 +10,23 @@
 package io.openliberty.transport.http_fat;
 
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
 
-import java.net.Socket;
-import java.net.URL;
-import java.util.List;
 import java.util.logging.Logger;
 
-import org.junit.After;
 import org.junit.AfterClass;
-import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import com.ibm.websphere.simplicity.RemoteFile;
-import com.ibm.websphere.simplicity.config.HttpEndpoint;
-import com.ibm.websphere.simplicity.config.ServerConfiguration;
-
-import componenttest.annotation.AllowedFFDC;
 import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
 import componenttest.topology.impl.LibertyServer;
-import componenttest.topology.utils.HttpUtils;
 
 /**
  * Tests to ensure that the netty configuration options are read.
- * Note that this bucket doesn't verify the properties actually work. 
+ * Note that this bucket doesn't verify the properties actually work.
  */
 @Mode(TestMode.FULL)
 @RunWith(FATRunner.class)
@@ -46,8 +34,6 @@ public class NettyConfigurationTests {
 
     private static final String CLASS_NAME = NettyConfigurationTests.class.getName();
     private static final Logger LOG = Logger.getLogger(CLASS_NAME);
-    private static final String NETTY_TCP_CLASS_NAME = "io.openliberty.netty.internal.tcp.TCPUtils";
-    private static boolean runningNetty = false;
 
     @Server("NettyConfigServer")
     public static LibertyServer server;
@@ -67,33 +53,69 @@ public class NettyConfigurationTests {
     }
 
     /**
-     * Checks that the config is read from the server.xml.
-     * 
+     * Verifies that the default netty configuration values are picked up when no explicit config is provided.
      * @throws Exception
      */
     @Test
     public void testNettyConfigurationPickedUp() throws Exception {
-            assertNotNull("scalerMinThreads not found",
-                          server.waitForStringInTrace(".*scalerMinThreads=1.*"));
-            assertNotNull("scalerMaxThreads not found",
-                          server.waitForStringInTrace(".*scalerMaxThreads=10.*"));
-            assertNotNull("scalerWindowSize not found",
-                          server.waitForStringInTrace(".*scalerWindowSize=1500.*"));
-            assertNotNull("scalerDownThreshold not found",
-                          server.waitForStringInTrace(".*scalerDownThreshold=0\\.15.*"));
-            assertNotNull("scalerUpThreshold not found",
-                          server.waitForStringInTrace(".*scalerUpThreshold=0\\.85.*"));
-            assertNotNull("scalerDownStep not found",
-                          server.waitForStringInTrace(".*scalerDownStep=1.*"));
-            assertNotNull("scalerUpStep not found",
-                          server.waitForStringInTrace(".*scalerUpStep=1.*"));
-            assertNotNull("scalerCycles not found",
-                          server.waitForStringInTrace(".*scalerCycles=3.*"));
-            assertNotNull("scalerMetricsWindowSize not found",
-                          server.waitForStringInTrace(".*scalerMetricsWindowSize=5000.*"));
-            assertNotNull("useNativeIO not found",
-                          server.waitForStringInTrace(".*useNativeIO=false.*"));
-            server.resetLogMarks();
+        LOG.info("Testing default netty configuration values");
+
+        // Verify default values are picked up
+        assertNotNull("Default scalerMinThreads=1 not found",
+                      server.waitForStringInTrace(".*scalerMinThreads=1.*"));
+        assertNotNull("Default scalerMaxThreads=4 not found",
+                      server.waitForStringInTrace(".*scalerMaxThreads=4.*"));
+        assertNotNull("Default scalerWindowSize=1500 not found",
+                      server.waitForStringInTrace(".*scalerWindowSize=1500.*"));
+        assertNotNull("Default scalerDownThreshold=0.15 not found",
+                      server.waitForStringInTrace(".*scalerDownThreshold=0\\.15.*"));
+        assertNotNull("Default scalerUpThreshold=0.85 not found",
+                      server.waitForStringInTrace(".*scalerUpThreshold=0\\.85.*"));
+        assertNotNull("Default scalerDownStep=1 not found",
+                      server.waitForStringInTrace(".*scalerDownStep=1.*"));
+        assertNotNull("Default scalerUpStep=1 not found",
+                      server.waitForStringInTrace(".*scalerUpStep=1.*"));
+        assertNotNull("Default scalerCycles=3 not found",
+                      server.waitForStringInTrace(".*scalerCycles=3.*"));
+        assertNotNull("Default scalerMetricsWindowSize=0 not found",
+                      server.waitForStringInTrace(".*scalerMetricsWindowSize=0.*"));
+        
+        LOG.info("Default netty configuration values verified successfully");
+        
+        LOG.info("Stopping server to apply updated configuration");
+        server.stopServer();
+        
+        // Update configuration file
+        server.setServerConfigurationFile("netty-custom-server.xml");
+        
+        // Restart
+        LOG.info("Restarting server with updated netty configuration");
+        server.startServer(NettyConfigurationTests.class.getSimpleName() + ".log", false);
+        
+        // Verify custom configuration values (all different from defaults)
+        LOG.info("Verifying custom netty configuration values");
+        assertNotNull("Custom scalerMinThreads=2 not found (default is 1)",
+                      server.waitForStringInTrace(".*scalerMinThreads=2.*"));
+        assertNotNull("Custom scalerMaxThreads=8 not found (default is 4)",
+                      server.waitForStringInTrace(".*scalerMaxThreads=8.*"));
+        assertNotNull("Custom scalerWindowSize=2000 not found (default is 1500)",
+                      server.waitForStringInTrace(".*scalerWindowSize=2000.*"));
+        assertNotNull("Custom scalerDownThreshold=0.20 not found (default is 0.15)",
+                      server.waitForStringInTrace(".*scalerDownThreshold=0\\.2.*"));
+        assertNotNull("Custom scalerUpThreshold=0.80 not found (default is 0.85)",
+                      server.waitForStringInTrace(".*scalerUpThreshold=0\\.8.*"));
+        assertNotNull("Custom scalerDownStep=2 not found (default is 1)",
+                      server.waitForStringInTrace(".*scalerDownStep=2.*"));
+        assertNotNull("Custom scalerUpStep=2 not found (default is 1)",
+                      server.waitForStringInTrace(".*scalerUpStep=2.*"));
+        assertNotNull("Custom scalerCycles=5 not found (default is 3)",
+                      server.waitForStringInTrace(".*scalerCycles=5.*"));
+        assertNotNull("Custom scalerMetricsWindowSize=10000 not found (default is 0)",
+                      server.waitForStringInTrace(".*scalerMetricsWindowSize=10000.*"));
+        assertNotNull("Custom useNativeIO=false not found",
+                      server.waitForStringInTrace(".*useNativeIO=false.*"));
+        
+        LOG.info("Custom configuration verified successfully - all values differ from the defaults!");
     }
 
 }

--- a/dev/io.openliberty.transport.http_fat/fat/src/io/openliberty/transport/http_fat/NettyConfigurationTests.java
+++ b/dev/io.openliberty.transport.http_fat/fat/src/io/openliberty/transport/http_fat/NettyConfigurationTests.java
@@ -1,0 +1,114 @@
+/*******************************************************************************
+ * Copyright (c) 2025, 2026 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.transport.http_fat;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.net.Socket;
+import java.net.URL;
+import java.util.List;
+import java.util.logging.Logger;
+
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.ibm.websphere.simplicity.RemoteFile;
+import com.ibm.websphere.simplicity.config.HttpEndpoint;
+import com.ibm.websphere.simplicity.config.ServerConfiguration;
+
+import componenttest.annotation.AllowedFFDC;
+import componenttest.annotation.Server;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.custom.junit.runner.Mode;
+import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.utils.HttpUtils;
+
+/**
+ * Tests to ensure that the netty configuration options are read.
+ * Note that this bucket doesn't verify the properties actually work. 
+ */
+@Mode(TestMode.FULL)
+@RunWith(FATRunner.class)
+public class NettyConfigurationTests {
+
+    private static final String CLASS_NAME = NettyConfigurationTests.class.getName();
+    private static final Logger LOG = Logger.getLogger(CLASS_NAME);
+    private static final String NETTY_TCP_CLASS_NAME = "io.openliberty.netty.internal.tcp.TCPUtils";
+    private static boolean runningNetty = false;
+
+    @Server("NettyConfigServer")
+    public static LibertyServer server;
+
+    @BeforeClass
+    public static void setup() throws Exception {
+        // Start the server and use the class name so we can find logs easily.
+        server.startServer(NettyConfigurationTests.class.getSimpleName() + ".log");
+
+        // Go through logs and check if Netty is being used.
+        // Wait for the TCP Channel to finish loading and get the TCP Channel started message.
+        // CWWKO0219I: TCP Channel defaultHttpEndpoint has been started and is now listening for requests on host *  (IPv6) port 8010.
+        String tcpChannelMessage = server.waitForStringInLog("CWWKO0219I: TCP Channel defaultHttpEndpoint");
+        LOG.info("Endpoint: " + tcpChannelMessage);
+
+        runningNetty = tcpChannelMessage.contains(NETTY_TCP_CLASS_NAME);
+        LOG.info("Running Netty? " + runningNetty);
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        // Stop the server
+        if (server != null && server.isStarted()) {
+            server.stopServer();
+        }
+    }
+
+    /**
+     * Checks that the config is read from the server.xml.
+     * 
+     * @throws Exception
+     */
+    @Test
+    public void testNettyConfigurationPickedUp() throws Exception {
+        if (runningNetty) {
+            // Verify all netty configuration properties are present in trace
+            assertNotNull("scalerMinThreads not found",
+                          server.waitForStringInTrace(".*scalerMinThreads=1.*"));
+            assertNotNull("scalerMaxThreads not found",
+                          server.waitForStringInTrace(".*scalerMaxThreads=10.*"));
+            assertNotNull("scalerWindowSize not found",
+                          server.waitForStringInTrace(".*scalerWindowSize=1500.*"));
+            assertNotNull("scalerDownThreshold not found",
+                          server.waitForStringInTrace(".*scalerDownThreshold=0\\.15.*"));
+            assertNotNull("scalerUpThreshold not found",
+                          server.waitForStringInTrace(".*scalerUpThreshold=0\\.85.*"));
+            assertNotNull("scalerDownStep not found",
+                          server.waitForStringInTrace(".*scalerDownStep=1.*"));
+            assertNotNull("scalerUpStep not found",
+                          server.waitForStringInTrace(".*scalerUpStep=1.*"));
+            assertNotNull("scalerCycles not found",
+                          server.waitForStringInTrace(".*scalerCycles=3.*"));
+            assertNotNull("scalerMetricsWindowSize not found",
+                          server.waitForStringInTrace(".*scalerMetricsWindowSize=5000.*"));
+            assertNotNull("useNativeIO not found",
+                          server.waitForStringInTrace(".*useNativeIO=false.*"));
+
+            server.resetLogMarks();
+        } else {
+            LOG.info("Test skipped since Netty is disabled");
+        }
+    }
+
+}

--- a/dev/io.openliberty.transport.http_fat/fat/src/io/openliberty/transport/http_fat/NettyConfigurationTests.java
+++ b/dev/io.openliberty.transport.http_fat/fat/src/io/openliberty/transport/http_fat/NettyConfigurationTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2025, 2026 IBM Corporation and others.
+ * Copyright (c) 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -56,15 +56,6 @@ public class NettyConfigurationTests {
     public static void setup() throws Exception {
         // Start the server and use the class name so we can find logs easily.
         server.startServer(NettyConfigurationTests.class.getSimpleName() + ".log");
-
-        // Go through logs and check if Netty is being used.
-        // Wait for the TCP Channel to finish loading and get the TCP Channel started message.
-        // CWWKO0219I: TCP Channel defaultHttpEndpoint has been started and is now listening for requests on host *  (IPv6) port 8010.
-        String tcpChannelMessage = server.waitForStringInLog("CWWKO0219I: TCP Channel defaultHttpEndpoint");
-        LOG.info("Endpoint: " + tcpChannelMessage);
-
-        runningNetty = tcpChannelMessage.contains(NETTY_TCP_CLASS_NAME);
-        LOG.info("Running Netty? " + runningNetty);
     }
 
     @AfterClass
@@ -82,8 +73,6 @@ public class NettyConfigurationTests {
      */
     @Test
     public void testNettyConfigurationPickedUp() throws Exception {
-        if (runningNetty) {
-            // Verify all netty configuration properties are present in trace
             assertNotNull("scalerMinThreads not found",
                           server.waitForStringInTrace(".*scalerMinThreads=1.*"));
             assertNotNull("scalerMaxThreads not found",
@@ -104,11 +93,7 @@ public class NettyConfigurationTests {
                           server.waitForStringInTrace(".*scalerMetricsWindowSize=5000.*"));
             assertNotNull("useNativeIO not found",
                           server.waitForStringInTrace(".*useNativeIO=false.*"));
-
             server.resetLogMarks();
-        } else {
-            LOG.info("Test skipped since Netty is disabled");
-        }
     }
 
 }

--- a/dev/io.openliberty.transport.http_fat/publish/files/netty-custom-server.xml
+++ b/dev/io.openliberty.transport.http_fat/publish/files/netty-custom-server.xml
@@ -7,7 +7,7 @@
     
     SPDX-License-Identifier: EPL-2.0
  -->
-<server description="Test Netty Default Config">
+<server description="Test Netty Custom Config">
 
     <include location="../fatTestCommon.xml"/>
 
@@ -17,6 +17,20 @@
                   httpsPort="${bvt.prop.HTTP_default.secure}">
         <tcpOptions portOpenRetries="60"/>
     </httpEndpoint>
+
+    <!-- Custom netty configuration with values different from the defaults -->
+    <netty
+        scalerMinThreads="2"
+        scalerMaxThreads="8"
+        scalerWindowSize="2000ms"
+        scalerDownThreshold="0.20"
+        scalerUpThreshold="0.80"
+        scalerDownStep="2"
+        scalerUpStep="2"
+        scalerCycles="5"
+        scalerMetricsWindowSize="10s"
+        useNativeIO="false"
+    />
 
     <featureManager>
         <feature>servlet-3.1</feature>

--- a/dev/io.openliberty.transport.http_fat/publish/servers/NettyConfigServer/bootstrap.properties
+++ b/dev/io.openliberty.transport.http_fat/publish/servers/NettyConfigServer/bootstrap.properties
@@ -1,0 +1,14 @@
+###############################################################################
+# Copyright (c) 2026 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-2.0/
+# 
+# SPDX-License-Identifier: EPL-2.0
+###############################################################################
+bootstrap.include=../testports.properties
+com.ibm.ws.logging.trace.specification=*=info:io.openliberty.netty*=all
+com.ibm.ws.logging.max.file.size=100
+com.ibm.ws.logging.max.files=10
+com.ibm.ws.logging.trace.format=BASIC

--- a/dev/io.openliberty.transport.http_fat/publish/servers/NettyConfigServer/jvm.options
+++ b/dev/io.openliberty.transport.http_fat/publish/servers/NettyConfigServer/jvm.options
@@ -1,0 +1,2 @@
+-Dcom.ibm.ws.beta.edition=true
+

--- a/dev/io.openliberty.transport.http_fat/publish/servers/NettyConfigServer/server.xml
+++ b/dev/io.openliberty.transport.http_fat/publish/servers/NettyConfigServer/server.xml
@@ -1,0 +1,40 @@
+<!--
+    Copyright (c) 2026 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License 2.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-2.0/
+    
+    SPDX-License-Identifier: EPL-2.0
+ -->
+<server description="Test Netty Config">
+
+    <include location="../fatTestCommon.xml"/>
+
+    <httpEndpoint id="defaultHttpEndpoint"
+                  host="*"
+                  httpPort="${bvt.prop.HTTP_default}"
+                  httpsPort="${bvt.prop.HTTP_default.secure}">
+        <tcpOptions portOpenRetries="60"/>
+    </httpEndpoint>
+
+    <!-- Note - this is internal as of writing (Feb, 2026) -->
+     <!-- useNativeIO to true by default, so false should be seen in logs -->
+    <netty 
+        scalerMinThreads="1"
+        scalerMaxThreads="10"
+        scalerWindowSize="1500ms"
+        scalerDownThreshold="0.15"
+        scalerUpThreshold="0.85"
+        scalerDownStep="1"
+        scalerUpStep="1"
+        scalerCycles="3"
+        scalerMetricsWindowSize="5s"
+        useNativeIO="false"
+    />
+
+    <featureManager>
+        <feature>servlet-3.1</feature>
+    </featureManager>
+
+</server>


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".



- Create configuration options to enable Native Transport (Epoll on Linux, Kqueue on Mac OS). Otherwise, it defaults to NIO.
  - Metatype: `useNativeIO` 
  - System Property: `io.openliberty.netty.internal.useNativeIO` (currently available working option)
  
for: #34020
fixes https://github.com/OpenLiberty/open-liberty/issues/34118