### PR TITLE
Jakarta Security 4.0 InMemoryIdentityStore FAT - Fix Defect 308549

### DIFF
--- a/dev/io.openliberty.security.jakartasec.4.0.internal_fat/fat/src/io/openliberty/security/jakartasec/fat/tests/InMemoryIdentityStoreTests.java
+++ b/dev/io.openliberty.security.jakartasec.4.0.internal_fat/fat/src/io/openliberty/security/jakartasec/fat/tests/InMemoryIdentityStoreTests.java
@@ -25,7 +25,6 @@ import static io.openliberty.security.jakartasec.fat.utils.Jakartasec40TestConst
 import static io.openliberty.security.jakartasec.fat.utils.Jakartasec40TestConstants.WRONG_CRED_ERROR_MSG;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import java.io.BufferedReader;
@@ -102,28 +101,15 @@ public class InMemoryIdentityStoreTests {
     public void testInMemStoreWarningAppearsOnce() throws Exception {
         Log.info(c, "testInMemStoreWarningAppearsOnce", "Testing warning message of in-mem identity store appearing only once");
 
-        // Mark the log before first authentication
-        server.setMarkToEndOfLog(); // reset the marks in the log so we are only looking at the output from the second call to the app
-
         // Should get 200 and proceed
         executeGetRequestBasicAuth(url, USER_THEO, VALID_PASSWORD, 200);
-
-        // Check that warning appears
-        assertNotNull("Warning message should appear in log",
-                      server.waitForStringInLogUsingMark(PRODUCTION_USE_WARNING_MSG));
-
-        // Mark log again
-        server.setMarkToEndOfLog();
-
         // Second authentication - warning should NOT appear again
         executeGetRequestBasicAuth(url, USER_LISA, VALID_PASSWORD, 200);
 
         // Wait a bit to ensure no warning appears
         Thread.sleep(2000);
 
-        // Verify warning does not appear again
-        assertNull("Warning should only appear once",
-                   server.waitForStringInLogUsingMark(PRODUCTION_USE_WARNING_MSG));
+        assertEquals("Warning message should appear in log once", 1, server.waitForMultipleStringsInLog(1, PRODUCTION_USE_WARNING_MSG));
 
         Log.info(c, "testInMemStoreWarningAppearsOnce", "Test passed");
     }


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

Fixes Defect [308549](https://wasrtc.hursley.ibm.com:9443/jazz/web/projects/WS-CD#action=com.ibm.team.workitem.viewWorkItem&id=308549)

### Issue Description
The issue was related to the test methods ordering, on the inmemory identity store test class.
JUnit 4 by default executes test methods in a non-deterministic order. Thus so we could not ensure that the corresponding scenario that checks the number of the warning occurrences will always be asserted successfully, by invoking the `server.waitForStringInLogUsingMark()`.

### Solution
We replaced the invocation of `server.waitForStringInLogUsingMark()` with the `server.waitForMultipleStringsInLog()` that checks the number of occurrences for the regex.