### PR TITLE
Fix schemaGen generated xsd is missing attributes for onError

### DIFF
--- a/dev/com.ibm.ws.config/src/com/ibm/ws/config/schemagen/internal/SchemaWriter.java
+++ b/dev/com.ibm.ws.config/src/com/ibm/ws/config/schemagen/internal/SchemaWriter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2014 IBM Corporation and others.
+ * Copyright (c) 2011, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -1141,9 +1141,14 @@ class SchemaWriter {
         }
 
         // If the type is onError then we should generate the onError enum.
-        AttributeDefinition optionAD = attribute.getType() == MetaTypeFactory.ON_ERROR_TYPE ? onErrorDefinition : attribute;
+        AttributeDefinition optionAD = attribute.getType() == MetaTypeFactory.ON_ERROR_TYPE && onErrorDefinition != null ? onErrorDefinition : attribute;
 
         String[] optionValues = optionAD != null ? optionAD.getOptionValues() : null;
+        
+        // If this is an onError type but has no options defined, provide default options
+        if (attribute.getType() == MetaTypeFactory.ON_ERROR_TYPE && (optionValues == null || optionValues.length == 0)) {
+            optionValues = new String[] { "WARN", "FAIL", "IGNORE" };
+        }
 
         final boolean altLabel = alternateLabel;
         DocumentationWriter docWriter = new DocumentationWriter() {

--- a/dev/com.ibm.ws.config/src/com/ibm/ws/config/schemagen/internal/TypeMember.java
+++ b/dev/com.ibm.ws.config/src/com/ibm/ws/config/schemagen/internal/TypeMember.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009 IBM Corporation and others.
+ * Copyright (c) 2009, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -85,10 +85,8 @@ class TypeMember {
         } else if (global) {
             return type.getGlobalSchemaType();
         } else {
-            type.getSchemaBaseType();
+            return type.getSchemaBaseType();
         }
-
-        return "xsd:string";
     }
 
     public void setCardinality(int cardinality) {


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] Fixes #34057
- [x] Fixes #34057


################################################################################################

Two bugs in the schema generation code (com.ibm.ws.config.schemagen):

Missing return statement in TypeMember.getType(): The method fails to return a value when global=false and type is not null.

Null pointer and missing default values for onError types: The code doesn't properly handle null onErrorDefinition parameters.

Stack trace when onErrorDefinition is null:

java.lang.NullPointerException
    at com.ibm.ws.config.schemagen.internal.SchemaWriter.writeAttribute(SchemaWriter.java:1146)