### PR TITLE
Updates for when appAuthorization is enabled without a PolicyFactory

### DIFF
--- a/dev/com.ibm.ws.ejbcontainer.security/src/com/ibm/ws/ejbcontainer/security/internal/EJBSecurityCollaboratorImpl.java
+++ b/dev/com.ibm.ws.ejbcontainer.security/src/com/ibm/ws/ejbcontainer/security/internal/EJBSecurityCollaboratorImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2025 IBM Corporation and others.
+ * Copyright (c) 2011, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -31,8 +31,6 @@ import javax.security.auth.login.CredentialExpiredException;
 import org.osgi.framework.ServiceReference;
 import org.osgi.service.component.ComponentContext;
 import org.osgi.service.component.annotations.Reference;
-import com.ibm.ws.kernel.security.thread.ThreadIdentityException;
-import com.ibm.ws.kernel.security.thread.ThreadIdentityManager;
 
 import com.ibm.ejs.container.BeanMetaData;
 import com.ibm.ejs.ras.TraceNLS;
@@ -55,6 +53,8 @@ import com.ibm.ws.ejbcontainer.EJBSecurityCollaborator;
 import com.ibm.ws.ejbcontainer.security.internal.jacc.EJBJaccAuthorizationHelper;
 import com.ibm.ws.ejbcontainer.security.jacc.EJBJaccService;
 import com.ibm.ws.ffdc.annotation.FFDCIgnore;
+import com.ibm.ws.kernel.security.thread.ThreadIdentityException;
+import com.ibm.ws.kernel.security.thread.ThreadIdentityManager;
 import com.ibm.ws.runtime.metadata.ComponentMetaData;
 import com.ibm.ws.runtime.metadata.MetaData;
 import com.ibm.ws.security.SecurityService;
@@ -159,7 +159,7 @@ public class EJBSecurityCollaboratorImpl implements EJBSecurityCollaborator<Secu
 
     protected void setEJBJaccService(ServiceReference<EJBJaccService> reference) {
         ejbJaccService.setReference(reference);
-        eah = new EJBJaccAuthorizationHelper(ejbJaccService);
+        eah = new EJBJaccAuthorizationHelper(ejbJaccService, this);
     }
 
     protected void unsetEJBJaccService(ServiceReference<EJBJaccService> reference) {
@@ -269,10 +269,10 @@ public class EJBSecurityCollaboratorImpl implements EJBSecurityCollaborator<Secu
 
             } catch (ThreadIdentityException e) {
                 throw new EJBAccessDeniedException(TraceNLS.getFormattedMessage(this.getClass(),
-                                                                            TraceConstants.MESSAGE_BUNDLE,
-                                                                            "EJB_AUTHZ_EXCLUDED",
-                                                                            new Object[] { "postInvoke" },
-                                                                            "syncToOs failed {0}."));
+                                                                                TraceConstants.MESSAGE_BUNDLE,
+                                                                                "EJB_AUTHZ_EXCLUDED",
+                                                                                new Object[] { "postInvoke" },
+                                                                                "syncToOs failed {0}."));
             }
         }
     }
@@ -799,12 +799,11 @@ public class EJBSecurityCollaboratorImpl implements EJBSecurityCollaborator<Secu
         waitedForSecurity = true;
     }
 
-
     /**
      * Sync the invocation Subject's identity to the thread, if request by the application.
      *
      * @param WebSecurityContext The security context object for this application invocation.
-     *            MUST NOT BE NULL.
+     *                               MUST NOT BE NULL.
      * @throws SecurityViolationException
      */
     private void syncToOSThread(EJBSecurityContext ejbSecurityContext) throws EJBAccessDeniedException {
@@ -824,10 +823,10 @@ public class EJBSecurityCollaboratorImpl implements EJBSecurityCollaborator<Secu
                 Tr.debug(tc, "Exception setting thread identity", tie);
             }
             throw new EJBAccessDeniedException(TraceNLS.getFormattedMessage(this.getClass(),
-                                                                        TraceConstants.MESSAGE_BUNDLE,
-                                                                        "EJB_AUTHZ_EXCLUDED",
-                                                                        new Object[] { "syncToOSThread" },
-                                                                        "syncToOs failed {0}."));
+                                                                            TraceConstants.MESSAGE_BUNDLE,
+                                                                            "EJB_AUTHZ_EXCLUDED",
+                                                                            new Object[] { "syncToOSThread" },
+                                                                            "syncToOs failed {0}."));
         }
     }
 
@@ -835,7 +834,7 @@ public class EJBSecurityCollaboratorImpl implements EJBSecurityCollaborator<Secu
      * Remove the invocation Subject's identity from the thread, if it was previously sync'ed.
      *
      * @param WebSecurityContext The security context object for this application invocation.
-     *            MUST NOT BE NULL.
+     *                               MUST NOT BE NULL.
      * @throws ThreadIdentityException
      */
     private void resetSyncToOSThread(SecurityCookieImpl securityCookie) throws ThreadIdentityException {

--- a/dev/com.ibm.ws.ejbcontainer.security/src/com/ibm/ws/ejbcontainer/security/internal/jacc/EJBJaccAuthorizationHelper.java
+++ b/dev/com.ibm.ws.ejbcontainer.security/src/com/ibm/ws/ejbcontainer/security/internal/jacc/EJBJaccAuthorizationHelper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015,2024 IBM Corporation and others.
+ * Copyright (c) 2015,2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -44,10 +44,13 @@ import com.ibm.wsspi.kernel.service.utils.AtomicServiceReference;
 public class EJBJaccAuthorizationHelper implements EJBAuthorizationHelper {
     private static final TraceComponent tc = Tr.register(EJBJaccAuthorizationHelper.class);
 
-    private AtomicServiceReference<EJBJaccService> jaccServiceRef = null;
+    private final AtomicServiceReference<EJBJaccService> jaccServiceRef;
 
-    public EJBJaccAuthorizationHelper(AtomicServiceReference<EJBJaccService> jaccServiceRef) {
+    private final EJBAuthorizationHelper defaultHelper;
+
+    public EJBJaccAuthorizationHelper(AtomicServiceReference<EJBJaccService> jaccServiceRef, EJBAuthorizationHelper defaultHelper) {
         this.jaccServiceRef = jaccServiceRef;
+        this.defaultHelper = defaultHelper;
     }
 
     protected AuditManager auditManager;
@@ -91,6 +94,11 @@ public class EJBJaccAuthorizationHelper implements EJBAuthorizationHelper {
      */
     @Override
     public void authorizeEJB(EJBRequestData request, Subject subject) throws EJBAccessDeniedException {
+        EJBJaccService ejbJaccService = jaccServiceRef.getService();
+        if (!ejbJaccService.isPolicyConfigured()) {
+            defaultHelper.authorizeEJB(request, subject);
+            return;
+        }
         auditManager = new AuditManager();
         Object req = auditManager.getHttpServletRequest();
         Object webRequest = auditManager.getWebRequest();
@@ -119,8 +127,8 @@ public class EJBJaccAuthorizationHelper implements EJBAuthorizationHelper {
             methodParameters = Arrays.asList(methodArguments);
         }
 
-        boolean isAuthorized = jaccServiceRef.getService().isAuthorized(applicationName, moduleName, beanName, methodName, methodInterface, methodSignature, methodParameters, ejb,
-                                                                        subject);
+        boolean isAuthorized = ejbJaccService.isAuthorized(applicationName, moduleName, beanName, methodName, methodInterface, methodSignature, methodParameters, ejb,
+                                                           subject);
         String authzUserName = subject.getPrincipals(WSPrincipal.class).iterator().next().getName();
 
         if (!isAuthorized) {
@@ -142,6 +150,10 @@ public class EJBJaccAuthorizationHelper implements EJBAuthorizationHelper {
 
     @Override
     public boolean isCallerInRole(EJBComponentMetaData cmd, EJBRequestData request, String roleName, String roleLink, Subject subject) {
+        EJBJaccService ejbJaccService = jaccServiceRef.getService();
+        if (!ejbJaccService.isPolicyConfigured()) {
+            return defaultHelper.isCallerInRole(cmd, request, roleName, roleLink, subject);
+        }
         // roleLink is not used.
         String applicationName = cmd.getJ2EEName().getApplication();
         String moduleName = cmd.getJ2EEName().getModule();
@@ -156,7 +168,7 @@ public class EJBJaccAuthorizationHelper implements EJBAuthorizationHelper {
         if (request.getBeanInstance() instanceof EnterpriseBean) {
             bean = (EnterpriseBean) request.getBeanInstance();
         }
-        return jaccServiceRef.getService().isSubjectInRole(applicationName, moduleName, beanName, methodName, methodParameters, roleName, bean, subject);
+        return ejbJaccService.isSubjectInRole(applicationName, moduleName, beanName, methodName, methodParameters, roleName, bean, subject);
     }
 
 }

--- a/dev/com.ibm.ws.ejbcontainer.security/src/com/ibm/ws/ejbcontainer/security/jacc/EJBJaccService.java
+++ b/dev/com.ibm.ws.ejbcontainer.security/src/com/ibm/ws/ejbcontainer/security/jacc/EJBJaccService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 IBM Corporation and others.
+ * Copyright (c) 2024, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -83,4 +83,11 @@ public interface EJBJaccService {
      * Reset the policyContext Handler as per JACC specification
      */
     public void resetPolicyContextHandlerInfo();
+
+    /**
+     * Determines if a Policy is configured. In EE 11, we create the EJBJaccService always even if there
+     * isn't a PolicyFactory defined because it can be added dynamically by applications in their web.xml
+     * or using the PolicyFactory.setPolicyFactory() method.
+     */
+    public boolean isPolicyConfigured();
 }

--- a/dev/com.ibm.ws.ejbcontainer.security/test/com/ibm/ws/ejbcontainer/security/internal/jacc/EJBJaccAuthorizationHelperTest.java
+++ b/dev/com.ibm.ws.ejbcontainer.security/test/com/ibm/ws/ejbcontainer/security/internal/jacc/EJBJaccAuthorizationHelperTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2024 IBM Corporation and others.
+ * Copyright (c) 2015, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -120,13 +120,15 @@ public class EJBJaccAuthorizationHelperTest {
                 will(returnValue(0));
                 one(cc).locateService("eJBJaccService", jsr);
                 will(returnValue(js));
+                one(js).isPolicyConfigured();
+                will(returnValue(true));
                 one(js).isAuthorized(APP_NAME, MODULE_NAME, BEAN_NAME, METHOD_NAME, METHOD_INTERFACE_NAME, METHOD_SIGNATURE, null, null, SUBJECT);
                 will(returnValue(false));
             }
         });
         ajsr.setReference(jsr);
         ajsr.activate(cc);
-        EJBJaccAuthorizationHelper ejah = new EJBJaccAuthorizationHelper(ajsr);
+        EJBJaccAuthorizationHelper ejah = new EJBJaccAuthorizationHelper(ajsr, null);
         try {
             ejah.authorizeEJB(erd, SUBJECT);
             fail("EJBAcessDeniedException is not caught");
@@ -187,13 +189,15 @@ public class EJBJaccAuthorizationHelperTest {
                 will(returnValue(0));
                 one(cc).locateService("eJBJaccService", jsr);
                 will(returnValue(js));
+                one(js).isPolicyConfigured();
+                will(returnValue(true));
                 one(js).isAuthorized(APP_NAME, MODULE_NAME, BEAN_NAME, METHOD_NAME, METHOD_INTERFACE_NAME, METHOD_SIGNATURE, Arrays.asList(ARG_LIST), eb, SUBJECT);
                 will(returnValue(true));
             }
         });
         ajsr.setReference(jsr);
         ajsr.activate(cc);
-        EJBJaccAuthorizationHelper ejah = new EJBJaccAuthorizationHelper(ajsr);
+        EJBJaccAuthorizationHelper ejah = new EJBJaccAuthorizationHelper(ajsr, null);
         try {
             ejah.authorizeEJB(erd, SUBJECT);
             // success
@@ -245,6 +249,8 @@ public class EJBJaccAuthorizationHelperTest {
                 will(returnValue(0));
                 one(cc).locateService("eJBJaccService", jsr);
                 will(returnValue(js));
+                one(js).isPolicyConfigured();
+                will(returnValue(true));
                 one(js).isSubjectInRole(APP_NAME, MODULE_NAME, BEAN_NAME, METHOD_NAME, Arrays.asList(ARG_LIST), ROLE, eb, SUBJECT);
                 will(returnValue(false));
             }
@@ -252,7 +258,7 @@ public class EJBJaccAuthorizationHelperTest {
 
         ajsr.setReference(jsr);
         ajsr.activate(cc);
-        EJBJaccAuthorizationHelper ejah = new EJBJaccAuthorizationHelper(ajsr);
+        EJBJaccAuthorizationHelper ejah = new EJBJaccAuthorizationHelper(ajsr, null);
         assertFalse(ejah.isCallerInRole(ecmd, erd, ROLE, null, SUBJECT));
     }
 
@@ -296,6 +302,8 @@ public class EJBJaccAuthorizationHelperTest {
                 will(returnValue(0));
                 one(cc).locateService("eJBJaccService", jsr);
                 will(returnValue(js));
+                one(js).isPolicyConfigured();
+                will(returnValue(true));
                 one(js).isSubjectInRole(APP_NAME, MODULE_NAME, BEAN_NAME, METHOD_NAME, null, ROLE, null, SUBJECT);
                 will(returnValue(true));
             }
@@ -303,7 +311,7 @@ public class EJBJaccAuthorizationHelperTest {
 
         ajsr.setReference(jsr);
         ajsr.activate(cc);
-        EJBJaccAuthorizationHelper ejah = new EJBJaccAuthorizationHelper(ajsr);
+        EJBJaccAuthorizationHelper ejah = new EJBJaccAuthorizationHelper(ajsr, null);
         assertTrue(ejah.isCallerInRole(ecmd, erd, ROLE, null, SUBJECT));
     }
 

--- a/dev/com.ibm.ws.security.authorization.jacc.ejb/src/com/ibm/ws/security/authorization/jacc/ejb/impl/EJBJaccServiceImpl.java
+++ b/dev/com.ibm.ws.security.authorization.jacc.ejb/src/com/ibm/ws/security/authorization/jacc/ejb/impl/EJBJaccServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024, 2025 IBM Corporation and others.
+ * Copyright (c) 2024, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -310,5 +310,15 @@ public class EJBJaccServiceImpl implements EJBJaccService {
             }
         }
         return methodSignatureList.toArray(new String[methodSignatureList.size()]);
+    }
+
+    @Override
+    public boolean isPolicyConfigured() {
+        JaccService jaccService = jaccServiceRef.getService();
+        if (jaccService == null) {
+            return false;
+        }
+        PolicyProxy policyProxy = jaccService.getPolicyProxy();
+        return policyProxy == null ? false : policyProxy.isPolicyConfigured();
     }
 }

--- a/dev/com.ibm.ws.security.authorization.jacc.web/src/com/ibm/ws/security/authorization/jacc/web/impl/WebJaccServiceImpl.java
+++ b/dev/com.ibm.ws.security.authorization.jacc.web/src/com/ibm/ws/security/authorization/jacc/web/impl/WebJaccServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024, 2025 IBM Corporation and others.
+ * Copyright (c) 2024, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -803,4 +803,13 @@ public class WebJaccServiceImpl implements WebJaccService {
         }
     }
 
+    @Override
+    public boolean isPolicyConfigured() {
+        JaccService jaccService = jaccServiceRef.getService();
+        if (jaccService == null) {
+            return false;
+        }
+        PolicyProxy policyProxy = jaccService.getPolicyProxy();
+        return policyProxy == null ? false : policyProxy.isPolicyConfigured();
+    }
 }

--- a/dev/com.ibm.ws.security.authorization.jacc/src/com/ibm/ws/security/authorization/jacc/common/PolicyProxy.java
+++ b/dev/com.ibm.ws.security.authorization.jacc/src/com/ibm/ws/security/authorization/jacc/common/PolicyProxy.java
@@ -41,4 +41,14 @@ public interface PolicyProxy {
         // Default is to throws exception since it isn't expected to be called for pre-EE 11 scenarios
         throw new UnsupportedOperationException();
     }
+
+    /**
+     * Determines if a Policy is configured.  In EE 11, we create the PolicyProxy always even if there
+     * isn't a PolicyFactory defined because it can be added dynamically by applications in their web.xml
+     * or using the PolicyFactory.setPolicyFactory() method.
+     */
+    default public boolean isPolicyConfigured() {
+        // return true for pre EE 11 versions since the PolicyProxy isn't created unless there is a Policy
+        return true;
+    }
 }

--- a/dev/com.ibm.ws.webcontainer.security/src/com/ibm/ws/webcontainer/security/WebAppSecurityCollaboratorImpl.java
+++ b/dev/com.ibm.ws.webcontainer.security/src/com/ibm/ws/webcontainer/security/WebAppSecurityCollaboratorImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2025 IBM Corporation and others.
+ * Copyright (c) 2011, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -308,7 +308,7 @@ public class WebAppSecurityCollaboratorImpl implements IWebAppSecurityCollaborat
             Tr.debug(tc, "enabling JACC service");
         }
         webJaccServiceRef.setReference(ref);
-        wasch = new WebAppJaccAuthorizationHelper(webJaccServiceRef);
+        wasch = new WebAppJaccAuthorizationHelper(webJaccServiceRef, this);
     }
 
     protected void unsetWebJaccService(ServiceReference<WebJaccService> ref) {

--- a/dev/com.ibm.ws.webcontainer.security/src/com/ibm/ws/webcontainer/security/WebJaccService.java
+++ b/dev/com.ibm.ws.webcontainer.security/src/com/ibm/ws/webcontainer/security/WebJaccService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024, 2025 IBM Corporation and others.
+ * Copyright (c) 2024, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -101,4 +101,11 @@ public interface WebJaccService {
      * Reset the policyContext Handler as per JACC specification
      */
     public void resetPolicyContextHandlerInfo();
+
+    /**
+     * Determines if a Policy is configured.  In EE 11, we create the WebJaccService always even if there
+     * isn't a PolicyFactory defined because it can be added dynamically by applications in their web.xml
+     * or using the PolicyFactory.setPolicyFactory() method.
+     */
+    public boolean isPolicyConfigured();
 }

--- a/dev/com.ibm.ws.webcontainer.security/src/com/ibm/ws/webcontainer/security/jacc/WebAppJaccAuthorizationHelper.java
+++ b/dev/com.ibm.ws.webcontainer.security/src/com/ibm/ws/webcontainer/security/jacc/WebAppJaccAuthorizationHelper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2024 IBM Corporation and others.
+ * Copyright (c) 2015, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -34,28 +34,33 @@ import com.ibm.ws.webcontainer.security.internal.PermitReply;
 import com.ibm.ws.webcontainer.security.internal.WebReply;
 import com.ibm.wsspi.kernel.service.utils.AtomicServiceReference;
 import com.ibm.wsspi.webcontainer.RequestProcessor;
-import com.ibm.wsspi.webcontainer.metadata.WebComponentMetaData;
 import com.ibm.wsspi.webcontainer.metadata.WebModuleMetaData;
 import com.ibm.wsspi.webcontainer.servlet.IExtendedRequest;
 
 public class WebAppJaccAuthorizationHelper implements WebAppAuthorizationHelper {
     private static final TraceComponent tc = Tr.register(WebAppJaccAuthorizationHelper.class);
 
-    private AtomicServiceReference<WebJaccService> jaccServiceRef = null;
+    private final AtomicServiceReference<WebJaccService> jaccServiceRef;
+    private final WebAppAuthorizationHelper defaultHelper;
     private static final WebReply DENY_AUTHZ_FAILED = new DenyReply("AuthorizationFailed");
 
-    public WebAppJaccAuthorizationHelper(AtomicServiceReference<WebJaccService> ref) {
+    public WebAppJaccAuthorizationHelper(AtomicServiceReference<WebJaccService> ref, WebAppAuthorizationHelper defaultHelper) {
         this.jaccServiceRef = ref;
+        this.defaultHelper = defaultHelper;
     }
 
     @Override
     public boolean isUserInRole(String role, IExtendedRequest req, Subject subject) {
+        WebJaccService webJaccService = jaccServiceRef.getService();
+        if (!webJaccService.isPolicyConfigured()) {
+            return defaultHelper.isUserInRole(role, req, subject);
+        }
         String servletName = null;
         RequestProcessor reqProc = req.getWebAppDispatcherContext().getCurrentServletReference();
         if (reqProc != null) {
             servletName = reqProc.getName();
         }
-        return jaccServiceRef.getService().isSubjectInRole(getApplicationName(), getModuleName(), servletName, role, req, subject);
+        return webJaccService.isSubjectInRole(getApplicationName(), getModuleName(), servletName, role, req, subject);
     }
 
     /**
@@ -69,8 +74,12 @@ public class WebAppJaccAuthorizationHelper implements WebAppAuthorizationHelper 
 
     @Override
     public boolean authorize(AuthenticationResult authResult, WebRequest webRequest, String uriName) {
+        WebJaccService webJaccService = jaccServiceRef.getService();
+        if (!webJaccService.isPolicyConfigured()) {
+            return defaultHelper.authorize(authResult, webRequest, uriName);
+        }
         HttpServletRequest req = webRequest.getHttpServletRequest();
-        boolean isAuthorized = jaccServiceRef.getService().isAuthorized(getApplicationName(), getModuleName(), uriName, req.getMethod(), req, authResult.getSubject());
+        boolean isAuthorized = webJaccService.isAuthorized(getApplicationName(), getModuleName(), uriName, req.getMethod(), req, authResult.getSubject());
         //String[] methodNameArray = new String[] { req.getMethod() };
         //WebResourcePermission webPerm = new WebResourcePermission(uriName, methodNameArray);
         WebReply reply = isAuthorized ? new PermitReply() : DENY_AUTHZ_FAILED;
@@ -105,10 +114,14 @@ public class WebAppJaccAuthorizationHelper implements WebAppAuthorizationHelper 
 
     @Override
     public boolean isSSLRequired(WebRequest webRequest, String uriName) {
+        WebJaccService webJaccService = jaccServiceRef.getService();
+        if (!webJaccService.isPolicyConfigured()) {
+            return defaultHelper.isSSLRequired(webRequest, uriName);
+        }
         HttpServletRequest req = webRequest.getHttpServletRequest();
         boolean isSSLRequired = false;
         if (!req.isSecure()) {
-            isSSLRequired = jaccServiceRef.getService().isSSLRequired(getApplicationName(), getModuleName(), uriName, req.getMethod(), req);
+            isSSLRequired = webJaccService.isSSLRequired(getApplicationName(), getModuleName(), uriName, req.getMethod(), req);
         }
         return isSSLRequired;
     }
@@ -123,6 +136,11 @@ public class WebAppJaccAuthorizationHelper implements WebAppAuthorizationHelper 
      */
     @Override
     public WebReply checkPrecludedAccess(WebRequest webRequest, String uriName) {
+        WebJaccService webJaccService = jaccServiceRef.getService();
+        if (!webJaccService.isPolicyConfigured()) {
+            return defaultHelper.checkPrecludedAccess(webRequest, uriName);
+        }
+
         WebReply webReply = null;
         /*
          * In order to check precluded access, WebUserDataPermission can be used,
@@ -132,7 +150,7 @@ public class WebAppJaccAuthorizationHelper implements WebAppAuthorizationHelper 
          */
         HttpServletRequest req = webRequest.getHttpServletRequest();
         boolean isExcluded = false;
-        isExcluded = jaccServiceRef.getService().isAccessExcluded(getApplicationName(), getModuleName(), uriName, req.getMethod(), req);
+        isExcluded = webJaccService.isAccessExcluded(getApplicationName(), getModuleName(), uriName, req.getMethod(), req);
         if (isExcluded) {
             webReply = new DenyReply("JACC provider denied the access.");
         }
@@ -141,13 +159,13 @@ public class WebAppJaccAuthorizationHelper implements WebAppAuthorizationHelper 
 
     protected String getApplicationName() {
         ComponentMetaData cmd = ComponentMetaDataAccessorImpl.getComponentMetaDataAccessor().getComponentMetaData();
-        WebModuleMetaData wmmd = (WebModuleMetaData) ((WebComponentMetaData) cmd).getModuleMetaData();
+        WebModuleMetaData wmmd = (WebModuleMetaData) cmd.getModuleMetaData();
         return wmmd.getConfiguration().getApplicationName();
     }
 
     protected String getModuleName() {
         ComponentMetaData cmd = ComponentMetaDataAccessorImpl.getComponentMetaDataAccessor().getComponentMetaData();
-        WebModuleMetaData wmmd = (WebModuleMetaData) ((WebComponentMetaData) cmd).getModuleMetaData();
+        WebModuleMetaData wmmd = (WebModuleMetaData) cmd.getModuleMetaData();
         return wmmd.getConfiguration().getModuleName();
     }
 

--- a/dev/com.ibm.ws.webcontainer.security/test/com/ibm/ws/webcontainer/security/jacc/WebAppJaccAuthorizationHelperTest.java
+++ b/dev/com.ibm.ws.webcontainer.security/test/com/ibm/ws/webcontainer/security/jacc/WebAppJaccAuthorizationHelperTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2024 IBM Corporation and others.
+ * Copyright (c) 2015, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -116,6 +116,8 @@ public class WebAppJaccAuthorizationHelperTest {
                 will(returnValue(0));
                 one(cc).locateService("webJaccService", jsr);
                 will(returnValue(js));
+                one(js).isPolicyConfigured();
+                will(returnValue(true));
                 one(js).isSubjectInRole(APP_NAME, MODULE_NAME, SERVLET_NAME, ROLE, ier, SUBJECT);
                 will(returnValue(true));
             }
@@ -125,7 +127,7 @@ public class WebAppJaccAuthorizationHelperTest {
 
         ajsr.setReference(jsr);
         ajsr.activate(cc);
-        WebAppJaccAuthorizationHelper wjah = new WebAppJaccAuthorizationHelper(ajsr);
+        WebAppJaccAuthorizationHelper wjah = new WebAppJaccAuthorizationHelper(ajsr, null);
         assertTrue(wjah.isUserInRole(ROLE, ier, SUBJECT));
     }
 
@@ -164,6 +166,8 @@ public class WebAppJaccAuthorizationHelperTest {
                 will(returnValue(0));
                 one(cc).locateService("webJaccService", jsr);
                 will(returnValue(js));
+                one(js).isPolicyConfigured();
+                will(returnValue(true));
                 one(js).isSubjectInRole(APP_NAME, MODULE_NAME, null, ROLE, ier, SUBJECT);
                 will(returnValue(false));
             }
@@ -173,7 +177,7 @@ public class WebAppJaccAuthorizationHelperTest {
 
         ajsr.setReference(jsr);
         ajsr.activate(cc);
-        WebAppJaccAuthorizationHelper wjah = new WebAppJaccAuthorizationHelper(ajsr);
+        WebAppJaccAuthorizationHelper wjah = new WebAppJaccAuthorizationHelper(ajsr, null);
         assertFalse(wjah.isUserInRole(ROLE, ier, SUBJECT));
     }
 
@@ -214,6 +218,8 @@ public class WebAppJaccAuthorizationHelperTest {
                 will(returnValue(0));
                 one(cc).locateService("webJaccService", jsr);
                 will(returnValue(js));
+                one(js).isPolicyConfigured();
+                will(returnValue(true));
                 one(js).isAuthorized(APP_NAME, MODULE_NAME, URI_NAME, METHOD_NAME, ier, SUBJECT);
                 will(returnValue(true));
             }
@@ -223,7 +229,7 @@ public class WebAppJaccAuthorizationHelperTest {
 
         ajsr.setReference(jsr);
         ajsr.activate(cc);
-        WebAppJaccAuthorizationHelper wjah = new WebAppJaccAuthorizationHelper(ajsr);
+        WebAppJaccAuthorizationHelper wjah = new WebAppJaccAuthorizationHelper(ajsr, null);
         assertTrue(wjah.authorize(AR, wr, URI_NAME));
     }
 
@@ -260,6 +266,8 @@ public class WebAppJaccAuthorizationHelperTest {
                 will(returnValue(0));
                 one(cc).locateService("webJaccService", jsr);
                 will(returnValue(js));
+                one(js).isPolicyConfigured();
+                will(returnValue(true));
                 one(js).isSSLRequired(APP_NAME, MODULE_NAME, URI_NAME, METHOD_NAME, ier);
                 will(returnValue(true));
             }
@@ -269,7 +277,7 @@ public class WebAppJaccAuthorizationHelperTest {
 
         ajsr.setReference(jsr);
         ajsr.activate(cc);
-        WebAppJaccAuthorizationHelper wjah = new WebAppJaccAuthorizationHelper(ajsr);
+        WebAppJaccAuthorizationHelper wjah = new WebAppJaccAuthorizationHelper(ajsr, null);
         assertTrue(wjah.isSSLRequired(wr, URI_NAME));
     }
 
@@ -298,13 +306,15 @@ public class WebAppJaccAuthorizationHelperTest {
                 will(returnValue(0));
                 one(cc).locateService("webJaccService", jsr);
                 will(returnValue(js));
+                one(js).isPolicyConfigured();
+                will(returnValue(true));
                 one(js).isSSLRequired(APP_NAME, MODULE_NAME, URI_NAME, METHOD_NAME, ier);
                 will(returnValue(false));
             }
         });
         ajsr.setReference(jsr);
         ajsr.activate(cc);
-        WebAppJaccAuthorizationHelper wjah = new WebAppJaccAuthorizationHelper(ajsr);
+        WebAppJaccAuthorizationHelper wjah = new WebAppJaccAuthorizationHelper(ajsr, null);
         assertFalse(wjah.isSSLRequired(wr, URI_NAME));
     }
 
@@ -339,6 +349,8 @@ public class WebAppJaccAuthorizationHelperTest {
                 will(returnValue(0));
                 one(cc).locateService("webJaccService", jsr);
                 will(returnValue(js));
+                one(js).isPolicyConfigured();
+                will(returnValue(true));
                 one(js).isAccessExcluded(APP_NAME, MODULE_NAME, URI_NAME, METHOD_NAME, ier);
                 will(returnValue(false));
             }
@@ -348,7 +360,7 @@ public class WebAppJaccAuthorizationHelperTest {
 
         ajsr.setReference(jsr);
         ajsr.activate(cc);
-        WebAppJaccAuthorizationHelper wjah = new WebAppJaccAuthorizationHelper(ajsr);
+        WebAppJaccAuthorizationHelper wjah = new WebAppJaccAuthorizationHelper(ajsr, null);
         assertNull(wjah.checkPrecludedAccess(wr, URI_NAME));
     }
 
@@ -383,6 +395,8 @@ public class WebAppJaccAuthorizationHelperTest {
                 will(returnValue(0));
                 one(cc).locateService("webJaccService", jsr);
                 will(returnValue(js));
+                one(js).isPolicyConfigured();
+                will(returnValue(true));
                 one(js).isAccessExcluded(APP_NAME, MODULE_NAME, URI_NAME, METHOD_NAME, ier);
                 will(returnValue(true));
             }
@@ -392,7 +406,7 @@ public class WebAppJaccAuthorizationHelperTest {
 
         ajsr.setReference(jsr);
         ajsr.activate(cc);
-        WebAppJaccAuthorizationHelper wjah = new WebAppJaccAuthorizationHelper(ajsr);
+        WebAppJaccAuthorizationHelper wjah = new WebAppJaccAuthorizationHelper(ajsr, null);
         WebReply output = wjah.checkPrecludedAccess(wr, URI_NAME);
         assertTrue(output instanceof DenyReply);
     }

--- a/dev/io.openliberty.security.authorization.internal.jacc.3.0/src/io/openliberty/security/authorization/jacc/internal/proxy/JakartaPolicyConfigProxy.java
+++ b/dev/io.openliberty.security.authorization.internal.jacc.3.0/src/io/openliberty/security/authorization/jacc/internal/proxy/JakartaPolicyConfigProxy.java
@@ -76,19 +76,17 @@ public class JakartaPolicyConfigProxy implements PolicyConfiguration {
 
     void resetDelegatePolicyConfig(boolean remove) throws PolicyContextException {
         PolicyConfigurationFactory delegateFactory = factoryProxy.getFactory();
-        if (delegateFactory != null) {
-            synchronized (this) {
-                PolicyConfiguration delegateConfig = delegateFactory.getPolicyConfiguration(contextId, remove);
-                if (remove) {
-                     delete(true);
-                }
-                setState(ContextState.OPEN);
-
-                // Order matters here.  Need to set the config before the factory to avoid a timing window in
-                // getDelegatePolicyConfig where we think the config is already set if the factory is updated
-                currentConfig.set(delegateConfig);
-                currentFactory.set(delegateFactory);
+        synchronized (this) {
+            PolicyConfiguration delegateConfig = delegateFactory == null ? null : delegateFactory.getPolicyConfiguration(contextId, remove);
+            if (remove) {
+                 delete(true);
             }
+            setState(ContextState.OPEN);
+
+            // Order matters here.  Need to set the config before the factory to avoid a timing window in
+            // getDelegatePolicyConfig where we think the config is already set if the factory is updated
+            currentConfig.set(delegateConfig);
+            currentFactory.set(delegateFactory);
         }
     }
 


### PR DESCRIPTION
- When a PolicyFactory is not configured, switch to use the default authorization function for the EJB and Web collaborators so that we get the default authorization checking
- Previously we wouldn't enable the Jacc / Authorization services unless a user provided a ProviderService OSGi service
- Update how we reset the PolicyConfiguration and PolicyConfigurationFactory when getPolicyConfiguration(PolicyContext, boolean) is called to always reset state regardless if there is a factory or not.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
