### PR TITLE
debug: FeatureList timeouts

### DIFF
--- a/dev/fattest.simplicity/src/componenttest/depchain/FeatureList.java
+++ b/dev/fattest.simplicity/src/componenttest/depchain/FeatureList.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2022 IBM Corporation and others.
+ * Copyright (c) 2017, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -12,10 +12,15 @@
  *******************************************************************************/
 package componenttest.depchain;
 
+import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
-import java.util.Scanner;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 import com.ibm.websphere.simplicity.log.Log;
 
@@ -33,7 +38,7 @@ public class FeatureList {
 
     @SuppressWarnings("resource")
     public static synchronized File get(LibertyServer server) throws Exception {
-        final String m = "createFeatureList";
+        final String m = "get";
 
         featureList = new File(server.getUserDir() + "/servers", FAT_FEATURE_LIST);
         if (featureList.exists())
@@ -45,23 +50,38 @@ public class FeatureList {
         Process featureListProc = new ProcessBuilder("java", "-jar", featureListJar, featureList.getAbsolutePath())
                         .redirectErrorStream(true)
                         .start();
+
+        // Create a thread to capture the output of the process (stdout + stderr)
+        Future<String> output = Executors.newSingleThreadExecutor().submit(() -> {
+            return new BufferedReader(new InputStreamReader(featureListProc.getInputStream(), StandardCharsets.UTF_8))
+                            .lines()
+                            .collect(Collectors.joining(System.lineSeparator()));
+        });
+
         boolean completed = featureListProc.waitFor(TIMEOUT_MINUTES, TimeUnit.MINUTES);
         if (!completed) {
-            Exception e = new Exception("Generating " + FAT_FEATURE_LIST + " timed out after " + TIMEOUT_MINUTES + " minutes. Aborting process.");
-            Log.error(c, m, e);
+            // Destroy the process (still capturing output)
             featureListProc.destroyForcibly();
             featureListProc.waitFor();
+
+            //Output error
+            Exception e = new Exception("Generating " + FAT_FEATURE_LIST + " timed out after "
+                                        + TIMEOUT_MINUTES + " minutes. Aborting process." + System.lineSeparator()
+                                        + output.get());
+            Log.error(c, m, e);
+
             reset();
             throw e;
         }
+
         int rc = featureListProc.exitValue();
         if (rc != 0) {
-            String cmdOutput;
-            try (Scanner s = new Scanner(featureListProc.getInputStream()).useDelimiter("\\A")) {
-                cmdOutput = s.hasNext() ? s.next() : "";
-            }
-            Exception e = new Exception("Process failed with rc=" + rc + " for " + featureList.getAbsolutePath() + " generation:\n" + cmdOutput);
+            //Output error
+            Exception e = new Exception("Process failed with rc=" + rc + " for " + featureList.getAbsolutePath()
+                                        + " generation:" + System.lineSeparator()
+                                        + output.get());
             Log.error(c, m, e);
+
             reset();
             throw e;
         }


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

Currently the FeatureList utility only outputs the process output the process returns an error code, meaning that debugging the process when it times out is impossible. 
Improve this utility by logging the process output after a timeout as well.
