### PR TITLE
Move appAuthentication-3.1 and webProfile-11.0 to beta

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.internal.versionless.jaspic-3.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.internal.versionless.jaspic-3.1.feature
@@ -3,7 +3,6 @@ symbolicName=io.openliberty.internal.versionless.jaspic-3.1
 visibility=private
 singleton=true
 -features= \
-    io.openliberty.noShip-1.0, \
     io.openliberty.appAuthentication-3.1
-kind=noship
-edition=full
+kind=beta
+edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.jwtSso1.0.internal.ee-11.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.jwtSso1.0.internal.ee-11.0.feature
@@ -6,11 +6,10 @@ visibility = private
   com.ibm.websphere.appserver.servlet-6.1, \
   io.openliberty.appSecurity-6.0, \
   io.openliberty.jsonp-2.1, \
-  io.openliberty.org.eclipse.microprofile.jwt-2.1, \
-  io.openliberty.noShip-1.0
+  io.openliberty.org.eclipse.microprofile.jwt-2.1
 -bundles=\
   io.openliberty.security.common.internal, \
   io.openliberty.security.jwtsso.internal, \
   io.openliberty.security.mp.jwt.internal
-kind=noship
-edition=full
+kind=beta
+edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/appAuthentication-3.1/io.openliberty.appAuthentication-3.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/appAuthentication-3.1/io.openliberty.appAuthentication-3.1.feature
@@ -15,13 +15,12 @@ Subsystem-Name: Jakarta Authentication 3.1
 -features=io.openliberty.xmlBinding.internal-4.0, \
   io.openliberty.appSecurity-6.0, \
   com.ibm.websphere.appserver.servlet-6.1, \
-  com.ibm.websphere.appserver.eeCompatible-11.0, \
-  io.openliberty.noShip-1.0
+  com.ibm.websphere.appserver.eeCompatible-11.0
 -bundles=\
   io.openliberty.security.jaspic.2.0.internal
 -jars=io.openliberty.jaspic.spi; location:=dev/spi/ibm/
 -files=dev/spi/ibm/javadoc/io.openliberty.jaspic.spi_1.1-javadoc.zip
-kind=noship
-edition=full
+kind=beta
+edition=core
 WLP-InstantOn-Enabled: true
 WLP-Platform: jakartaee-11.0

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/webProfile-11.0/io.openliberty.webProfile-11.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/webProfile-11.0/io.openliberty.webProfile-11.0.feature
@@ -26,6 +26,6 @@ Subsystem-Name: Jakarta EE Web Profile 11.0
   io.openliberty.expressionLanguage-6.0, \
   io.openliberty.jsonp-2.1, \
   io.openliberty.data-1.0
-kind=noship
-edition=full
+kind=beta
+edition=core
 WLP-InstantOn-Enabled: true


### PR DESCRIPTION
- Move appAuthentication-3.1 and webProfile-11.0 as well as the platform 11.0 enablement of the jaspic and appAuthentication versionless features to beta
- Also switch `io.openliberty.jwtSso1.0.internal.ee-11.0` auto feature to beta

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
