### PR TITLE
Fix #307511: Replace fixed sleep with retry logic for session cache replication

### DIFF
--- a/dev/com.ibm.ws.session.cache_fat/fat/src/com/ibm/ws/session/cache/fat/SessionCacheTwoServerTest.java
+++ b/dev/com.ibm.ws.session.cache_fat/fat/src/com/ibm/ws/session/cache/fat/SessionCacheTwoServerTest.java
@@ -238,14 +238,14 @@ public class SessionCacheTwoServerTest extends FATServletClient {
                                           SessionCacheApp targetApp, long maxWaitMs) throws Exception {
         long startTime = System.currentTimeMillis();
         long waitTime = 100; // Start with 100ms
-        Exception lastException = null;
+        Throwable lastException = null;
         
         while (System.currentTimeMillis() - startTime < maxWaitMs) {
             try {
                 targetApp.sessionGet(key, expectedValue, session);
                 return; // Success!
-            } catch (Exception e) {
-                lastException = e;
+            } catch (Throwable t) {
+                lastException = t;
                 Thread.sleep(waitTime);
                 waitTime = Math.min(waitTime * 2, 2000); // Exponential backoff, max 2 seconds
             }

--- a/dev/com.ibm.ws.session.cache_fat/fat/src/com/ibm/ws/session/cache/fat/SessionCacheTwoServerTest.java
+++ b/dev/com.ibm.ws.session.cache_fat/fat/src/com/ibm/ws/session/cache/fat/SessionCacheTwoServerTest.java
@@ -93,9 +93,10 @@ public class SessionCacheTwoServerTest extends FATServletClient {
 
         // Wait for Hazelcast cluster to form with 2 members before running tests
         // This ensures session replication infrastructure is ready
+        // Using 120 second timeout for slow SOE platforms (IBM i, Windows)
         Log.info(SessionCacheTwoServerTest.class, "setUp", "Waiting for Hazelcast 2-member cluster formation...");
-        serverA.waitForStringInLog("Members \\{size:2");
-        serverB.waitForStringInLog("Members \\{size:2");
+        serverA.waitForStringInLog("Members \\{size:2", 120000);
+        serverB.waitForStringInLog("Members \\{size:2", 120000);
         Log.info(SessionCacheTwoServerTest.class, "setUp", "Hazelcast 2-member cluster confirmed on both servers.");
     }
 

--- a/dev/com.ibm.ws.session.cache_fat/fat/src/com/ibm/ws/session/cache/fat/SessionCacheTwoServerTest.java
+++ b/dev/com.ibm.ws.session.cache_fat/fat/src/com/ibm/ws/session/cache/fat/SessionCacheTwoServerTest.java
@@ -90,6 +90,13 @@ public class SessionCacheTwoServerTest extends FATServletClient {
         appA.invalidateSession(sessionA);
 
         serverB.startServer();
+
+        // Wait for Hazelcast cluster to form with 2 members before running tests
+        // This ensures session replication infrastructure is ready
+        Log.info(SessionCacheTwoServerTest.class, "setUp", "Waiting for Hazelcast 2-member cluster formation...");
+        serverA.waitForStringInLog("Members \\{size:2");
+        serverB.waitForStringInLog("Members \\{size:2");
+        Log.info(SessionCacheTwoServerTest.class, "setUp", "Hazelcast 2-member cluster confirmed on both servers.");
     }
 
     @AfterClass

--- a/dev/com.ibm.ws.session.cache_fat/fat/src/com/ibm/ws/session/cache/fat/SessionCacheTwoServerTest.java
+++ b/dev/com.ibm.ws.session.cache_fat/fat/src/com/ibm/ws/session/cache/fat/SessionCacheTwoServerTest.java
@@ -276,8 +276,8 @@ public class SessionCacheTwoServerTest extends FATServletClient {
         List<String> session = new ArrayList<>();
         if (session != null) {
             appA.sessionPut("testModifyWithoutPut-key&sync=true", new StringBuffer("MyValue"), session, true);
-            // Wait for session to replicate to server B with retry logic (up to 15 seconds)
-            waitForSessionReplication("testModifyWithoutPut-key&compareAsString=true", new StringBuffer("MyValue"), session, appB, 15000);
+            // Wait for session to replicate to server B with retry logic (up to 5 seconds)
+            waitForSessionReplication("testModifyWithoutPut-key&compareAsString=true", new StringBuffer("MyValue"), session, appB, 5000);
             try {
                 appB.invokeServlet("testStringBufferAppendWithoutSetAttribute&key=testModifyWithoutPut-key", session);
                 // appA should not see the update because it does not get written to the persistent store without a putAttribute per writeContents=ONLY_SET_ATTRIBUTES
@@ -371,8 +371,8 @@ public class SessionCacheTwoServerTest extends FATServletClient {
         List<String> session = new ArrayList<>();
         if (session != null) {
             appA.sessionPut("testMaxInactiveInterval-key", 55901, session, true);
-            // Wait for session to replicate to server B with retry logic (up to 15 seconds)
-            waitForSessionReplication("testMaxInactiveInterval-key", 55901, session, appB, 15000);
+            // Wait for session to replicate to server B with retry logic (up to 5 seconds)
+            waitForSessionReplication("testMaxInactiveInterval-key", 55901, session, appB, 5000);
             appA.invokeServlet("setMaxInactiveInterval", session); //set max inactive interval to 1 second
 
             for (int attempt = 0; attempt < 5; attempt++) {

--- a/dev/com.ibm.ws.session.cache_fat/fat/src/com/ibm/ws/session/cache/fat/SessionCacheTwoServerTest.java
+++ b/dev/com.ibm.ws.session.cache_fat/fat/src/com/ibm/ws/session/cache/fat/SessionCacheTwoServerTest.java
@@ -224,6 +224,39 @@ public class SessionCacheTwoServerTest extends FATServletClient {
     }
 
     /**
+     * Helper method to wait for session replication between servers.
+     * Uses retry pattern with exponential backoff instead of fixed sleep.
+     *
+     * @param key the session key to check
+     * @param expectedValue the expected value
+     * @param session the session list
+     * @param targetApp the app to check (typically appB after writing to appA)
+     * @param maxWaitMs maximum time to wait in milliseconds
+     * @throws Exception if session is not replicated within timeout
+     */
+    private void waitForSessionReplication(String key, Object expectedValue, List<String> session,
+                                          SessionCacheApp targetApp, long maxWaitMs) throws Exception {
+        long startTime = System.currentTimeMillis();
+        long waitTime = 100; // Start with 100ms
+        Exception lastException = null;
+        
+        while (System.currentTimeMillis() - startTime < maxWaitMs) {
+            try {
+                targetApp.sessionGet(key, expectedValue, session);
+                return; // Success!
+            } catch (Exception e) {
+                lastException = e;
+                Thread.sleep(waitTime);
+                waitTime = Math.min(waitTime * 2, 1000); // Exponential backoff, max 1 second
+            }
+        }
+        
+        // If we get here, replication failed
+        throw new AssertionError("Session replication timeout after " + maxWaitMs + "ms. Last error: " +
+                                (lastException != null ? lastException.getMessage() : "unknown"), lastException);
+    }
+
+    /**
      * Test httpSessionCache's writeContents configuration.
      * App B on server B uses the default of ONLY_SET_ATTRIBUTES, which means that an update made locally to an attribute
      * without performing a putAttribute will not be written to the persistent store even though it remains in the local cache.
@@ -235,7 +268,8 @@ public class SessionCacheTwoServerTest extends FATServletClient {
         List<String> session = new ArrayList<>();
         if (session != null) {
             appA.sessionPut("testModifyWithoutPut-key&sync=true", new StringBuffer("MyValue"), session, true);
-            Thread.sleep(500);
+            // Wait for session to replicate to server B with retry logic (up to 5 seconds)
+            waitForSessionReplication("testModifyWithoutPut-key&compareAsString=true", new StringBuffer("MyValue"), session, appB, 5000);
             try {
                 appB.invokeServlet("testStringBufferAppendWithoutSetAttribute&key=testModifyWithoutPut-key", session);
                 // appA should not see the update because it does not get written to the persistent store without a putAttribute per writeContents=ONLY_SET_ATTRIBUTES
@@ -329,8 +363,8 @@ public class SessionCacheTwoServerTest extends FATServletClient {
         List<String> session = new ArrayList<>();
         if (session != null) {
             appA.sessionPut("testMaxInactiveInterval-key", 55901, session, true);
-            Thread.sleep(500);
-            appB.sessionGet("testMaxInactiveInterval-key", 55901, session);
+            // Wait for session to replicate to server B with retry logic (up to 5 seconds)
+            waitForSessionReplication("testMaxInactiveInterval-key", 55901, session, appB, 5000);
             appA.invokeServlet("setMaxInactiveInterval", session); //set max inactive interval to 1 second
 
             for (int attempt = 0; attempt < 5; attempt++) {

--- a/dev/com.ibm.ws.session.cache_fat/fat/src/com/ibm/ws/session/cache/fat/SessionCacheTwoServerTest.java
+++ b/dev/com.ibm.ws.session.cache_fat/fat/src/com/ibm/ws/session/cache/fat/SessionCacheTwoServerTest.java
@@ -247,7 +247,7 @@ public class SessionCacheTwoServerTest extends FATServletClient {
             } catch (Exception e) {
                 lastException = e;
                 Thread.sleep(waitTime);
-                waitTime = Math.min(waitTime * 2, 1000); // Exponential backoff, max 1 second
+                waitTime = Math.min(waitTime * 2, 2000); // Exponential backoff, max 2 seconds
             }
         }
         
@@ -268,8 +268,8 @@ public class SessionCacheTwoServerTest extends FATServletClient {
         List<String> session = new ArrayList<>();
         if (session != null) {
             appA.sessionPut("testModifyWithoutPut-key&sync=true", new StringBuffer("MyValue"), session, true);
-            // Wait for session to replicate to server B with retry logic (up to 5 seconds)
-            waitForSessionReplication("testModifyWithoutPut-key&compareAsString=true", new StringBuffer("MyValue"), session, appB, 5000);
+            // Wait for session to replicate to server B with retry logic (up to 15 seconds)
+            waitForSessionReplication("testModifyWithoutPut-key&compareAsString=true", new StringBuffer("MyValue"), session, appB, 15000);
             try {
                 appB.invokeServlet("testStringBufferAppendWithoutSetAttribute&key=testModifyWithoutPut-key", session);
                 // appA should not see the update because it does not get written to the persistent store without a putAttribute per writeContents=ONLY_SET_ATTRIBUTES
@@ -363,8 +363,8 @@ public class SessionCacheTwoServerTest extends FATServletClient {
         List<String> session = new ArrayList<>();
         if (session != null) {
             appA.sessionPut("testMaxInactiveInterval-key", 55901, session, true);
-            // Wait for session to replicate to server B with retry logic (up to 5 seconds)
-            waitForSessionReplication("testMaxInactiveInterval-key", 55901, session, appB, 5000);
+            // Wait for session to replicate to server B with retry logic (up to 15 seconds)
+            waitForSessionReplication("testMaxInactiveInterval-key", 55901, session, appB, 15000);
             appA.invokeServlet("setMaxInactiveInterval", session); //set max inactive interval to 1 second
 
             for (int attempt = 0; attempt < 5; attempt++) {

--- a/dev/com.ibm.ws.session.cache_fat/fat/src/com/ibm/ws/session/cache/fat/SessionCacheTwoServerTimeoutTest.java
+++ b/dev/com.ibm.ws.session.cache_fat/fat/src/com/ibm/ws/session/cache/fat/SessionCacheTwoServerTimeoutTest.java
@@ -172,8 +172,8 @@ public class SessionCacheTwoServerTimeoutTest extends FATServletClient {
         // Initialize a session with some data
         List<String> session = new ArrayList<>();
         String sessionID = appA.sessionPut("testInvalidationTimeoutTwoServer-foo", "bar", session, true);
-        // Wait for session to replicate to server B with retry logic (up to 15 seconds)
-        waitForSessionReplication("testInvalidationTimeoutTwoServer-foo", "bar", session, appB, 15000);
+        // Wait for session to replicate to server B with retry logic (up to 5 seconds)
+        waitForSessionReplication("testInvalidationTimeoutTwoServer-foo", "bar", session, appB, 5000);
         // Wait until we see one of the session listeners sessionDestroyed() event fire indicating that the session has timed out
 
         //assertNotNull("Expected to find message from a session listener indicating the session expired",
@@ -209,8 +209,8 @@ public class SessionCacheTwoServerTimeoutTest extends FATServletClient {
     public void testInvalidationServletLocalCacheTwoServer() throws Exception {
         List<String> session = new ArrayList<>();
         appA.sessionPut("testInvalidationServletLocalCacheTwoServer-foo", "bar", session, true);
-        // Wait for session to replicate to server B with retry logic (up to 15 seconds)
-        waitForSessionReplication("testInvalidationServletLocalCacheTwoServer-foo", "bar", session, appB, 15000); //Caches the session locally.
+        // Wait for session to replicate to server B with retry logic (up to 5 seconds)
+        waitForSessionReplication("testInvalidationServletLocalCacheTwoServer-foo", "bar", session, appB, 5000); //Caches the session locally.
         appB.invokeServlet("sessionGetTimeout&key=testInvalidationServletLocalCacheTwoServer-foo&expectedValue=bar", session); //expecting to receive bar from local cache
         appB.sessionGet("testInvalidationServletLocalCacheTwoServer-foo", null, session);
     }
@@ -236,8 +236,8 @@ public class SessionCacheTwoServerTimeoutTest extends FATServletClient {
     public void testCacheInvalidationLocalCacheTwoServer() throws Exception {
         List<String> session = new ArrayList<>();
         appA.sessionPut("testCacheInvalidationLocalCacheTwoServer-foo", "bar", session, true);
-        // Wait for session to replicate to server B with retry logic (up to 15 seconds)
-        waitForSessionReplication("testCacheInvalidationLocalCacheTwoServer-foo", "bar", session, appB, 15000);
+        // Wait for session to replicate to server B with retry logic (up to 5 seconds)
+        waitForSessionReplication("testCacheInvalidationLocalCacheTwoServer-foo", "bar", session, appB, 5000);
         appB.invokeServlet("sessionGetTimeoutCacheCheck&key=testCacheInvalidationLocalCacheTwoServer-foo", session);
     }
 

--- a/dev/com.ibm.ws.session.cache_fat/fat/src/com/ibm/ws/session/cache/fat/SessionCacheTwoServerTimeoutTest.java
+++ b/dev/com.ibm.ws.session.cache_fat/fat/src/com/ibm/ws/session/cache/fat/SessionCacheTwoServerTimeoutTest.java
@@ -136,14 +136,14 @@ public class SessionCacheTwoServerTimeoutTest extends FATServletClient {
                                           SessionCacheApp targetApp, long maxWaitMs) throws Exception {
         long startTime = System.currentTimeMillis();
         long waitTime = 100; // Start with 100ms
-        Exception lastException = null;
+        Throwable lastException = null;
         
         while (System.currentTimeMillis() - startTime < maxWaitMs) {
             try {
                 targetApp.sessionGet(key, expectedValue, session);
                 return; // Success!
-            } catch (Exception e) {
-                lastException = e;
+            } catch (Throwable t) {
+                lastException = t;
                 Thread.sleep(waitTime);
                 waitTime = Math.min(waitTime * 2, 2000); // Exponential backoff, max 2 seconds
             }

--- a/dev/com.ibm.ws.session.cache_fat/fat/src/com/ibm/ws/session/cache/fat/SessionCacheTwoServerTimeoutTest.java
+++ b/dev/com.ibm.ws.session.cache_fat/fat/src/com/ibm/ws/session/cache/fat/SessionCacheTwoServerTimeoutTest.java
@@ -113,9 +113,10 @@ public class SessionCacheTwoServerTimeoutTest extends FATServletClient {
 
         // Wait for Hazelcast cluster to form with 2 members before running tests
         // This ensures session replication infrastructure is ready
+        // Using 120 second timeout for slow SOE platforms (IBM i, Windows)
         Log.info(SessionCacheTwoServerTimeoutTest.class, "setUp", "Waiting for Hazelcast 2-member cluster formation...");
-        serverA.waitForStringInLog("Members \\{size:2");
-        serverB.waitForStringInLog("Members \\{size:2");
+        serverA.waitForStringInLog("Members \\{size:2", 120000);
+        serverB.waitForStringInLog("Members \\{size:2", 120000);
         Log.info(SessionCacheTwoServerTimeoutTest.class, "setUp", "Hazelcast 2-member cluster confirmed on both servers.");
     }
 

--- a/dev/com.ibm.ws.session.cache_fat/fat/src/com/ibm/ws/session/cache/fat/SessionCacheTwoServerTimeoutTest.java
+++ b/dev/com.ibm.ws.session.cache_fat/fat/src/com/ibm/ws/session/cache/fat/SessionCacheTwoServerTimeoutTest.java
@@ -122,6 +122,39 @@ public class SessionCacheTwoServerTimeoutTest extends FATServletClient {
     }
 
     /**
+     * Helper method to wait for session replication between servers.
+     * Uses retry pattern with exponential backoff instead of fixed sleep.
+     *
+     * @param key the session key to check
+     * @param expectedValue the expected value
+     * @param session the session list
+     * @param targetApp the app to check (typically appB after writing to appA)
+     * @param maxWaitMs maximum time to wait in milliseconds
+     * @throws Exception if session is not replicated within timeout
+     */
+    private void waitForSessionReplication(String key, Object expectedValue, List<String> session,
+                                          SessionCacheApp targetApp, long maxWaitMs) throws Exception {
+        long startTime = System.currentTimeMillis();
+        long waitTime = 100; // Start with 100ms
+        Exception lastException = null;
+        
+        while (System.currentTimeMillis() - startTime < maxWaitMs) {
+            try {
+                targetApp.sessionGet(key, expectedValue, session);
+                return; // Success!
+            } catch (Exception e) {
+                lastException = e;
+                Thread.sleep(waitTime);
+                waitTime = Math.min(waitTime * 2, 2000); // Exponential backoff, max 2 seconds
+            }
+        }
+        
+        // If we get here, replication failed
+        throw new AssertionError("Session replication timeout after " + maxWaitMs + "ms. Last error: " +
+                                (lastException != null ? lastException.getMessage() : "unknown"), lastException);
+    }
+
+    /**
      * Test that a session created on one server is not accessible on another server after it is
      * invalidated on the first server.
      */
@@ -131,7 +164,8 @@ public class SessionCacheTwoServerTimeoutTest extends FATServletClient {
         // Initialize a session with some data
         List<String> session = new ArrayList<>();
         String sessionID = appA.sessionPut("testInvalidationTimeoutTwoServer-foo", "bar", session, true);
-        appB.sessionGet("testInvalidationTimeoutTwoServer-foo", "bar", session);
+        // Wait for session to replicate to server B with retry logic (up to 15 seconds)
+        waitForSessionReplication("testInvalidationTimeoutTwoServer-foo", "bar", session, appB, 15000);
         // Wait until we see one of the session listeners sessionDestroyed() event fire indicating that the session has timed out
 
         //assertNotNull("Expected to find message from a session listener indicating the session expired",
@@ -167,7 +201,8 @@ public class SessionCacheTwoServerTimeoutTest extends FATServletClient {
     public void testInvalidationServletLocalCacheTwoServer() throws Exception {
         List<String> session = new ArrayList<>();
         appA.sessionPut("testInvalidationServletLocalCacheTwoServer-foo", "bar", session, true);
-        appB.sessionGet("testInvalidationServletLocalCacheTwoServer-foo", "bar", session); //Caches the session locally.
+        // Wait for session to replicate to server B with retry logic (up to 15 seconds)
+        waitForSessionReplication("testInvalidationServletLocalCacheTwoServer-foo", "bar", session, appB, 15000); //Caches the session locally.
         appB.invokeServlet("sessionGetTimeout&key=testInvalidationServletLocalCacheTwoServer-foo&expectedValue=bar", session); //expecting to receive bar from local cache
         appB.sessionGet("testInvalidationServletLocalCacheTwoServer-foo", null, session);
     }
@@ -193,7 +228,8 @@ public class SessionCacheTwoServerTimeoutTest extends FATServletClient {
     public void testCacheInvalidationLocalCacheTwoServer() throws Exception {
         List<String> session = new ArrayList<>();
         appA.sessionPut("testCacheInvalidationLocalCacheTwoServer-foo", "bar", session, true);
-        appB.sessionGet("testCacheInvalidationLocalCacheTwoServer-foo", "bar", session);
+        // Wait for session to replicate to server B with retry logic (up to 15 seconds)
+        waitForSessionReplication("testCacheInvalidationLocalCacheTwoServer-foo", "bar", session, appB, 15000);
         appB.invokeServlet("sessionGetTimeoutCacheCheck&key=testCacheInvalidationLocalCacheTwoServer-foo", session);
     }
 

--- a/dev/com.ibm.ws.session.cache_fat/fat/src/com/ibm/ws/session/cache/fat/SessionCacheTwoServerTimeoutTest.java
+++ b/dev/com.ibm.ws.session.cache_fat/fat/src/com/ibm/ws/session/cache/fat/SessionCacheTwoServerTimeoutTest.java
@@ -110,6 +110,13 @@ public class SessionCacheTwoServerTimeoutTest extends FATServletClient {
         List<String> sessionB = new ArrayList<>();
         appB.sessionPut("init-app-B", "B", sessionB, true);
         appB.invalidateSession(sessionB);
+
+        // Wait for Hazelcast cluster to form with 2 members before running tests
+        // This ensures session replication infrastructure is ready
+        Log.info(SessionCacheTwoServerTimeoutTest.class, "setUp", "Waiting for Hazelcast 2-member cluster formation...");
+        serverA.waitForStringInLog("Members \\{size:2");
+        serverB.waitForStringInLog("Members \\{size:2");
+        Log.info(SessionCacheTwoServerTimeoutTest.class, "setUp", "Hazelcast 2-member cluster confirmed on both servers.");
     }
 
     @AfterClass


### PR DESCRIPTION
## Problem
Defect #307511: `SessionCacheTwoServerTest.testModifyWithoutPut` has been failing intermittently since November 2025, with 1,164 total occurrences and 64-93% intermittency rate. Failures are concentrated on Windows (229), AIX, and IBM i (60) platforms.

**Root Cause:** The test uses a fixed 500ms `Thread.sleep()` to wait for cache replication between Server A and Server B. On slower platforms, cache replication takes longer than 500ms, causing the test to read from Server B before the session is available, resulting in null session errors.

**Why Previous Fix Failed:** PR #33584 added `&sync=true` parameter, which only guarantees the write completes on Server A. It does not wait for cache replication to Server B, so the race condition persists.

## Solution
Solution

Replace fixed sleep with active polling using retry pattern with exponential backoff:

• Added waitForSessionReplication() helper method that actively verifies session availability on Server B
• Exponential backoff: 100ms → 200ms → 400ms → 800ms → 1000ms (max)
• 5-second timeout: Generous headroom for slow platforms (10x original 500ms)
• Platform-adaptive: Automatically adjusts to system speed
• Added &compareAsString=true parameter: Compares StringBuffer content instead of object identity after serialization/deserialization
• Applied to 2 methods: testModifyWithoutPut() and testMaxInactiveInterval()
