### PR TITLE
Increase password length for FIPS140-3

### DIFF
--- a/dev/io.openliberty.security.jakartasec.4.0.internal_fat/fat/src/io/openliberty/security/jakartasec/fat/utils/Jakartasec40TestConstants.java
+++ b/dev/io.openliberty.security.jakartasec.4.0.internal_fat/fat/src/io/openliberty/security/jakartasec/fat/utils/Jakartasec40TestConstants.java
@@ -19,7 +19,7 @@ public class Jakartasec40TestConstants {
      */
 
     // Test credentials
-    public static final String VALID_PASSWORD = "secret1";
+    public static final String VALID_PASSWORD = "reallysecretpassw0rd";
     public static final String INVALID_PASSWORD = "bad_password";
 
     // Users with valid groups
@@ -37,10 +37,10 @@ public class Jakartasec40TestConstants {
     public static final String PRODUCTION_USE_WARNING_MSG = "CWWKS2600W"; // Warning about using in-memory store
     public static final String WRONG_CRED_ERROR_MSG = "CWWKS1859E"; // The password was not decrypted because a decoding error was reported
 
-    // XOR and AES-256 encoded (All decode to "secret1")
-    public static final String PASSWORD_XOR_VALID = "{xor}LDo8LTorbg==";
-    public static final String PASSWORD_AES_VALID = "{aes}ARAFCrWIYJCL7ZBNjN+MKcJoozBmbZyJPood6X6sCqMIRBaouZSd4B0u0Gcgdp/tXWwuOwi/mqYLS0cGTwuU95tgP4Y+6hgtvG2ST2gT+ghTPhLJWfiXTrvBRvR5yf2F9hkmM7SG/WRQNA==";
-    public static final String PASSWORD_HASH_VALID = "{hash}ARAAAAAUUEJLREYyV2l0aEhtYWNTSEE1MTIwAAAAIKJLaCvuDfiQYK8H/6SWdTzmbMxndGqWyUWnCaA3ZPOZQAAAACBnjkRtcavFNC2k2qbwEitLlmHZKTYRmeuuCh8z1nFyyw==";
+    // XOR and AES-256 encoded (All decode to "reallysecretpassw0rd")
+    public static final String PASSWORD_XOR_VALID = "{xor}LTo+MzMmLDo8LTorLz4sLChvLTs=";
+    public static final String PASSWORD_AES_VALID = "{aes}ARB1cE2gxoEqBslQEaIs6YtFYjKFXresn8v7rkpD7I8EnQAGL8YayKrendxKW/zv4VOxwWNUv3yAUxSsAzeMi9nkWYBGf3LblwzeJYh3/t5hjoztC0/KCILy8GLlQbN4J66gr/IS9xpTL3iF0hiqOr/UzkA+8Nw=";
+    public static final String PASSWORD_HASH_VALID = "{hash}ARAAAAAUUEJLREYyV2l0aEhtYWNTSEE1MTIwAAAAIH65H/2pM41HF6H5aauqbRDWcw1tZKyAF2R3/gLq2VNJQAAAACDRoEzIXF5ZrDd7rGpEOId7k6GB0ulMxbT4v2f2/72j2w==";
 
     // XOR, but bad encoding
     public static final String PASSWORD_XOR_INVALID = "{xor}LLTxlkwjljsdforbg=";


### PR DESCRIPTION
FIPS140-3 has a minimum hash password length requirement of 10 characters. Increase the length of the base password to be greater then 10 and update the corresponding XOR, Hash and AES encrypted values.

Fixes [#308579](https://wasrtc.hursley.ibm.com:9443/jazz/web/projects/WS-CD#action=com.ibm.team.workitem.viewWorkItem&id=308579)

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".