### PR TITLE
ReadOnlySocket: Use the current socket layer during initialization

### DIFF
--- a/dev/com.ibm.ws.transport.http/src/io/openliberty/http/netty/channel/ReadOnlySocket.java
+++ b/dev/com.ibm.ws.transport.http/src/io/openliberty/http/netty/channel/ReadOnlySocket.java
@@ -39,16 +39,11 @@ public class ReadOnlySocket extends Socket{
     private final ChannelConfig config;
 
     /**
-     * Create a Read-only view of a Netty Channel's socket. If the Netty channel has a 
-     * parent channel, the child socket might not have all of the expcted information. In 
-     * such cases the parent channel will be used instead. 
+     * Create a Read-only view of a Netty Channel's socket.
      * @param channel the Netty Channel
      */
     public ReadOnlySocket(Channel channel){
         this.nettyChannel = channel;
-        if(channel.parent() != null){
-            channel = channel.parent();
-        }
 
         this.local = (InetSocketAddress) channel.localAddress();
         this.remote = (InetSocketAddress) channel.remoteAddress();

--- a/dev/com.ibm.ws.transport.http/src/io/openliberty/http/netty/channel/ReadOnlySocket.java
+++ b/dev/com.ibm.ws.transport.http/src/io/openliberty/http/netty/channel/ReadOnlySocket.java
@@ -44,7 +44,6 @@ public class ReadOnlySocket extends Socket{
      */
     public ReadOnlySocket(Channel channel){
         this.nettyChannel = channel;
-
         this.local = (InetSocketAddress) channel.localAddress();
         this.remote = (InetSocketAddress) channel.remoteAddress();
         this.config = channel.config();


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

For #31333
