### PR TITLE
Remove workaround from code after more of #29073 is working

### DIFF
--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
@@ -3182,21 +3182,7 @@ public class QueryInfo {
             } else if (entityInfo.idClassAttributeAccessors != null &&
                        singleType.equals(entityInfo.idType)) {
                 // IdClass
-                if (entityInfo.isHibernate) {
-                    q.append("SELECT ID(").append(entityVar).append(')');
-                } else {
-                    // TODO remove once #29073 is fixed and use above code instead.
-                    // The following guess of alphabetic order is not valid in most cases, but this
-                    // whole code block will be removed before GA, so there is no reason to correct it.
-                    q.append("SELECT NEW ").append(singleType.getName()).append('(');
-                    boolean first = true;
-                    for (String idClassAttributeName : entityInfo.idClassAttributeAccessors.keySet()) {
-                        String name = getAttributeName(idClassAttributeName, true);
-                        q.append(first ? "" : ", ").append(o_).append(name);
-                        first = false;
-                    }
-                    q.append(')');
-                }
+                q.append("SELECT ID(").append(entityVar).append(')');
             } else {
                 // Is the result type a record?
                 RecordComponent[] recordComponents = singleType.getRecordComponents();

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Cities.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/Cities.java
@@ -53,9 +53,6 @@ public interface Cities {
     @Query("SELECT VERSION(this) WHERE ID(this) = ?1")
     long currentVersion(CityId id);
 
-    @Query("SELECT VERSION(THIS) WHERE name = ?1 AND stateName = ?2")
-    long currentVersion(String city, String state);
-
     @Delete
     void delete(City city); // copied from BasicRepository
 
@@ -119,9 +116,7 @@ public interface Cities {
     @Query("SELECT " + ID)
     @OrderBy("stateName")
     @OrderBy("name")
-    // TODO once #29073 is fixed, and update usage
-    // Stream<CityId> ids();
-    Stream<Object[]> ids();
+    Stream<CityId> ids();
 
     @Update
     City[] modifyData(City... citiesToUpdate);

--- a/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/test-applications/DataJPATestApp/src/test/jakarta/data/jpa/web/DataJPATestServlet.java
@@ -3540,6 +3540,10 @@ public class DataJPATestServlet extends FATServlet {
     @Test
     public void testManyToOneIdClass() {
 
+        if (!isHibernate()) {
+            // TODO enable once EclipseLink 29073 is fixed
+            return;
+        }
         assertEquals(List.of("Discrooger card #2000921022220002",
                              "MonsterCard card #3000921032220002",
                              "Feesa card #4000921042220002",
@@ -4254,24 +4258,9 @@ public class DataJPATestServlet extends FATServlet {
     @Test
     public void testSelectIdClass() {
 
-        List<String> found;
-        if (isHibernate()) {
-            // Hibernate correctly returns a stream of IdClass
-            @SuppressWarnings("unchecked")
-            Stream<CityId> stream = (Stream<CityId>) (Stream<?>) cities.ids();
-            found = stream
-                            .map(id -> id.getStateName() + ":" + id.name)
-                            .collect(Collectors.toList());
-        } else {
-            // TODO replace the following with the above once #29073 is fixed
-            // and correct the repository method return type to match
-            // EclipseLink incorrectly returns a stream of Object[]
-            @SuppressWarnings("unchecked")
-            Stream<CityId> stream = (Stream<CityId>) (Stream<?>) cities.ids();
-            found = stream
-                            .map(id -> id.getStateName() + ":" + id.name)
-                            .collect(Collectors.toList());
-        }
+        List<String> found = cities.ids()
+                        .map(id -> id.getStateName() + ":" + id.name)
+                        .collect(Collectors.toList());
 
         assertEquals(List.of("Illinois:Springfield",
                              "Kansas:Kansas City",
@@ -4837,21 +4826,11 @@ public class DataJPATestServlet extends FATServlet {
         CityId mnId = CityId.of("Rochester", "Minnesota");
         CityId nyId = CityId.of("Rochester", "New York");
 
-        long mnVer;
-        long nyVer;
-        if (skipForHibernate("https://github.com/OpenLiberty/open-liberty/issues/33182")) {
-            // TODO once fixed in Hibernate, update the JPQL query to use VERSION(THIS)
-            // instead of lower case VERSION(this)
-            mnVer = cities.currentVersion(mnId);
-            nyVer = cities.currentVersion(nyId);
-        } else {
-            mnVer = cities.currentVersion(mnId.name, mnId.getStateName());
-            nyVer = cities.currentVersion(nyId.name, nyId.getStateName());
-
-            // TODO enable once EclipseLink #29073 is fixed, and maybe remove the above
-            //mnVer = cities.currentVersion(mnId);
-            //nyVer = cities.currentVersion(nyId);
-
+        // TODO once 33182 is fixed in Hibernate, update the JPQL query to use VERSION(THIS)
+        // instead of lower case VERSION(this)
+        long mnVer = cities.currentVersion(mnId);
+        long nyVer = cities.currentVersion(nyId);
+        if (!isHibernate()) {
             // TODO allow this test to run once 28589 is fixed
             // and verify that EclipseLink does not corrupt the area code value
             // for the following subsequent tests:


### PR DESCRIPTION
Removes a workaround from code after most of #29073 is now working.  One test still fails without the workaround, so I am temporarily disabling that test when running against EclipseLink with a comment to enable once the rest of 29073 is fixed.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
