### PR TITLE
Update from serviceability review that was missed

### DIFF
--- a/dev/io.openliberty.concurrent.internal.cdi/src/io/openliberty/concurrent/internal/cdi/ConcurrencyExtension.java
+++ b/dev/io.openliberty.concurrent.internal.cdi/src/io/openliberty/concurrent/internal/cdi/ConcurrencyExtension.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021,2025 IBM Corporation and others.
+ * Copyright (c) 2021,2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -136,10 +136,10 @@ public class ConcurrencyExtension implements Extension {
                 addBeans(event, listFromApp, extSvc);
         });
 
-        //TODO add NLS message
         if (!successState) {
-            throw new IllegalStateException("Could not register all managed service beans because the "
-                                            + "ConcurrencyExtensionMetadata service was unavailable.");
+            // Could not register all managed service beans because the
+            // ConcurrencyExtensionMetadata service was unavailable.
+            throw new IllegalStateException();
         }
     }
 


### PR DESCRIPTION
This was a change requested during the concurrent-3.2 serviceability review that I intended to include in the PR for it, but somehow missed.  The requested update was to replace an english-only message for an error that should be unreachable and instead put a comment into the code.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
