### PR TITLE
App start fails when servlet def in fragment but mapping in web xml

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/protected/com.ibm.websphere.appserver.containerServices-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/protected/com.ibm.websphere.appserver.containerServices-1.0.feature
@@ -20,7 +20,7 @@ IBM-Process-Types: server, \
  com.ibm.ws.javaee.version, \
  com.ibm.ws.serialization
 -jars=com.ibm.websphere.appserver.spi.containerServices; location:=dev/spi/ibm/
--files=dev/spi/ibm/javadoc/com.ibm.websphere.appserver.spi.containerServices_4.1-javadoc.zip
+-files=dev/spi/ibm/javadoc/com.ibm.websphere.appserver.spi.containerServices_4.2-javadoc.zip
 kind=ga
 edition=core
 WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.spi.containerServices/bnd.bnd
+++ b/dev/com.ibm.websphere.appserver.spi.containerServices/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017, 2025 IBM Corporation and others.
+# Copyright (c) 2017, 2026 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -11,7 +11,7 @@
 #     IBM Corporation - initial API and implementation
 #*******************************************************************************
 -include= ~../cnf/resources/bnd/bundle.props
-bVersion: 4.1
+bVersion: 4.2
 
 Bundle-Name: WebSphere Container Services SPI
 Bundle-Description: WebSphere Container Services SPI, version ${bVersion}

--- a/dev/com.ibm.ws.container.service/src/com/ibm/ws/container/service/config/ServletConfigurator.java
+++ b/dev/com.ibm.ws.container.service/src/com/ibm/ws/container/service/config/ServletConfigurator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2020 IBM Corporation and others.
+ * Copyright (c) 2012, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -105,7 +105,11 @@ public interface ServletConfigurator {
 
     public ConfigSource getConfigSource();
 
+    public void setConfigSource(ConfigSource source);
+
     public String getLibraryURI();
+
+    public void setLibraryURI(String libraryURI);
 
     boolean getMetadataCompleted();
 

--- a/dev/com.ibm.ws.container.service/src/com/ibm/ws/container/service/config/package-info.java
+++ b/dev/com.ibm.ws.container.service/src/com/ibm/ws/container/service/config/package-info.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2015 IBM Corporation and others.
+ * Copyright (c) 2011, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -10,6 +10,6 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-/** @version 2.1 */
-@org.osgi.annotation.versioning.Version("2.1")
+/** @version 2.2 */
+@org.osgi.annotation.versioning.Version("2.2")
 package com.ibm.ws.container.service.config;

--- a/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/osgi/container/config/WebAppConfigurator.java
+++ b/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/osgi/container/config/WebAppConfigurator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2021 IBM Corporation and others.
+ * Copyright (c) 2011, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -356,9 +356,17 @@ public class WebAppConfigurator implements ServletConfigurator {
         return this.currentSource;
     }
 
+    public void setConfigSource(ConfigSource source) {
+        this.currentSource = source;
+    }
+
     @Override
     public String getLibraryURI() {
         return this.currentLibraryURI;
+    }
+
+    public void setLibraryURI(String libraryURI) {
+        this.currentLibraryURI = libraryURI;
     }
 
     @Override

--- a/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/osgi/container/config/WebAppConfiguratorHelper.java
+++ b/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/osgi/container/config/WebAppConfiguratorHelper.java
@@ -3451,13 +3451,7 @@ public class WebAppConfiguratorHelper implements ServletConfiguratorHelper {
                 List<String> urlPatterns = servletMapping.getURLPatterns();
                 for (String urlPattern : urlPatterns) {
                     if (isServletSpecLevel31OrHigher()) {
-                        String existingName = urlToServletNameMap.put(urlPattern, servletName);
-                        if ((existingName != null) && !(existingName.equals(servletName))) {
-                            Tr.error(tc,"duplicate.url.pattern.for.servlet.mapping", urlPattern, servletName, existingName);
-                            throw new UnableToAdaptException(nls.getFormattedMessage("duplicate.url.pattern.for.servlet.mapping",
-                                                                                     new Object[]{urlPattern, servletName, existingName} ,
-                                                                                     "servlet-mapping value matches multiple servlets: " + urlPattern));
-                        }
+                        urlToServletNameMap.put(urlPattern, servletName);
                     }
                     webAppConfiguration.addServletMapping(servletName, urlPattern);
                 }

--- a/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/osgi/container/config/WebAppConfiguratorHelper.java
+++ b/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/osgi/container/config/WebAppConfiguratorHelper.java
@@ -3460,6 +3460,73 @@ public class WebAppConfiguratorHelper implements ServletConfiguratorHelper {
                                  + " , the value from annotation is ignored");
                 }
             }
+            
+            // NOTE: The following two cases (ANNOTATION -> WEB_XML and ANNOTATION -> WEB_FRAGMENT) are
+            // commented out to avoid introducing behavior changes for existing users.
+            //
+            // While these cases would implement correct Jakarta EE precedence rules, they could cause
+            // existing applications to behave differently:
+            //
+            // 1. ANNOTATION -> WEB_XML: web.xml mapping would REPLACE annotation mapping
+            //    - Before: annotation mapping used (web.xml mapping silently ignored)
+            //    - After: web.xml mapping replaces annotation mapping
+            //    - Risk: Servlet responds to different URLs than before
+            //
+            // 2. ANNOTATION -> WEB_FRAGMENT: web-fragment mapping would ADD to annotation mapping
+            //    - Before: only annotation mapping used (web-fragment mapping silently ignored)
+            //    - After: both annotation AND web-fragment mappings active
+            //    - Risk: Servlet responds to more URLs than before
+            //
+            // These cases are not required to fix the reported issue (servlet-mapping in
+            // web.xml referencing servlet definition in web-fragment.xml), which is handled by the
+            // WEB_FRAGMENT -> WEB_XML case above.
+            //
+            // If spec-compliant annotation handling is needed in the future, these cases can be
+            // uncommented and the behavior change documented in release notes.
+            
+            
+            // } else if (existedServletMapping.getSource() == ConfigSource.ANNOTATION && configurator.getConfigSource() == ConfigSource.WEB_XML) {
+            //     // WEB_XML overrides ANNOTATION - replace the existing mapping
+            //     if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+            //         Tr.debug(tc, "servlet-mapping for servlet " + servletName + " from web.xml overrides the value from annotation");
+            //     }
+            //     // Update the servlet mapping map with the new WEB_XML mapping
+            //     List<String> urlPatterns = servletMapping.getURLPatterns();
+            //     for (String urlPattern : urlPatterns) {
+            //         if (isServletSpecLevel31OrHigher()) {
+            //             String existingName = urlToServletNameMap.put(urlPattern, servletName);
+            //             if ((existingName != null) && !(existingName.equals(servletName))) {
+            //                 Tr.error(tc,"duplicate.url.pattern.for.servlet.mapping", urlPattern, servletName, existingName);
+            //                 throw new UnableToAdaptException(nls.getFormattedMessage("duplicate.url.pattern.for.servlet.mapping",
+            //                                                                          new Object[]{urlPattern, servletName, existingName} ,
+            //                                                                          "servlet-mapping value matches multiple servlets: " + urlPattern));
+            //             }
+            //         }
+            //         webAppConfiguration.addServletMapping(servletName, urlPattern);
+            //     }
+            //     if (urlPatterns.size() > 0) {
+            //         servletMappingMap.put(servletName, createConfigItem(urlPatterns));
+            //     }
+            // } else if (existedServletMapping.getSource() == ConfigSource.ANNOTATION && configurator.getConfigSource() == ConfigSource.WEB_FRAGMENT) {
+            //     // WEB_FRAGMENT adds to ANNOTATION - additive (different sources, different URL patterns)
+            //     if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+            //         Tr.debug(tc, "servlet-mapping for servlet " + servletName + " from web-fragment.xml in " + configurator.getLibraryURI()
+            //                      + " adds to annotation mapping");
+            //     }
+            //     for (String urlPattern : servletMapping.getURLPatterns()) {
+            //         if (isServletSpecLevel31OrHigher()) {
+            //             String existingName = urlToServletNameMap.put(urlPattern, servletName);
+            //             if ((existingName != null) && !(existingName.equals(servletName))) {
+            //                 Tr.error(tc,"duplicate.url.pattern.for.servlet.mapping", urlPattern, servletName, existingName);
+            //                 throw new UnableToAdaptException(nls.getFormattedMessage("duplicate.url.pattern.for.servlet.mapping",
+            //                                                                          new Object[]{urlPattern, servletName, existingName} ,
+            //                                                                          "servlet-mapping value matches multiple servlets: " + urlPattern));
+            //             }
+            //         }
+            //         webAppConfiguration.addServletMapping(servletName, urlPattern);
+            //     }
+            // }
+            
         }
     }
 

--- a/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/osgi/container/config/WebAppConfiguratorHelper.java
+++ b/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/osgi/container/config/WebAppConfiguratorHelper.java
@@ -2625,9 +2625,21 @@ public class WebAppConfiguratorHelper implements ServletConfiguratorHelper {
      * files before processing the mappings, which is necessary when a servlet-mapping in
      * web.xml references a servlet whose definition is provided in a web-fragment.xml.
      *
-     * @param servletMappings the list of servlet mappings to defer
+     * <p>We only defer mappings for servlets that don't have a definition yet.
+     * If the servlet is already defined (e.g., from an earlier source like annotations annotations or web.xml),
+     * we process the mapping immediately. This 
+     * <ul>
+     * <li>allows processServletMappingConfig() to apply the correct merge rules based on ConfigSource
+     *     (web.xml > web-fragment.xml > annotations)</li>
+     * <li>prevents duplicate mapping attempts that would occur if we deferred all mappings and then
+     *     tried to add them again after annotations have already added them</li>
+     * <li>maintains the existing precedence behavior where earlier sources override later ones</li>
+     * </ul>
+     *
+     * @param servletMappings the list of servlet mappings to process or defer
+     * @throws UnableToAdaptException if servlet mapping processing fails
      */
-    private void storeDeferredServletMappings(List<ServletMapping> servletMappings) {
+    private void storeDeferredServletMappings(List<ServletMapping> servletMappings) throws UnableToAdaptException {
         if (servletMappings == null || servletMappings.isEmpty()) {
             return;
         }
@@ -2636,7 +2648,21 @@ public class WebAppConfiguratorHelper implements ServletConfiguratorHelper {
         String currentLibraryURI = configurator.getLibraryURI();
         
         for (ServletMapping servletMapping : servletMappings) {
-            deferredServletMappings.add(new DeferredServletMapping(servletMapping, currentSource, currentLibraryURI));
+            String servletName = servletMapping.getServletName();
+            Map<String, ConfigItem<ServletConfig>> servletMap = configurator.getConfigItemMap("servlet");
+            
+            // Check if servlet definition exists
+            if (servletMap.get(servletName) == null) {
+                // Servlet not defined yet - defer mapping until all servlet definitions are collected
+                // This handles the case where web.xml has a servlet-mapping but the servlet definition
+                // is in a web-fragment.xml that hasn't been processed yet
+                deferredServletMappings.add(new DeferredServletMapping(servletMapping, currentSource, currentLibraryURI));
+            } else {
+                // Servlet already defined - process mapping immediately to maintain proper precedence
+                // This ensures processServletMappingConfig() can apply merge rules correctly and
+                // prevents duplicate mappings when annotations have already added mappings
+                processServletMappingConfig(servletMapping);
+            }
         }
     }
 

--- a/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/osgi/container/config/WebAppConfiguratorHelper.java
+++ b/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/osgi/container/config/WebAppConfiguratorHelper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 IBM Corporation and others.
+ * Copyright (c) 2011, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -16,6 +16,7 @@
 //      148426          10/06/14        bitonti                 Give extension default error page precedence in Servlet 3.0
 //      PI67942         10/21/16        zaroman                 encode URI after dispatch
 //      11909           12/11/20        jimblye                 Allow context-root to be overridden in server.xml
+//                      02/06/26.       jimblye                 Defer servlet mappings until webfragment servlet defs processed
 
 package com.ibm.ws.webcontainer.osgi.container.config;
 
@@ -156,6 +157,24 @@ import com.ibm.wsspi.webcontainer.webapp.WebAppConfig;
  * from web.xml, web-fragment.xml and annotations.  Configure them into the WebAppConfiguration.
  */
 public class WebAppConfiguratorHelper implements ServletConfiguratorHelper {
+    
+    /**
+     * Helper class to store servlet mappings for deferred processing.
+     * This allows all servlet definitions to be collected before processing mappings.
+     */
+    private static class DeferredServletMapping {
+        final ServletMapping servletMapping;
+        final ConfigSource source;
+        final String libraryURI;
+        
+        DeferredServletMapping(ServletMapping servletMapping, ConfigSource source, String libraryURI) {
+            this.servletMapping = servletMapping;
+            this.source = source;
+            this.libraryURI = libraryURI;
+        }
+    }
+    
+    private final List<DeferredServletMapping> deferredServletMappings = new ArrayList<>();
     private static final String CLASS_NAME = WebAppConfiguratorHelper.class.getSimpleName();
 
     private static final TraceComponent tc = Tr.register(WebAppConfiguratorHelper.class, WebContainerConstants.TR_GROUP, WebContainerConstants.NLS_PROPS);
@@ -818,7 +837,9 @@ public class WebAppConfiguratorHelper implements ServletConfiguratorHelper {
         
         configureSessionConfig(webApp.getSessionConfig());
         configureServlets(webApp, webApp.getServlets());
-        configureServletMappings(webApp.getServletMappings());
+        
+        // Defer servlet mapping processing until all servlet definitions are collected
+        storeDeferredServletMappings(webApp.getServletMappings());
         configureLocaleEncodingMap(webApp.getLocaleEncodingMappingList());
         configureListener(webApp.getListeners());
         configureEnvEntries(webApp.getEnvEntries());
@@ -856,7 +877,9 @@ public class WebAppConfiguratorHelper implements ServletConfiguratorHelper {
         configureDistributableFromFragment(webFragment.isSetDistributable());
         configureSessionConfig(webFragment.getSessionConfig());
         configureServlets(webFragment, webFragment.getServlets());
-        configureServletMappings(webFragment.getServletMappings());
+        
+        // Defer servlet mapping processing until all servlet definitions are collected
+        storeDeferredServletMappings(webFragment.getServletMappings());
         configureLocaleEncodingMap(webFragment.getLocaleEncodingMappingList());
         configureListener(webFragment.getListeners());
         configureEnvEntries(webFragment.getEnvEntries());
@@ -913,7 +936,11 @@ public class WebAppConfiguratorHelper implements ServletConfiguratorHelper {
     @Override
     public void configureDefaults() throws UnableToAdaptException {
 
-        //I think we need to process specifiedClasses first to find what servlets were defined 
+        // Process all deferred servlet mappings now that all servlet definitions have been collected
+        // from web.xml and all web-fragment.xml files
+        processDeferredServletMappings();
+        
+        //I think we need to process specifiedClasses first to find what servlets were defined
         //in case a filter is mapped to * (all servlets)
         configureSpecifiedClasses();
 
@@ -2564,9 +2591,52 @@ public class WebAppConfiguratorHelper implements ServletConfiguratorHelper {
         }
     }
 
-    private void configureServletMappings(List<ServletMapping> servletMappings) throws UnableToAdaptException {
+    /**
+     * Process all deferred servlet mappings after all servlet definitions have been collected.
+     * The deferred mappings retain their original source context for proper merging rules and error messages.
+     *
+     * @throws UnableToAdaptException if servlet mapping processing fails
+     */
+    private void processDeferredServletMappings() throws UnableToAdaptException {
+
+        // Save the current context
+	    ConfigSource savedSource = configurator.getConfigSource();
+        String savedLibraryURI = configurator.getLibraryURI();
+
+        for (DeferredServletMapping deferred : deferredServletMappings) {          
+            try {
+	            // Retrieve the context from for this servlet mapping
+                // Needed for proper merging rules in processServletMappingConfig(...)
+                configurator.setConfigSource(deferred.source);
+                configurator.setLibraryURI(deferred.libraryURI);
+                processServletMappingConfig(deferred.servletMapping);
+            } finally {
+                // Restore the saved context
+                configurator.setConfigSource(savedSource);
+                configurator.setLibraryURI(savedLibraryURI);
+            }
+        }
+        deferredServletMappings.clear();
+    }
+
+    /**
+     * Store servlet mappings for deferred processing.
+     * This allows all servlet definitions to be collected from web.xml and web-fragment.xml
+     * files before processing the mappings, which is necessary when a servlet-mapping in
+     * web.xml references a servlet whose definition is provided in a web-fragment.xml.
+     *
+     * @param servletMappings the list of servlet mappings to defer
+     */
+    private void storeDeferredServletMappings(List<ServletMapping> servletMappings) {
+        if (servletMappings == null || servletMappings.isEmpty()) {
+            return;
+        }
+        
+        ConfigSource currentSource = configurator.getConfigSource();
+        String currentLibraryURI = configurator.getLibraryURI();
+        
         for (ServletMapping servletMapping : servletMappings) {
-            processServletMappingConfig(servletMapping);
+            deferredServletMappings.add(new DeferredServletMapping(servletMapping, currentSource, currentLibraryURI));
         }
     }
 

--- a/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/osgi/container/config/WebAppConfiguratorHelper.java
+++ b/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/osgi/container/config/WebAppConfiguratorHelper.java
@@ -3409,26 +3409,52 @@ public class WebAppConfiguratorHelper implements ServletConfiguratorHelper {
         } else {
             if ((existedServletMapping.getSource() == ConfigSource.WEB_XML && configurator.getConfigSource() == ConfigSource.WEB_XML)
                 || (existedServletMapping.getSource() == ConfigSource.WEB_FRAGMENT && configurator.getConfigSource() == ConfigSource.WEB_FRAGMENT)) {
+                // Same source - add additional mappings (additive within same source)
                 for (String urlPattern : servletMapping.getURLPatterns()) {
                     if (isServletSpecLevel31OrHigher()) {
-                        // Strange to 'put' on error cases.                     
+                        // Strange to 'put' on error cases.
                         String  existingName =  urlToServletNameMap.put(urlPattern,servletName);
                         if ((existingName != null) && !(existingName.equals(servletName))) {
                             Tr.error(tc,"duplicate.url.pattern.for.servlet.mapping", urlPattern, servletName, existingName);
                             throw new UnableToAdaptException( nls.getFormattedMessage("duplicate.url.pattern.for.servlet.mapping",
-                                                                                      new Object[]{urlPattern, servletName, existingName} , 
+                                                                                      new Object[]{urlPattern, servletName, existingName} ,
                                                                                       "servlet-mapping value matches multiple servlets: " + urlPattern));
                         }
                     }
                     webAppConfiguration.addServletMapping(servletName, urlPattern);
                 }
+            } else if (existedServletMapping.getSource() == ConfigSource.WEB_FRAGMENT && configurator.getConfigSource() == ConfigSource.WEB_XML) {
+                // WEB_XML overrides WEB_FRAGMENT - replace the existing mapping
+                if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                    Tr.debug(tc, "servlet-mapping for servlet " + servletName + " from web.xml overrides the value from web-fragment.xml in "
+                                 + existedServletMapping.getLibraryURI());
+                }
+                // Update the servlet mapping map with the new WEB_XML mapping
+                List<String> urlPatterns = servletMapping.getURLPatterns();
+                for (String urlPattern : urlPatterns) {
+                    if (isServletSpecLevel31OrHigher()) {
+                        String existingName = urlToServletNameMap.put(urlPattern, servletName);
+                        if ((existingName != null) && !(existingName.equals(servletName))) {
+                            Tr.error(tc,"duplicate.url.pattern.for.servlet.mapping", urlPattern, servletName, existingName);
+                            throw new UnableToAdaptException(nls.getFormattedMessage("duplicate.url.pattern.for.servlet.mapping",
+                                                                                     new Object[]{urlPattern, servletName, existingName} ,
+                                                                                     "servlet-mapping value matches multiple servlets: " + urlPattern));
+                        }
+                    }
+                    webAppConfiguration.addServletMapping(servletName, urlPattern);
+                }
+                if (urlPatterns.size() > 0) {
+                    servletMappingMap.put(servletName, createConfigItem(urlPatterns));
+                }
             } else if (existedServletMapping.getSource() == ConfigSource.WEB_XML && configurator.getConfigSource() == ConfigSource.WEB_FRAGMENT) {
+                // WEB_XML has precedence - ignore WEB_FRAGMENT
                 if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
                     Tr.debug(tc, "servlet-mapping for servlet " + servletName + " is configured in web.xml, the value from web-fragment.xml in "
                                  + configurator.getLibraryURI()
                                  + " is ignored");
                 }
             } else if (existedServletMapping.getSource() == ConfigSource.WEB_FRAGMENT && configurator.getConfigSource() == ConfigSource.ANNOTATION) {
+                // WEB_FRAGMENT has precedence over ANNOTATION - ignore ANNOTATION
                 if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
                     Tr.debug(tc, "servlet-mapping for servlet " + servletName + " is configured in web-fragment.xml from " + existedServletMapping.getLibraryURI()
                                  + " , the value from annotation is ignored");

--- a/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/osgi/container/config/WebAppConfiguratorHelper.java
+++ b/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/osgi/container/config/WebAppConfiguratorHelper.java
@@ -418,6 +418,10 @@ public class WebAppConfiguratorHelper implements ServletConfiguratorHelper {
         public void addServletMapping(String servletName, String urlPattern) {
             config.addServletMapping(servletName, urlPattern);
         }
+        
+        public void removeServletMappings(String servletName) {
+            config.removeServletMappings(servletName);
+        }
 
         public Map<JNDIEnvironmentRefType, Map<String, String>> getAllRefBindings() {
             return config.getAllRefBindings();
@@ -2957,7 +2961,12 @@ public class WebAppConfiguratorHelper implements ServletConfiguratorHelper {
         }
 
         Map<String, ConfigItem<List<String>>> servletMappingMap = configurator.getConfigItemMap("servlet-mapping");
-        if (!servletMappingMap.containsKey(servletName)) {
+        // Check if there's an existing mapping
+        ConfigItem<List<String>> existingMapping = servletMappingMap.get(servletName);
+        
+        // Per Servlet spec: XML mappings (web.xml or web-fragment.xml)
+        // override annotation mappings. Only process annotations if no XML mapping exists.
+        if (existingMapping == null) {
             AnnotationValue urlPatternListValue = webServletAnnotation.getValue("value");
             List<? extends AnnotationValue> urlPatternList = (null == urlPatternListValue ? null : urlPatternListValue.getArrayValue());
             if (null == urlPatternList || urlPatternList.isEmpty()) {
@@ -2982,7 +2991,7 @@ public class WebAppConfiguratorHelper implements ServletConfiguratorHelper {
                     if ((existingName != null) && !existingName.equals(servletName)) {
                         Tr.error(tc, "duplicate.url.pattern.for.servlet.mapping", urlText, servletName, existingName);
                         throw new UnableToAdaptException(nls.getFormattedMessage("duplicate.url.pattern.for.servlet.mapping",
-                                                                                 new Object[] { urlText, servletName, existingName }, 
+                                                                                 new Object[] { urlText, servletName, existingName },
                                                                                  "servlet-mapping value matches multiple servlets: " + urlText));
                     }
                 }
@@ -2991,6 +3000,12 @@ public class WebAppConfiguratorHelper implements ServletConfiguratorHelper {
                     Tr.debug(tc, methodName + ": Map servlet [ " + servletName + " ] to URL [ " + urlText + " ]");
                 }
                 webAppConfiguration.addServletMapping(servletName, urlText);
+            }
+        } else {
+            // Existing mapping found - skip annotation (XML or other annotation has precedence)
+            if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                Tr.debug(tc, methodName + ": Skipping annotation mapping for servlet [ " + servletName +
+                         " ] - already has " + existingMapping.getSource() + " mapping");
             }
         }
 
@@ -3429,6 +3444,9 @@ public class WebAppConfiguratorHelper implements ServletConfiguratorHelper {
                     Tr.debug(tc, "servlet-mapping for servlet " + servletName + " from web.xml overrides the value from web-fragment.xml in "
                                  + existedServletMapping.getLibraryURI());
                 }
+                // Remove the old web-fragment mappings from webAppConfiguration before adding new web.xml mappings
+                webAppConfiguration.removeServletMappings(servletName);
+                
                 // Update the servlet mapping map with the new WEB_XML mapping
                 List<String> urlPatterns = servletMapping.getURLPatterns();
                 for (String urlPattern : urlPatterns) {
@@ -3454,79 +3472,15 @@ public class WebAppConfiguratorHelper implements ServletConfiguratorHelper {
                                  + " is ignored");
                 }
             } else if (existedServletMapping.getSource() == ConfigSource.WEB_FRAGMENT && configurator.getConfigSource() == ConfigSource.ANNOTATION) {
-                // WEB_FRAGMENT has precedence over ANNOTATION - ignore ANNOTATION
+                // This case should never occur because annotation processing (configureWebServletAnnotation)
+                // skips annotations when any XML mapping exists (web.xml or web-fragment.xml).
+                // Per Servlet spec, XML mappings  override annotations.
+                // Annotations are processed before deferred mappings, so they 
+                // are prevented from being added when XML mappings exist.
                 if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-                    Tr.debug(tc, "servlet-mapping for servlet " + servletName + " is configured in web-fragment.xml from " + existedServletMapping.getLibraryURI()
-                                 + " , the value from annotation is ignored");
+                    Tr.debug(tc, "WEB_FRAGMENT -> ANNOTATION case encountered (should never happen - annotations are skipped when XML mappings exist)");
                 }
             }
-            
-            // NOTE: The following two cases (ANNOTATION -> WEB_XML and ANNOTATION -> WEB_FRAGMENT) are
-            // commented out to avoid introducing behavior changes for existing users.
-            //
-            // While these cases would implement correct Jakarta EE precedence rules, they could cause
-            // existing applications to behave differently:
-            //
-            // 1. ANNOTATION -> WEB_XML: web.xml mapping would REPLACE annotation mapping
-            //    - Before: annotation mapping used (web.xml mapping silently ignored)
-            //    - After: web.xml mapping replaces annotation mapping
-            //    - Risk: Servlet responds to different URLs than before
-            //
-            // 2. ANNOTATION -> WEB_FRAGMENT: web-fragment mapping would ADD to annotation mapping
-            //    - Before: only annotation mapping used (web-fragment mapping silently ignored)
-            //    - After: both annotation AND web-fragment mappings active
-            //    - Risk: Servlet responds to more URLs than before
-            //
-            // These cases are not required to fix the reported issue (servlet-mapping in
-            // web.xml referencing servlet definition in web-fragment.xml), which is handled by the
-            // WEB_FRAGMENT -> WEB_XML case above.
-            //
-            // If spec-compliant annotation handling is needed in the future, these cases can be
-            // uncommented and the behavior change documented in release notes.
-            
-            
-            // } else if (existedServletMapping.getSource() == ConfigSource.ANNOTATION && configurator.getConfigSource() == ConfigSource.WEB_XML) {
-            //     // WEB_XML overrides ANNOTATION - replace the existing mapping
-            //     if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-            //         Tr.debug(tc, "servlet-mapping for servlet " + servletName + " from web.xml overrides the value from annotation");
-            //     }
-            //     // Update the servlet mapping map with the new WEB_XML mapping
-            //     List<String> urlPatterns = servletMapping.getURLPatterns();
-            //     for (String urlPattern : urlPatterns) {
-            //         if (isServletSpecLevel31OrHigher()) {
-            //             String existingName = urlToServletNameMap.put(urlPattern, servletName);
-            //             if ((existingName != null) && !(existingName.equals(servletName))) {
-            //                 Tr.error(tc,"duplicate.url.pattern.for.servlet.mapping", urlPattern, servletName, existingName);
-            //                 throw new UnableToAdaptException(nls.getFormattedMessage("duplicate.url.pattern.for.servlet.mapping",
-            //                                                                          new Object[]{urlPattern, servletName, existingName} ,
-            //                                                                          "servlet-mapping value matches multiple servlets: " + urlPattern));
-            //             }
-            //         }
-            //         webAppConfiguration.addServletMapping(servletName, urlPattern);
-            //     }
-            //     if (urlPatterns.size() > 0) {
-            //         servletMappingMap.put(servletName, createConfigItem(urlPatterns));
-            //     }
-            // } else if (existedServletMapping.getSource() == ConfigSource.ANNOTATION && configurator.getConfigSource() == ConfigSource.WEB_FRAGMENT) {
-            //     // WEB_FRAGMENT adds to ANNOTATION - additive (different sources, different URL patterns)
-            //     if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-            //         Tr.debug(tc, "servlet-mapping for servlet " + servletName + " from web-fragment.xml in " + configurator.getLibraryURI()
-            //                      + " adds to annotation mapping");
-            //     }
-            //     for (String urlPattern : servletMapping.getURLPatterns()) {
-            //         if (isServletSpecLevel31OrHigher()) {
-            //             String existingName = urlToServletNameMap.put(urlPattern, servletName);
-            //             if ((existingName != null) && !(existingName.equals(servletName))) {
-            //                 Tr.error(tc,"duplicate.url.pattern.for.servlet.mapping", urlPattern, servletName, existingName);
-            //                 throw new UnableToAdaptException(nls.getFormattedMessage("duplicate.url.pattern.for.servlet.mapping",
-            //                                                                          new Object[]{urlPattern, servletName, existingName} ,
-            //                                                                          "servlet-mapping value matches multiple servlets: " + urlPattern));
-            //             }
-            //         }
-            //         webAppConfiguration.addServletMapping(servletName, urlPattern);
-            //     }
-            // }
-            
         }
     }
 


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x]  "Fixes #34023 " 
- [x]  "Fixes #34023 " 

This is the replacement for #34008.  It corrects a problem that #34008 would have introduced.  34008 did not handle the case where a servlet mapping is defined in both the web.xml and the web-fragment.xml.  In that case, the mapping in web.xml should override the mapping in the fragment, but the mapping in the web.xml was being ignored.