### PR TITLE
Corrections to how sort criteria is added, tracking of JPQL parameter count, and Constraints with Expressions

### DIFF
--- a/dev/io.openliberty.data.1.0.internal/src/io/openliberty/data/internal/v1_0/Data_1_0.java
+++ b/dev/io.openliberty.data.1.0.internal/src/io/openliberty/data/internal/v1_0/Data_1_0.java
@@ -120,12 +120,12 @@ public class Data_1_0 implements DataVersionCompatibility {
                                           String o_,
                                           String attrName,
                                           AttributeConstraint constraint,
-                                          int qp,
+                                          int prevNumJPQLParams,
                                           boolean isCollection,
                                           Annotation[] annos) {
         if (attrName.charAt(attrName.length() - 1) != ')')
             q.append(o_);
-        return q.append(attrName).append("=?").append(qp);
+        return q.append(attrName).append("=?").append(prevNumJPQLParams + 1);
     }
 
     @Override
@@ -200,10 +200,10 @@ public class Data_1_0 implements DataVersionCompatibility {
                                   String[] attrNames,
                                   AttributeConstraint[] constraints,
                                   char[] updateOps,
-                                  int qpNext) {
+                                  int prevNumJPQLParams) {
         // In Data 1.0, all constraints are the equality condition
         constraints[p] = AttributeConstraint.Equal;
-        return qpNext + 1;
+        return prevNumJPQLParams + 1;
     }
 
     @Override

--- a/dev/io.openliberty.data.1.0.internal/src/io/openliberty/data/internal/v1_0/Data_1_0.java
+++ b/dev/io.openliberty.data.1.0.internal/src/io/openliberty/data/internal/v1_0/Data_1_0.java
@@ -16,6 +16,7 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Method;
 import java.sql.Connection;
+import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 
@@ -134,13 +135,22 @@ public class Data_1_0 implements DataVersionCompatibility {
     }
 
     @Override
-    @Trivial
+    public int generateConstraint(StringBuilder q,
+                                  String entityVar_,
+                                  Object constraint,
+                                  int jpqlParamCount,
+                                  Set<String> jpqlParamNames,
+                                  Map<Object, Object> jpqlParams) {
+        throw new UnsupportedOperationException("jakarta.data.constraint.Constraint");
+    }
+
+    @Override
     public int generateRestrictions(StringBuilder q,
                                     String entityVar_,
                                     Object restriction,
                                     int jpqlParamCount,
                                     Set<String> jpqlParamNames,
-                                    Map<Object, Object> qrParams) {
+                                    Map<Object, Object> jpqlParams) {
         throw new UnsupportedOperationException("jakarta.data.restrict.Restriction");
     }
 
@@ -148,6 +158,14 @@ public class Data_1_0 implements DataVersionCompatibility {
     @Trivial
     public Annotation getCountAnnotation(Method method) {
         return null;
+    }
+
+    @Override
+    @Trivial
+    public Map<Integer, Object> getDeferredConstraints(boolean alwaysDefer,
+                                                       int maxIndex,
+                                                       Object[] methodParams) {
+        return Collections.emptyMap();
     }
 
     @Override

--- a/dev/io.openliberty.data.1.1.internal/src/io/openliberty/data/internal/v1_1/Data_1_1.java
+++ b/dev/io.openliberty.data.1.1.internal/src/io/openliberty/data/internal/v1_1/Data_1_1.java
@@ -216,7 +216,7 @@ public class Data_1_1 implements DataVersionCompatibility {
                                           String o_,
                                           String attrName,
                                           AttributeConstraint constraint,
-                                          int qp,
+                                          int prevNumJPQLParams,
                                           boolean isCollection,
                                           Annotation[] annos) {
         StringBuilder attributeExpr = new StringBuilder();
@@ -279,30 +279,30 @@ public class Data_1_1 implements DataVersionCompatibility {
             case LessThan:
             case LessThanEqual:
                 q.append(attributeExpr).append(constraint.operator());
-                appendParam(q, ignoreCase, qp);
+                appendParam(q, ignoreCase, prevNumJPQLParams + 1);
                 break;
             case Between:
                 q.append(attributeExpr).append(constraint.operator());
-                appendParam(q, ignoreCase, qp);
+                appendParam(q, ignoreCase, prevNumJPQLParams + 1);
                 q.append(" AND ");
-                appendParam(q, ignoreCase, qp + 1);
+                appendParam(q, ignoreCase, prevNumJPQLParams + 2);
                 break;
             case In:
                 if (ignoreCase)
                     throw new UnsupportedOperationException(); // should be unreachable
                 q.append(attributeExpr).append(constraint.operator());
-                appendParam(q, ignoreCase, qp);
+                appendParam(q, ignoreCase, prevNumJPQLParams + 1);
                 break;
             // TODO 1.1: escape characters and custom wildcards
             case Like:
                 q.append(attributeExpr).append(constraint.operator());
-                appendParam(q, ignoreCase, qp);
+                appendParam(q, ignoreCase, prevNumJPQLParams + 1);
                 break;
             case LikeEscaped:
                 q.append(attributeExpr).append(constraint.operator());
-                appendParam(q, ignoreCase, qp);
+                appendParam(q, ignoreCase, prevNumJPQLParams + 1);
                 q.append(" ESCAPE ");
-                appendParam(q, false, qp + 1);
+                appendParam(q, false, prevNumJPQLParams + 2);
                 break;
             case Null:
                 q.append(attributeExpr).append(constraint.operator());
@@ -310,20 +310,20 @@ public class Data_1_1 implements DataVersionCompatibility {
             case Contains:
                 q.append(attributeExpr) //
                                 .append(negated ? " NOT" : "") //
-                                .append(" LIKE CONCAT('%', ");
-                appendParam(q, ignoreCase, qp).append(", '%')");
+                                .append(" LIKE ('%' || ");
+                appendParam(q, ignoreCase, prevNumJPQLParams + 1).append(" || '%')");
                 break;
             case EndsWith:
                 q.append(attributeExpr) //
                                 .append(negated ? " NOT" : "") //
-                                .append(" LIKE CONCAT('%', ");
-                appendParam(q, ignoreCase, qp).append(')');
+                                .append(" LIKE ('%' || ");
+                appendParam(q, ignoreCase, prevNumJPQLParams + 1).append(')');
                 break;
             case StartsWith:
                 q.append(attributeExpr) //
                                 .append(negated ? " NOT" : "") //
-                                .append(" LIKE CONCAT(");
-                appendParam(q, ignoreCase, qp).append(", '%')");
+                                .append(" LIKE (");
+                appendParam(q, ignoreCase, prevNumJPQLParams + 1).append(" || '%')");
                 break;
             // TODO operation for collection containing?
             //case ???:
@@ -861,8 +861,8 @@ public class Data_1_1 implements DataVersionCompatibility {
                                   String[] attrNames,
                                   AttributeConstraint[] constraints,
                                   char[] updateOps,
-                                  int qpNext) {
-        int qpOriginal = qpNext;
+                                  int prevNumJPQLParams) {
+        int numJPQLParams = prevNumJPQLParams;
 
         for (Annotation anno : paramAnnos)
             if (anno instanceof Is) {
@@ -870,43 +870,43 @@ public class Data_1_1 implements DataVersionCompatibility {
             } else if (anno instanceof Assign) {
                 attrNames[p] = ((Assign) anno).value();
                 updateOps[p] = '=';
-                qpNext++;
+                numJPQLParams++;
             } else if (anno instanceof Add) {
                 attrNames[p] = ((Add) anno).value();
                 updateOps[p] = '+';
-                qpNext++;
+                numJPQLParams++;
             } else if (anno instanceof Multiply) {
                 attrNames[p] = ((Multiply) anno).value();
                 updateOps[p] = '*';
-                qpNext++;
+                numJPQLParams++;
             } else if (anno instanceof Divide) {
                 attrNames[p] = ((Divide) anno).value();
                 updateOps[p] = '/';
-                qpNext++;
+                numJPQLParams++;
             } else if (anno instanceof SubtractFrom) {
                 attrNames[p] = ((SubtractFrom) anno).value();
                 updateOps[p] = '-';
-                qpNext++;
+                numJPQLParams++;
             }
 
         if (constraints[p] == null && Constraint.class.isAssignableFrom(paramType)) {
             constraints[p] = toAttributeConstraint(null, paramType);
         }
 
-        if (qpNext == qpOriginal) {
+        if (numJPQLParams == prevNumJPQLParams) {
             if (constraints[p] == null)
                 constraints[p] = AttributeConstraint.Equal;
 
             // no annotation indicating a constraint or update
-            qpNext += constraints[p].numMethodParams();
-        } else if (qpNext - qpOriginal > 1) {
+            numJPQLParams += constraints[p].numMethodParams();
+        } else if (numJPQLParams - prevNumJPQLParams > 1) {
             // TODO possibly allow a redundant Constraint that matches the Is annotation.
-            qpNext = PARAM_ANNOS_CONFLICT;
+            numJPQLParams = PARAM_ANNOS_CONFLICT;
         } else if (false) { // TODO 1.1 check if paramType is a Constraint
-            qpNext = PARAM_ANNO_CONFLICTS_WITH_CONSTRAINT;
+            numJPQLParams = PARAM_ANNO_CONFLICTS_WITH_CONSTRAINT;
         }
 
-        return qpNext;
+        return numJPQLParams;
     }
 
     @Override

--- a/dev/io.openliberty.data.1.1.internal/src/io/openliberty/data/internal/v1_1/Data_1_1.java
+++ b/dev/io.openliberty.data.1.1.internal/src/io/openliberty/data/internal/v1_1/Data_1_1.java
@@ -17,10 +17,12 @@ import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Method;
 import java.sql.Connection;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Stream;
 
 import javax.sql.DataSource;
 
@@ -139,6 +141,11 @@ public class Data_1_1 implements DataVersionCompatibility {
                            Insert.class,
                            Update.class,
                            Save.class);
+
+    /**
+     * Empty size 0 array that indicates no Constraint values.
+     */
+    private static final Object[] NO_VALUES = new Object[0];
 
     /**
      * Annotations that represent operations that are allowed for methods of a
@@ -354,29 +361,31 @@ public class Data_1_1 implements DataVersionCompatibility {
     /**
      * Appends JPQL to the partially built query to represent a Constraint.
      *
-     * @param q              partially built query ending with the WHERE clause.
+     * @param q              partially built query to which to append JPQL
+     *                           representing the Constraint.
      * @param entityVar_     entity identifier variable name and . character.
      * @param constraint     the Constraint for which to generate JPQL.
-     * @param jpqlParamCount number of named or positional parameters in the
-     *                           partially built query.
-     * @param jpqlParamNames names of named parameters in the partially bulit
+     * @param jpqlParamCount number of named or positional parameters identified
+     *                           up to this point for the JPQL.
+     * @param jpqlParamNames names of named parameters in the partially built
      *                           query. Empty if the query uses positional
      *                           parameeters or has none. If using named parameters,
      *                           this method should add any that are generated.
-     * @param xprParams      list for this method to populate with the name of
+     * @param jpqlParams     list for this method to populate with the name of
      *                           named parameters or index of positional parameters,
-     *                           mapped to value, for values (if any) obtained from
-     *                           the Expression.
+     *                           mapped to value, for each value obtained from the
+     *                           processed Restriction(s).
      * @return the new count of named or positional parameters, including any that
-     *         were generated for the Restriction(s).
+     *         were generated for the Constraint.
      */
+    @Override
     // TODO @Trivial // avoid tracing values found in Expression.toString()
-    private int generateConstraint(StringBuilder q,
-                                   String entityVar_,
-                                   Constraint<?> constraint,
-                                   int jpqlParamCount,
-                                   Set<String> jpqlParamNames,
-                                   Map<Object, Object> xprParams) {
+    public int generateConstraint(StringBuilder q,
+                                  String entityVar_,
+                                  Object constraint,
+                                  int jpqlParamCount,
+                                  Set<String> jpqlParamNames,
+                                  Map<Object, Object> jpqlParams) {
 
         boolean positionalParams = jpqlParamNames.isEmpty();
 
@@ -457,7 +466,7 @@ public class Data_1_1 implements DataVersionCompatibility {
                                                 exp1,
                                                 jpqlParamCount,
                                                 jpqlParamNames,
-                                                xprParams);
+                                                jpqlParams);
 
             if (exp2 != null) {
                 if (c == AttributeConstraint.LikeEscaped ||
@@ -475,7 +484,7 @@ public class Data_1_1 implements DataVersionCompatibility {
                                                     exp2,
                                                     jpqlParamCount,
                                                     jpqlParamNames,
-                                                    xprParams);
+                                                    jpqlParams);
             }
         } else if (exps != null) { // IN or NOT IN
             q.append('(');
@@ -488,7 +497,7 @@ public class Data_1_1 implements DataVersionCompatibility {
                                                     exps.get(i),
                                                     jpqlParamCount,
                                                     jpqlParamNames,
-                                                    xprParams);
+                                                    jpqlParams);
             }
             q.append(')');
         }
@@ -514,7 +523,7 @@ public class Data_1_1 implements DataVersionCompatibility {
      *                           mapped to value, for values (if any) obtained from
      *                           the Expression.
      * @return the new count of named or positional parameters, including any that
-     *         were generated for the Restriction(s).
+     *         were generated for the Expression.
      */
     // TODO @Trivial // avoid tracing values found in Expression.toString()
     private int generateExpression(StringBuilder q,
@@ -550,6 +559,7 @@ public class Data_1_1 implements DataVersionCompatibility {
                     q.append(name.toUpperCase()).append('(');
                     break;
                 case TextFunctionExpression.CONCAT:
+                    q.append('(');
                     break;
                 case NumericFunctionExpression.NEG:
                     q.append('-');
@@ -591,6 +601,7 @@ public class Data_1_1 implements DataVersionCompatibility {
             switch (name) {
                 case NumericFunctionExpression.ABS:
                 case NumericFunctionExpression.LENGTH:
+                case TextFunctionExpression.CONCAT:
                 case TextFunctionExpression.LEFT:
                 case TextFunctionExpression.RIGHT:
                 case TextFunctionExpression.LOWER:
@@ -724,6 +735,38 @@ public class Data_1_1 implements DataVersionCompatibility {
     }
 
     @Override
+    @Trivial // to avoid tracing values supplied to repository methods
+    public Map<Integer, Object> getDeferredConstraints(boolean alwaysDefer,
+                                                       int maxIndex,
+                                                       Object[] methodParams) {
+        final boolean trace = TraceComponent.isAnyTracingEnabled();
+        if (trace && tc.isEntryEnabled())
+            Tr.entry(this, tc, "getDeferredConstraints",
+                     alwaysDefer,
+                     maxIndex,
+                     Stream.of(methodParams) //
+                                     .map(o -> o == null ? null : o.getClass().getName()) //
+                                     .toList());
+
+        Map<Integer, Object> deferred = null;
+
+        for (int i = 0; i <= maxIndex; i++)
+            if (methodParams[i] instanceof Constraint c &&
+                (alwaysDefer || hasNonLiteralExpression(c))) {
+                if (deferred == null)
+                    deferred = new HashMap<>();
+                deferred.put(i, c);
+            }
+
+        if (deferred == null)
+            deferred = Collections.emptyMap();
+
+        if (trace && tc.isEntryEnabled())
+            Tr.exit(this, tc, "getDeferredConstraints", deferred.keySet());
+        return deferred;
+    }
+
+    @Override
     @Trivial
     public Class<?> getEntityClass(Find find) {
         return find.value();
@@ -780,6 +823,37 @@ public class Data_1_1 implements DataVersionCompatibility {
         return returnValue;
     }
 
+    /**
+     * Determine if the constraint applies to one or more values that are
+     * expressions other than literal expressions.
+     *
+     * @param constraint instance of Constraint supplied to a repository method.
+     * @return true if the constraint applies to any non-literal expressions.
+     */
+    @Trivial
+    private boolean hasNonLiteralExpression(Constraint constraint) {
+        return switch (constraint) {
+            case AtLeast c -> !(c.bound() instanceof Literal);
+            case AtMost c -> !(c.bound() instanceof Literal);
+            case Between c -> !(c.lowerBound() instanceof Literal) ||
+                              !(c.upperBound() instanceof Literal);
+            case EqualTo c -> !(c.expression() instanceof Literal);
+            case GreaterThan c -> !(c.bound() instanceof Literal);
+            case In c -> c.expressions().stream().anyMatch(e -> !(e instanceof Literal));
+            case LessThan c -> !(c.bound() instanceof Literal);
+            case Like c -> !(c.pattern() instanceof Literal);
+            case NotBetween c -> !(c.lowerBound() instanceof Literal) ||
+                                 !(c.upperBound() instanceof Literal);
+            case NotEqualTo c -> !(c.expression() instanceof Literal);
+            case NotIn c -> c.expressions().stream().anyMatch(e -> !(e instanceof Literal));
+            case NotLike c -> !(c.pattern() instanceof Literal);
+            case NotNull c -> false;
+            case Null c -> false;
+            default -> throw new UnsupportedOperationException("Constraint: " +
+                                                               constraint.getClass().getName());
+        };
+    }
+
     @Override
     public int inspectMethodParam(int p,
                                   Class<?> paramType,
@@ -824,13 +898,7 @@ public class Data_1_1 implements DataVersionCompatibility {
                 constraints[p] = AttributeConstraint.Equal;
 
             // no annotation indicating a constraint or update
-            if (false) { // TODO 1.1 check if paramType is a Constraint
-                // qpNext increment will vary by Constraint subtype
-                // TODO 1.1: if Constraint.class and generated upfront,
-                // qpNext = PARAM_CONSTRAINT_DEFERRED;
-            } else {
-                qpNext += constraints[p].numMethodParams();
-            }
+            qpNext += constraints[p].numMethodParams();
         } else if (qpNext - qpOriginal > 1) {
             // TODO possibly allow a redundant Constraint that matches the Is annotation.
             qpNext = PARAM_ANNOS_CONFLICT;
@@ -1014,7 +1082,7 @@ public class Data_1_1 implements DataVersionCompatibility {
             values = new Object[] { c.pattern(), c.escape() };
         else if (constraintOrValue instanceof NotNull ||
                  constraintOrValue instanceof Null)
-            values = new Object[0];
+            values = NO_VALUES;
         else if (constraintOrValue instanceof Constraint)
             throw new UnsupportedOperationException("Constraint: " +
                                                     constraintOrValue.getClass().getName());
@@ -1022,11 +1090,12 @@ public class Data_1_1 implements DataVersionCompatibility {
             return null;
 
         for (int i = 0; i < values.length; i++)
-            if (values[i] instanceof Literal)
-                values[i] = ((Literal) values[i]).value();
+            if (values[i] instanceof Literal literal)
+                values[i] = literal.value();
             else if (values[i] instanceof Character)
                 ; // the escape character for Like and NotLike
             else
+                // non-Literal constraint - should be unreachable
                 throw new UnsupportedOperationException(values[i].getClass().getName());
 
         if (isList)

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/CursoredPageImpl.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/CursoredPageImpl.java
@@ -59,6 +59,18 @@ public class CursoredPageImpl<T> implements CursoredPage<T> {
     private final Object[] args;
 
     /**
+     * Map of JPQL parameter names/indices and values that are added due to
+     * Restrictions and Constraints. Null indicates none are added.
+     */
+    private final Map<Object, Object> constraintJPQLParams;
+
+    /**
+     * Map of method parameter index to non-Literal Constraints that are supplied
+     * at execution time.
+     */
+    private final Map<Integer, Object> deferredConstraints;
+
+    /**
      * Indicates the direction of pagination relative to a cursor.
      * In the case of a first page requested with offset pagination,
      * where there is no cursor, the direction is forward.
@@ -89,13 +101,15 @@ public class CursoredPageImpl<T> implements CursoredPage<T> {
     /**
      * Construct a new CursoredPage.
      *
-     * @param queryInfo       query information.
-     * @param em              the entity manager.
-     * @param pageRequest     the request for this page.
-     * @param args            values that are supplied to the repository method.
-     * @param addedJPQLParams map of JPQL parameter names/indices and values that are
-     *                            added due to repository special parameters.
-     *                            Null indicates none are added.
+     * @param queryInfo            query information.
+     * @param em                   the entity manager.
+     * @param pageRequest          the request for this page.
+     * @param args                 values that are supplied to the repository method.
+     * @param deferredConstraints  map of method parameter index to non-Literal
+     *                                 Constraints that are supplied at execution time.
+     * @param constraintJPQLParams map of JPQL parameter names/indices and values that are
+     *                                 added due to Constraints and Restrictions.
+     *                                 Null indicates none are added.
      * @throws Exception if an error occurs.
      */
     @Trivial // avoid tracing customer data
@@ -103,39 +117,53 @@ public class CursoredPageImpl<T> implements CursoredPage<T> {
                      EntityManager em,
                      PageRequest pageRequest,
                      Object[] args,
-                     Map<Object, Object> addedJPQLParams) throws Exception {
+                     Map<Integer, Object> deferredConstraints,
+                     Map<Object, Object> constraintJPQLParams) throws Exception {
         final boolean trace = TraceComponent.isAnyTracingEnabled();
         if (trace && tc.isEntryEnabled())
-            Tr.entry(tc, "<init>", queryInfo, pageRequest, queryInfo.loggable(args));
+            Tr.entry(tc, "<init>",
+                     queryInfo,
+                     pageRequest,
+                     queryInfo.loggable(args),
+                     deferredConstraints.keySet(),
+                     constraintJPQLParams == null ? null : constraintJPQLParams.keySet());
 
         if (pageRequest == null)
             queryInfo.missingPageRequest();
 
         this.args = args;
+        this.constraintJPQLParams = constraintJPQLParams;
+        this.deferredConstraints = deferredConstraints;
         this.queryInfo = queryInfo;
         this.pageRequest = pageRequest;
         this.isForward = this.pageRequest.mode() != PageRequest.Mode.CURSOR_PREVIOUS;
-
-        Optional<PageRequest.Cursor> cursor = this.pageRequest.cursor();
 
         int maxPageSize = this.pageRequest.size();
         int firstResult = this.pageRequest.mode() == PageRequest.Mode.OFFSET //
                         ? queryInfo.computeOffset(this.pageRequest) //
                         : 0;
 
-        String jpql = cursor.isEmpty() ? queryInfo.jpql : //
-                        isForward ? queryInfo.jpqlAfterCursor : //
-                                        queryInfo.jpqlBeforeCursor;
+        String jpql;
+        Optional<PageRequest.Cursor> cursor = this.pageRequest.cursor();
+        Map<Object, Object> addedJPQLParams;
 
         if (cursor.isPresent()) {
-            if (addedJPQLParams == null)
-                addedJPQLParams = new LinkedHashMap<>();
+            jpql = isForward ? queryInfo.jpqlAfterCursor : queryInfo.jpqlBeforeCursor;
+
+            addedJPQLParams = constraintJPQLParams == null //
+                            ? new LinkedHashMap<>() //
+                            : new LinkedHashMap<>(constraintJPQLParams);
+
             addParametersForCursor(cursor.get(), addedJPQLParams);
+        } else { // no Cursor in PageRequest
+            jpql = queryInfo.jpql;
+
+            addedJPQLParams = constraintJPQLParams;
         }
 
         @SuppressWarnings("unchecked")
         TypedQuery<T> query = (TypedQuery<T>) em.createQuery(jpql, Object.class);
-        queryInfo.setParameters(query, args, addedJPQLParams);
+        queryInfo.setParameters(query, args, deferredConstraints, addedJPQLParams);
 
         query.setFirstResult(firstResult);
         query.setMaxResults(maxPageSize + (maxPageSize == Integer.MAX_VALUE //
@@ -162,8 +190,9 @@ public class CursoredPageImpl<T> implements CursoredPage<T> {
      * the addedJPQLParams map.
      *
      * @param cursor          the cursor
-     * @param addedJPQLParams map of JPQL parameter names/indices and values that
-     *                            are added due to repository special parameters.
+     * @param addedJPQLParams JPQL parameters added for repository special parameters.
+     *                            This method adds parameters for the elements of a
+     *                            Cursor that is present on a PageRequest.
      * @throws Exception if an error occurs
      */
     private void addParametersForCursor(Cursor cursor,
@@ -246,7 +275,7 @@ public class CursoredPageImpl<T> implements CursoredPage<T> {
             if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
                 Tr.debug(this, tc, "query for count: " + queryInfo.jpqlCount);
             TypedQuery<Long> query = em.createQuery(queryInfo.jpqlCount, Long.class);
-            queryInfo.setParameters(query, args, null);
+            queryInfo.setParameters(query, args, deferredConstraints, constraintJPQLParams);
 
             return query.getSingleResult();
         } catch (Exception x) {

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/PageImpl.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/PageImpl.java
@@ -17,6 +17,7 @@ import static io.openliberty.data.internal.persistence.cdi.DataExtension.exc;
 import java.util.AbstractList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.RandomAccess;
 import java.util.stream.Stream;
@@ -40,10 +41,22 @@ public class PageImpl<T> implements Page<T> {
     private static final TraceComponent tc = Tr.register(PageImpl.class);
 
     /**
+     * Map of JPQL parameter names/indices and values that are added due to
+     * repository special parameters. Null indicates none are added.
+     */
+    private final Map<Object, Object> addedJPQLParams;
+
+    /**
      * Values that are supplied when invoking the repository method that
      * requests the page.
      */
     private final Object[] args;
+
+    /**
+     * Map of method parameter index to non-Literal Constraints that are supplied
+     * at execution time.
+     */
+    private final Map<Integer, Object> deferredConstraints;
 
     /**
      * The request for this page.
@@ -69,17 +82,24 @@ public class PageImpl<T> implements Page<T> {
     /**
      * Construct a new Page.
      *
-     * @param queryInfo   query information.
-     * @param em          the entity manager.
-     * @param pageRequest the request for this page.
-     * @param args        values that are supplied to the repository method.
+     * @param queryInfo           query information.
+     * @param em                  the entity manager.
+     * @param pageRequest         the request for this page.
+     * @param args                values that are supplied to the repository method.
+     * @param deferredConstraints map of method parameter index to non-Literal
+     *                                Constraints that are supplied at execution time.
+     * @param addedJPQLParams     map of JPQL parameter names/indices and values that are
+     *                                added due to repository special parameters.
+     *                                Null indicates none are added.
      * @throws Exception if an error occurs.
      */
     @Trivial
     PageImpl(QueryInfo queryInfo,
              EntityManager em,
              PageRequest pageRequest,
-             Object[] args) {
+             Object[] args,
+             Map<Integer, Object> deferredConstraints,
+             Map<Object, Object> addedJPQLParams) {
         final boolean trace = TraceComponent.isAnyTracingEnabled();
         if (trace && tc.isEntryEnabled())
             Tr.entry(tc, "<init>", queryInfo, pageRequest, queryInfo.loggable(args));
@@ -96,6 +116,8 @@ public class PageImpl<T> implements Page<T> {
                       queryInfo.method.getGenericReturnType().getTypeName(),
                       CursoredPage.class.getName());
 
+        this.addedJPQLParams = addedJPQLParams;
+        this.deferredConstraints = deferredConstraints;
         this.queryInfo = queryInfo;
         this.pageRequest = pageRequest;
         this.args = args;
@@ -103,7 +125,7 @@ public class PageImpl<T> implements Page<T> {
         @SuppressWarnings("unchecked")
         TypedQuery<T> query = (TypedQuery<T>) em.createQuery(queryInfo.jpql,
                                                              Object.class);
-        queryInfo.setParameters(query, args, null);
+        queryInfo.setParameters(query, args, deferredConstraints, addedJPQLParams);
 
         int maxPageSize = pageRequest.size();
         query.setFirstResult(queryInfo.computeOffset(pageRequest));
@@ -148,7 +170,7 @@ public class PageImpl<T> implements Page<T> {
             if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
                 Tr.debug(this, tc, "query for count: " + queryInfo.jpqlCount);
             TypedQuery<Long> query = em.createQuery(queryInfo.jpqlCount, Long.class);
-            queryInfo.setParameters(query, args, null);
+            queryInfo.setParameters(query, args, deferredConstraints, addedJPQLParams);
 
             return query.getSingleResult();
         } catch (Exception x) {

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
@@ -3014,25 +3014,26 @@ public class QueryInfo {
         AttributeConstraint[] attrConstraints = //
                         new AttributeConstraint[numAttributeParams];
         char[] updateOps = new char[numAttributeParams];
-        int[] qpStarts = new int[numAttributeParams + 1];
+        int[] numPreviousJPQLParams = new int[numAttributeParams + 1];
         StringBuilder[] constraintJPQL = new StringBuilder[numAttributeParams];
 
         // p is the repository method parameter number (0-based)
         // qp is the JPQL query parameter number (1-based)
-        int qp = 1;
+        int numJPQLParams = 0;
         for (int p = 0; p < numAttributeParams; p++) {
-            qpStarts[p] = qp;
+            numPreviousJPQLParams[p] = numJPQLParams;
 
             Object constraint = constraints.get(p);
             if (constraint == null) {
-                qp = compat.inspectMethodParam(p,
-                                               paramTypes[p],
-                                               annosForAllParams[p],
-                                               attrNames,
-                                               attrConstraints,
-                                               updateOps,
-                                               qp);
-                if (qp == DataVersionCompatibility.PARAM_ANNO_CONFLICTS_WITH_CONSTRAINT)
+                numJPQLParams = compat.inspectMethodParam(p,
+                                                          paramTypes[p],
+                                                          annosForAllParams[p],
+                                                          attrNames,
+                                                          attrConstraints,
+                                                          updateOps,
+                                                          numJPQLParams);
+                if (numJPQLParams == DataVersionCompatibility //
+                                .PARAM_ANNO_CONFLICTS_WITH_CONSTRAINT)
                     throw exc(UnsupportedOperationException.class,
                               "CWWKD1117.anno.constraint.conflict",
                               p + 1,
@@ -3040,7 +3041,8 @@ public class QueryInfo {
                               repositoryInterface.getName(),
                               Arrays.toString(annosForAllParams[p]),
                               paramTypes[p].getClass().getName());
-                else if (qp == DataVersionCompatibility.PARAM_ANNOS_CONFLICT)
+                else if (numJPQLParams == DataVersionCompatibility //
+                                .PARAM_ANNOS_CONFLICT)
                     throw exc(UnsupportedOperationException.class,
                               "CWWKD1118.param.anno.conflict",
                               p + 1,
@@ -3050,14 +3052,12 @@ public class QueryInfo {
 
             } else {
                 constraintJPQL[p] = new StringBuilder(50);
-                int numJPQLParams = qp - 1;
                 numJPQLParams = compat.generateConstraint(constraintJPQL[p],
                                                           o_,
                                                           constraint,
                                                           numJPQLParams,
                                                           jpqlParamNames,
                                                           jpqlParams);
-                qp = numJPQLParams + 1;
             }
 
             // Determine the entity attribute name, first from @By or an assignment
@@ -3083,7 +3083,7 @@ public class QueryInfo {
             attrNames[p] = getAttributeName(name, true);
         }
 
-        qpStarts[numAttributeParams] = qp;
+        numPreviousJPQLParams[numAttributeParams] = numJPQLParams;
 
         // Write new JPQL, starting with SELECT or UPDATE
         if (q == null && type == FIND) { // SELECT
@@ -3151,7 +3151,7 @@ public class QueryInfo {
                         }
 
                         jpqlParamCount++;
-                        q.append('?').append(qpStarts[p]);
+                        q.append('?').append(numPreviousJPQLParams[p] + 1);
 
                         if (withFunction)
                             q.append(')');
@@ -3204,14 +3204,14 @@ public class QueryInfo {
                 boolean isCollection = entityInfo.collectionElementTypes //
                                 .containsKey(name);
 
-                jpqlParamCount += qpStarts[p + 1] - qpStarts[p];
+                jpqlParamCount += numPreviousJPQLParams[p + 1] - numPreviousJPQLParams[p];
 
                 if (constraintJPQL[p] == null) {
                     compat.appendConstraint(q,
                                             o_,
                                             name,
                                             attrConstraints[p],
-                                            qpStarts[p],
+                                            numPreviousJPQLParams[p],
                                             isCollection,
                                             annosForAllParams[p]);
                 } else {

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
@@ -113,6 +113,14 @@ public class QueryInfo {
     public static final Class<?> ENTITY_TBD = Query.class;
 
     /**
+     * Placeholder to indicate there are no repository method parameters
+     * for which processing must be deferred until a value is available
+     * because they are Constraint-typed.
+     */
+    private static final Map<Integer, Object> NO_CONSTRAINTS_DEFERRED = //
+                    Collections.emptyMap();
+
+    /**
      * Indicates the repository method has no Sort, Sort[], or Order parameters
      * for dynamic sort criteria and also does not define any static sort criteria.
      */
@@ -459,88 +467,139 @@ public class QueryInfo {
     }
 
     /**
-     * Construct a copy of a source QueryInfo, but with different JPQL and sorts.
+     * Construct a copy of a source QueryInfo, but with different JPQL and
+     * possibly different sorts.
      *
-     * @param source      QueryInfo from which to copy.
-     * @param restriction Restriction value that was supplied to the repository method.
-     *                        Otherwise null.
-     * @param qrParams    Map to be populated with JPQL parameter names and values
-     *                        for Restrictions. Map keys are the named parameter name
-     *                        or positional parameter index. Map values are obtained
-     *                        from the Restriction(s). The first positional parameter
-     *                        index starts at jpqlParamCount, which is updated by
-     *                        this method as JPQL parameters for repository method
-     *                        special parameters are added.
-     * @param jpql        JPQL to use instead of the JPQL from source.
-     * @param sorts       Sorts to use instead of the sorts from source.
+     * @param source        QueryInfo from which to copy.
+     * @param constraints   map of method parameter index (0-based) to deferred
+     *                          Constraint at the position. Empty if none.
+     * @param restriction   Restriction value that was supplied to the repository method.
+     *                          Otherwise null.
+     * @param jpqlParams    Map to be populated with JPQL parameter names and values
+     *                          for Constraints and Restrictions. Map keys are the
+     *                          named parameter name or positional parameter index.
+     *                          Map values are obtained from the Constraints or
+     *                          Restrictions. The first positional parameter index
+     *                          starts at jpqlParamCount, which is updated by this
+     *                          method when JPQL parameters for repository method
+     *                          special parameters are added.
+     * @param jpql          JPQL to use instead of the JPQL from source.
+     * @param sortsOverride If present, sorts to use instead of the sorts from source.
+     *                          A value is supplied when the repostiory method has
+     *                          Order or Sort parameters. Otherwise null.
      */
+    // TODO 1.1 avoid logging customer data
     private QueryInfo(QueryInfo source,
+                      Map<Integer, Object> constraints,
                       Object restriction,
-                      Map<Object, Object> qrParams,
+                      Map<Object, Object> jpqlParams,
                       PageRequest pageReq,
-                      List<Sort<Object>> sorts) {
+                      List<Sort<Object>> sortsOverride) {
         entityInfo = source.entityInfo;
         entityParamType = source.entityParamType;
         entityVar = source.entityVar;
         entityVar_ = source.entityVar_;
-        hasWhere = source.hasWhere;
         isOptional = source.isOptional;
-        jpqlAfterCursor = source.jpqlAfterCursor;
-        jpqlBeforeCursor = source.jpqlBeforeCursor;
-        jpqlCount = source.jpqlCount;
-        jpqlDelete = source.jpqlDelete;
-        jpqlParamCount = source.jpqlParamCount;
-        jpqlParamNames = source.jpqlParamNames.isEmpty() //
-                        ? source.jpqlParamNames //
-                        : new LinkedHashSet<>(source.jpqlParamNames);
         maxResults = source.maxResults;
         method = source.method;
         multiType = source.multiType;
         producer = source.producer;
         repositoryInterface = source.repositoryInterface;
-        restrictAt = source.restrictAt;
         returnArrayType = source.returnArrayType;
         singleType = source.singleType;
         singleTypeElementType = source.singleTypeElementType;
-        specialParamsStartAt = source.specialParamsStartAt;
-        this.sorts = sorts;
+        sorts = sortsOverride == null ? source.sorts : sortsOverride;
         type = source.type;
         validateParams = source.validateParams;
 
+        DataVersionCompatibility compat = entityInfo.builder.provider.compat;
         StringBuilder q;
-        if (restriction == null) {
-            q = new StringBuilder(source.jpql);
-        } else {
-            int len = source.jpql.length();
-            q = new StringBuilder(len + 200);
-            if (restrictAt >= 0 && restrictAt < len)
-                q.append(source.jpql.substring(0, restrictAt));
-            else
-                q.append(source.jpql).append(' ');
 
-            q.append(hasWhere ? "AND " : "WHERE ");
-            hasWhere = true;
+        if (constraints.isEmpty()) {
+            hasWhere = source.hasWhere;
+            jpqlAfterCursor = source.jpqlAfterCursor;
+            jpqlBeforeCursor = source.jpqlBeforeCursor;
+            jpqlCount = source.jpqlCount;
+            jpqlDelete = source.jpqlDelete;
+            jpqlParamCount = source.jpqlParamCount;
+            jpqlParamNames = source.jpqlParamNames.isEmpty() //
+                            ? source.jpqlParamNames //
+                            : new LinkedHashSet<>(source.jpqlParamNames);
+            restrictAt = source.restrictAt;
+            specialParamsStartAt = source.specialParamsStartAt;
 
-            jpqlParamCount = entityInfo.builder.provider.compat //
-                            .generateRestrictions(q,
-                                                  entityVar_,
-                                                  restriction,
-                                                  jpqlParamCount,
-                                                  jpqlParamNames,
-                                                  qrParams);
+            if (restriction == null) {
+                // no Constraints deferred or Restriction
+                q = new StringBuilder(source.jpql);
+            } else {
+                // has Restriction, but no Constraints deferred
+                int len = source.jpql.length();
+                q = new StringBuilder(len + 200);
+                if (restrictAt >= 0 && restrictAt < len)
+                    q.append(source.jpql.substring(0, restrictAt));
+                else
+                    q.append(source.jpql).append(' ');
 
-            if (restrictAt >= 0 && restrictAt < len) {
-                int newPosition = q.length();
-                q.append(' ').append(source.jpql.substring(restrictAt));
-                restrictAt = newPosition;
+                q.append(hasWhere ? "AND " : "WHERE ");
+                hasWhere = true;
+
+                jpqlParamCount = compat.generateRestrictions(q,
+                                                             entityVar_,
+                                                             restriction,
+                                                             jpqlParamCount,
+                                                             jpqlParamNames,
+                                                             jpqlParams);
+
+                if (restrictAt >= 0 && restrictAt < len) {
+                    int newPosition = q.length();
+                    q.append(' ').append(source.jpql.substring(restrictAt));
+                    restrictAt = newPosition;
+                }
             }
+        } else {
+            // Constraints were deferred until execution
+            // Generate new JPQL for Query by Parameters
+            Annotation methodTypeAnno = method.getAnnotation(Find.class);
+            if (methodTypeAnno == null) {
+                methodTypeAnno = method.getAnnotation(Update.class);
+                if (methodTypeAnno == null) {
+                    methodTypeAnno = method.getAnnotation(Delete.class);
+                    if (methodTypeAnno == null) {
+                        methodTypeAnno = compat.getCountAnnotation(method);
+                        if (methodTypeAnno == null) {
+                            methodTypeAnno = compat.getExistsAnnotation(method);
+                        }
+                    }
+                }
+            }
+
+            boolean countPages = Page.class.equals(multiType) ||
+                                 CursoredPage.class.equals(multiType);
+
+            q = initQueryByParameters(methodTypeAnno, countPages, constraints, jpqlParams);
+
+            if (restriction != null) {
+                q.append(hasWhere ? " AND " : " WHERE ");
+                hasWhere = true;
+                jpqlParamCount = compat.generateRestrictions(q,
+                                                             entityVar_,
+                                                             restriction,
+                                                             jpqlParamCount,
+                                                             jpqlParamNames,
+                                                             jpqlParams);
+            }
+
+            // If there are no overrides from Order/Sort parameters, keep the
+            // static Sorts from the source QueryInfo.
+            if (sortsOverride == null)
+                sortsOverride = source.sorts;
         }
 
         boolean forward = pageReq == null ||
                           pageReq.mode() != PageRequest.Mode.CURSOR_PREVIOUS;
         StringBuilder order = null; // ORDER BY clause based on Sorts
-        if (sorts != null)
-            for (Sort<?> sort : sorts) {
+        if (sortsOverride != null)
+            for (Sort<?> sort : sortsOverride) {
                 validateSort(sort);
                 order = order == null //
                                 ? new StringBuilder(100).append(" ORDER BY ") //
@@ -1010,7 +1069,7 @@ public class QueryInfo {
                      "to be returned as " + singleType.getName());
 
         TypedQuery<Long> query = em.createQuery(jpql, Long.class);
-        setParameters(query, args, null);
+        setParameters(query, args, NO_CONSTRAINTS_DEFERRED, null); // TODO 1.1 constraints
 
         Long count = query.getSingleResult();
 
@@ -1737,7 +1796,7 @@ public class QueryInfo {
             Tr.entry(this, tc, "execute", type); // DELETE or UPDATE
 
         jakarta.persistence.Query update = em.createQuery(jpql);
-        setParameters(update, args, null);
+        setParameters(update, args, NO_CONSTRAINTS_DEFERRED, null); // TODO 1.1 constraints
 
         int updateCount = update.executeUpdate();
 
@@ -1771,7 +1830,7 @@ public class QueryInfo {
 
         TypedQuery<?> query = em.createQuery(jpql, Object.class);
         query.setMaxResults(1);
-        setParameters(query, args, null);
+        setParameters(query, args, NO_CONSTRAINTS_DEFERRED, null); // TODO 1.1 constraints
 
         List<?> results = query.getResultList();
         boolean found = !results.isEmpty();
@@ -1811,6 +1870,7 @@ public class QueryInfo {
         if (trace && tc.isEntryEnabled())
             Tr.entry(this, tc, "find", type);
 
+        DataVersionCompatibility compat = entityInfo.builder.provider.compat;
         Limit limit = null;
         int max = maxResults;
         PageRequest pageReq = null;
@@ -1844,7 +1904,7 @@ public class QueryInfo {
                 @SuppressWarnings("unchecked")
                 List<Sort<Object>> newList = supplySorts(sortList, (Sort<Object>[]) param);
                 sortList = newList;
-            } else if (entityInfo.builder.provider.compat.isRestriction(param)) {
+            } else if (compat.isRestriction(param)) {
                 if (restriction == null)
                     restriction = param;
                 else
@@ -1878,7 +1938,13 @@ public class QueryInfo {
             }
         }
 
-        boolean requiresNewQuery = restriction != null;
+        Map<Integer, Object> deferredConstraints = args == null || args.length == 0 //
+                        ? NO_CONSTRAINTS_DEFERRED //
+                        : compat.getDeferredConstraints(restriction != null,
+                                                        specialParamsStartAt - 1,
+                                                        args);
+        boolean requiresNewQuery = restriction != null ||
+                                   !deferredConstraints.isEmpty();
 
         if (sortList == null && sortPositions.length > 0)
             sortList = sorts;
@@ -1898,6 +1964,7 @@ public class QueryInfo {
 
         QueryInfo queryInfo = requiresNewQuery //
                         ? new QueryInfo(this, //
+                                        deferredConstraints, //
                                         restriction, //
                                         addedJPQLParams = new LinkedHashMap<>(), //
                                         pageReq, //
@@ -1907,10 +1974,10 @@ public class QueryInfo {
         Object returnValue = queryInfo.find(limit,
                                             max,
                                             pageReq,
-                                            sortList,
                                             em,
                                             txStatus,
                                             args,
+                                            deferredConstraints,
                                             addedJPQLParams);
 
         if (isOptional) {
@@ -1938,16 +2005,17 @@ public class QueryInfo {
      * Execute a repository find query, and possibly also a delete operation
      * if find-and-delete.
      *
-     * @param limit           Limit, if specified as a repository method parameter
-     * @param max             maximum number of results to return
-     * @param pageReq         PageRequest, if specified as a repository method parameter
-     * @param sortList        combined list of Sorts
-     * @param em              entity manager.
-     * @param txStatus        transaction status.
-     * @param args            method parameters.
-     * @param addedJPQLParams map of JPQL parameter names/indices and values that are
-     *                            added due to repository special parameters.
-     *                            Null indicates none are added.
+     * @param limit               Limit, if a repository method parameter
+     * @param max                 maximum number of results to return
+     * @param pageReq             PageRequest, if a repository method parameter
+     * @param em                  entity manager.
+     * @param txStatus            transaction status.
+     * @param args                method parameters.
+     * @param deferredConstraints map of method parameter index to non-Literal
+     *                                Constraints that are supplied at execution time.
+     * @param addedJPQLParams     map of JPQL parameter names/indices and values that
+     *                                are added due to repository special parameters.
+     *                                Null indicates none are added.
      * @return results, before wrapping in an Optional or CompletionStage.
      * @throws Exception if an error occurs.
      */
@@ -1955,10 +2023,10 @@ public class QueryInfo {
     private Object find(Limit limit,
                         int max,
                         PageRequest pageReq,
-                        List<Sort<Object>> sortList,
                         EntityManager em,
                         int txStatus,
                         Object[] args,
+                        Map<Integer, Object> deferredConstraints,
                         Map<Object, Object> addedJPQLParams) throws Exception {
         final boolean trace = TraceComponent.isAnyTracingEnabled();
         if (trace && tc.isEntryEnabled())
@@ -1966,7 +2034,7 @@ public class QueryInfo {
                      "Limit: " + limit,
                      "max results: " + max,
                      "PageRequest: " + pageReq,
-                     "Sorts: " + sortList,
+                     "non-literal Constraints at: " + deferredConstraints.keySet(),
                      "added JPQL params: " + (addedJPQLParams == null //
                                      ? null //
                                      : addedJPQLParams.keySet()));
@@ -1974,10 +2042,22 @@ public class QueryInfo {
         Object returnValue;
 
         if (CursoredPage.class.equals(multiType)) {
-            returnValue = new CursoredPageImpl<>(this, em, pageReq, args, addedJPQLParams);
+            returnValue = new CursoredPageImpl<>(//
+                            this, //
+                            em, //
+                            pageReq, //
+                            args, //
+                            deferredConstraints, //
+                            addedJPQLParams);
         } else if (Page.class.equals(multiType)) {
             PageRequest req = limit == null ? pageReq : toPageRequest(limit);
-            returnValue = new PageImpl<>(this, em, req, args);
+            returnValue = new PageImpl<>(//
+                            this, //
+                            em, //
+                            req, //
+                            args, //
+                            deferredConstraints, //
+                            addedJPQLParams);
         } else if (pageReq != null &&
                    !PageRequest.Mode.OFFSET.equals(pageReq.mode())) {
             throw exc(IllegalArgumentException.class,
@@ -1994,7 +2074,7 @@ public class QueryInfo {
                          entityInfo.entityClass.getName());
 
             TypedQuery<?> query = em.createQuery(jpql, Object.class);
-            setParameters(query, args, addedJPQLParams);
+            setParameters(query, args, deferredConstraints, addedJPQLParams);
 
             if (type == FIND_AND_DELETE)
                 query.setLockMode(LockModeType.PESSIMISTIC_WRITE);
@@ -2871,23 +2951,39 @@ public class QueryInfo {
      * Count, Delete, Exists, Find, or Update.
      * Allowed special parameter types vary by method annotation.
      *
-     * @param q          JPQL query to which to append a WHERE clause.
-     *                       Or null in the case of Find/Update methods
-     *                       to create a new JPQL query.
-     * @param methodAnno Count, Delete, Exists, Find, or Update. Never null.
-     * @param countPages indicates whether or not to count pages.
-     *                       Only applies for find queries.
+     * @param q           JPQL query to which to append a WHERE clause.
+     *                        Or null in the case of Find/Update methods
+     *                        to create a new JPQL query.
+     * @param methodAnno  Count, Delete, Exists, Find, or Update. Never null.
+     * @param countPages  indicates whether or not to count pages.
+     *                        Only applies for find queries.
+     * @param constraints map of method parameter index (0-based) to deferred
+     *                        Constraint at the position. Empty if Constraint
+     *                        values are not yet available or there are no
+     *                        deferred Constraints.
+     * @param jpqlParams  Map to be populated with JPQL parameter names and values
+     *                        for Constraints and Restrictions. Map keys are the
+     *                        named parameter name or positional parameter index.
+     *                        Map values are obtained from the Constraints or
+     *                        Restrictions. The first positional parameter index
+     *                        starts at jpqlParamCount, which is updated by this
+     *                        method when JPQL parameters for repository method
+     *                        special parameters are added.
      */
     @Trivial
     private StringBuilder generateParamBasedQuery(StringBuilder q,
                                                   Annotation methodAnno,
-                                                  boolean countPages) {
+                                                  boolean countPages,
+                                                  Map<Integer, Object> constraints,
+                                                  Map<Object, Object> jpqlParams) {
         boolean trace = TraceComponent.isAnyTracingEnabled();
         if (trace && tc.isEntryEnabled())
             Tr.entry(this, tc, "generateParamBasedQuery",
                      q,
                      methodAnno == null ? null : methodAnno.annotationType().getSimpleName(),
-                     countPages);
+                     countPages,
+                     constraints.keySet(),
+                     jpqlParams == null ? null : jpqlParams.keySet());
 
         String o = entityVar;
         String o_ = entityVar_;
@@ -2915,43 +3011,54 @@ public class QueryInfo {
 
         // Arrays to be populated per repository method parameter
         String[] attrNames = new String[numAttributeParams];
-        AttributeConstraint[] constraints = //
+        AttributeConstraint[] attrConstraints = //
                         new AttributeConstraint[numAttributeParams];
         char[] updateOps = new char[numAttributeParams];
-        int[] qpStarts = new int[numAttributeParams];
+        int[] qpStarts = new int[numAttributeParams + 1];
+        StringBuilder[] constraintJPQL = new StringBuilder[numAttributeParams];
 
         // p is the repository method parameter number (0-based)
         // qp is the JPQL query parameter number (1-based)
-        for (int p = 0, qp = 1; p < numAttributeParams; p++) {
+        int qp = 1;
+        for (int p = 0; p < numAttributeParams; p++) {
             qpStarts[p] = qp;
 
-            qp = compat.inspectMethodParam(p,
-                                           paramTypes[p],
-                                           annosForAllParams[p],
-                                           attrNames,
-                                           constraints,
-                                           updateOps,
-                                           qp);
+            Object constraint = constraints.get(p);
+            if (constraint == null) {
+                qp = compat.inspectMethodParam(p,
+                                               paramTypes[p],
+                                               annosForAllParams[p],
+                                               attrNames,
+                                               attrConstraints,
+                                               updateOps,
+                                               qp);
+                if (qp == DataVersionCompatibility.PARAM_ANNO_CONFLICTS_WITH_CONSTRAINT)
+                    throw exc(UnsupportedOperationException.class,
+                              "CWWKD1117.anno.constraint.conflict",
+                              p + 1,
+                              method.getName(),
+                              repositoryInterface.getName(),
+                              Arrays.toString(annosForAllParams[p]),
+                              paramTypes[p].getClass().getName());
+                else if (qp == DataVersionCompatibility.PARAM_ANNOS_CONFLICT)
+                    throw exc(UnsupportedOperationException.class,
+                              "CWWKD1118.param.anno.conflict",
+                              p + 1,
+                              method.getName(),
+                              repositoryInterface.getName(),
+                              Arrays.toString(annosForAllParams[p]));
 
-            if (qp == DataVersionCompatibility.PARAM_ANNO_CONFLICTS_WITH_CONSTRAINT)
-                throw exc(UnsupportedOperationException.class,
-                          "CWWKD1117.anno.constraint.conflict",
-                          p + 1,
-                          method.getName(),
-                          repositoryInterface.getName(),
-                          Arrays.toString(annosForAllParams[p]),
-                          paramTypes[p].getClass().getName());
-            else if (qp == DataVersionCompatibility.PARAM_ANNOS_CONFLICT)
-                throw exc(UnsupportedOperationException.class,
-                          "CWWKD1118.param.anno.conflict",
-                          p + 1,
-                          method.getName(),
-                          repositoryInterface.getName(),
-                          Arrays.toString(annosForAllParams[p]));
-
-            else if (qp == DataVersionCompatibility.PARAM_CONSTRAINT_DEFERRED)
-                // TODO 1.1
-                throw new IllegalArgumentException("jakarta.data.constraint.Constraint");
+            } else {
+                constraintJPQL[p] = new StringBuilder(50);
+                int numJPQLParams = qp - 1;
+                numJPQLParams = compat.generateConstraint(constraintJPQL[p],
+                                                          o_,
+                                                          constraint,
+                                                          numJPQLParams,
+                                                          jpqlParamNames,
+                                                          jpqlParams);
+                qp = numJPQLParams + 1;
+            }
 
             // Determine the entity attribute name, first from @By or an assignment
             // annotation.
@@ -2975,6 +3082,8 @@ public class QueryInfo {
             }
             attrNames[p] = getAttributeName(name, true);
         }
+
+        qpStarts[numAttributeParams] = qp;
 
         // Write new JPQL, starting with SELECT or UPDATE
         if (q == null && type == FIND) { // SELECT
@@ -3082,7 +3191,7 @@ public class QueryInfo {
         // append the WHERE clause
         // p is the repository method parameter position (0-based)
         for (int p = 0; p < numAttributeParams; p++) {
-            if (constraints[p] != null) {
+            if (attrConstraints[p] != null || constraintJPQL[p] != null) {
                 if (hasWhere) {
                     q.append(" AND ");
                 } else {
@@ -3095,15 +3204,24 @@ public class QueryInfo {
                 boolean isCollection = entityInfo.collectionElementTypes //
                                 .containsKey(name);
 
-                jpqlParamCount++;
+                jpqlParamCount += qpStarts[p + 1] - qpStarts[p];
 
-                compat.appendConstraint(q,
-                                        o_,
-                                        name,
-                                        constraints[p],
-                                        qpStarts[p],
-                                        isCollection,
-                                        annosForAllParams[p]);
+                if (constraintJPQL[p] == null) {
+                    compat.appendConstraint(q,
+                                            o_,
+                                            name,
+                                            attrConstraints[p],
+                                            qpStarts[p],
+                                            isCollection,
+                                            annosForAllParams[p]);
+                } else {
+                    if (name.charAt(name.length() - 1) != ')')
+                        q.append(o_);
+
+                    q.append(name).append(constraintJPQL[p]);
+
+                    // TODO @IgnoreCase on Constraint with expression
+                }
             }
         }
         if (hasWhere)
@@ -3733,6 +3851,7 @@ public class QueryInfo {
 
             boolean countPages = Page.class.equals(multiType) || CursoredPage.class.equals(multiType);
             StringBuilder q = null;
+            boolean validateNumberOfMethodArgs = true;
 
             // spec-defined annotation types
             Delete delete = method.getAnnotation(Delete.class);
@@ -3777,7 +3896,14 @@ public class QueryInfo {
             } else {
                 if (methodTypeAnno != null) {
                     // Query by Parameters
-                    q = initQueryByParameters(methodTypeAnno, countPages);
+                    q = initQueryByParameters(methodTypeAnno,
+                                              countPages,
+                                              NO_CONSTRAINTS_DEFERRED,
+                                              null);
+
+                    // Only validate if Constraint parameters correspond one-to-one
+                    // with JPQL parameters.
+                    validateNumberOfMethodArgs = jpqlParamCount == specialParamsStartAt;
                 } else {
                     // Query by Method Name
                     q = initQueryByMethodName(countPages);
@@ -3852,7 +3978,7 @@ public class QueryInfo {
 
             jpql = q == null ? jpql : q.toString();
 
-            validate();
+            validate(validateNumberOfMethodArgs);
 
             if (trace && tc.isEntryEnabled())
                 Tr.exit(this, tc, "init", new Object[] { this, entityInfo });
@@ -4197,27 +4323,46 @@ public class QueryInfo {
      * Count, Delete, Exists, Find, or Update.
      *
      * @param methodTypeAnno Count, Delete, Exists, Find, or Update annotation.
-     *                           The Insert, Save, and Query annotations are never supplied to this method.
-     * @param countPages     whether to generate a count query (for Page.totalElements and Page.totalPages).
+     *                           The Insert, Save, and Query annotations are never
+     *                           supplied to this method.
+     * @param countPages     whether to generate a count query (for Page.totalElements
+     *                           and Page.totalPages).
+     * @param constraints    map of method parameter index (0-based) to deferred
+     *                           Constraint at the position. Null indicates
+     *                           Constraint values are not yet avaiable or there
+     *                           are no deferred Constraints.
+     * @param jpqlParams     Map to be populated with JPQL parameter names and values
+     *                           for Constraints and Restrictions. Map keys are the
+     *                           named parameter name or positional parameter index.
+     *                           Map values are obtained from the Constraints or
+     *                           Restrictions. The first positional parameter index
+     *                           starts at jpqlParamCount, which is updated by this
+     *                           method when JPQL parameters for repository method
+     *                           special parameters are added.
      * @return the generated query written to a StringBuilder.
      */
     @Trivial
-    private StringBuilder initQueryByParameters(Annotation methodTypeAnno, boolean countPages) {
+    private StringBuilder initQueryByParameters(Annotation methodTypeAnno,
+                                                boolean countPages,
+                                                Map<Integer, Object> constraints,
+                                                Map<Object, Object> jpqlParams) {
         final boolean trace = TraceComponent.isAnyTracingEnabled();
         if (trace && tc.isEntryEnabled())
             Tr.entry(this, tc, "initQueryByParameters",
                      methodTypeAnno == null ? null : methodTypeAnno.annotationType().getSimpleName(),
-                     countPages);
+                     countPages,
+                     constraints.keySet(),
+                     jpqlParams == null ? null : jpqlParams.keySet());
 
         String o = entityVar;
         StringBuilder q = null;
 
         if (methodTypeAnno instanceof Find) {
             type = FIND;
-            q = generateParamBasedQuery(null, methodTypeAnno, countPages);
+            q = generateParamBasedQuery(null, methodTypeAnno, countPages, constraints, jpqlParams);
         } else if (methodTypeAnno instanceof Update) {
             type = QM_UPDATE;
-            q = generateParamBasedQuery(null, methodTypeAnno, countPages);
+            q = generateParamBasedQuery(null, methodTypeAnno, countPages, constraints, jpqlParams);
         } else if (methodTypeAnno instanceof Delete) {
             if (isFindAndDelete()) {
                 type = FIND_AND_DELETE;
@@ -4232,14 +4377,14 @@ public class QueryInfo {
                     q.append(' ').append(o);
             }
             if (method.getParameterCount() > 0)
-                generateParamBasedQuery(q, methodTypeAnno, countPages);
+                generateParamBasedQuery(q, methodTypeAnno, countPages, constraints, jpqlParams);
         } else if ("Count".equals(methodTypeAnno.annotationType().getSimpleName())) {
             type = COUNT;
             q = new StringBuilder(150).append("SELECT COUNT(").append(o).append(") FROM ").append(entityInfo.name);
             if (o != THIS)
                 q.append(' ').append(o);
             if (method.getParameterCount() > 0)
-                generateParamBasedQuery(q, methodTypeAnno, countPages);
+                generateParamBasedQuery(q, methodTypeAnno, countPages, constraints, jpqlParams);
         } else if ("Exists".equals(methodTypeAnno.annotationType().getSimpleName())) {
             type = EXISTS;
             validateReturnForExists();
@@ -4249,7 +4394,7 @@ public class QueryInfo {
             if (o != THIS)
                 q.append(' ').append(o);
             if (method.getParameterCount() > 0)
-                generateParamBasedQuery(q, methodTypeAnno, countPages);
+                generateParamBasedQuery(q, methodTypeAnno, countPages, constraints, jpqlParams);
         } else {
             // unreachable
             throw new IllegalArgumentException(methodTypeAnno.toString());
@@ -5578,14 +5723,17 @@ public class QueryInfo {
     /**
      * Sets query parameters from repository method arguments.
      *
-     * @param query           the query
-     * @param args            repository method arguments
-     * @param addedJPQLParams map of JPQL parameter names/indices and values
-     *                            for repository method special parameters.
+     * @param query               the query
+     * @param args                repository method arguments
+     * @param deferredConstraints map of method parameter index to non-Literal
+     *                                Constraints that are supplied at execution time.
+     * @param addedJPQLParams     map of JPQL parameter names/indices and values
+     *                                for repository method special parameters.
      */
     @Trivial // avoid logging customer data
     void setParameters(jakarta.persistence.Query query,
                        Object[] args,
+                       Map<Integer, Object> deferredConstraints,
                        Map<Object, Object> addedJPQLParams) {
         final boolean trace = TraceComponent.isAnyTracingEnabled();
         final int numArgs = args == null ? 0 : args.length;
@@ -5604,22 +5752,26 @@ public class QueryInfo {
                 Object value;
                 while (addedJPQLParams != null &&
                        (value = addedJPQLParams.getOrDefault(paramNum, NONE)) != NONE) {
-                    // Generated positional parameter
+                    // Positional parameter generated at execution time from an
+                    // Expression within a Restriction or Constraint
                     if (trace && tc.isDebugEnabled())
-                        Tr.debug(this, tc, "[e] set ?" + paramNum + ' ' + loggable(value));
+                        Tr.debug(this, tc, "[X] set ?" + paramNum + ' ' + loggable(value));
                     query.setParameter(paramNum++, value);
                 }
+                if (deferredConstraints.containsKey(a))
+                    // Handled above: Constraint with non-Literal Expression
+                    // supplied at execution time
+                    continue;
                 value = args[a];
                 Object[] constraintValues = compat.toConstraintValues(value);
-                // TODO 1.1 check for non-literal expressions? Ideally at earlier point.
                 if (constraintValues == null) { // Normal positional parameter
                     if (trace && tc.isDebugEnabled())
-                        Tr.debug(this, tc, "[m] set ?" + paramNum + ' ' + loggable(value));
+                        Tr.debug(this, tc, "[M] set ?" + paramNum + ' ' + loggable(value));
                     query.setParameter(paramNum++, value);
-                } else { // Constraint
+                } else { // Literal Expression from a Constraint
                     for (Object cvalue : constraintValues) {
                         if (trace && tc.isDebugEnabled())
-                            Tr.debug(this, tc, "[c] set ?" + paramNum + ' ' + loggable(cvalue));
+                            Tr.debug(this, tc, "[L] set ?" + paramNum + ' ' + loggable(cvalue));
                         query.setParameter(paramNum++, cvalue);
                     }
                 }
@@ -6088,19 +6240,19 @@ public class QueryInfo {
 
     /**
      * Validate this instance. This is invoked at the end of initialization.
+     *
+     * @param validateNumberOfMethodArgs indicates whether to validate the
+     *                                       number of repository method arguments
+     *                                       versus the number of JPQL parameters.
      */
     @Trivial
-    private void validate() {
+    private void validate(boolean validateNumberOfMethodArgs) {
         if (type == null)
             throw excUnsupportedMethod();
 
-        // TODO 1.1: comparisons of methodParamCount vs jpqlParamCount won't be
-        // valid when Constraints and Restrictions are present because there is
-        // no longer a one-to-one correspondence between method parameters and
-        // query parameters.
-
         int methodParamCount = method.getParameterCount();
-        if (jpql != null &&
+        if (validateNumberOfMethodArgs &&
+            jpql != null &&
             methodParamCount < jpqlParamCount &&
             type != LC_DELETE &&
             type != LC_UPDATE &&

--- a/dev/io.openliberty.data.internal.persistence/test/io/openliberty/data/internal/persistence/orm/MockVersionCompatibility.java
+++ b/dev/io.openliberty.data.internal.persistence/test/io/openliberty/data/internal/persistence/orm/MockVersionCompatibility.java
@@ -15,6 +15,7 @@ package io.openliberty.data.internal.persistence.orm;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Method;
+import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 
@@ -50,13 +51,23 @@ public class MockVersionCompatibility implements DataVersionCompatibility {
     }
 
     @Override
+    public int generateConstraint(StringBuilder q,
+                                  String entityVar_,
+                                  Object constraint,
+                                  int jpqlParamCount,
+                                  Set<String> jpqlParamNames,
+                                  Map<Object, Object> jpqlParams) {
+        throw new UnsupportedOperationException("jakarta.data.constraint.Constraint");
+    }
+
+    @Override
     @Trivial
     public int generateRestrictions(StringBuilder q,
                                     String entityVar_,
                                     Object restriction,
                                     int jpqlParamCount,
                                     Set<String> jpqlParamNames,
-                                    Map<Object, Object> qrParams) {
+                                    Map<Object, Object> jpqlParams) {
         throw new UnsupportedOperationException();
     }
 
@@ -64,6 +75,14 @@ public class MockVersionCompatibility implements DataVersionCompatibility {
     @Trivial
     public Annotation getCountAnnotation(Method method) {
         return null;
+    }
+
+    @Override
+    @Trivial
+    public Map<Integer, Object> getDeferredConstraints(boolean alwaysDefer,
+                                                       int maxIndex,
+                                                       Object[] methodParams) {
+        return Collections.emptyMap();
     }
 
     @Override

--- a/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/version/DataVersionCompatibility.java
+++ b/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/version/DataVersionCompatibility.java
@@ -45,12 +45,6 @@ public interface DataVersionCompatibility {
     final int PARAM_ANNOS_CONFLICT = -2;
 
     /**
-     * Return code for inspectMethodParam that indicates that the Constraint subtype
-     * is not determined until method invocation.
-     */
-    final int PARAM_CONSTRAINT_DEFERRED = -3;
-
-    /**
      * Append a constraint such as o.myAttribute < ?1 to the JPQL query.
      *
      * @param q            JPQL query to which to append.
@@ -82,6 +76,33 @@ public interface DataVersionCompatibility {
     boolean atLeast(int major, int minor);
 
     /**
+     * Appends JPQL to the partially built query to represent a Constraint.
+     *
+     * @param q              partially built query to which to append JPQL
+     *                           representing the Constraint.
+     * @param entityVar_     entity identifier variable name and . character.
+     * @param constraint     the Constraint for which to generate JPQL.
+     * @param jpqlParamCount number of named or positional parameters identified
+     *                           up to this point for the JPQL.
+     * @param jpqlParamNames names of named parameters in the partially built
+     *                           query. Empty if the query uses positional
+     *                           parameeters or has none. If using named parameters,
+     *                           this method should add any that are generated.
+     * @param jpqlParams     list for this method to populate with the name of
+     *                           named parameters or index of positional parameters,
+     *                           mapped to value, for each value obtained from the
+     *                           processed Restriction(s).
+     * @return the new count of named or positional parameters, including any that
+     *         were generated for the Constraint.
+     */
+    int generateConstraint(StringBuilder q,
+                           String entityVar_,
+                           Object constraint,
+                           int jpqlParamCount,
+                           Set<String> jpqlParamNames,
+                           Map<Object, Object> jpqlParams);
+
+    /**
      * Appends JPQL to the partially built query to implement a Restriction
      * parameter of a repository method.
      *
@@ -95,10 +116,10 @@ public interface DataVersionCompatibility {
      *                           parameeters or has none. If using named parameters,
      *                           this method should add any that are generated for
      *                           the restriction part of the query.
-     * @param qrParams       initially empty list for this method to populate
-     *                           with the name of named parameters or index of
-     *                           positional parameters, mapped to value, for each
-     *                           value obtained from the processed Restriction(s).
+     * @param jpqlParams     list for this method to populate with the name of
+     *                           named parameters or index of positional parameters,
+     *                           mapped to value, for each value obtained from the
+     *                           processed Restriction(s).
      * @return the new count of named or positional parameters, including any that
      *         were generated for the Restriction(s).
      */
@@ -107,7 +128,7 @@ public interface DataVersionCompatibility {
                              Object restriction,
                              int jpqlParamCount,
                              Set<String> jpqlParamNames,
-                             Map<Object, Object> qrParams);
+                             Map<Object, Object> jpqlParams);
 
     /**
      * Obtains the Count annotation if present on the method. Otherwise null.
@@ -116,6 +137,24 @@ public interface DataVersionCompatibility {
      * @return Count annotation if present, otherwise null.
      */
     Annotation getCountAnnotation(Method method);
+
+    /**
+     * Identify Constraint-typed repository method parameters for which
+     * processing is deferred. Constraints that operate on non-literal
+     * expressions are always deferred until the expression instance is
+     * available.
+     *
+     * @param alwaysDefer  indicates that processing of every Constraint-typed
+     *                         method parameter is always deferred.
+     * @param maxIndex     method parameters positioned up to this index are
+     *                         inspected.
+     * @param methodParams repository method parameters.
+     * @return map of method parameter index (0-based) to Constraint instance
+     *         at that position. The empty map indicates none.
+     */
+    Map<Integer, Object> getDeferredConstraints(boolean alwaysDefer,
+                                                int maxIndex,
+                                                Object[] methodParams);
 
     /**
      * Obtains the entity class from the Find annotation value, if present.

--- a/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/version/DataVersionCompatibility.java
+++ b/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/version/DataVersionCompatibility.java
@@ -47,20 +47,23 @@ public interface DataVersionCompatibility {
     /**
      * Append a constraint such as o.myAttribute < ?1 to the JPQL query.
      *
-     * @param q            JPQL query to which to append.
-     * @param o_           entity identifier variable.
-     * @param attrName     entity attribute name.
-     * @param constraint   type of constraint to apply to the entity attribute.
-     * @param qp           query parameter position (1-based).
-     * @param isCollection whether the entity attribute is a collection.
-     * @param annos        method parameter annotations.
+     * @param q                 JPQL query to which to append.
+     * @param o_                entity identifier variable.
+     * @param attrName          entity attribute name.
+     * @param constraint        type of constraint to apply to the entity attribute.
+     * @param prevNumJPQLParams count of JQPL query parameters required for repository
+     *                              method parameters up to, but not including, the
+     *                              repository method parameter for the constraint
+     *                              being appended.
+     * @param isCollection      whether the entity attribute is a collection.
+     * @param annos             method parameter annotations.
      * @return the updated JPQL query.
      */
     StringBuilder appendConstraint(StringBuilder q,
                                    String o_,
                                    String attrName,
                                    AttributeConstraint constraint,
-                                   int qp,
+                                   int prevNumJPQLParams,
                                    boolean isCollection,
                                    Annotation[] annos);
 
@@ -200,31 +203,33 @@ public interface DataVersionCompatibility {
      * Find/Delete/Update method to determine its meaning. Based on the meaning,
      * updates one or more of (attrNames, constraints, updateOps) at position p.
      *
-     * @param p           repository method parameter index (0-based).
-     * @param paramType   class of the repository method parameter at index p.
-     *                        When generating the query upfront, this comes from
-     *                        the repository method signature. When generating the
-     *                        query at invocation time and a Constraint subtype is
-     *                        supplied, this is the class of the supplied instance.
-     *                        The latter should be done in response to receiving a
-     *                        PARAM_CONSTRAINT_DEFERRED return code during the
-     *                        attempt at upfront query generation.
-     * @param paramAnnos  annotations on the repository method parameter at index p.
-     * @param attrNames   the implementer can update this at position p to supply
-     *                        the entity attribute name from the value of an
-     *                        assignment annotation.
-     * @param constraints the implementer can update this at position p to supply
-     *                        the constraint type indicated by the Is annotation or
-     *                        a constraint type method parameter.
-     * @param updateOps   the implementer can update this at position p to supply
-     *                        the update operation indicated by an assignment
-     *                        annotation.
-     * @param qpNext      the next JQPL query parameter index to use (1-based)
-     *                        for the current repository method parameter.
-     * @return the next JPQL query parameter index to use (1-based) for the
-     *         subsequent repository method parameter. Otherwise returns an
-     *         error code: PARAM_ANNO_CONFLICTS_WITH_CONSTRAINT or
-     *         PARAM_ANNOS_CONFLICT or PARAM_CONSTRAINT_DEFERRED.
+     * @param p                 repository method parameter index (0-based).
+     * @param paramType         class of the repository method parameter at index p.
+     *                              When generating the query upfront, this is from
+     *                              the repository method signature. When generating
+     *                              the query at invocation time and a Constraint
+     *                              subtype is supplied, this is the class of the
+     *                              supplied instance.
+     * @param paramAnnos        annotations on the repository method parameter at
+     *                              index p.
+     * @param attrNames         the implementer can update this at position p to
+     *                              supply the entity attribute name from the value
+     *                              of an assignment annotation.
+     * @param constraints       the implementer can update this at position p to
+     *                              supply the constraint type indicated by the
+     *                              Is annotation or by a Constraint-typed method
+     *                              parameter.
+     * @param updateOps         the implementer can update this at position p to
+     *                              supply the update operation indicated by an
+     *                              assignment annotation.
+     * @param prevNumJPQLParams count of JQPL query parameters required for
+     *                              repository method parameters up to, but not
+     *                              including, the current repository method
+     *                              parameter being inspected.
+     * @return count of JPQL query parameters required for repository method
+     *         parameters up to and including the current one. Otherwise returns
+     *         an error code: PARAM_ANNO_CONFLICTS_WITH_CONSTRAINT or
+     *         PARAM_ANNOS_CONFLICT.
      */
     int inspectMethodParam(int p,
                            Class<?> paramType,
@@ -232,7 +237,7 @@ public interface DataVersionCompatibility {
                            String[] attrNames,
                            AttributeConstraint[] constraints,
                            char[] updateOps,
-                           int qpNext);
+                           int prevNumJPQLParams);
 
     /**
      * Determines if the special parameter value is a Restriction.

--- a/dev/io.openliberty.data.internal_fat_1_1/test-applications/Data_1_1_App/src/test/jakarta/data/v1_1/web/Data_1_1_Servlet.java
+++ b/dev/io.openliberty.data.internal_fat_1_1/test-applications/Data_1_1_App/src/test/jakarta/data/v1_1/web/Data_1_1_Servlet.java
@@ -40,6 +40,7 @@ import jakarta.data.page.PageRequest;
 import jakarta.data.page.PageRequest.Cursor;
 import jakarta.data.restrict.Restrict;
 import jakarta.data.restrict.Restriction;
+import jakarta.data.spi.expression.literal.NumericLiteral;
 import jakarta.inject.Inject;
 import jakarta.servlet.ServletConfig;
 import jakarta.servlet.ServletException;
@@ -78,10 +79,61 @@ public class Data_1_1_Servlet extends FATServlet {
     /**
      * Tests that the Between and NotBetween constraint types can be assigned to
      * repository method parameters to enforce that matching entity attributes
-     * are either within or not within a range.
+     * are either within or not within a range of non-Literal expressions.
      */
     @Test
-    public void testBetweenAndNotBetweenConstraints() {
+    public void testBetweenAndNotBetweenConstraintsWithExpressions() {
+        Between<Integer> denominator2to10LessThanNumerator = //
+                        Between.bounds(_Fraction.numerator.plus(2),
+                                       _Fraction.numerator.plus(10));
+
+        NotBetween<Integer> numeratorNot8to12LessThanDenominator = //
+                        NotBetween.bounds(_Fraction.denominator.minus(12),
+                                          _Fraction.denominator.minus(8));
+
+        assertEquals(List.of("One Fifth",
+                             "Four Sevenths",
+                             "Five Sevenths",
+                             "One Eighth",
+                             "Five Eighths",
+                             "Four Ninths",
+                             "Five Ninths",
+                             "Four Elevenths",
+                             "Five Elevenths",
+                             "Eight Elevenths",
+                             "Nine Elevenths",
+                             "Five Twelfths",
+                             "Eight Thirteenths",
+                             "Nine Thirteenths",
+                             "Eleven Thirteenths",
+                             "Nine Fourteenths",
+                             "Eleven Fourteenths",
+                             "Eight Fifteenths",
+                             "Eleven Fifteenths",
+                             "Nine Sixteenths",
+                             "Eleven Sixteenths",
+                             "Eleven Seventeenths",
+                             "Fourteen Seventeenths",
+                             "Fifteen Seventeenths",
+                             "Eleven Eighteenths",
+                             "Fourteen Nineteenths",
+                             "Fifteen Nineteenths"),
+                     fractions.withDenominatorBetweenNamedBeforeAndNumeratorNotBetween //
+                     (denominator2to10LessThanNumerator,
+                      "One Fourth",
+                      numeratorNot8to12LessThanDenominator,
+                      true) // must be reduced
+                                     .map(f -> f.name)
+                                     .toList());
+    }
+
+    /**
+     * Tests that the Between and NotBetween constraint types can be assigned to
+     * repository method parameters to enforce that matching entity attributes
+     * are either within or not within a range of Literal values.
+     */
+    @Test
+    public void testBetweenAndNotBetweenConstraintsWithLiterals() {
 
         assertEquals(List.of("One Fourteenth",
                              "Eleven Fourteenths",
@@ -99,6 +151,37 @@ public class Data_1_1_Servlet extends FATServlet {
                       true)
                                      .map(f -> f.name)
                                      .collect(Collectors.toList()));
+    }
+
+    /**
+     * Tests that the Between and NotBetween constraint types can be assigned to
+     * repository method parameters to enforce that matching entity attributes
+     * are either within or not within a range of mostly Literals, but with one
+     * non-Literal expression.
+     */
+    @Test
+    public void testBetweenAndNotBetweenConstraintsWithOneExpression() {
+
+        assertEquals(List.of("One Sixth",
+                             "One Seventh",
+                             "One Eighth",
+                             "One Ninth",
+                             "Two Ninths",
+                             "Eight Ninths",
+                             "One Tenth",
+                             "Nine Tenths",
+                             "One Eleventh",
+                             "Two Elevenths",
+                             "Ten Elevenths",
+                             "One Twelfth",
+                             "Eleven Twelfths"),
+                     fractions.withDenominatorBetweenNamedBeforeAndNumeratorNotBetween //
+                     (Between.bounds(6, 12),
+                      "Two Sevenths",
+                      NotBetween.bounds(3, _Fraction.name.length().minus(5)),
+                      true) // must be reduced
+                                     .map(f -> f.name)
+                                     .toList());
     }
 
     /**
@@ -553,7 +636,34 @@ public class Data_1_1_Servlet extends FATServlet {
     }
 
     /**
-     * Tests that the Like constraint types can be assigned to a repository
+     * Tests that the Like constraint type can be assigned to a repository
+     * method parameter to enforce that an entity attributes is matched
+     * according to a computed expression.
+     */
+    @Test
+    public void testLikeConstraintWithExpression() {
+
+        Like first3CharsAlsoAppearLaterInName = //
+                        Like.pattern(_Fraction.name
+                                        .left(3)
+                                        .append("%")
+                                        .prepend("___%"),
+                                     '^');
+
+        assertEquals(List.of("Eight Eighteenths",
+                             "Four Fourteenths",
+                             "Nine Nineteenths",
+                             "Seven Seventeenths",
+                             "Six Sixteenths",
+                             "Twelve Twentieths"),
+                     fractions.named(first3CharsAlsoAppearLaterInName,
+                                     Order.by(_Fraction.name.asc()),
+                                     Limit.of(10)));
+
+    }
+
+    /**
+     * Tests that the Like constraint type can be assigned to a repository
      * method parameter to enforce that an entity attributes is matched
      * according to a literal value.
      */
@@ -710,10 +820,63 @@ public class Data_1_1_Servlet extends FATServlet {
 
     /**
      * Tests that a Constraint parameter and Is annotation parameter can be
-     * intermixed on a single repository method.
+     * intermixed on a single repository method. Both Literal and non-Literal
+     * expressions are supplied to the Constraint.
      */
     @Test
     public void testMixConstraintAndIsAnno() {
+        In<Integer> numeratorConstraint = In
+                        .expressions(NumericLiteral.of(1),
+                                     NumericLiteral.of(2),
+                                     _Fraction.denominator.minus(_Fraction.numerator).times(3));
+
+        Sort<Fraction> alphabetizedByName = Sort.asc(_Fraction.NAME);
+
+        assertEquals(List.of("One Eighth",
+                             "Six Eighths", // (8 - 6) * 3 = 6
+                             "Two Eighths"),
+                     fractions.withNumeratorsAndDenominator(numeratorConstraint,
+                                                            8,
+                                                            alphabetizedByName));
+    }
+
+    /**
+     * Tests that a Constraint parameter and Is annotation parameter can be
+     * intermixed on a single repository method. Only non-Literal expressions
+     * are supplied to the Constraint.
+     */
+    @Test
+    public void testMixExpressionConstraintAndIsAnno() {
+        In<Integer> numeratorConstraint = In
+                        .expressions(_Fraction.name.length().minus(_Fraction.numerator),
+                                     _Fraction.denominator.minus(1),
+                                     _Fraction.denominator.minus(_Fraction.numerator.times(2)));
+
+        Sort<Fraction> reverseAlphabetizedByName = Sort.desc(_Fraction.NAME);
+
+        assertEquals(List.of(// length(name) - numerator     = 12 - 6      = 6
+                             "Six Twelfths",
+
+                             // length(name) - numerator     = 14 - 7      = 7
+                             "Seven Twelfths",
+
+                             // denominator - numerator * 2  = 12 - 4 * 2  = 4
+                             "Four Twelfths",
+
+                             // denominator - 1              = 12 - 1      = 11
+                             "Eleven Twelfths"),
+                     fractions.withNumeratorsAndDenominator(numeratorConstraint,
+                                                            12,
+                                                            reverseAlphabetizedByName));
+    }
+
+    /**
+     * Tests that a Constraint parameter and Is annotation parameter can be
+     * intermixed on a single repository method. Only Literal expressions
+     * are supplied to the Constraint.
+     */
+    @Test
+    public void testMixLiteralConstraintAndIsAnno() {
         Sort<Fraction> alphabetizedByName = Sort.asc(_Fraction.NAME);
 
         assertEquals(List.of("Eight Ninths",


### PR DESCRIPTION
Corrections to how sort criteria is added, tracking of JPQL parameter count, and Constraints with Expressions, and adds tests. This also refactors/renames a field to be more meaningful (count of JPQL parameters previously found) and less error prone.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

