### PR TITLE
Revert "enabled the test and added retry logic to the intermittent failing statement"

### DIFF
--- a/dev/wlp.lib.extract_fat/fat/src/wlp/lib/extract/ExternalDependencyDownloadTest.java
+++ b/dev/wlp.lib.extract_fat/fat/src/wlp/lib/extract/ExternalDependencyDownloadTest.java
@@ -60,9 +60,9 @@ public class ExternalDependencyDownloadTest {
         }
     }
 
-    //    @Mode(TestMode.QUARANTINE)
-    //    @Test
-    //    Test should not be hitting an external site.  Need to find a better implemenation before re-enabling.
+//    @Mode(TestMode.QUARANTINE)
+//    @Test
+//    Test should not be hitting an external site.  Need to find a better implemenation before re-enabling.
     public void testHTTP2HTTPSRedirect() throws Exception {
         String serverName = "http2httpsRedirectGood";
         String dependencyTargetFile = "shared/lib/" + serverName + ".testfile.jar";
@@ -133,7 +133,8 @@ public class ExternalDependencyDownloadTest {
         assertBadInstall("/redirectnotfound", "depRedirectNotFound");
     }
 
-    @Test
+    // test intermittently fails.  disabling until we can make it more stable.
+//    @Test
     public void testInstallProtocolRedirect() throws Exception {
         assertGoodInstall("/protocolchange", "depProtoChange");
     }
@@ -142,7 +143,7 @@ public class ExternalDependencyDownloadTest {
      * Generate a sample with the given dependency and server name and ensure that installing it fails.
      *
      * @param dependencyPath the path to download the dependency from, relative to the root of the dependency hosting app
-     * @param serverName     the server name that should be included in the sample
+     * @param serverName the server name that should be included in the sample
      * @throws Exception
      */
     private void assertGoodInstall(String dependencyPath, String serverName) throws Exception {
@@ -159,34 +160,17 @@ public class ExternalDependencyDownloadTest {
         Log.info(ExternalDependencyDownloadTest.class, "getServerFolderFiles", listFiles(hostingServer.getUserDir() + "/servers"));
         Log.info(ExternalDependencyDownloadTest.class, "getServerFiles", listFiles(hostingServer.getUserDir() + "/servers/" + serverName));
 
-        int count = 0;
-        boolean flag = false;
+        // This method uses the sample jar created above
+        installServer.installSampleWithExternalDependencies(serverName);
 
-        while (count < 15) {
-            try {
-                // This method uses the sample jar created above
-                installServer.installSampleWithExternalDependencies(serverName);
-                flag = true;
-                break;
-            } catch (Exception e) {
-                Log.info(LibertyServer.class, "installSampleWithExternalDependencies",
-                         String.format("Error Occurred During %d attempt of Liberty install: %s", count, e.getMessage()));
-                count++;
-            }
-        }
-
-        if (flag) {
-            assertTrue(installServer.fileExistsInLibertyServerRoot(dependencyTargetFile));
-        } else {
-            fail("Could not create Liberty server installation instance");
-        }
+        assertTrue(installServer.fileExistsInLibertyServerRoot(dependencyTargetFile));
     }
 
     /**
      * Generate a sample with the given dependency and server name and ensure that installing it fails.
      *
      * @param dependencyPath the path to download the dependency from, relative to the root of the dependency hosting app
-     * @param serverName     the server name that should be included in the sample
+     * @param serverName the server name that should be included in the sample
      * @throws Exception
      */
     private void assertBadInstall(String dependencyPath, String serverName) throws Exception {
@@ -212,7 +196,7 @@ public class ExternalDependencyDownloadTest {
      * The sample has one external dependency which points to a path under the depedencyHost app.
      *
      * @param dependencyPath the path to download the dependency from, relative to the root of the dependency hosting app
-     * @param serverName     the server name that should be included in the sample
+     * @param serverName the server name that should be included in the sample
      * @throws Exception
      */
     private void prepareSampleJar(String dependencyPath, String serverName) throws Exception {
@@ -252,9 +236,9 @@ public class ExternalDependencyDownloadTest {
      * <li>A generated externaldependencies.xml</li>
      * </li>
      *
-     * @param outSample            the jar file to write the new sample to
-     * @param serverName           the name of the server to include in the sample jar
-     * @param dependencyUrl        the URL which the externaldependencies.xml file should point to
+     * @param outSample the jar file to write the new sample to
+     * @param serverName the name of the server to include in the sample jar
+     * @param dependencyUrl the URL which the externaldependencies.xml file should point to
      * @param dependencyTargetPath the path which the external dependency should be downloaded to
      */
     private static void createExternalDependencySample(File outSample, String serverName, String dependencyUrl, String dependencyTargetPath) throws IOException {
@@ -351,8 +335,8 @@ public class ExternalDependencyDownloadTest {
      * <p>
      * The generated file specifies one dependency with the given url and target path.
      *
-     * @param out                  the ZipOutputStream to write to
-     * @param dependencyUrl        the URL hosting the dependency
+     * @param out the ZipOutputStream to write to
+     * @param dependencyUrl the URL hosting the dependency
      * @param dependencyTargetPath the destination path for the dependency
      * @throws IOException
      */


### PR DESCRIPTION
Reverts OpenLiberty/open-liberty#33849

The test is failing hard now in all builds for some reason.  Looks like some more investigation needs to be done as to why it fails before re-enabling it again.