### PR TITLE
Added changes for SSL options loading after endpoint has been started

### DIFF
--- a/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/stack/transport/GenericEndpointImpl.java
+++ b/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/stack/transport/GenericEndpointImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2025 IBM Corporation and others.
+ * Copyright (c) 2021, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -654,6 +654,15 @@ public class GenericEndpointImpl {
 					this);
 		}
 		sslOptions = config;
+		// If the endpoint has already started, we need to queue another start
+		// so that the ssl endpoint is properly started as well. If the config
+		// is unchanged, this will leave the endpoints as is when doing the chain start
+		if (endpointStarted && getEndpointOptions() != null) {
+			applyNewConfiguration(getEndpointOptions());
+		}
+		else if (c_logger.isTraceDebugEnabled()) {
+			c_logger.traceDebug("Set SSL options without starting chain. EndpointStarted ? " + endpointStarted + ", Endpoint Options: " + getEndpointOptions());
+		}
 	}
 
 	@Trivial


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [ ] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

Fix timing issue on SSL SIP endpoint startup where the SSL options are loaded after the activate is called and so the SSL endpoint is never started even though everything is configured for it.