### PR TITLE
Fix EJB timing issue with Jakarta Data

### DIFF
--- a/dev/com.ibm.ws.injection/src/com/ibm/ws/injectionengine/osgi/internal/OSGiReferenceContextImpl.java
+++ b/dev/com.ibm.ws.injection/src/com/ibm/ws/injectionengine/osgi/internal/OSGiReferenceContextImpl.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2015 IBM Corporation and others.
+ * Copyright (c) 2012, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -28,8 +28,8 @@ public class OSGiReferenceContextImpl extends ReferenceContextImpl implements De
 
     @Override
     public synchronized void process() throws InjectionException {
-        scopeData.removeDeferredReferenceData(this);
         super.process();
+        scopeData.removeDeferredReferenceData(this);
     }
 
     @Override

--- a/dev/io.openliberty.data.internal_fat_datastore/publish/servers/io.openliberty.data.internal.fat.datastore/bootstrap.properties
+++ b/dev/io.openliberty.data.internal_fat_datastore/publish/servers/io.openliberty.data.internal.fat.datastore/bootstrap.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2023,2025 IBM Corporation and others.
+# Copyright (c) 2023,2026 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -11,4 +11,4 @@
 #     IBM Corporation - initial API and implementation
 ###############################################################################
 bootstrap.include=../testports.properties
-com.ibm.ws.logging.trace.specification=*=info:data=all:persistenceService=all:com.ibm.ws.ejbcontainer.runtime.*=all:com.ibm.ws.ejbcontainer.osgi.internal.*=all:com.ibm.ws.metadata.ejb.*=all:com.ibm.ws.injectionengine.osgi.internal.*=all:com.ibm.ws.injectionengine.*=all
+com.ibm.ws.logging.trace.specification=*=info:data=all:persistenceService=all


### PR DESCRIPTION
During application start, Jakarta Data is attempting to lookup a java:module reference before it is available. The call should be blocked until deferred reference metadata is processed, but another thread has removed the deferred metadata before actually processing it resulting in the Jakarta Data thread continuing with the lookup before it is ready.

- move the call to remove the deferred metadata until after the call to process has completed
- reduce trace in failing test back to the level when the failure last occurred in builds.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".