### PR TITLE
JMS [Netty]: Avoid using temp buffer

### DIFF
--- a/dev/com.ibm.ws.messaging.comms.client/src/com/ibm/ws/sib/jfapchannel/impl/NettyConnectionReadCompletedCallback.java
+++ b/dev/com.ibm.ws.messaging.comms.client/src/com/ibm/ws/sib/jfapchannel/impl/NettyConnectionReadCompletedCallback.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022, 2025 IBM Corporation and others.
+ * Copyright (c) 2022, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -159,8 +159,6 @@ public class NettyConnectionReadCompletedCallback extends BaseConnectionReadCall
 					done = true;
 					WsByteBuffer contextBuffer = buff;
 
-					contextBuffer.flip();
-
 					// Notify PMI that read has completed.
 					if (conversation.getConversationType() == Conversation.CLIENT)
 					{
@@ -224,7 +222,6 @@ public class NettyConnectionReadCompletedCallback extends BaseConnectionReadCall
 						if (!closing)
 						{
 							// Crude way to ensure we end up with the right sized read buffer.
-
 							contextBuffer.clear();
 
 							boolean forceQueue = false;

--- a/dev/com.ibm.ws.messaging.comms.client/src/com/ibm/ws/sib/jfapchannel/netty/NettyToWsBufferDecoder.java
+++ b/dev/com.ibm.ws.messaging.comms.client/src/com/ibm/ws/sib/jfapchannel/netty/NettyToWsBufferDecoder.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022, 2023 IBM Corporation and others.
+ * Copyright (c) 2022, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -14,6 +14,7 @@ import java.util.List;
 
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.ws.sib.jfapchannel.JFapChannelConstants;
+import com.ibm.ws.sib.jfapchannel.buffer.WsByteBuffer;
 import com.ibm.ws.sib.jfapchannel.buffer.WsByteBufferPool;
 import com.ibm.ws.sib.utils.ras.SibTr;
 
@@ -52,26 +53,22 @@ public class NettyToWsBufferDecoder extends ByteToMessageDecoder {
 			SibTr.debug(this, tc, "decode", ctx.channel().remoteAddress() + " decoding message [ " + in.toString(StandardCharsets.UTF_8) + " ] from Netty ByteBuf to WSByteBuffer");
 		}
 
-		// TODO: Verify if this is the most effective way to do this. See https://github.com/OpenLiberty/open-liberty/issues/24816
-
-		ByteBuf temp = in.readBytes(in.readableBytes());
-
 		byte[] bytes;
 		int offset;
-		int length = temp.readableBytes();
-
-		if (temp.hasArray()) {
-			bytes = temp.array();
-			offset = temp.arrayOffset();
+		int length = in.readableBytes();
+	
+		if (in.hasArray()) {
+			bytes = in.array();
+			offset = in.arrayOffset() + in.readerIndex();
 		} else {
 			bytes = new byte[length];
-			temp.getBytes(temp.readerIndex(), bytes);
+			in.getBytes(in.readerIndex(), bytes);
 			offset = 0;
 		}
-
-		out.add(WsByteBufferPool.getInstance().wrap(bytes).position(in.readerIndex()));
-		temp.release();
-
+	
+		WsByteBuffer wrapped = WsByteBufferPool.getInstance().wrap(bytes, offset, length);
+		out.add(wrapped);
+		in.skipBytes(length);  // skip the read bytes
 
 		if (tc.isEntryEnabled())
 			SibTr.exit(this, tc, "decode", ctx.channel());


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

fixes #24816


-  I saw both sides of the if statement entered, so the code was kept.  


- Removed the use of the temp buffer as it was unnecessary.  However, by doing so, it caused issues later on in the callback, so the flip became unnecessary (already in read mode). 

