### PR TITLE
Fix Netty assertion due to misused API to update window update ratio in H2

### DIFF
--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/netty/pipeline/http2/LibertyUpgradeCodec.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/netty/pipeline/http2/LibertyUpgradeCodec.java
@@ -168,12 +168,17 @@ public class LibertyUpgradeCodec implements UpgradeCodecFactory {
         LibertyInboundHttp2ToHttpAdapter listener = new LibertyInboundHttp2ToHttpAdapter(connection, maxContentlength, false, false, channel);
         HttpToHttp2ConnectionHandler handler = new HttpToHttp2ConnectionHandlerBuilder().frameListener(listener).connection(connection).initialSettings(initialSettings).encoderIgnoreMaxHeaderListSize(true).decoderEnforceMaxRstFramesPerWindow(httpConfig.getH2MaxResetFrames(), frameWindowSize).encoderEnforceMaxRstFramesPerWindow(httpConfig.getH2MaxResetFrames(), frameWindowSize).limitFieldSize(httpConfig.getLimitOfFieldSize()).limitNumHeaders(httpConfig.getLimitOnNumberOfHeaders()).maxHeaderBlockSize(httpConfig.getH2MaxHeaderBlockSize()).build();
         if (!httpConfig.getH2LimitWindowUpdateFrames()) {
-            ((DefaultHttp2LocalFlowController) handler.decoder().flowController()).windowUpdateRatio(0.99999f);
-            try {
-                ((DefaultHttp2LocalFlowController) handler.decoder().flowController()).windowUpdateRatio(connection.connectionStream(), 0.9999f);
-            } catch (Http2Exception e) {
-                e.printStackTrace();
-            }
+            // Execute this in event loop due to assertions
+            channel.eventLoop().execute(() -> {
+                ((DefaultHttp2LocalFlowController) handler.decoder().flowController()).windowUpdateRatio(0.99999f);
+                try {
+                    ((DefaultHttp2LocalFlowController) handler.decoder().flowController()).windowUpdateRatio(connection.connectionStream(), 0.9999f);
+                } catch (Http2Exception e) {
+                    if (TraceComponent.isAnyTracingEnabled() && tc.isErrorEnabled()) {
+                        Tr.error(tc, "Encountered error while attempting to update window ratio: " + e.getMessage() + ". Continuing with default window update ratio.", e);
+                    }
+                }
+            });
         }
         return handler;
     }


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

fixes #32869