### PR TITLE
Adding jNoSQL data integration tests

### DIFF
--- a/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
+++ b/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
@@ -3068,6 +3068,11 @@
     </dependency>
     <dependency>
       <groupId>org.eclipse.jnosql.mapping</groupId>
+      <artifactId>jnosql-mapping-document</artifactId>
+      <version>1.1.12</version>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jnosql.mapping</groupId>
       <artifactId>jnosql-mapping-semistructured</artifactId>
       <version>1.1.12</version>
     </dependency>

--- a/dev/cnf/oss_dependencies.maven
+++ b/dev/cnf/oss_dependencies.maven
@@ -609,6 +609,7 @@ org.eclipse.jetty:jetty-util:9.4.39.v20210325
 org.eclipse.jetty:jetty-util:9.4.7.RC0
 org.eclipse.jetty:jetty-websocket:8.2.0.v20160908
 org.eclipse.jnosql.communication:jnosql-communication-semistructured:1.1.12
+org.eclipse.jnosql.mapping:jnosql-mapping-document:1.1.12
 org.eclipse.jnosql.mapping:jnosql-mapping-semistructured:1.1.12
 org.eclipse.microprofile.config:microprofile-config-api:1.1
 org.eclipse.microprofile.config:microprofile-config-api:1.2.1

--- a/dev/io.openliberty.data.internal_fat_nosql/.classpath
+++ b/dev/io.openliberty.data.internal_fat_nosql/.classpath
@@ -3,6 +3,7 @@
 	<classpathentry kind="src" path="fat/src"/>
 	<classpathentry kind="src" path="generated-src"/>
 	<classpathentry kind="src" path="test-applications/DataNoSQLApp/src"/>
+	<classpathentry kind="src" path="test-applications/DataNoSQLIntegrationApp/src"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17">
 		<attributes>

--- a/dev/io.openliberty.data.internal_fat_nosql/bnd.bnd
+++ b/dev/io.openliberty.data.internal_fat_nosql/bnd.bnd
@@ -15,7 +15,8 @@ bVersion=1.0
 
 src: \
   fat/src,\
-  test-applications/DataNoSQLApp/src
+  test-applications/DataNoSQLApp/src,\
+  test-applications/DataNoSQLIntegrationApp/src
 
 javac.source: 17
 javac.target: 17
@@ -32,9 +33,11 @@ fat.test.container.images: public.ecr.aws/docker/library/mongo:8.0
 	io.openliberty.jakarta.data.1.0,\
 	io.openliberty.jakarta.interceptor.2.1,\
 	io.openliberty.jakarta.nosql.1.0,\
+	io.openliberty.jakarta.persistence.3.1,\
 	io.openliberty.jakarta.servlet.6.0,\
 	io.openliberty.jakarta.transaction.2.0,\
 	io.openliberty.org.eclipse.microprofile.config.3.0,\
 	io.openliberty.org.testcontainers;version=latest,\
 	org.eclipse.jnosql.communication:jnosql-communication-semistructured;version=1.1.12,\
-	org.eclipse.jnosql.mapping:jnosql-mapping-semistructured;version=1.1.12
+	org.eclipse.jnosql.mapping:jnosql-mapping-semistructured;version=1.1.12,\
+	org.eclipse.jnosql.mapping:jnosql-mapping-document;version=1.1.12

--- a/dev/io.openliberty.data.internal_fat_nosql/build.gradle
+++ b/dev/io.openliberty.data.internal_fat_nosql/build.gradle
@@ -51,5 +51,6 @@ task addJNoSQL(type: Copy) {
 
 addRequiredLibraries {
   dependsOn addJNoSQL
+  dependsOn addDerbyJava17Plus
   dependsOn copyTestContainers
 }

--- a/dev/io.openliberty.data.internal_fat_nosql/fat/src/test/jakarta/data/nosql/DataNoSQLIntegrationTest.java
+++ b/dev/io.openliberty.data.internal_fat_nosql/fat/src/test/jakarta/data/nosql/DataNoSQLIntegrationTest.java
@@ -1,0 +1,57 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package test.jakarta.data.nosql;
+
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.runner.RunWith;
+import org.testcontainers.containers.MongoDBContainer;
+
+import com.ibm.websphere.simplicity.ShrinkHelper;
+
+import componenttest.annotation.MinimumJavaLevel;
+import componenttest.annotation.Server;
+import componenttest.annotation.TestServlet;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.utils.FATServletClient;
+import test.jakarta.data.nosql.integration.web.DataNoSQLIntegrationServlet;
+
+@RunWith(FATRunner.class)
+@MinimumJavaLevel(javaLevel = 17)
+public class DataNoSQLIntegrationTest extends FATServletClient {
+
+    public static MongoDBContainer mongoDBContainer = FATSuite.mongoDBContainer;
+
+    @Server("io.openliberty.data.internal.fat.nosql.integrate")
+    @TestServlet(servlet = DataNoSQLIntegrationServlet.class, contextRoot = "DataNoSQLIntegrationApp")
+    public static LibertyServer server;
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        WebArchive war = ShrinkHelper.buildDefaultApp("DataNoSQLIntegrationApp", "test.jakarta.data.nosql.integration.web");
+        ShrinkHelper.exportAppToServer(server, war);
+
+        server.addEnvVar("MONGO_DBNAME", "testdb");
+        server.addEnvVar("MONGO_HOST", mongoDBContainer.getHost() + ":" + String.valueOf(mongoDBContainer.getMappedPort(27017)));
+        server.addEnvVar("JNOSQL_VERSION", FATSuite.JNOSQL_VERSION);
+
+        server.startServer();
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        server.stopServer();
+    }
+}

--- a/dev/io.openliberty.data.internal_fat_nosql/fat/src/test/jakarta/data/nosql/FATSuite.java
+++ b/dev/io.openliberty.data.internal_fat_nosql/fat/src/test/jakarta/data/nosql/FATSuite.java
@@ -28,7 +28,8 @@ import componenttest.custom.junit.runner.AlwaysPassesTest;
 @SuiteClasses({
                 AlwaysPassesTest.class,
                 DataContainerNoSQLTest.class,
-                DataNoSQLTest.class
+                DataNoSQLTest.class,
+                DataNoSQLIntegrationTest.class
 })
 public class FATSuite extends TestContainerSuite {
 

--- a/dev/io.openliberty.data.internal_fat_nosql/generated-src/test/jakarta/data/nosql/integration/web/_County.java
+++ b/dev/io.openliberty.data.internal_fat_nosql/generated-src/test/jakarta/data/nosql/integration/web/_County.java
@@ -1,0 +1,38 @@
+/*
+*  Copyright (c) 2023 Otávio Santana and others
+*   All rights reserved. This program and the accompanying materials
+*   are made available under the terms of the Eclipse Public License v1.0
+*   and Apache License v2.0 which accompanies this distribution.
+*   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+*   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+*
+*   You may elect to redistribute this code under either of these licenses.
+*
+*   Contributors:
+*
+*   Otavio Santana
+*/
+package test.jakarta.data.nosql.integration.web;
+
+import jakarta.data.metamodel.StaticMetamodel;
+import javax.annotation.processing.Generated;
+import org.eclipse.jnosql.mapping.semistructured.metamodel.attributes.NoSQLAttribute;
+import org.eclipse.jnosql.mapping.semistructured.metamodel.attributes.StringAttribute;
+import org.eclipse.jnosql.mapping.semistructured.metamodel.attributes.CriteriaAttribute;
+//CHECKSTYLE:OFF
+@StaticMetamodel(County.class)
+@Generated(value = "The StaticMetamodel of the class County provider by Eclipse JNoSQL", date = "2026-01-05T12:00:00.000000")
+public interface _County {
+
+        String NAME = "_id";
+        String POPULATION = "population";
+        String ZIPCODES = "zipcodes";
+        String COUNTYSEAT = "countySeat";
+   
+        StringAttribute<County> name = new NoSQLAttribute<>(NAME);
+        CriteriaAttribute<County> population = new NoSQLAttribute<>(POPULATION);
+        CriteriaAttribute<County> zipcodes = new NoSQLAttribute<>(ZIPCODES);
+        StringAttribute<County> countySeat = new NoSQLAttribute<>(COUNTYSEAT);
+
+}
+//CHECKSTYLE:ON

--- a/dev/io.openliberty.data.internal_fat_nosql/publish/servers/io.openliberty.data.internal.fat.nosql.integrate/bootstrap.properties
+++ b/dev/io.openliberty.data.internal_fat_nosql/publish/servers/io.openliberty.data.internal.fat.nosql.integrate/bootstrap.properties
@@ -1,0 +1,14 @@
+###############################################################################
+# Copyright (c) 2022,2025 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-2.0/
+# 
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+###############################################################################
+bootstrap.include=../testports.properties
+com.ibm.ws.logging.trace.specification=*=info:data=all

--- a/dev/io.openliberty.data.internal_fat_nosql/publish/servers/io.openliberty.data.internal.fat.nosql.integrate/bootstrap.properties
+++ b/dev/io.openliberty.data.internal_fat_nosql/publish/servers/io.openliberty.data.internal.fat.nosql.integrate/bootstrap.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2022,2025 IBM Corporation and others.
+# Copyright (c) 2026 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at

--- a/dev/io.openliberty.data.internal_fat_nosql/publish/servers/io.openliberty.data.internal.fat.nosql.integrate/server.xml
+++ b/dev/io.openliberty.data.internal_fat_nosql/publish/servers/io.openliberty.data.internal.fat.nosql.integrate/server.xml
@@ -1,0 +1,49 @@
+<!--
+    Copyright (c) 2022, 2026 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License 2.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-2.0/
+    
+    SPDX-License-Identifier: EPL-2.0
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<server>
+
+  <featureManager>
+    <!-- Uses presistence to confirm Liberty's Data implementation is used in the integration tests -->
+    <feature>componenttest-2.0</feature>
+    <feature>data-1.0</feature>
+    <feature>persistence-3.2</feature>
+    <feature>nosql-1.0</feature>
+    <feature>servlet-6.1</feature>
+    <feature>mpConfig-3.1</feature>
+    <feature>jsonb-3.0</feature>
+  </featureManager>
+
+  <include location="../fatTestPorts.xml"/>
+
+
+  <application location="DataNoSQLIntegrationApp.war">
+  	<classloader commonLibraryRef="jnosql, JDBCLibrary" />
+  </application>
+
+  <dataSource id="LibertyDataSource" jndiName="jdbc/LibertyDataSource">
+    <jdbcDriver libraryRef="JDBCLibrary"/>
+    <properties.derby.embedded createDatabase="create" databaseName="memory:libertydb" user="dbuser1" password="dbpwd1"/>
+  </dataSource>
+
+  <library id="jnosql">
+    <fileset dir="${shared.resource.dir}/jnosql-${JNOSQL_VERSION}" includes="*.jar" />
+  </library>
+  
+  <library id="JDBCLibrary">
+    <fileset dir="${shared.resource.dir}/derbyJava17Plus" includes="*.jar"/>
+  </library>
+    
+  <variable name="jnosql.document.database" value="${MONGO_DBNAME}"/>
+  <variable name="jnosql.mongodb.host" value="${MONGO_HOST}"/>
+
+</server>

--- a/dev/io.openliberty.data.internal_fat_nosql/publish/servers/io.openliberty.data.internal.fat.nosql.integrate/server.xml
+++ b/dev/io.openliberty.data.internal_fat_nosql/publish/servers/io.openliberty.data.internal.fat.nosql.integrate/server.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2022, 2026 IBM Corporation and others.
+    Copyright (c) 2026 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -13,7 +13,7 @@
 <server>
 
   <featureManager>
-    <!-- Uses presistence to confirm Liberty's Data implementation is used in the integration tests -->
+    <!-- Uses persistence to confirm Liberty's Data implementation is used in the integration tests -->
     <feature>componenttest-2.0</feature>
     <feature>data-1.0</feature>
     <feature>persistence-3.2</feature>

--- a/dev/io.openliberty.data.internal_fat_nosql/test-applications/DataNoSQLIntegrationApp/resources/WEB-INF/classes/META-INF/persistence.xml
+++ b/dev/io.openliberty.data.internal_fat_nosql/test-applications/DataNoSQLIntegrationApp/resources/WEB-INF/classes/META-INF/persistence.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- 
 /*******************************************************************************
- * Copyright (c) 2024, 2025 IBM Corporation and others.
+ * Copyright (c) 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/dev/io.openliberty.data.internal_fat_nosql/test-applications/DataNoSQLIntegrationApp/resources/WEB-INF/classes/META-INF/persistence.xml
+++ b/dev/io.openliberty.data.internal_fat_nosql/test-applications/DataNoSQLIntegrationApp/resources/WEB-INF/classes/META-INF/persistence.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- 
+/*******************************************************************************
+ * Copyright (c) 2024, 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+-->
+<persistence xmlns="https://jakarta.ee/xml/ns/persistence"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="https://jakarta.ee/xml/ns/persistence https://jakarta.ee/xml/ns/persistence/persistence_3_2.xsd"
+             version="3.2">
+    
+    <persistence-unit name="LibertyProvider">
+    	<provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
+        <jta-data-source>jdbc/LibertyDataSource</jta-data-source>
+        <properties>
+        	<property name="jakarta.persistence.schema-generation.database.action" value="create"/>
+            <property name="eclipselink.logging.parameters" value="true"/>
+        </properties>
+    </persistence-unit>
+
+</persistence>

--- a/dev/io.openliberty.data.internal_fat_nosql/test-applications/DataNoSQLIntegrationApp/src/test/jakarta/data/nosql/integration/web/Counties.java
+++ b/dev/io.openliberty.data.internal_fat_nosql/test-applications/DataNoSQLIntegrationApp/src/test/jakarta/data/nosql/integration/web/Counties.java
@@ -1,0 +1,29 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package test.jakarta.data.nosql.integration.web;
+
+import jakarta.data.repository.Delete;
+import jakarta.data.repository.Repository;
+import jakarta.data.repository.Save;
+
+/**
+ * Repository for the County entity.
+ */
+@Repository(provider = "Eclipse_JNoSQL")
+public interface Counties {
+
+    @Delete
+    void remove(County c);
+
+    @Save
+    void save(County c);
+
+}

--- a/dev/io.openliberty.data.internal_fat_nosql/test-applications/DataNoSQLIntegrationApp/src/test/jakarta/data/nosql/integration/web/County.java
+++ b/dev/io.openliberty.data.internal_fat_nosql/test-applications/DataNoSQLIntegrationApp/src/test/jakarta/data/nosql/integration/web/County.java
@@ -1,0 +1,61 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package test.jakarta.data.nosql.integration.web;
+
+import java.util.Arrays;
+
+import jakarta.nosql.Column;
+import jakarta.nosql.Entity;
+import jakarta.nosql.Id;
+
+@Entity
+public class County {
+    @Id
+    public String name;
+
+    @Column
+    public Integer population;
+
+    @Column
+    public Integer[] zipcodes;
+
+    @Column
+    public String countySeat;
+
+    public static County of(String name, String stateName, Integer population, Integer[] zipcodes, String countySeat) {
+        County inst = new County();
+        inst.name = name;
+        inst.population = population;
+        inst.zipcodes = zipcodes;
+        inst.countySeat = countySeat;
+        return inst;
+    }
+
+    @Override
+    public String toString() {
+        return "County of " + name + " population " + population + " zipcodes " + Arrays.toString(zipcodes) + " countySeat " + countySeat;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (!(o instanceof County))
+            return false;
+
+        County inst = (County) o;
+
+        return this.name.equals(inst.name) &&
+               this.population.equals(inst.population) &&
+               Arrays.equals(this.zipcodes, inst.zipcodes) &&
+               this.countySeat.equals(inst.countySeat);
+    }
+}

--- a/dev/io.openliberty.data.internal_fat_nosql/test-applications/DataNoSQLIntegrationApp/src/test/jakarta/data/nosql/integration/web/DataNoSQLIntegrationServlet.java
+++ b/dev/io.openliberty.data.internal_fat_nosql/test-applications/DataNoSQLIntegrationApp/src/test/jakarta/data/nosql/integration/web/DataNoSQLIntegrationServlet.java
@@ -1,0 +1,114 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package test.jakarta.data.nosql.integration.web;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.util.Optional;
+
+import jakarta.annotation.Resource;
+import jakarta.inject.Inject;
+import jakarta.persistence.EntityManagerFactory;
+import jakarta.persistence.PersistenceUnit;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.transaction.UserTransaction;
+
+import org.eclipse.jnosql.mapping.document.DocumentTemplate;
+import org.junit.Test;
+
+import componenttest.app.FATServlet;
+
+@SuppressWarnings("serial")
+@WebServlet("/*")
+public class DataNoSQLIntegrationServlet extends FATServlet {
+
+    @PersistenceUnit(unitName = "LibertyProvider", name = "jpa/LibertyProvider")
+    private EntityManagerFactory libertyEMF;
+
+    @Inject
+    DocumentTemplate jNoSQLtemplate;
+
+    @Inject
+    Counties counties; //JNoSQL
+
+    //TODO Re-enable after future JNoSQL Release
+    //@Inject
+    //Segments segments; //Liberty
+
+    @Resource
+    private UserTransaction tx;
+
+    @Test
+    public void testPersistenceUnits() throws Exception {
+        assertNotNull(libertyEMF);
+    }
+
+    @Test
+    public void testJNoSQLProvider() throws Exception {
+        //Create entity
+        Integer[] zipCodes = new Integer[] { 55009, 55018, 55026, 55027, 55066, 55089, 55946, 55963, 55983, 55992 };
+        County expected = County.of("Goodhue", "Minnesota", 48013, zipCodes, "Red Wing");
+
+        counties.save(expected);
+
+        //Ensure JNoSQL data provider was used
+        County actual = jNoSQLtemplate.find(County.class, "Goodhue").get();//hibernateEMF.createEntityManager().find(County.class, "Goodhue");
+
+        assertEquals(expected, actual);
+
+        //Ensure the Liberty persistence unit was not used
+        try {
+            tx.begin();
+            County unexpected = libertyEMF.createEntityManager().find(County.class, "Goodhue");
+            tx.commit();
+            fail("Should not be able to access County with Liberty's EMF since it's annotated with JNoSQL's @Entity");
+        } catch (IllegalArgumentException e) {
+            //pass
+        }
+
+        counties.remove(expected);
+    }
+
+    //TODO Re-enable after future JNoSQL Release
+    //@Test
+    public void testLibertyProvider() throws Exception {
+
+        Segment expected = Segment.of(5, 10, 2, 4);
+
+        //TODO Re-enable after future JNoSQL Release
+        //expected = segments.save(expected);
+        int expectedId = expected.id;
+
+        //Ensure the Liberty persistence unit was used
+        tx.begin();
+        Segment actual = libertyEMF.createEntityManager().find(Segment.class, expectedId);
+        tx.commit();
+
+        assertEquals(expected, actual);
+
+        //Ensure the JNoSQL data provider was not used
+        tx.begin();
+        Optional<Segment> unexpected = jNoSQLtemplate.find(Segment.class, expectedId);
+        tx.commit();
+
+        assertTrue(unexpected.isEmpty());
+
+        //TODO Re-enable after future JNoSQL Release
+        //segments.remove(expected);
+
+    }
+
+}

--- a/dev/io.openliberty.data.internal_fat_nosql/test-applications/DataNoSQLIntegrationApp/src/test/jakarta/data/nosql/integration/web/Segment.java
+++ b/dev/io.openliberty.data.internal_fat_nosql/test-applications/DataNoSQLIntegrationApp/src/test/jakarta/data/nosql/integration/web/Segment.java
@@ -1,0 +1,61 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package test.jakarta.data.nosql.integration.web;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+
+/**
+ * Entity with embeddables that are Java records.
+ */
+@Entity
+public class Segment {
+
+    @GeneratedValue
+    @Id
+    public int id;
+
+    public int x1, y1;
+    public int x2, y2;
+
+    public static Segment of(int x1, int y1, int x2, int y2) {
+        Segment inst = new Segment();
+        inst.x1 = x1;
+        inst.y1 = y1;
+        inst.x2 = x2;
+        inst.y2 = y2;
+        return inst;
+    }
+
+    @Override
+    public String toString() {
+        return "Segment#" + id + " (" +
+               x1 + ", " + y1 + ") -> (" +
+               x2 + ", " + y2 + ")";
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (!(o instanceof Segment))
+            return false;
+
+        Segment inst = (Segment) o;
+
+        return this.id == inst.id &&
+               this.x1 == inst.x1 &&
+               this.y1 == inst.y1 &&
+               this.x2 == inst.x2 &&
+               this.y2 == inst.y2;
+    }
+}

--- a/dev/io.openliberty.data.internal_fat_nosql/test-applications/DataNoSQLIntegrationApp/src/test/jakarta/data/nosql/integration/web/Segments.java
+++ b/dev/io.openliberty.data.internal_fat_nosql/test-applications/DataNoSQLIntegrationApp/src/test/jakarta/data/nosql/integration/web/Segments.java
@@ -1,0 +1,29 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package test.jakarta.data.nosql.integration.web;
+
+import jakarta.data.repository.Delete;
+import jakarta.data.repository.Repository;
+import jakarta.data.repository.Save;
+
+@Repository(provider = "Liberty",
+            // NOTE: Repository API JavaDoc requires use of a
+            // PersistenceUnit reference (not name)
+            dataStore = "java:comp/env/jpa/LibertyProvider")
+public interface Segments {
+
+    @Delete
+    void remove(Segment s);
+
+    @Save
+    Segment save(Segment s);
+
+}


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

Adds tests for using jNoSQL's data provider at the same time as Open Liberty's data provider. Currently jNoSQL is accepting any provider name resulting in multiple matching instances for `@Repository(provider = "Liberty"`. I fixed the behavior in jNoSQL, but it'll need a new release, so the test is disabled for now.