### PR TITLE
Fix SIP UDP Netty deadlocks

### DIFF
--- a/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/channel/resolver/impl/netty/SipResolverTcpTransport.java
+++ b/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/channel/resolver/impl/netty/SipResolverTcpTransport.java
@@ -13,6 +13,7 @@ import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.nio.charset.Charset;
 import java.util.*;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 
@@ -690,6 +691,7 @@ class SipResolverTcpTransport implements SipResolverTransport {
             if (c_logger.isTraceEntryExitEnabled()) {
                 c_logger.traceEntry(this, "channelInactive remote disconnected: " + ctx.channel().remoteAddress());
             }
+            emptyMessageQueue();
             m_channel = null;
         }
 
@@ -700,8 +702,9 @@ class SipResolverTcpTransport implements SipResolverTransport {
             }
             emptyMessageQueue();
             // Run this out of the eventloop
-            if (ctx.channel().eventLoop().inEventLoop())
-                GenericEndpointImpl.getExecutorService().execute(() -> {
+            ExecutorService executor = GenericEndpointImpl.getExecutorService();
+            if (ctx.channel().eventLoop().inEventLoop() && executor != null)
+                executor.execute(() -> {
                     try {
                         readError((Exception)e);
                     } catch (Exception e2) {
@@ -711,6 +714,9 @@ class SipResolverTcpTransport implements SipResolverTransport {
                     }
                 });
             else {
+                if(executor == null && c_logger.isTraceDebugEnabled()) {
+                    c_logger.traceDebug("exceptionCaught found null executor, running error logic in Netty thread.");
+                }
                 readError((Exception) e);
                 // tell the channel to close; the netty framework will be notified
                 ctx.close();
@@ -748,10 +754,14 @@ class SipResolverTcpTransport implements SipResolverTransport {
                 processingMessage = false;
                 return;
             }
+            if (GenericEndpointImpl.getExecutorService() == null) {
+                // We should not process messages in the event loop of Netty so throw exception here
+                ctx.fireExceptionCaught(new NettyException("Null executor service while processing message!"));
+            }
             GenericEndpointImpl.getExecutorService().execute(() -> {
                 try {
                     try {
-                        readComplete(ctx, msg);
+                        readComplete(ctx, ReferenceCountUtil.retain(msg));
                     } catch(Exception e) {
                         // An exception was caught reading the message. Fire exceptionCaught and
                         // return so that we do not keep processing messages but close properly.

--- a/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/channel/resolver/impl/netty/SipResolverTcpTransport.java
+++ b/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/channel/resolver/impl/netty/SipResolverTcpTransport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2023 IBM Corporation and others.
+ * Copyright (c) 2021, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -13,10 +13,12 @@ import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.nio.charset.Charset;
 import java.util.*;
+import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 
 import com.ibm.sip.util.log.Log;
 import com.ibm.sip.util.log.LogMgr;
+import com.ibm.ws.sip.stack.transport.GenericEndpointImpl;
 
 import io.netty.bootstrap.Bootstrap;
 import io.netty.buffer.*;
@@ -25,6 +27,7 @@ import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.channel.socket.nio.NioSocketChannel;
 import io.netty.handler.timeout.ReadTimeoutHandler;
 import io.netty.handler.timeout.WriteTimeoutHandler;
+import io.netty.util.ReferenceCountUtil;
 import io.openliberty.netty.internal.*;
 import io.openliberty.netty.internal.exception.NettyException;
 
@@ -665,6 +668,14 @@ class SipResolverTcpTransport implements SipResolverTransport {
 
     private class SipResolverTcpTransportHandler extends SimpleChannelInboundHandler<ByteBuf> {
 
+        private boolean processingMessage = false;
+        private static final int DEFAULT_MAX_QUEUE = 50;
+        private final LinkedBlockingQueue<ByteBuf> messageQueue;
+
+        public SipResolverTcpTransportHandler() {
+            this.messageQueue = new LinkedBlockingQueue<ByteBuf>(DEFAULT_MAX_QUEUE);
+        }
+
         /** Called when a new connection is established */
         @Override
         public void channelActive(ChannelHandlerContext ctx) throws Exception {
@@ -687,9 +698,23 @@ class SipResolverTcpTransport implements SipResolverTransport {
             if (c_logger.isTraceEntryExitEnabled()) {
                 c_logger.traceEntry(this, "exceptionCaught: " + e.getMessage());
             }
-            readError((Exception) e);
-            // tell the channel to close; the netty framework will be notified
-            ctx.close();
+            emptyMessageQueue();
+            // Run this out of the eventloop
+            if (ctx.channel().eventLoop().inEventLoop())
+                GenericEndpointImpl.getExecutorService().execute(() -> {
+                    try {
+                        readError((Exception)e);
+                    } catch (Exception e2) {
+                        // Ignore exception because this is already after the exception handling finished
+                    } finally {
+                        ctx.close();
+                    }
+                });
+            else {
+                readError((Exception) e);
+                // tell the channel to close; the netty framework will be notified
+                ctx.close();
+            }
         }
 
         @Override
@@ -697,9 +722,70 @@ class SipResolverTcpTransport implements SipResolverTransport {
             if (c_logger.isTraceEntryExitEnabled()) {
                 c_logger.traceEntry(this, "channelRead0 message length: " + msg.readableBytes());
             }
-            ByteBuf b = (ByteBuf) msg;
-            readComplete(ctx, b.retain());
+            messageQueue.offer(ReferenceCountUtil.retain(msg));
+            if (processingMessage) {
+                if (messageQueue.remainingCapacity() == 0) {
+                    if (c_logger.isTraceDebugEnabled()) {
+                        c_logger.traceDebug("Queue reached capacity. Reads are paused.");
+                    }
+                    pauseReading(ctx);
+                }
+            } else {
+                processingMessage = true;
+                processNextMessage(ctx);
+            }
         }
+
+        // This is designed so that the logic besides what runs in the Liberty executor pool
+        // needs to run on the event loop, otherwise there could be race conditions that show up.
+        private void processNextMessage(final ChannelHandlerContext ctx){
+            ByteBuf msg = messageQueue.poll();
+            // Continue reading again if isn't autoread and we have space to queue more messages
+            if(!ctx.channel().config().isAutoRead() && messageQueue.remainingCapacity() > DEFAULT_MAX_QUEUE/2){
+                resumeReading(ctx);
+            }
+            if (msg == null) {
+                processingMessage = false;
+                return;
+            }
+            GenericEndpointImpl.getExecutorService().execute(() -> {
+                try {
+                    try {
+                        readComplete(ctx, msg);
+                    } catch(Exception e) {
+                        // An exception was caught reading the message. Fire exceptionCaught and
+                        // return so that we do not keep processing messages but close properly.
+                        ctx.fireExceptionCaught(e);
+                        return;
+                    }
+                } finally {
+                    ReferenceCountUtil.release(msg);
+                }
+                ctx.channel().eventLoop().execute(() -> processNextMessage(ctx));
+            });
+        }
+
+        private void emptyMessageQueue() {
+            ByteBuf msg;
+            while ((msg = messageQueue.poll()) != null) {
+                ReferenceCountUtil.safeRelease(msg);
+            }
+        }
+
+        private void pauseReading(ChannelHandlerContext context) {
+            ChannelConfig config = context.channel().config();
+            if (config.isAutoRead()) {
+                config.setAutoRead(false);
+            }
+        }
+
+        private void resumeReading(ChannelHandlerContext context) {
+            ChannelConfig config = context.channel().config();
+            if (!config.isAutoRead()) {
+                config.setAutoRead(true);
+            }
+        }
+
     }
 
     /**

--- a/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/channel/resolver/impl/netty/SipResolverUdpTransport.java
+++ b/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/channel/resolver/impl/netty/SipResolverUdpTransport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2006, 2025 IBM Corporation and others.
+ * Copyright (c) 2006, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -13,14 +13,17 @@ import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.nio.charset.Charset;
 import java.util.*;
+import java.util.concurrent.LinkedBlockingQueue;
 
 import com.ibm.sip.util.log.Log;
 import com.ibm.sip.util.log.LogMgr;
+import com.ibm.ws.sip.stack.transport.GenericEndpointImpl;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.*;
 import io.netty.channel.socket.DatagramPacket;
 import io.netty.handler.codec.MessageToMessageDecoder;
+import io.netty.util.ReferenceCountUtil;
 import io.openliberty.netty.internal.*;
 import io.openliberty.netty.internal.exception.NettyException;
 
@@ -593,7 +596,12 @@ class SipResolverUdpTransport implements SipResolverTransport {
 
     private class SipResolverUdpTransportHandler extends SimpleChannelInboundHandler<ByteBuf> {
 
+        private boolean processingMessage = false;
+        private static final int DEFAULT_MAX_QUEUE = 50;
+        private final LinkedBlockingQueue<ByteBuf> messageQueue;
+
         public SipResolverUdpTransportHandler() {
+            this.messageQueue = new LinkedBlockingQueue<ByteBuf>(DEFAULT_MAX_QUEUE);
         }
 
         @Override
@@ -601,7 +609,47 @@ class SipResolverUdpTransport implements SipResolverTransport {
             if (c_logger.isTraceEntryExitEnabled()) {
                 c_logger.traceEntry(this, "channelRead0 message length: " + msg.readableBytes());
             }
-            messageRead(ctx, msg.retain());
+            messageQueue.offer(ReferenceCountUtil.retain(msg));
+            if (processingMessage) {
+                if (messageQueue.remainingCapacity() == 0) {
+                    if (c_logger.isTraceDebugEnabled()) {
+                        c_logger.traceDebug("Queue reached capacity. Reads are paused.");
+                    }
+                    pauseReading(ctx);
+                }
+            } else {
+                processingMessage = true;
+                processNextMessage(ctx);
+            }
+        }
+
+        // This is designed so that the logic besides what runs in the Liberty executor pool
+        // needs to run on the event loop, otherwise there could be race conditions that show up.
+        private void processNextMessage(final ChannelHandlerContext ctx){
+            ByteBuf msg = messageQueue.poll();
+            // Continue reading again if isn't autoread and we have space to queue more messages
+            if(!ctx.channel().config().isAutoRead() && messageQueue.remainingCapacity() > DEFAULT_MAX_QUEUE/2){
+                resumeReading(ctx);
+            }
+            if (msg == null) {
+                processingMessage = false;
+                return;
+            }
+            GenericEndpointImpl.getExecutorService().execute(() -> {
+                try {
+                    try {
+                        messageRead(ctx, msg);
+                    } catch(Exception e) {
+                        // An exception was caught reading the message. Fire exceptionCaught and
+                        // return so that we do not keep processing messages but close properly.
+                        ctx.fireExceptionCaught(e);
+                        return;
+                    }
+                } finally {
+                    ReferenceCountUtil.release(msg);
+                }
+                ctx.channel().eventLoop().execute(() -> processNextMessage(ctx));
+            });
         }
 
         @Override
@@ -609,9 +657,23 @@ class SipResolverUdpTransport implements SipResolverTransport {
             if (c_logger.isTraceEntryExitEnabled()) {
                 c_logger.traceEntry(this, "exceptionCaught: " + e.getMessage());
             }
-            readError(ctx, e);
-            // tell the channel to close; the netty framework will be notified
-            ctx.close();
+            emptyMessageQueue();
+            // Run this out of the eventloop
+            if (ctx.channel().eventLoop().inEventLoop())
+                GenericEndpointImpl.getExecutorService().execute(() -> {
+                    try {
+                        readError(ctx, e);
+                    } catch (Exception e2) {
+                        // Ignore exception because this is already after the exception handling finished
+                    } finally {
+                        ctx.close();
+                    }
+                });
+            else {
+                readError(ctx, e);
+                // tell the channel to close; the netty framework will be notified
+                ctx.close();
+            }
         }
 
         /** Called when a new connection is established */
@@ -630,6 +692,28 @@ class SipResolverUdpTransport implements SipResolverTransport {
             }
             channel = null;
         }
+
+        private void emptyMessageQueue() {
+            ByteBuf msg;
+            while ((msg = messageQueue.poll()) != null) {
+                ReferenceCountUtil.safeRelease(msg);
+            }
+        }
+
+        private void pauseReading(ChannelHandlerContext context) {
+            ChannelConfig config = context.channel().config();
+            if (config.isAutoRead()) {
+                config.setAutoRead(false);
+            }
+        }
+
+        private void resumeReading(ChannelHandlerContext context) {
+            ChannelConfig config = context.channel().config();
+            if (!config.isAutoRead()) {
+                config.setAutoRead(true);
+            }
+        }
+
     }
 
     private final class SipMessageBufferDatagramDecoder extends MessageToMessageDecoder<DatagramPacket> {

--- a/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/channel/resolver/impl/netty/SipResolverUdpTransport.java
+++ b/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/channel/resolver/impl/netty/SipResolverUdpTransport.java
@@ -13,6 +13,7 @@ import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.nio.charset.Charset;
 import java.util.*;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.LinkedBlockingQueue;
 
 import com.ibm.sip.util.log.Log;
@@ -635,6 +636,10 @@ class SipResolverUdpTransport implements SipResolverTransport {
                 processingMessage = false;
                 return;
             }
+            if (GenericEndpointImpl.getExecutorService() == null) {
+                // We should not process messages in the event loop of Netty so throw exception here
+                ctx.fireExceptionCaught(new NettyException("Null executor service while processing message!"));
+            }
             GenericEndpointImpl.getExecutorService().execute(() -> {
                 try {
                     try {
@@ -659,8 +664,9 @@ class SipResolverUdpTransport implements SipResolverTransport {
             }
             emptyMessageQueue();
             // Run this out of the eventloop
-            if (ctx.channel().eventLoop().inEventLoop())
-                GenericEndpointImpl.getExecutorService().execute(() -> {
+            ExecutorService executor = GenericEndpointImpl.getExecutorService();
+            if (ctx.channel().eventLoop().inEventLoop() && executor != null) {
+                executor.execute(() -> {
                     try {
                         readError(ctx, e);
                     } catch (Exception e2) {
@@ -669,7 +675,10 @@ class SipResolverUdpTransport implements SipResolverTransport {
                         ctx.close();
                     }
                 });
-            else {
+            } else {
+                if(executor == null && c_logger.isTraceDebugEnabled()) {
+                    c_logger.traceDebug("exceptionCaught found null executor, running error logic in Netty thread.");
+                }
                 readError(ctx, e);
                 // tell the channel to close; the netty framework will be notified
                 ctx.close();
@@ -690,6 +699,7 @@ class SipResolverUdpTransport implements SipResolverTransport {
             if (c_logger.isTraceEntryExitEnabled()) {
                 c_logger.traceEntry(this, "channelInactive remote disconnected: " + ctx.channel().remoteAddress());
             }
+            emptyMessageQueue();
             channel = null;
         }
 

--- a/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/channel/resolver/impl/netty/SipResolverUdpTransport.java
+++ b/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/channel/resolver/impl/netty/SipResolverUdpTransport.java
@@ -146,9 +146,9 @@ class SipResolverUdpTransport implements SipResolverTransport {
 
         if (c_logger.isTraceDebugEnabled()) {
             c_logger.traceDebug(
-                    "SipResolverTcpTransport: contructor: _ConnectFailuresAllowed: " + _ConnectFailuresAllowed);
+                    "SipResolverUdpTransport: contructor: _ConnectFailuresAllowed: " + _ConnectFailuresAllowed);
             c_logger.traceDebug(
-                    "SipResolverTcpTransport: contructor: _TransportErrorsAllowed: " + _TransportErrorsAllowed);
+                    "SipResolverUdpTransport: contructor: _TransportErrorsAllowed: " + _TransportErrorsAllowed);
         }
 
         if (c_logger.isTraceEntryExitEnabled())

--- a/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/stack/transport/netty/SipDatagramHandler.java
+++ b/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/stack/transport/netty/SipDatagramHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2021, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -9,14 +9,20 @@
  *******************************************************************************/
 package com.ibm.ws.sip.stack.transport.netty;
 
+import java.io.IOException;
+import java.util.concurrent.LinkedBlockingQueue;
+
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.ws.sip.stack.transport.GenericEndpointImpl;
 import com.ibm.ws.sip.stack.transport.sip.netty.*;
 
+import io.netty.channel.ChannelConfig;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.util.Attribute;
 import io.netty.util.AttributeKey;
+import io.netty.util.ReferenceCountUtil;
 import jain.protocol.ip.sip.ListeningPoint;
 
 public class SipDatagramHandler extends SimpleChannelInboundHandler<SipMessageEvent> {
@@ -24,6 +30,14 @@ public class SipDatagramHandler extends SimpleChannelInboundHandler<SipMessageEv
     private static final TraceComponent tc = Tr.register(SipDatagramHandler.class);
 
     final private AttributeKey<SipUdpConnLink> attrKey = AttributeKey.valueOf("SipUdpConnLink");
+
+    private boolean processingMessage = false;
+    private static final int DEFAULT_MAX_QUEUE = 50;
+    private final LinkedBlockingQueue<SipMessageEvent> messageQueue;
+
+    public SipDatagramHandler() {
+        this.messageQueue = new LinkedBlockingQueue<SipMessageEvent>(DEFAULT_MAX_QUEUE);
+    }
 
     /**
      * Called when a new connection is established
@@ -55,24 +69,6 @@ public class SipDatagramHandler extends SimpleChannelInboundHandler<SipMessageEv
     }
 
     @Override
-    public void channelInactive(ChannelHandlerContext ctx) throws Exception {
-        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-            Tr.debug(this, tc, "channelInactive", ctx.channel().remoteAddress() + " has been disconnected");
-        }
-
-        Attribute<SipUdpConnLink> attr = ctx.channel().attr(attrKey);
-        SipUdpConnLink connLink = attr.get();
-        // clean up from connections table
-        if (connLink != null) {
-            connLink.close();
-        } else {
-            if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-                Tr.debug(this, tc, "channelInactive", ctx.name() + "could not find a SIP channel");
-            }
-        }
-    }
-
-    @Override
     protected void channelRead0(ChannelHandlerContext ctx, SipMessageEvent msg) throws Exception {
         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
             Tr.debug(this, tc, "channelRead0. " + ctx.channel() + ". [" + msg.getSipMsg().getMarkedBytesNumber()
@@ -80,11 +76,62 @@ public class SipDatagramHandler extends SimpleChannelInboundHandler<SipMessageEv
         }
         Attribute<SipUdpConnLink> attr = ctx.channel().attr(attrKey);
         SipUdpConnLink connLink = attr.get();
+        if (connLink == null) {
+            if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                Tr.debug(this, tc, "processNextMessage", "could not associate an incoming message with a SIP channel");
+            }
+            throw new IOException("could not associate an incoming message with a SIP channel");
+        }
+        messageQueue.offer(ReferenceCountUtil.retain(msg));
+        if (processingMessage) {
+            if (messageQueue.remainingCapacity() == 0) {
+                if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                    Tr.debug(this, tc, "Queue reached capacity. Reads are paused.");
+                }
+                pauseReading(ctx);
+            }
+        } else {
+            processingMessage = true;
+            processNextMessage(ctx, connLink);
+        }
+    }
+
+    // This is designed so that the logic besides what runs in the Liberty executor pool
+    // needs to run on the event loop, otherwise there could be race conditions that show up.
+    private void processNextMessage(final ChannelHandlerContext ctx, final SipUdpConnLink connLink) {
+        SipMessageEvent msg = messageQueue.poll();
+        // Continue reading again if isn't autoread and we have space to queue more messages
+        if(!ctx.channel().config().isAutoRead() && messageQueue.remainingCapacity() > DEFAULT_MAX_QUEUE/2){
+            resumeReading(ctx);
+        }
+        if (msg == null) {
+            processingMessage = false;
+            return;
+        }
+        GenericEndpointImpl.getExecutorService().execute(() -> {
+            try {
+                connLink.complete(msg.getSipMsg(), msg.getRemoteAddress());
+            } finally {
+                ReferenceCountUtil.release(msg);
+            }
+            ctx.channel().eventLoop().execute(() -> processNextMessage(ctx, connLink));
+        });
+    }
+
+    @Override
+    public void channelInactive(ChannelHandlerContext ctx) throws Exception {
+        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+            Tr.debug(this, tc, "channelInactive", ctx.channel().remoteAddress() + " has been disconnected");
+        }
+        emptyMessageQueue();
+        Attribute<SipUdpConnLink> attr = ctx.channel().attr(attrKey);
+        SipUdpConnLink connLink = attr.get();
+        // clean up from connections table
         if (connLink != null) {
-            connLink.complete(msg.getSipMsg(), msg.getRemoteAddress());
+            GenericEndpointImpl.getExecutorService().execute(() -> connLink.close());
         } else {
             if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-                Tr.debug(this, tc, "channelRead0", "could not find a SIP channel");
+                Tr.debug(this, tc, "channelInactive", ctx.name() + "could not find a SIP channel");
             }
         }
     }
@@ -94,11 +141,12 @@ public class SipDatagramHandler extends SimpleChannelInboundHandler<SipMessageEv
         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
             Tr.debug(this, tc, "exceptionCaught. " + cause.getClass());
         }
+        emptyMessageQueue();
         Attribute<SipUdpConnLink> attr = ctx.channel().attr(attrKey);
         if (cause instanceof Exception) {
             SipUdpConnLink connLink = attr.get();
             if (connLink != null) {
-                connLink.close(cause);
+                GenericEndpointImpl.getExecutorService().execute(() -> connLink.close(cause));
             } else {
                 if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
                     Tr.debug(this, tc, "exceptionCaught", "could not find a SIP channel");
@@ -107,5 +155,27 @@ public class SipDatagramHandler extends SimpleChannelInboundHandler<SipMessageEv
         }
         ctx.close();
     }
+
+    private void emptyMessageQueue() {
+        SipMessageEvent msg;
+        while ((msg = messageQueue.poll()) != null) {
+            ReferenceCountUtil.safeRelease(msg);
+        }
+    }
+
+    private void pauseReading(ChannelHandlerContext context) {
+        ChannelConfig config = context.channel().config();
+        if (config.isAutoRead()) {
+            config.setAutoRead(false);
+        }
+    }
+
+    private void resumeReading(ChannelHandlerContext context) {
+        ChannelConfig config = context.channel().config();
+        if (!config.isAutoRead()) {
+            config.setAutoRead(true);
+        }
+    }
+
 }
 

--- a/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/stack/transport/netty/SipDatagramHandler.java
+++ b/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/stack/transport/netty/SipDatagramHandler.java
@@ -10,6 +10,7 @@
 package com.ibm.ws.sip.stack.transport.netty;
 
 import java.io.IOException;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.LinkedBlockingQueue;
 
 import com.ibm.websphere.ras.Tr;
@@ -24,6 +25,8 @@ import io.netty.util.Attribute;
 import io.netty.util.AttributeKey;
 import io.netty.util.ReferenceCountUtil;
 import jain.protocol.ip.sip.ListeningPoint;
+
+import io.openliberty.netty.internal.exception.NettyException;
 
 public class SipDatagramHandler extends SimpleChannelInboundHandler<SipMessageEvent> {
 
@@ -78,7 +81,7 @@ public class SipDatagramHandler extends SimpleChannelInboundHandler<SipMessageEv
         SipUdpConnLink connLink = attr.get();
         if (connLink == null) {
             if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-                Tr.debug(this, tc, "processNextMessage", "could not associate an incoming message with a SIP channel");
+                Tr.debug(this, tc, "channelRead0", "could not associate an incoming message with a SIP channel");
             }
             throw new IOException("could not associate an incoming message with a SIP channel");
         }
@@ -108,6 +111,10 @@ public class SipDatagramHandler extends SimpleChannelInboundHandler<SipMessageEv
             processingMessage = false;
             return;
         }
+        if (GenericEndpointImpl.getExecutorService() == null) {
+            // We should not process messages in the event loop of Netty so throw exception here
+            ctx.fireExceptionCaught(new NettyException("Null executor service while processing message!"));
+        }
         GenericEndpointImpl.getExecutorService().execute(() -> {
             try {
                 connLink.complete(msg.getSipMsg(), msg.getRemoteAddress());
@@ -128,7 +135,16 @@ public class SipDatagramHandler extends SimpleChannelInboundHandler<SipMessageEv
         SipUdpConnLink connLink = attr.get();
         // clean up from connections table
         if (connLink != null) {
-            GenericEndpointImpl.getExecutorService().execute(() -> connLink.close());
+            ExecutorService executor = GenericEndpointImpl.getExecutorService();
+            if(executor != null) {
+                executor.execute(() -> connLink.close());
+            }
+            else {
+                if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                    Tr.debug(this, tc, "channelInactive", "Running logic in Netty event loop because found null executor for channel: " + ctx.channel());
+                }
+                connLink.close();
+            }
         } else {
             if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
                 Tr.debug(this, tc, "channelInactive", ctx.name() + "could not find a SIP channel");
@@ -146,7 +162,16 @@ public class SipDatagramHandler extends SimpleChannelInboundHandler<SipMessageEv
         if (cause instanceof Exception) {
             SipUdpConnLink connLink = attr.get();
             if (connLink != null) {
-                GenericEndpointImpl.getExecutorService().execute(() -> connLink.close(cause));
+                ExecutorService executor = GenericEndpointImpl.getExecutorService();
+                if(executor != null) {
+                    executor.execute(() -> connLink.close(cause));
+                }
+                else {
+                    if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                        Tr.debug(this, tc, "exceptionCaught", "Running logic in Netty event loop because found null executor for channel: " + ctx.channel());
+                    }
+                    connLink.close(cause);
+                }
             } else {
                 if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
                     Tr.debug(this, tc, "exceptionCaught", "could not find a SIP channel");

--- a/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/stack/transport/netty/SipStreamHandler.java
+++ b/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/stack/transport/netty/SipStreamHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2021, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -9,15 +9,20 @@
  *******************************************************************************/
 package com.ibm.ws.sip.stack.transport.netty;
 
+import java.util.concurrent.LinkedBlockingQueue;
+
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.ws.sip.stack.transaction.transport.connections.SipMessageByteBuffer;
+import com.ibm.ws.sip.stack.transport.GenericEndpointImpl;
 import com.ibm.ws.sip.stack.transport.sip.netty.*;
 
+import io.netty.channel.ChannelConfig;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.util.Attribute;
 import io.netty.util.AttributeKey;
+import io.netty.util.ReferenceCountUtil;
 import jain.protocol.ip.sip.ListeningPoint;
 import java.io.IOException;
 
@@ -26,6 +31,14 @@ public class SipStreamHandler extends SimpleChannelInboundHandler<SipMessageByte
     private static final TraceComponent tc = Tr.register(SipStreamHandler.class);
 
     final private AttributeKey<SipTcpInboundConnLink> attrKey = AttributeKey.valueOf("SipTcpInboundConnLink");
+
+    private boolean processingMessage = false;
+    private static final int DEFAULT_MAX_QUEUE = 50;
+    private final LinkedBlockingQueue<SipMessageByteBuffer> messageQueue;
+
+    public SipStreamHandler() {
+        this.messageQueue = new LinkedBlockingQueue<SipMessageByteBuffer>(DEFAULT_MAX_QUEUE);
+    }
 
     /**
      * Called when a new connection is established
@@ -62,16 +75,46 @@ public class SipStreamHandler extends SimpleChannelInboundHandler<SipMessageByte
         }
         Attribute<SipTcpInboundConnLink> attr = ctx.channel().attr(attrKey);
         SipTcpInboundConnLink connLink = attr.get();
-
-        if (connLink != null) {
-            connLink.complete(msg);
-        } else {
+        if (connLink == null) {
             if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-                Tr.debug(this, tc, "channelRead0", "could not associate an incoming message with a SIP channel");
+                Tr.debug(this, tc, "processNextMessage", "could not associate an incoming message with a SIP channel");
             }
             throw new IOException("could not associate an incoming message with a SIP channel");
         }
+        messageQueue.offer(ReferenceCountUtil.retain(msg));
+        if (processingMessage) {
+            if (messageQueue.remainingCapacity() == 0) {
+                if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                    Tr.debug(this, tc, "Queue reached capacity. Reads are paused.");
+                }
+                pauseReading(ctx);
+            }
+        } else {
+            processingMessage = true;
+            processNextMessage(ctx, connLink);
+        }
+    }
 
+    // This is designed so that the logic besides what runs in the Liberty executor pool
+    // needs to run on the event loop, otherwise there could be race conditions that show up.
+    private void processNextMessage(final ChannelHandlerContext ctx, final SipTcpInboundConnLink connLink){
+        SipMessageByteBuffer msg = messageQueue.poll();
+        // Continue reading again if isn't autoread and we have space to queue more messages
+        if(!ctx.channel().config().isAutoRead() && messageQueue.remainingCapacity() > DEFAULT_MAX_QUEUE/2){
+            resumeReading(ctx);
+        }
+        if (msg == null) {
+            processingMessage = false;
+            return;
+        }
+        GenericEndpointImpl.getExecutorService().execute(() -> {
+            try {
+                connLink.complete(msg);
+            } finally {
+                ReferenceCountUtil.release(msg);
+            }
+            ctx.channel().eventLoop().execute(() -> processNextMessage(ctx, connLink));
+        });
     }
 
     @Override
@@ -79,12 +122,12 @@ public class SipStreamHandler extends SimpleChannelInboundHandler<SipMessageByte
         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
             Tr.debug(this, tc, "channelInactive", ctx.channel().remoteAddress() + " has been disconnected");
         }
-
+        emptyMessageQueue();
         Attribute<SipTcpInboundConnLink> attr = ctx.channel().attr(attrKey);
         SipTcpInboundConnLink connLink = attr.get();
         // clean up from connections table
         if (connLink != null) {
-            connLink.destroy();
+            GenericEndpointImpl.getExecutorService().execute(() -> connLink.destroy());
         } else {
             if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
                 Tr.debug(this, tc, "channelInactive", "could not find a SIP channel");
@@ -97,11 +140,12 @@ public class SipStreamHandler extends SimpleChannelInboundHandler<SipMessageByte
         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
             Tr.debug(this, tc, "exceptionCaught. " + cause.getClass());
         }
+        emptyMessageQueue();
         Attribute<SipTcpInboundConnLink> attr = ctx.channel().attr(attrKey);
         if (cause instanceof Exception) {
             SipTcpInboundConnLink connLink = attr.get();
             if (connLink != null) {
-                connLink.destroy((Exception) cause);
+                GenericEndpointImpl.getExecutorService().execute(() -> connLink.destroy((Exception) cause));
             } else {
                 if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
                     Tr.debug(this, tc, "exceptionCaught", "could not find a SIP channel");
@@ -110,4 +154,26 @@ public class SipStreamHandler extends SimpleChannelInboundHandler<SipMessageByte
         }
         ctx.close();
     }
+
+    private void emptyMessageQueue() {
+        SipMessageByteBuffer msg;
+        while ((msg = messageQueue.poll()) != null) {
+            ReferenceCountUtil.safeRelease(msg);
+        }
+    }
+
+    private void pauseReading(ChannelHandlerContext context) {
+        ChannelConfig config = context.channel().config();
+        if (config.isAutoRead()) {
+            config.setAutoRead(false);
+        }
+    }
+
+    private void resumeReading(ChannelHandlerContext context) {
+        ChannelConfig config = context.channel().config();
+        if (!config.isAutoRead()) {
+            config.setAutoRead(true);
+        }
+    }
+
 }

--- a/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/stack/transport/netty/SipStreamHandler.java
+++ b/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/stack/transport/netty/SipStreamHandler.java
@@ -9,6 +9,7 @@
  *******************************************************************************/
 package com.ibm.ws.sip.stack.transport.netty;
 
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.LinkedBlockingQueue;
 
 import com.ibm.websphere.ras.Tr;
@@ -25,6 +26,8 @@ import io.netty.util.AttributeKey;
 import io.netty.util.ReferenceCountUtil;
 import jain.protocol.ip.sip.ListeningPoint;
 import java.io.IOException;
+
+import io.openliberty.netty.internal.exception.NettyException;
 
 public class SipStreamHandler extends SimpleChannelInboundHandler<SipMessageByteBuffer> {
 
@@ -77,7 +80,7 @@ public class SipStreamHandler extends SimpleChannelInboundHandler<SipMessageByte
         SipTcpInboundConnLink connLink = attr.get();
         if (connLink == null) {
             if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-                Tr.debug(this, tc, "processNextMessage", "could not associate an incoming message with a SIP channel");
+                Tr.debug(this, tc, "channelRead0", "could not associate an incoming message with a SIP channel");
             }
             throw new IOException("could not associate an incoming message with a SIP channel");
         }
@@ -107,6 +110,10 @@ public class SipStreamHandler extends SimpleChannelInboundHandler<SipMessageByte
             processingMessage = false;
             return;
         }
+        if (GenericEndpointImpl.getExecutorService() == null) {
+            // We should not process messages in the event loop of Netty so throw exception here
+            ctx.fireExceptionCaught(new NettyException("Null executor service while processing message!"));
+        }
         GenericEndpointImpl.getExecutorService().execute(() -> {
             try {
                 connLink.complete(msg);
@@ -127,7 +134,16 @@ public class SipStreamHandler extends SimpleChannelInboundHandler<SipMessageByte
         SipTcpInboundConnLink connLink = attr.get();
         // clean up from connections table
         if (connLink != null) {
-            GenericEndpointImpl.getExecutorService().execute(() -> connLink.destroy());
+            ExecutorService executor = GenericEndpointImpl.getExecutorService();
+            if(executor != null) {
+                executor.execute(() -> connLink.destroy());
+            }
+            else {
+                if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                    Tr.debug(this, tc, "channelInactive", "Running logic in Netty event loop because found null executor for channel: " + ctx.channel());
+                }
+                connLink.destroy();
+            }
         } else {
             if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
                 Tr.debug(this, tc, "channelInactive", "could not find a SIP channel");
@@ -145,7 +161,16 @@ public class SipStreamHandler extends SimpleChannelInboundHandler<SipMessageByte
         if (cause instanceof Exception) {
             SipTcpInboundConnLink connLink = attr.get();
             if (connLink != null) {
-                GenericEndpointImpl.getExecutorService().execute(() -> connLink.destroy((Exception) cause));
+                ExecutorService executor = GenericEndpointImpl.getExecutorService();
+                if(executor != null) {
+                    executor.execute(() -> connLink.destroy((Exception) cause));
+                }
+                else {
+                    if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                        Tr.debug(this, tc, "exceptionCaught", "Running logic in Netty event loop because found null executor for channel: " + ctx.channel());
+                    }
+                    connLink.destroy((Exception) cause);
+                }
             } else {
                 if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
                     Tr.debug(this, tc, "exceptionCaught", "could not find a SIP channel");

--- a/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/stack/transport/sip/netty/SipOutboundConnLink.java
+++ b/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/stack/transport/sip/netty/SipOutboundConnLink.java
@@ -219,7 +219,7 @@ public abstract class SipOutboundConnLink extends SipConnLink {
 		// needs to run on the event loop, otherwise there could be race conditions that show up.
 		private void processNextMessage(final ChannelHandlerContext ctx) {
 			SipMessageByteBuffer msg = messageQueue.poll();
-			if(!ctx.channel().config().isAutoRead() && messageQueue.remainingCapacity() > 0){
+			if(!ctx.channel().config().isAutoRead() && messageQueue.remainingCapacity() > DEFAULT_MAX_QUEUE/2){
 				resumeReading(ctx);
 			}
 			if (msg == null) {


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [ ] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

Fixes intermittent issues in SIP Netty runs with a deadlock between the Liberty executor pool and the Netty executors.