### PR TITLE
Fix timer calendar early timeout test

### DIFF
--- a/dev/com.ibm.ws.ejbcontainer.timer.calendar_fat/test-applications/TimerCalTestEJB.jar/src/com/ibm/ws/ejbcontainer/timer/cal/ejb/EarlyTimeoutBean.java
+++ b/dev/com.ibm.ws.ejbcontainer.timer.calendar_fat/test-applications/TimerCalTestEJB.jar/src/com/ibm/ws/ejbcontainer/timer/cal/ejb/EarlyTimeoutBean.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2009, 2021 IBM Corporation and others.
+ * Copyright (c) 2009, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -15,6 +15,7 @@ package com.ibm.ws.ejbcontainer.timer.cal.ejb;
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertNull;
 import static junit.framework.Assert.assertTrue;
+import static org.junit.Assert.assertNotNull;
 
 import java.util.Calendar;
 import java.util.Collection;
@@ -47,6 +48,9 @@ public class EarlyTimeoutBean {
         ivFired = null;
         Timer timer = ivContext.getBusinessObject(EarlyTimeoutBean.class).createTimer(persistent);
 
+        // verify a timer could be created that met the criteria being tested
+        assertNotNull("timer not created off 0 ms boundary", timer);
+
         // createTimer already checked the scheduling; just cancel
         timer.cancel();
 
@@ -56,47 +60,59 @@ public class EarlyTimeoutBean {
 
     @TransactionAttribute(TransactionAttributeType.REQUIRES_NEW)
     public Timer createTimer(boolean persistent) {
-        Calendar beforeCreate = Calendar.getInstance();
-        int second = beforeCreate.get(Calendar.SECOND);
-        ScheduleExpression schedule = new ScheduleExpression().second(second).minute("*").hour("*");
-        String info = "T1:" + beforeCreate.getTimeInMillis();
-        Timer timer = ivTimerService.createCalendarTimer(schedule, new TimerConfig(info, persistent));
-        Calendar afterCreate = Calendar.getInstance();
+        Timer timer = null;
 
-        // Verify the timer is scheduled to go off about a minute from now;
-        // taking into account that the timer may have been created at exactly
-        // a second boundary (i.e. milliseconds=0) or that the system may
-        // be very slow and thus the timer was actually created much later
-        // than the time captured before the create call.
+        // If a timer is created at a time when milliseconds is 0, then the
+        // created timer will not meet the criteria being tested, so try a
+        // few times until the timer can be created appropriately.
+        for (int i = 0; i < 5 && timer == null; i++) {
+            Calendar beforeCreate = Calendar.getInstance();
+            int second = beforeCreate.get(Calendar.SECOND);
+            ScheduleExpression schedule = new ScheduleExpression().second(second).minute("*").hour("*");
+            String info = "T1:" + beforeCreate.getTimeInMillis();
+            timer = ivTimerService.createCalendarTimer(schedule, new TimerConfig(info, persistent));
+            Calendar afterCreate = Calendar.getInstance();
 
-        // The earliest time that the timer may expire is immediately,
-        // but only if the timer was created at exactly a second boundary
-        // (i.e. milliseconds = 0), otherwise it can expire no earlier
-        // than one minute from now.
-        long minAcceptableTime, maxAcceptableTime;
-        long nextTimeout = timer.getNextTimeout().getTime();
-        if (beforeCreate.get(Calendar.MILLISECOND) == 0
-            || beforeCreate.get(Calendar.SECOND) < afterCreate.get(Calendar.SECOND)) {
-            // if beforeCreate == 0 milliseconds or timer create has rolled over to new second
-            // Timer could have been created at exactly 0ms and might fire immediately,
-            // but still could have been created not at 0ms and fire up to 1 minute later.
-            // This would also catch the case where server created timer too slowly
+            // Verify the timer is scheduled to go off about a minute from now;
+            // taking into account that the timer may have been created at exactly
+            // a second boundary (i.e. milliseconds=0) or that the system may
+            // be very slow and thus the timer was actually created much later
+            // than the time captured before the create call.
 
-            minAcceptableTime = beforeCreate.getTimeInMillis();
-            afterCreate.set(Calendar.MILLISECOND, 0); // round off milliseconds
-            maxAcceptableTime = afterCreate.getTimeInMillis() + 60 * 1000;
+            // The earliest time that the timer may expire is immediately,
+            // but only if the timer was created at exactly a second boundary
+            // (i.e. milliseconds = 0), otherwise it can expire no earlier
+            // than one minute from now.
+            long minAcceptableTime, maxAcceptableTime;
+            long nextTimeout = timer.getNextTimeout().getTime();
+            if (beforeCreate.get(Calendar.MILLISECOND) == 0
+                || beforeCreate.get(Calendar.SECOND) < afterCreate.get(Calendar.SECOND)) {
+                // if beforeCreate == 0 milliseconds or timer create has rolled over to new second
+                // Timer could have been created at exactly 0ms and might fire immediately,
+                // but still could have been created not at 0ms and fire up to 1 minute later.
+                // This would also catch the case where server created timer too slowly
 
-            assertTrue("Next timeout not at least the time created: min=" + minAcceptableTime + ", actual=" + nextTimeout,
-                       nextTimeout >= minAcceptableTime);
-            assertTrue("Next timeout greater than 1 minute past create time: max=" + maxAcceptableTime + ", actual=" + nextTimeout,
-                       nextTimeout <= maxAcceptableTime);
-        } else {
-            // What we are actually trying to test and will happen most of the time:
-            // timeout should go off exactly 1 minute from now
-            beforeCreate.set(Calendar.MILLISECOND, 0); // round off milliseconds
-            minAcceptableTime = beforeCreate.getTimeInMillis() + 60 * 1000;
+                minAcceptableTime = beforeCreate.getTimeInMillis();
+                afterCreate.set(Calendar.MILLISECOND, 0); // round off milliseconds
+                maxAcceptableTime = afterCreate.getTimeInMillis() + 60 * 1000;
 
-            assertEquals("Next timeout not 1 minute from scheduled time:", minAcceptableTime, nextTimeout);
+                assertTrue("Next timeout not at least the time created: min=" + minAcceptableTime + ", actual=" + nextTimeout,
+                           nextTimeout >= minAcceptableTime);
+                assertTrue("Next timeout greater than 1 minute past create time: max=" + maxAcceptableTime + ", actual=" + nextTimeout,
+                           nextTimeout <= maxAcceptableTime);
+
+                // Timer was created at the 0 millisecond boundary; does not test the intended scenario.
+                // Cancel and clear the timer; loop again to try and create timer appropriately.
+                timer.cancel();
+                timer = null;
+            } else {
+                // What we are actually trying to test and will happen most of the time:
+                // timeout should go off exactly 1 minute from now
+                beforeCreate.set(Calendar.MILLISECOND, 0); // round off milliseconds
+                minAcceptableTime = beforeCreate.getTimeInMillis() + 60 * 1000;
+
+                assertEquals("Next timeout not 1 minute from scheduled time:", minAcceptableTime, nextTimeout);
+            }
         }
 
         // Since the current transaction that created the timer has not committed,


### PR DESCRIPTION
- handle timer create when current time has 0 ms


- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".