### PR TITLE
Get line separator from system for getAttributesForUser

### DIFF
--- a/dev/com.ibm.ws.security.registry_test.servlet/test-applications/userRegistry/src/web/UserRegistryServlet.java
+++ b/dev/com.ibm.ws.security.registry_test.servlet/test-applications/userRegistry/src/web/UserRegistryServlet.java
@@ -228,7 +228,7 @@ public class UserRegistryServlet extends HttpServlet {
                 response = convertFromMap(ur.getAttributesForUser(
                         userSecurityName,
                         Arrays.stream(attributeNames.split(",")).collect(Collectors.toSet())
-                )).replaceAll("\n", "");
+                )).replaceAll(System.getProperty("line.separator"), "");
             } else if ("getUsersByAttribute".equals(method)) {
                 String attributeName = req.getParameter("attributeName");
                 String value = req.getParameter("value");


### PR DESCRIPTION
replacing `/n` does not resolve line breaks on windows, meaning this test failed on windows as the response was multiple

Fixes [#308677](https://wasrtc.hursley.ibm.com:9443/jazz/web/projects/WS-CD#action=com.ibm.team.workitem.viewWorkItem&id=308677)

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
