### PR TITLE
Debug patch - Defect 302196 - IBMi - microprofile.config.fat - StressTest

### DIFF
--- a/dev/com.ibm.ws.microprofile.config.1.1_fat/fat/src/com/ibm/ws/microprofile/config/fat/tests/StressTest.java
+++ b/dev/com.ibm.ws.microprofile.config.1.1_fat/fat/src/com/ibm/ws/microprofile/config/fat/tests/StressTest.java
@@ -12,6 +12,7 @@ package com.ibm.ws.microprofile.config.fat.tests;
 import java.io.File;
 
 import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -20,6 +21,7 @@ import org.junit.runner.RunWith;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
 import com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions;
+import com.ibm.websphere.simplicity.log.Log;
 import com.ibm.ws.microprofile.appConfig.stress.test.StressTestServlet;
 import com.ibm.ws.microprofile.config.fat.suite.SharedShrinkWrapApps;
 
@@ -62,9 +64,38 @@ public class StressTest extends FATServletClient {
                                                                           + ".war/resources/META-INF/services/org.eclipse.microprofile.config.spi.ConfigSource"),
                                                                  "services/org.eclipse.microprofile.config.spi.ConfigSource");
 
+        // DEBUG: Log WAR contents before deployment
+        Log.info(StressTest.class, "setUp", "=== WAR Archive Contents ===");
+        stress_war.getContent().forEach((path, node) -> {
+            Log.info(StressTest.class, "setUp", "  " + path.get());
+        });
+        
+        // DEBUG: Export to temp location for inspection on IBMi
+        String osName = System.getProperty("os.name");
+//        if (osName != null && osName.toLowerCase().contains("os/400")) {
+//            File tempWar = new File("/tmp/stress_debug.war");
+//            stress_war.as(ZipExporter.class).exportTo(tempWar, true);
+//            Log.info(StressTest.class, "setUp", "DEBUG: Exported WAR to " + tempWar.getAbsolutePath() + " for inspection");
+//        }
+
         ShrinkHelper.exportDropinAppToServer(server, stress_war, DeployOptions.SERVER_ONLY);
 
         server.startServer();
+        
+        // DEBUG: Verify deployed files on IBMi
+        if (osName != null && osName.toLowerCase().contains("os/400")) {
+            String dropinsPath = server.getServerRoot() + "/dropins/stress.war";
+            Log.info(StressTest.class, "setUp", "DEBUG: Checking deployed WAR at: " + dropinsPath);
+            File deployedWar = new File(dropinsPath);
+            if (deployedWar.exists()) {
+                Log.info(StressTest.class, "setUp", "DEBUG: Deployed WAR exists, size: " + deployedWar.length());
+            } else {
+                Log.info(StressTest.class, "setUp", "DEBUG: WARNING - Deployed WAR not found!");
+            }
+        }
+        
+        // Wait for application to be fully started
+        server.waitForStringInLog("CWWKZ0001I.*stress");
     }
 
     @AfterClass

--- a/dev/com.ibm.ws.microprofile.config.1.1_fat/publish/servers/StressServer/bootstrap.properties
+++ b/dev/com.ibm.ws.microprofile.config.1.1_fat/publish/servers/StressServer/bootstrap.properties
@@ -1,2 +1,7 @@
 bootstrap.include=../testports.properties
 osgi.console=7779
+
+# Enable detailed classloading and app manager traces for debugging IBMi issues
+com.ibm.ws.logging.trace.specification=*=info:com.ibm.ws.classloading*=all:com.ibm.ws.app.manager*=all:com.ibm.ws.artifact*=all:com.ibm.ws.adaptable.module*=all
+
+

--- a/dev/com.ibm.ws.microprofile.config.1.1_fat/test-applications/stress.war/src/com/ibm/ws/microprofile/appConfig/stress/test/StressTestServlet.java
+++ b/dev/com.ibm.ws.microprofile.config.1.1_fat/test-applications/stress.war/src/com/ibm/ws/microprofile/appConfig/stress/test/StressTestServlet.java
@@ -14,6 +14,8 @@ package com.ibm.ws.microprofile.appConfig.stress.test;
 
 import static org.junit.Assert.fail;
 
+import java.io.File;
+import java.net.URL;
 import java.util.Iterator;
 
 import javax.servlet.annotation.WebServlet;
@@ -35,7 +37,130 @@ public class StressTestServlet extends FATServlet {
     public static final String DYNAMIC_REFRESH_INTERVAL_PROP_NAME = "microprofile.config.refresh.rate";
 
     @Test
-    public void testLargeConfigSources() throws Exception {
+    public void test1_Diagnostics() throws Exception {
+        System.out.println("=== Classloader Diagnostics ===");
+        
+        boolean classLoadSuccess = false;
+        
+        // Check if TestUtils class can be loaded
+        try {
+            Class<?> testUtilsClass = Class.forName("com.ibm.ws.microprofile.appConfig.test.utils.TestUtils");
+            System.out.println("SUCCESS: TestUtils class loaded: " + testUtilsClass.getName());
+            System.out.println("ClassLoader: " + testUtilsClass.getClassLoader());
+            
+            // Get the code source location
+            java.security.CodeSource codeSource = testUtilsClass.getProtectionDomain().getCodeSource();
+            if (codeSource != null) {
+                System.out.println("Code source location: " + codeSource.getLocation());
+            }
+            classLoadSuccess = true;
+        } catch (ClassNotFoundException e) {
+            System.out.println("ERROR: TestUtils class not found via Class.forName!");
+            e.printStackTrace();
+        } catch (NoClassDefFoundError e) {
+            System.out.println("ERROR: NoClassDefFoundError for TestUtils class!");
+            e.printStackTrace();
+        }
+        
+        // Check classloader hierarchy - ALWAYS run this
+        System.out.println("\n=== Classloader Hierarchy ===");
+        ClassLoader cl = Thread.currentThread().getContextClassLoader();
+        System.out.println("Current thread classloader: " + cl);
+        int level = 0;
+        while (cl != null && level < 10) {
+            System.out.println("  Level " + level + ": " + cl.getClass().getName());
+            if (cl instanceof java.net.URLClassLoader) {
+                java.net.URLClassLoader urlCl = (java.net.URLClassLoader) cl;
+                System.out.println("    URLs:");
+                for (java.net.URL url : urlCl.getURLs()) {
+                    System.out.println("      " + url);
+                }
+            }
+            cl = cl.getParent();
+            level++;
+        }
+        
+        // Check for testAppUtils.jar in WEB-INF/lib - ALWAYS run this
+        System.out.println("\n=== Resource Location Check ===");
+        try {
+            URL resourceUrl = getClass().getClassLoader().getResource("com/ibm/ws/microprofile/appConfig/test/utils/TestUtils.class");
+            System.out.println("TestUtils.class resource URL: " + resourceUrl);
+            
+            if (resourceUrl != null) {
+                if (resourceUrl.getProtocol().equals("jar")) {
+                    String jarPath = resourceUrl.getPath();
+                    System.out.println("JAR path from URL: " + jarPath);
+                    
+                    // Extract the actual file path
+                    if (jarPath.startsWith("file:")) {
+                        int endIndex = jarPath.indexOf("!");
+                        if (endIndex > 0) {
+                            String filePath = jarPath.substring(5, endIndex);
+                            System.out.println("Extracted file path: " + filePath);
+                            File jarFile = new File(filePath);
+                            System.out.println("JAR file exists: " + jarFile.exists());
+                            if (jarFile.exists()) {
+                                System.out.println("JAR file size: " + jarFile.length());
+                                System.out.println("JAR file readable: " + jarFile.canRead());
+                                System.out.println("JAR file absolute path: " + jarFile.getAbsolutePath());
+                            } else {
+                                System.out.println("ERROR: JAR file does not exist at: " + filePath);
+                                // Check parent directory
+                                File parentDir = jarFile.getParentFile();
+                                if (parentDir != null) {
+                                    System.out.println("Parent directory exists: " + parentDir.exists());
+                                    if (parentDir.exists()) {
+                                        System.out.println("Parent directory contents:");
+                                        File[] files = parentDir.listFiles();
+                                        if (files != null) {
+                                            for (File f : files) {
+                                                System.out.println("  - " + f.getName() + " (size: " + f.length() + ")");
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                } else {
+                    System.out.println("Resource protocol is not 'jar': " + resourceUrl.getProtocol());
+                }
+            } else {
+                System.out.println("ERROR: TestUtils.class resource URL is NULL - class not found in classpath!");
+            }
+        } catch (Exception e) {
+            System.out.println("ERROR checking resource: " + e.getMessage());
+            e.printStackTrace();
+        }
+        
+        // Only fail the test if class loading failed
+        if (!classLoadSuccess) {
+            throw new AssertionError("TestUtils class could not be loaded - see diagnostic output above");
+        }
+    }
+
+    @Test
+    public void test2_EnvironmentValidation() throws Exception {
+        System.out.println("=== Environment Validation ===");
+        System.out.println("OS Name: " + System.getProperty("os.name"));
+        System.out.println("OS Version: " + System.getProperty("os.version"));
+        System.out.println("Java Version: " + System.getProperty("java.version"));
+        System.out.println("File Encoding: " + System.getProperty("file.encoding"));
+        System.out.println("User Dir: " + System.getProperty("user.dir"));
+        
+        // Try to instantiate TestUtils directly
+        try {
+            TestUtils.class.getName();
+            System.out.println("SUCCESS: TestUtils class accessible");
+        } catch (NoClassDefFoundError e) {
+            System.out.println("ERROR: TestUtils class not accessible");
+            e.printStackTrace();
+            throw e;
+        }
+    }
+
+    @Test
+    public void test3_LargeConfigSources() throws Exception {
         int size = 10000;
         Config config = setupLargeConfigSource(size);
         try {


### PR DESCRIPTION

- [X] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [ ] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

Defect 302196 - Test Failure: com.ibm.ws.microprofile.config.fat.tests.StressTest.StressTestServlet.testLargeConfigSources_EE8_FEATURES_MicroProfile_33

The problem seems to happen only on IBMi : 

StressTestServlet.testLargeConfigSources_EE8_FEATURES_MicroProfile_33:junit.framework.AssertionFailedError: 2024-10-06-15:35:30:471 ERROR: Caught exception attempting to call test method testLargeConfigSources on servlet com.ibm.ws.microprofile.appConfig.stress.test.StressTestServlet
java.lang.ClassFormatError: Could not read class 'com.ibm.ws.microprofile.appConfig.test.utils.TestUtils' as resource 'com/ibm/ws/microprofile/appConfig/test/utils/TestUtils.class'
    at com.ibm.ws.classloading.internal.AppClassLoader.findClassBytes(AppClassLoader.java:544)
    at com.ibm.ws.classloading.internal.AppClassLoader.findClass(AppClassLoader.java:324)
    at com.ibm.ws.classloading.internal.AppClassLoader.findOrDelegateLoadClass(AppClassLoader.java:705)
    at com.ibm.ws.classloading.internal.AppClassLoader.loadClass(AppClassLoader.java:584)
    at com.ibm.ws.classloading.internal.AppClassLoader.loadClass(AppClassLoader.java:553)
    at java.lang.ClassLoader.loadClass(ClassLoader.java:876)
    at com.ibm.ws.microprofile.appConfig.stress.test.StressTestServlet.testLargeConfigSources(StressTestServlet.java:43)
    at componenttest.app.FATServlet.doGet(FATServlet.java:80)
    at javax.servlet.http.HttpServlet.service(HttpServlet.java:686)
    at javax.servlet.http.HttpServlet.service(HttpServlet.java:791)
    at com.ibm.ws.webcontainer.servlet.ServletWrapper.service(ServletWrapper.java:1266)
    at com.ibm.ws.webcontainer.servlet.ServletWrapper.handleRequest(ServletWrapper.java:754)
    at com.ibm.ws.webcontainer.servlet.ServletWrapper.handleRequest(ServletWrapper.java:451)
    at com.ibm.ws.webcontainer.filter.WebAppFilterManager.invokeFilters(WebAppFilterManager.java:1362)
    at com.ibm.ws.webcontainer.filter.WebAppFilterManager.invokeFilters(WebAppFilterManager.java:1078)
    at com.ibm.ws.webcontainer.servlet.CacheServletWrapper.handleRequest(CacheServletWrapper.java:77)
    at com.ibm.ws.webcontainer40.servlet.CacheServletWrapper40.handleRequest(CacheServletWrapper40.java:87)
    at com.ibm.ws.webcontainer.WebContainer.handleRequest(WebContainer.java:978)
    at com.ibm.ws.webcontainer.osgi.DynamicVirtualHost$2.run(DynamicVirtualHost.java:293)
    at com.ibm.ws.http.dispatcher.internal.channel.HttpDispatcherLink$TaskWrapper.run(HttpDispatcherLink.java:1260)
    at com.ibm.ws.http.dispatcher.internal.channel.HttpDispatcherLink.wrapHandlerAndExecute(HttpDispatcherLink.java:476)
    at com.ibm.ws.http.dispatcher.internal.channel.HttpDispatcherLink.ready(HttpDispatcherLink.java:435)
    at com.ibm.ws.http.channel.internal.inbound.HttpInboundLink.handleDiscrimination(HttpInboundLink.java:569)
    at com.ibm.ws.http.channel.internal.inbound.HttpInboundLink.handleNewRequest(HttpInboundLink.java:503)
    at com.ibm.ws.http.channel.internal.inbound.HttpInboundLink.processRequest(HttpInboundLink.java:363)
    at com.ibm.ws.http.channel.internal.inbound.HttpInboundLink.ready(HttpInboundLink.java:330)
    at com.ibm.ws.tcpchannel.internal.NewConnectionInitialReadCallback.sendToDiscriminators(NewConnectionInitialReadCallback.java:169)
    at com.ibm.ws.tcpchannel.internal.NewConnectionInitialReadCallback.complete(NewConnectionInitialReadCallback.java:77)
    at com.ibm.ws.tcpchannel.internal.WorkQueueManager.requestComplete(WorkQueueManager.java:516)
    at com.ibm.ws.tcpchannel.internal.WorkQueueManager.attemptIO(WorkQueueManager.java:586)
    at com.ibm.ws.tcpchannel.internal.WorkQueueManager.workerRun(WorkQueueManager.java:970)
    at com.ibm.ws.tcpchannel.internal.WorkQueueManager$Worker.run(WorkQueueManager.java:1059)
    at com.ibm.ws.threading.internal.ExecutorServiceImpl$RunnableWrapper.run(ExecutorServiceImpl.java:298)
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1160)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
    at java.lang.Thread.run(Thread.java:825)
Caused by: java.io.IOException: com.ibm.wsspi.adaptable.module.UnableToAdaptException: java.io.FileNotFoundException: /home/JAZZ_BLD/Build/workspace/ebcTestRunner/dev/autoFVT/image/output/wlp/usr/servers/StressServer/workarea/org.eclipse.osgi/49/data/cache/com.ibm.ws.app.manager_0/.cache/WEB-INF/lib/testAppUtils.jar (A file or directory in the path name does not exist.)
    at com.ibm.ws.classloading.internal.ContainerClassLoader$EntryUniversalResource.getActualBytes(ContainerClassLoader.java:376)
    at com.ibm.ws.classloading.internal.ContainerClassLoader$EntryUniversalResource.getByteResourceInformation(ContainerClassLoader.java:365)
    at com.ibm.ws.classloading.internal.ContainerClassLoader$SmartClassPathImpl.getByteResourceInformation(ContainerClassLoader.java:1226)
    at com.ibm.ws.classloading.internal.ContainerClassLoader.findClassBytes(ContainerClassLoader.java:1628)
    at com.ibm.ws.classloading.internal.AppClassLoader.findClassBytes(AppClassLoader.java:540)
Caused by: com.ibm.wsspi.adaptable.module.UnableToAdaptException: java.io.FileNotFoundException: /home/JAZZ_BLD/Build/workspace/ebcTestRunner/dev/autoFVT/image/output/wlp/usr/servers/StressServer/workarea/org.eclipse.osgi/49/data/cache/com.ibm.ws.app.manager_0/.cache/WEB-INF/lib/testAppUtils.jar (A file or directory in the path name does not exist.)
    at com.ibm.ws.adaptable.module.internal.AdaptableEntryImpl.adapt(AdaptableEntryImpl.java:106)
    at com.ibm.ws.classloading.internal.ContainerClassLoader$EntryUniversalResource.getActualBytes(ContainerClassLoader.java:373)
Caused by: java.io.FileNotFoundException: /home/JAZZ_BLD/Build/workspace/ebcTestRunner/dev/autoFVT/image/output/wlp/usr/servers/StressServer/workarea/org.eclipse.osgi/49/data/cache/com.ibm.ws.app.manager_0/.cache/WEB-INF/lib/testAppUtils.jar (A file or directory in the path name does not exist.)
    at java.util.zip.ZipFile.open(Native Method)
    at java.util.zip.ZipFile.<init>(ZipFile.java:247)
    at java.util.zip.ZipFile.<init>(ZipFile.java:172)
    at java.util.zip.ZipFile.<init>(ZipFile.java:186)
    at com.ibm.ws.artifact.zip.cache.internal.ZipFileUtils$1.run(ZipFileUtils.java:41)
    at com.ibm.ws.artifact.zip.cache.internal.ZipFileUtils$1.run(ZipFileUtils.java:38)
    at java.security.AccessController.doPrivileged(AccessController.java:746)
    at com.ibm.ws.artifact.zip.cache.internal.ZipFileUtils.openZipFile(ZipFileUtils.java:38)
    at com.ibm.ws.artifact.zip.cache.internal.ZipFileUtils.openZipFile(ZipFileUtils.java:30)
    at com.ibm.ws.artifact.zip.cache.internal.ZipFileData.openZipFile(ZipFileData.java:744)
    at com.ibm.ws.artifact.zip.cache.internal.ZipFileData.openZipFile(ZipFileData.java:705)
    at com.ibm.ws.artifact.zip.cache.internal.ZipFileReaper.open(ZipFileReaper.java:1556)
    at com.ibm.ws.artifact.zip.cache.internal.ZipFileReaper.open(ZipFileReaper.java:1503)
    at com.ibm.ws.artifact.zip.cache.internal.ZipFileHandleImpl.open(ZipFileHandleImpl.java:171)
    at com.ibm.ws.artifact.zip.internal.ZipFileEntry.getInputStream(ZipFileEntry.java:191)
    at com.ibm.ws.artifact.overlay.internal.DirectoryBasedOverlayContainerImpl$OverlayDelegatingEntry.getInputStream(DirectoryBasedOverlayContainerImpl.java:499)
    at com.ibm.ws.adaptable.module.internal.AdaptableEntryImpl.adapt(AdaptableEntryImpl.java:104)

    at componenttest.topology.utils.FATServletClient.assertTestResponse(FATServletClient.java:106)
    at componenttest.topology.utils.FATServletClient.runTest(FATServletClient.java:91)
    at componenttest.custom.junit.runner.SyntheticServletTest.invokeExplosively(SyntheticServletTest.java:49)
    at componenttest.custom.junit.runner.FATRunner$1.evaluate(FATRunner.java:209)
    at componenttest.rules.repeater.RepeatTests$CompositeRepeatTestActionStatement.evaluate(RepeatTests.java:149)
    at componenttest.custom.junit.runner.FATRunner$2.evaluate(FATRunner.java:374)
    at componenttest.custom.junit.runner.FATRunner.run(FATRunner.java:178)
