### PR TITLE
Fix EJB timer test NullPointerException

### DIFF
--- a/dev/com.ibm.ws.ejbcontainer.async_fat/publish/servers/com.ibm.ws.ejbcontainer.async.fat.AsyncRemoteServer/bootstrap.properties
+++ b/dev/com.ibm.ws.ejbcontainer.async_fat/publish/servers/com.ibm.ws.ejbcontainer.async.fat.AsyncRemoteServer/bootstrap.properties
@@ -1,4 +1,4 @@
 bootstrap.include=../testports.properties
-com.ibm.ws.logging.trace.specification=*=info:EJBContainer=all:JITDeploy=all:Injection=all:Threading=all:logservice=all:com.ibm.ws.app.manager.*=all:com.ibm.ws.runtime.update.*=all
+com.ibm.ws.logging.trace.specification=*=info:EJBContainer=all:JITDeploy=all:Injection=all:logservice=all:com.ibm.ws.app.manager.*=all:com.ibm.ws.runtime.update.*=all
 ds.logLevel=debug
 ds.lock.timeout.milliseconds=30000

--- a/dev/com.ibm.ws.ejbcontainer.timer.calendar_fat/publish/servers/com.ibm.ws.ejbcontainer.timer.cal.fat.PersistentTimerServer/bootstrap.properties
+++ b/dev/com.ibm.ws.ejbcontainer.timer.calendar_fat/publish/servers/com.ibm.ws.ejbcontainer.timer.cal.fat.PersistentTimerServer/bootstrap.properties
@@ -1,3 +1,3 @@
 bootstrap.include=../testports.properties
-com.ibm.ws.logging.trace.specification=EJBContainer=all:persistentExecutor=all:persistenceService=all:runtime.update=all:Threading=all
+com.ibm.ws.logging.trace.specification=EJBContainer=all:persistentExecutor=all:persistenceService=all:runtime.update=all
 ds.logLevel=debug

--- a/dev/com.ibm.ws.ejbcontainer.timer.calendar_fat/test-applications/TimerCalTestWeb.war/src/com/ibm/ws/ejbcontainer/timer/cal/web/NextTimeoutPersistentServlet.java
+++ b/dev/com.ibm.ws.ejbcontainer.timer.calendar_fat/test-applications/TimerCalTestWeb.war/src/com/ibm/ws/ejbcontainer/timer/cal/web/NextTimeoutPersistentServlet.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2009, 2021 IBM Corporation and others.
+ * Copyright (c) 2009, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -210,6 +210,11 @@ public class NextTimeoutPersistentServlet extends AbstractServlet {
 
             Date nextTimeout = ivBean.getNextTimeoutFromExpiration();
             String failure = ivBean.getNextTimeoutFailureFromExpiration();
+
+            // Timer catch-up may have occurred on slow systems; no more timers expected
+            if (nextTimeout == null && System.currentTimeMillis() > nextExpectedTimeout) {
+                numExpectedTimeouts = 0;
+            }
 
             svLogger.info(numExpectedTimeouts + ": nextTimeout=" + nextTimeout + ", failure=" + failure);
 


### PR DESCRIPTION
For slow hardware where timers are running late; reset the number of expected to 0 if timer catch-up has occurred

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".