### PR TITLE
do not cancel timerB on provisional response

### DIFF
--- a/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/stack/transaction/transactions/ct/SIPInviteClientTransactionImpl.java
+++ b/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/stack/transaction/transactions/ct/SIPInviteClientTransactionImpl.java
@@ -196,7 +196,8 @@ public class SIPInviteClientTransactionImpl
 						if( SIPTransactionHelper.isProvionalResponse(sipResponse.getStatusCode() ) )
 						{
 							setState( STATE_PROCEEDING);
-							notCalling();
+							//notCalling();
+							cancelTimerA();
 							sendResponseToUA( sipResponse );
 						}
 						else if( SIPTransactionHelper.isOKFinalResponse( sipResponse.getStatusCode() ) )
@@ -395,7 +396,7 @@ public class SIPInviteClientTransactionImpl
 				"Timer B fired on transaction " + toString());
 		}
 		updateSipTimersInvocationsPMICounter();
-		if (getState() == STATE_CALLING) {
+		if ((getState() == STATE_CALLING) || (getState() == STATE_PROCEEDING)) {
 			notifyTransactionTimeoutToUA();
 			destroyTransaction();
 		}
@@ -644,6 +645,16 @@ public class SIPInviteClientTransactionImpl
 			m_timerB.cancel();
 		}
 	}
+
+	private void cancelTimerA() {
+                // timer A and timer B are only relevant in the "calling" state
+                c_logger.traceDebug("Tibor says cancelling timerA");
+		if (m_timerA != null) {
+                        m_timerA.cancel();
+                }
+        }
+
+
 
 	/** return the most recent response */
 	public Response getMostRecentResponse()


### PR DESCRIPTION
- [ x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [ ] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

Memory leak observed with a b2bua application provided by external contributor when the 200 OK response to initial INVITE contains the wrong branch in its VIA header. Keeping TimerB alive until a valid final response arrives will prevent the memory leak. 
