### PR TITLE
Apply WebContrainer `redirectToRelativeUrl` property to Context Roots

### DIFF
--- a/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/extension/DefaultExtensionProcessor.java
+++ b/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/extension/DefaultExtensionProcessor.java
@@ -636,10 +636,21 @@ private ICollaboratorHelper collabHelper;
                 //end PI31447
                 
                 String queryString = httpRequest.getQueryString(); //PM88028
-
+				
                 if (!requestString.endsWith("/")) {
                     if (isInclude == false) {
-                        String tmpURL = requestString + "/"; // append a slash for redirect purposes.
+						                    // Build the redirect URL - use relative URL if configured
+						String tmpURL;
+						if (WCCustomProperties.REDIRECT_TO_RELATIVE_URL) {
+							// Use relative URL (request URI only)
+							tmpURL = req.getRequestURI();
+							System.out.println("DEBUG DefaultExtensionProcessor: Using RELATIVE URL, tmpURL: " + tmpURL);
+						} else {
+							// Use absolute URL (original behavior)
+							tmpURL = requestString;
+							System.out.println("DEBUG DefaultExtensionProcessor: Using ABSOLUTE URL, tmpURL: " + tmpURL);
+						}
+
 //                        String qString;
 //                        if ((qString = req.getQueryString()) != null) { // if query string exists; add it.
 //                            tmpURL += "?" + qString;

--- a/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/webapp/WebApp.java
+++ b/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/webapp/WebApp.java
@@ -4893,7 +4893,17 @@ public abstract class WebApp extends BaseContainer implements ServletContext, IS
                 // PK79143 Start
                 // dispatchContext.sendRedirect (((HttpServletRequest)
                 // req).getRequestURL() + "/");
-                ((HttpServletResponse) res).sendRedirect(((HttpServletRequest) req).getRequestURL() + "/");
+                	String redirectURL;
+                    if (WCCustomProperties.REDIRECT_TO_RELATIVE_URL) {
+                        // Use relative URL (request URI only)
+                        redirectURL = req.getRequestURI() + "/";
+                        System.out.println("DEBUG Webapp: Using RELATIVE URL, tmpURL: " + redirectURL);
+                    } else {
+                        // Use absolute URL (original behavior)
+                        redirectURL = contextPath + "/";
+                        System.out.println("DEBUG WebApp: Using ABSOLUTE URL, tmpURL: " + redirectURL);
+                    }
+                ((HttpServletResponse) res).sendRedirect(redirectURL);
                 // PK79143 End
 
                 if (com.ibm.ejs.ras.TraceComponent.isAnyTracingEnabled() && logger.isLoggable(Level.FINE))


### PR DESCRIPTION
- [ ] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [ ] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

fixes #34087

Redirects occur within `DefaultExtensionProcessor` , but I also noticed that the `com.ibm.ws.webcontainer.redirectcontextroot` property ([link](https://www.ibm.com/docs/en/was/8.5.5?topic=configuration-web-container-custom-properties#redirectcontextroot)) applied here and needed a check within WebApp, too. 