### PR TITLE
Add getAllDeclaredCallerRoles to SecurityContextImpl

### DIFF
--- a/dev/com.ibm.ws.security.authorization.builtin/src/com/ibm/ws/security/authorization/builtin/internal/BuiltinAuthorizationService.java
+++ b/dev/com.ibm.ws.security.authorization.builtin/src/com/ibm/ws/security/authorization/builtin/internal/BuiltinAuthorizationService.java
@@ -14,6 +14,7 @@ package com.ibm.ws.security.authorization.builtin.internal;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -208,6 +209,22 @@ public class BuiltinAuthorizationService implements AuthorizationService {
             }
         }
         return granted;
+    }
+
+    @Override
+    public Set<String> getAllDeclaredRolesForResourceForSubject(String resourceName, Subject subject) {
+        Set<String> roles = new HashSet<String>(Collections.EMPTY_SET);
+        WSCredential wsCred = getWSCredentialFromSubject(subject);
+        if (wsCred != null) {
+            String accessId = getAccessId(wsCred);
+            String realmName = getRealmName(wsCred);
+
+            Collection<String> foundRoles = getRolesForAccessId(resourceName, accessId, realmName);
+            if (foundRoles != null) {
+                roles.addAll(foundRoles);
+            }
+        }
+        return roles;
     }
 
     /**

--- a/dev/com.ibm.ws.security.authorization/src/com/ibm/ws/security/authorization/AuthorizationService.java
+++ b/dev/com.ibm.ws.security.authorization/src/com/ibm/ws/security/authorization/AuthorizationService.java
@@ -14,6 +14,7 @@ package com.ibm.ws.security.authorization;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Set;
 
 import javax.security.auth.Subject;
@@ -89,4 +90,21 @@ public interface AuthorizationService {
     default boolean isStarStarRoleMapped(String resourceName) {
         return false;
     }
+    /**
+     *
+     * Retrieve all declared roles subject is assigned to within the provided resource
+     *
+     * Any dynamically assigned roles should not be returned.
+     *
+     * @param resourceName the name of the resource being accessed, used to
+     *            look up the corresponding authorization table. Must not be {@code null}.
+     * @param subject the Subject which roles we are trying to find in the resource. Must not be {@code null}.
+     *
+     * @return {@code Set<String>} of all the roles assigned to the subject in the resource.
+     *            Returns an empty set if no roles for
+     */
+    default Set<String> getAllDeclaredRolesForResourceForSubject(String resourceName, Subject subject){
+        return new HashSet<String>(Collections.EMPTY_SET);
+    }
+
 }

--- a/dev/com.ibm.ws.security.javaeesec.cdi/src/com/ibm/ws/security/javaeesec/cdi/extensions/SecurityContextImpl.java
+++ b/dev/com.ibm.ws.security.javaeesec.cdi/src/com/ibm/ws/security/javaeesec/cdi/extensions/SecurityContextImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2025 IBM Corporation and others.
+ * Copyright (c) 2017, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -13,9 +13,7 @@
 package com.ibm.ws.security.javaeesec.cdi.extensions;
 
 import java.security.Principal;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 
 import javax.security.auth.Subject;
 import javax.security.enterprise.AuthenticationStatus;
@@ -24,6 +22,9 @@ import javax.security.enterprise.authentication.mechanism.http.AuthenticationPar
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import com.ibm.websphere.ras.Tr;
+import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.websphere.security.cred.WSCredential;
 import com.ibm.ws.runtime.metadata.ComponentMetaData;
 import com.ibm.ws.security.authorization.AuthorizationService;
 import com.ibm.ws.security.context.SubjectManager;
@@ -39,6 +40,9 @@ import com.ibm.ws.webcontainer.security.util.WebConfigUtils;
  *
  */
 public class SecurityContextImpl implements SecurityContext {
+
+
+    private static final TraceComponent tc = Tr.register(SecurityContextImpl.class);
 
     /*
      * (non-Javadoc)
@@ -164,6 +168,26 @@ public class SecurityContextImpl implements SecurityContext {
         return false;
     }
 
+    /*
+     * (non-Javadoc)
+     *
+     * Available as part of Jakarta Security 4.0 onwards
+     *
+     * @see jakarta.security.enterprise.SecurityContext#getAllDeclaredCallerRoles()
+     */
+    public Set<String> getAllDeclaredCallerRoles() {
+        Set<String> roles = new HashSet<>();
+        Subject callerSubject = getCallerSubject();
+        WSCredential wsCred = getWSCredentialFromSubject(callerSubject);
+        if(wsCred != null ) {
+            if(!wsCred.isUnauthenticated()) {
+                AuthorizationService authService = SecurityContextHelper.getAuthorizationService();
+                roles.addAll(authService.getAllDeclaredRolesForResourceForSubject(getApplicationName(), callerSubject));
+            }
+        }
+        return roles;
+    }
+
     private Subject getCallerSubject() {
         SubjectManagerService subjectManagerService = SecurityContextHelper.getSubjectManagerService();
         if (subjectManagerService != null) {
@@ -178,5 +202,24 @@ public class SecurityContextImpl implements SecurityContext {
     private String getApplicationName() {
         ComponentMetaData cmd = ComponentMetaDataAccessorImpl.getComponentMetaDataAccessor().getComponentMetaData();
         return cmd.getJ2EEName().getApplication();
+    }
+
+    private WSCredential getWSCredentialFromSubject(Subject subject) {
+        if (subject != null) {
+            java.util.Collection<Object> publicCreds = subject.getPublicCredentials();
+
+            if (publicCreds != null && publicCreds.size() > 0) {
+                java.util.Iterator<Object> publicCredIterator = publicCreds.iterator();
+
+                while (publicCredIterator.hasNext()) {
+                    Object cred = publicCredIterator.next();
+
+                    if (cred instanceof WSCredential) {
+                        return (WSCredential) cred;
+                    }
+                }
+            }
+        }
+        return null;
     }
 }

--- a/dev/io.openliberty.security.jakartasec.4.0.internal_fat/bnd.bnd
+++ b/dev/io.openliberty.security.jakartasec.4.0.internal_fat/bnd.bnd
@@ -17,7 +17,8 @@ src: \
     fat/src,\
     test-applications/inmemory/WEB-INF,\
     test-applications/inmemory/src,\
-    test-applications/ham/src
+    test-applications/ham/src,\
+    test-applications/declaredroles/src
         
 -dependson: \
     build.changeDetector,\

--- a/dev/io.openliberty.security.jakartasec.4.0.internal_fat/fat/src/io/openliberty/security/jakartasec/fat/FATSuite.java
+++ b/dev/io.openliberty.security.jakartasec.4.0.internal_fat/fat/src/io/openliberty/security/jakartasec/fat/FATSuite.java
@@ -27,6 +27,8 @@ import io.openliberty.security.jakartasec.fat.tests.MultipleHAMDuplicateTests;
 import io.openliberty.security.jakartasec.fat.tests.MultipleHAMInbuiltQualifiersTests;
 import io.openliberty.security.jakartasec.fat.tests.MultipleHAMInbuiltTests;
 import io.openliberty.security.jakartasec.fat.tests.SingleHAMInbuiltCustomQualifierTests;
+import io.openliberty.security.jakartasec.fat.tests.AppRolesTests;
+import io.openliberty.security.jakartasec.fat.tests.AppBndRolesTests;
 
 @RunWith(Suite.class)
 @SuiteClasses({
@@ -40,8 +42,9 @@ import io.openliberty.security.jakartasec.fat.tests.SingleHAMInbuiltCustomQualif
                 SingleHAMInbuiltCustomQualifierTests.class,
                 MissingCustomHandlerTests.class,
                 InMemoryIdentityStoreELWarningTest.class,
-                InMemoryIdentityStoreEnablementTests.class
+                InMemoryIdentityStoreEnablementTests.class,
+                AppRolesTests.class,
+                AppBndRolesTests.class
 })
-
 public class FATSuite {
 }

--- a/dev/io.openliberty.security.jakartasec.4.0.internal_fat/fat/src/io/openliberty/security/jakartasec/fat/tests/AppBndRolesTests.java
+++ b/dev/io.openliberty.security.jakartasec.4.0.internal_fat/fat/src/io/openliberty/security/jakartasec/fat/tests/AppBndRolesTests.java
@@ -1,0 +1,100 @@
+package io.openliberty.security.jakartasec.fat.tests;
+
+import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.websphere.simplicity.log.Log;
+import componenttest.annotation.Server;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.custom.junit.runner.Mode;
+import componenttest.topology.impl.LibertyServer;
+import declared.roles.DeclaredRolesApplication;
+import declared.roles.RolesResource;
+import declared.roles.RunAsBean;
+import declared.roles.RunAsResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.FileAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.io.File;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+import static io.openliberty.security.jakartasec.fat.utils.Jakartasec40TestConstants.*;
+import static io.openliberty.security.jakartasec.fat.utils.Utils.*;
+import static org.junit.Assert.*;
+
+@RunWith(FATRunner.class)
+@Mode(Mode.TestMode.LITE)
+public class AppBndRolesTests {
+
+    private final static Class<?> c = AppBndRolesTests.class;
+
+    private final static String APP_NAME = "appPermissions";
+    private final static String ROLES_RESOURCE_PATH = "/roles";
+    private final static String RUNAS_RESOURCE_PATH = "/runas";
+
+    private static String url;
+
+    @Server("appPermissionsServer")
+    public static LibertyServer server;
+
+    @BeforeClass
+    public static void setup() throws Exception {
+        Log.info(c, "setUp", "Starting server setup...");
+        WebArchive app = ShrinkWrap.create(WebArchive.class, APP_NAME+".war").addClass(DeclaredRolesApplication.class).addClass(RolesResource.class).addClass(RunAsResource.class).addClass(RunAsBean.class).addAsWebInfResource(new File("test-applications/declaredroles/WEB-INF/web.xml")).add(new FileAsset(new File("test-applications/declaredroles/META-INF/ibm-application-bnd.xml")),"META-INF/ibm-application-bnd.xml");
+        ShrinkHelper.exportAppToServer(server, app, ShrinkHelper.DeployOptions.SERVER_ONLY);
+
+        server.addDropinDefaultConfiguration("dropins/app1_noRoles.xml");
+
+        server.startServer();
+        assertNotNull(server.waitForStringInLog("CWWKS4105I"));
+
+        url = "http://localhost:" + server.getHttpDefaultPort() + "/" + APP_NAME;
+
+        Log.info(c, "setUp", "Server started successfully");
+    }
+
+    @Test
+    public void testAppBndRoles() throws Exception {
+        Set<String> expectedResult = Collections.singleton("Role1");
+        String result = executeGetRequestBasicAuth(url + ROLES_RESOURCE_PATH, USER1, USER1_PASSWORD, 200);
+        Set<String> returnedRoles = convertStringToSet(result);
+        assertEquals(expectedResult, returnedRoles);
+        assertTrue("Expected Role Role1 in set, but got " + result, expectedResult.containsAll(returnedRoles));
+
+        Set<String> expectedResult2 = Collections.singleton("Role2");
+        String result2 = executeGetRequestBasicAuth(url + ROLES_RESOURCE_PATH, USER3, USER3_PASSWORD, 200);
+        Set<String> returnedRoles2 = convertStringToSet(result2);
+        assertEquals(expectedResult2, returnedRoles2);
+        assertTrue("Expected Role Role3 in set, but got " + result2, expectedResult2.containsAll(returnedRoles2));
+
+        Set<String> expectedResult3 = new HashSet<>();
+        expectedResult3.add("Role1");
+        expectedResult3.add("Role3");
+        String result3 = executeGetRequestBasicAuth(url + ROLES_RESOURCE_PATH, USER2, USER2_PASSWORD, 200);
+        Set<String> returnedRoles3 = convertStringToSet(result3);
+        assertTrue("Expected Role Role3 in set, but got " + result3, expectedResult3.containsAll(returnedRoles3));
+    }
+
+    @Test
+    public void testRunAsRoles() throws Exception {
+        String result = executeGetRequestNoAuth(url + RUNAS_RESOURCE_PATH,200);
+        Set<String> returnedRoles = convertStringToSet(result);
+        assertTrue("Expected empty set, but got " + result, returnedRoles.isEmpty());
+
+        Set<String> expectedResult2 = Collections.singleton("Role2");
+        String result2 = executeGetRequestBasicAuth(url + RUNAS_RESOURCE_PATH, USER3, USER3_PASSWORD, 200);
+        Set<String> returnedRoles2 = convertStringToSet(result2);
+        assertEquals(expectedResult2, returnedRoles2);
+        assertTrue("Expected Role Role2 in set, but got " + result2, expectedResult2.containsAll(returnedRoles2));
+    }
+
+    @AfterClass
+    public static void teardwon() throws Exception {
+        server.stopServer();
+    }
+}

--- a/dev/io.openliberty.security.jakartasec.4.0.internal_fat/fat/src/io/openliberty/security/jakartasec/fat/tests/AppRolesTests.java
+++ b/dev/io.openliberty.security.jakartasec.4.0.internal_fat/fat/src/io/openliberty/security/jakartasec/fat/tests/AppRolesTests.java
@@ -1,0 +1,112 @@
+package io.openliberty.security.jakartasec.fat.tests;
+
+import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.websphere.simplicity.log.Log;
+import componenttest.annotation.Server;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.custom.junit.runner.Mode;
+import componenttest.topology.impl.LibertyServer;
+import declared.roles.DeclaredRolesApplication;
+import declared.roles.NoRoleResource;
+import declared.roles.RolesResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.io.File;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+import static io.openliberty.security.jakartasec.fat.utils.Jakartasec40TestConstants.*;
+import static io.openliberty.security.jakartasec.fat.utils.Utils.convertStringToSet;
+import static io.openliberty.security.jakartasec.fat.utils.Utils.executeGetRequestBasicAuth;
+import static org.junit.Assert.*;
+
+@RunWith(FATRunner.class)
+@Mode(Mode.TestMode.LITE)
+public class AppRolesTests {
+
+    private final static Class<?> c = AppRolesTests.class;
+
+    private final static String APP_NAME = "appPermissions";
+    private final static String APP_NAME_2 = "appPermissions2";
+    private final static String RESOURCE_PATH = "/roles";
+
+    private static String urlApp1;
+    private static String urlApp2;
+
+    @Server("appPermissionsServer")
+    public static LibertyServer server;
+
+    @BeforeClass
+    public static void setup() throws Exception {
+        Log.info(c, "setUp", "Starting server setup...");
+        WebArchive app = ShrinkWrap.create(WebArchive.class, APP_NAME+".war").addClass(DeclaredRolesApplication.class).addClass(RolesResource.class).addClass(NoRoleResource.class).addAsWebInfResource(new File("test-applications/declaredroles/WEB-INF/web.xml"));
+        ShrinkHelper.exportAppToServer(server, app, ShrinkHelper.DeployOptions.SERVER_ONLY);
+        WebArchive app2 = ShrinkWrap.create(WebArchive.class, APP_NAME_2+".war").addClass(DeclaredRolesApplication.class).addClass(RolesResource.class).addAsWebInfResource(new File("test-applications/declaredroles/WEB-INF/web.xml"));
+        ShrinkHelper.exportAppToServer(server, app2, ShrinkHelper.DeployOptions.SERVER_ONLY);
+
+        server.addDropinDefaultConfiguration("dropins/app1.xml");
+        server.addDropinDefaultConfiguration("dropins/app2.xml");
+
+        server.startServer();
+
+        assertNotNull(server.waitForStringInLog("CWWKS4105I"));
+
+        urlApp1 = "http://localhost:" + server.getHttpDefaultPort() + "/" + APP_NAME + RESOURCE_PATH;
+        urlApp2 = "http://localhost:" + server.getHttpDefaultPort() + "/" + APP_NAME_2 + RESOURCE_PATH;
+        Log.info(c, "setUp", "Server started successfully");
+    }
+
+    @Test
+    public void singleUserSingleAppRolesTest() throws Exception {
+        Set<String> expectedResult = Collections.singleton("Role1");
+        String result = executeGetRequestBasicAuth(urlApp1, USER1, USER1_PASSWORD, 200);
+        Set<String> returnedRoles = convertStringToSet(result);
+        assertEquals(expectedResult, returnedRoles);
+        assertTrue("Expected Role Role1 in set, but got " + result, expectedResult.containsAll(returnedRoles));
+    }
+
+    @Test
+    public void singleUserTwoAppRolesTest() throws Exception {
+        String result = executeGetRequestBasicAuth(urlApp1, USER2, USER2_PASSWORD, 200);
+        Set<String> expectedResult = new HashSet<>();
+        expectedResult.add("Role1");
+        expectedResult.add("Role2");
+        Set<String> returnedRoles = convertStringToSet(result);
+        assertEquals(expectedResult.size(), returnedRoles.size());
+        assertTrue("Expected Roles Role1, Role2 in set, but got " + result, expectedResult.containsAll(returnedRoles));
+    }
+
+    @Test
+    public void singleUserOneRolePerApplicationTest() throws Exception {
+        String result = executeGetRequestBasicAuth(urlApp1, USER3, USER3_PASSWORD, 200);
+        Set<String> expectedResult = Collections.singleton("Role1");
+        Set<String> returnedRoles = convertStringToSet(result);
+        assertEquals(expectedResult, returnedRoles);
+        assertTrue("Expected Role Role1 in set, but got " + result, expectedResult.containsAll(returnedRoles));
+
+        String result2 = executeGetRequestBasicAuth(urlApp2, USER3, USER3_PASSWORD, 200);
+        Set<String> expectedResult2 = Collections.singleton("Role2");
+        Set<String> returnedRoles2 = convertStringToSet(result2);
+        assertEquals(expectedResult2, returnedRoles2);
+        assertTrue("Expected Role Role2 in set, but got " + result, expectedResult2.containsAll(returnedRoles2));
+    }
+
+    @Test
+    public void authenticatedUserNoRolesTest() throws Exception {
+        String url = "http://localhost:" + server.getHttpDefaultPort() + "/" + APP_NAME + "/noroles";
+        String result = executeGetRequestBasicAuth(url, USER4, USER4_PASSWORD, 200);
+        Set<String> returnedRoles = convertStringToSet(result);
+        assertTrue("Expected an empty set, but got " + result, returnedRoles.isEmpty());
+    }
+
+    @AfterClass
+    public static void teardown() throws Exception {
+        server.stopServer();
+    }
+}

--- a/dev/io.openliberty.security.jakartasec.4.0.internal_fat/fat/src/io/openliberty/security/jakartasec/fat/tests/UnauthenticatedDeclaredRolesTests.java
+++ b/dev/io.openliberty.security.jakartasec.4.0.internal_fat/fat/src/io/openliberty/security/jakartasec/fat/tests/UnauthenticatedDeclaredRolesTests.java
@@ -1,0 +1,102 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.security.jakartasec.fat.tests;
+
+
+import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.websphere.simplicity.log.Log;
+import componenttest.annotation.Server;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.custom.junit.runner.Mode;
+import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.utils.FATServletClient;
+import declared.roles.DeclaredRolesApplication;
+import declared.roles.NoRoleResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.After;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.URL;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(FATRunner.class)
+@Mode(Mode.TestMode.LITE)
+public class UnauthenticatedDeclaredRolesTests extends FATServletClient {
+
+    private static final Class<?> c = UnauthenticatedDeclaredRolesTests.class;
+
+    public static final String SERVER_NAME = "basicServer";
+    public static final String APP_NAME = "DeclaredRoles";
+    private static final String CONTEXT_ROOT = "/" + APP_NAME;
+    private static final String RESOURCE_PATH = "/noroles";
+
+    private static String url = null;
+
+    @Server(SERVER_NAME)
+    //@TestServlet(servlet = UnauthenticatedServlet.class, contextRoot = APP_NAME)
+    public static LibertyServer server;
+
+    @BeforeClass
+    public static void setup() throws Exception {
+        Log.info(c, "setUp", "Starting server setup...");
+        WebArchive app = ShrinkWrap.create(WebArchive.class, APP_NAME+".war").addClass(DeclaredRolesApplication.class).addClass(NoRoleResource.class);
+        ShrinkHelper.exportDropinAppToServer(server, app, ShrinkHelper.DeployOptions.SERVER_ONLY);
+        server.startServer();
+
+        server.waitForStringInLog("CWWKS4105I");
+        Log.info(c, "setUp", "Server started successfully");
+    }
+
+
+      @Test
+      public void unauthenticatedTest() throws Exception {
+        String url = "http://localhost:" + server.getHttpDefaultPort() + CONTEXT_ROOT + RESOURCE_PATH;
+        URL urlObj = new URL(url);
+        HttpURLConnection conn = (HttpURLConnection) urlObj.openConnection();
+
+          conn.setRequestMethod("GET");
+          conn.setDoInput(true);
+
+          int responseCode = conn.getResponseCode();
+          assertEquals("Expected status code " + 200 + " but got " + responseCode,
+                  200, responseCode);
+
+          // Read response
+          StringBuilder response = new StringBuilder();
+          if (responseCode == 200) {
+              BufferedReader in = new BufferedReader(new InputStreamReader(conn.getInputStream()));
+              String inputLine;
+              while ((inputLine = in.readLine()) != null) {
+                  response.append(inputLine);
+              }
+              in.close();
+          }
+
+          conn.disconnect();
+
+          // Unauthenticated users should have 0 roles.
+          assertEquals("[]", response.toString());
+      }
+
+      @After
+      public void teardown() throws Exception {
+        server.stopServer();
+      }
+}

--- a/dev/io.openliberty.security.jakartasec.4.0.internal_fat/fat/src/io/openliberty/security/jakartasec/fat/utils/Jakartasec40TestConstants.java
+++ b/dev/io.openliberty.security.jakartasec.4.0.internal_fat/fat/src/io/openliberty/security/jakartasec/fat/utils/Jakartasec40TestConstants.java
@@ -41,6 +41,16 @@ public class Jakartasec40TestConstants {
     public static final String USER_SALLY = "sally"; // AES encoded password
     public static final String USER_THEO = "theo"; // AES encoded password
 
+    // App Roles Users
+    public final static String USER1 = "user1";
+    public final static String USER1_PASSWORD = "user1pwd";
+    public final static String USER2 = "user2";
+    public final static String USER2_PASSWORD = "user2pwd";
+    public final static String USER3 = "user3";
+    public final static String USER3_PASSWORD = "user3pwd";
+    public final static String USER4 = "user4";
+    public final static String USER4_PASSWORD = "user4pwd";
+
     // Users with invalid groups or bad encoding
     public static final String USER_BILL = "bill"; // valid password but wrong groups
     public static final String USER_JOHNNY = "johnny"; // bad XOR encoding

--- a/dev/io.openliberty.security.jakartasec.4.0.internal_fat/fat/src/io/openliberty/security/jakartasec/fat/utils/Utils.java
+++ b/dev/io.openliberty.security.jakartasec.4.0.internal_fat/fat/src/io/openliberty/security/jakartasec/fat/utils/Utils.java
@@ -1,0 +1,104 @@
+package io.openliberty.security.jakartasec.fat.utils;
+
+import com.ibm.websphere.simplicity.log.Log;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.assertEquals;
+
+public class Utils {
+
+    private static final Class<?> c = Utils.class;
+
+    /**
+     * Helper method to execute GET request with Basic Authentication.
+     */
+    public static String executeGetRequestBasicAuth(String url, String username, String password, int expectedStatusCode) throws Exception {
+        URL urlObj = new URL(url);
+        HttpURLConnection conn = (HttpURLConnection) urlObj.openConnection();
+
+        // Set Basic Authentication header
+        String auth = username + ":" + password;
+        String encodedAuth = Base64.getEncoder().encodeToString(auth.getBytes());
+        conn.setRequestProperty("Authorization", "Basic " + encodedAuth);
+
+        conn.setRequestMethod("GET");
+        conn.setDoInput(true);
+
+        int responseCode = conn.getResponseCode();
+        assertEquals("Expected status code " + expectedStatusCode + " but got " + responseCode,
+                expectedStatusCode, responseCode);
+
+        // Read response
+        StringBuilder response = new StringBuilder();
+        if (responseCode == 200) {
+            BufferedReader in = new BufferedReader(new InputStreamReader(conn.getInputStream()));
+            String inputLine;
+            while ((inputLine = in.readLine()) != null) {
+                response.append(inputLine);
+            }
+            in.close();
+        }
+
+        conn.disconnect();
+
+        Log.info(c, "executeGetRequestBasicAuth",
+                "Request to " + url + " with user " + username + " returned status " + responseCode);
+
+        return response.toString();
+    }
+
+    /**
+     * Helper method for making requests without providing any authorizaiton - useful for RunAs resources
+     * @param url
+     * @param expectedStatusCode
+     * @return
+     * @throws Exception
+     */
+    public static String executeGetRequestNoAuth(String url, int expectedStatusCode) throws Exception {
+        URL urlObj = new URL(url);
+        HttpURLConnection conn = (HttpURLConnection) urlObj.openConnection();
+
+        conn.setRequestMethod("GET");
+        conn.setDoInput(true);
+
+        int responseCode = conn.getResponseCode();
+        assertEquals("Expected status code " + expectedStatusCode + " but got " + responseCode,
+                expectedStatusCode, responseCode);
+
+        // Read response
+        StringBuilder response = new StringBuilder();
+        if (responseCode == 200) {
+            BufferedReader in = new BufferedReader(new InputStreamReader(conn.getInputStream()));
+            String inputLine;
+            while ((inputLine = in.readLine()) != null) {
+                response.append(inputLine);
+            }
+            in.close();
+        }
+
+        conn.disconnect();
+
+        Log.info(c, "executeGetRequestBasicAuth",
+                "Request to " + url + " returned status " + responseCode);
+
+        return response.toString();
+    }
+
+    public static Set<String> convertStringToSet(String input){
+        input = input.replaceAll("^\\[","").replaceAll("]$","").trim();
+        if (input.isBlank()){
+            return Collections.EMPTY_SET;
+        }
+        return Arrays.stream(input.split(",")).map(String::trim).collect(Collectors.toSet());
+
+    }
+}

--- a/dev/io.openliberty.security.jakartasec.4.0.internal_fat/publish/files/dropins/app1.xml
+++ b/dev/io.openliberty.security.jakartasec.4.0.internal_fat/publish/files/dropins/app1.xml
@@ -1,0 +1,15 @@
+<server>
+    <application type="war" id="appPermissions" name="appPermissions"
+                 location="appPermissions.war">
+        <application-bnd>
+            <security-role name="Role1">
+                <user name="user1" />
+                <user name="user2" />
+                <user name="user3" />
+            </security-role>
+            <security-role name="Role2">
+                <user name="user2" />
+            </security-role>
+        </application-bnd>
+    </application>
+</server>

--- a/dev/io.openliberty.security.jakartasec.4.0.internal_fat/publish/files/dropins/app1_noRoles.xml
+++ b/dev/io.openliberty.security.jakartasec.4.0.internal_fat/publish/files/dropins/app1_noRoles.xml
@@ -1,0 +1,5 @@
+<server>
+    <application type="war" id="appPermissions" name="appPermissions"
+                 location="appPermissions.war">
+    </application>
+</server>

--- a/dev/io.openliberty.security.jakartasec.4.0.internal_fat/publish/files/dropins/app2.xml
+++ b/dev/io.openliberty.security.jakartasec.4.0.internal_fat/publish/files/dropins/app2.xml
@@ -1,0 +1,13 @@
+<server>
+    <application type="war" id="appPermissions2" name="appPermissions2"
+                 location="appPermissions2.war">
+        <application-bnd>
+            <security-role name="Role1">
+                <user name="user4" />
+            </security-role>
+            <security-role name="Role2">
+                <user name="user3" />
+            </security-role>
+        </application-bnd>
+    </application>
+</server>

--- a/dev/io.openliberty.security.jakartasec.4.0.internal_fat/publish/files/dropins/app2_noRoles.xml
+++ b/dev/io.openliberty.security.jakartasec.4.0.internal_fat/publish/files/dropins/app2_noRoles.xml
@@ -1,0 +1,5 @@
+<server>
+    <application type="war" id="appPermissions2" name="appPermissions2"
+                 location="appPermissions2.war">
+    </application>
+</server>

--- a/dev/io.openliberty.security.jakartasec.4.0.internal_fat/publish/servers/appPermissionsServer/bootstrap.properties
+++ b/dev/io.openliberty.security.jakartasec.4.0.internal_fat/publish/servers/appPermissionsServer/bootstrap.properties
@@ -1,0 +1,10 @@
+bootstrap.include=../testports.properties
+
+com.ibm.ws.logging.trace.specification=*=info=enabled:\
+jakarta.security.*=all=enabled:\
+com.ibm.ws.webcontainer.security.*=all=enabled:\
+io.openliberty.security.*=all:\
+org.apache.http.client.*=all
+
+com.ibm.ws.logging.max.file.size=0
+ds.loglevel=debug

--- a/dev/io.openliberty.security.jakartasec.4.0.internal_fat/publish/servers/appPermissionsServer/server.xml
+++ b/dev/io.openliberty.security.jakartasec.4.0.internal_fat/publish/servers/appPermissionsServer/server.xml
@@ -1,0 +1,21 @@
+<server description="JavaEESec Multiple Module Global Login Cert FAT">
+
+    <featureManager>
+        <feature>servlet-6.1</feature>
+        <feature>appSecurity-6.0</feature>
+        <feature>appAuthorization-3.0</feature>
+        <feature>timedexit-1.0</feature>
+        <feature>componentTest-2.0</feature>
+        <feature>restfulWS-4.0</feature>
+    </featureManager>
+
+    <include location="../fatTestPorts.xml" />
+
+    <basicRegistry id="basic" realm="BasicRealm">
+        <user name="user1" password="user1pwd"/>
+        <user name="user2" password="user2pwd" />
+        <user name="user3" password="user3pwd"/>
+        <user name="user4" password="user4pwd"/>
+    </basicRegistry>
+
+</server>

--- a/dev/io.openliberty.security.jakartasec.4.0.internal_fat/test-applications/declaredroles/META-INF/ibm-application-bnd.xml
+++ b/dev/io.openliberty.security.jakartasec.4.0.internal_fat/test-applications/declaredroles/META-INF/ibm-application-bnd.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+-->
+<application-bnd xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://websphere.ibm.com/xml/ns/javaee"
+                 xsi:schemaLocation="http://websphere.ibm.com/xml/ns/javaee http://websphere.ibm.com/xml/ns/javaee/ibm-application-bnd_1_0.xsd" version="1.0">
+    <security-role name="Role1">
+        <user name="user1" />
+        <user name="user2" />
+    </security-role>
+    <security-role name="Role2">
+        <user name="user3" />
+        <run-as userid="user4"/>
+    </security-role>
+    <security-role name="Role3">
+        <user name="user2"/>
+        <user name="user4"/>
+    </security-role>
+</application-bnd>

--- a/dev/io.openliberty.security.jakartasec.4.0.internal_fat/test-applications/declaredroles/WEB-INF/web.xml
+++ b/dev/io.openliberty.security.jakartasec.4.0.internal_fat/test-applications/declaredroles/WEB-INF/web.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<web-app xmlns="https://jakarta.ee/xml/ns/jakartaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_6_0.xsd"
+         version="6.0">
+    <display-name>Declared Roles Application</display-name>
+
+    <security-constraint>
+        <web-resource-collection>
+            <web-resource-name>Protected REST API</web-resource-name>
+            <url-pattern>/roles/*</url-pattern>
+            <http-method>GET</http-method>
+            <http-method>POST</http-method>
+        </web-resource-collection>
+        <auth-constraint>
+            <role-name>Role1</role-name>
+            <role-name>Role2</role-name>
+        </auth-constraint>
+    </security-constraint>
+
+    <!-- Define security roles -->
+    <security-role>
+        <role-name>Role1</role-name>
+    </security-role>
+    <security-role>
+        <role-name>Role2</role-name>
+    </security-role>
+
+</web-app>

--- a/dev/io.openliberty.security.jakartasec.4.0.internal_fat/test-applications/declaredroles/src/declared/roles/DeclaredRolesApplication.java
+++ b/dev/io.openliberty.security.jakartasec.4.0.internal_fat/test-applications/declaredroles/src/declared/roles/DeclaredRolesApplication.java
@@ -1,0 +1,8 @@
+package declared.roles;
+
+import jakarta.ws.rs.ApplicationPath;
+import jakarta.ws.rs.core.Application;
+
+@ApplicationPath("/")
+public class DeclaredRolesApplication extends Application{
+}

--- a/dev/io.openliberty.security.jakartasec.4.0.internal_fat/test-applications/declaredroles/src/declared/roles/NoRoleResource.java
+++ b/dev/io.openliberty.security.jakartasec.4.0.internal_fat/test-applications/declaredroles/src/declared/roles/NoRoleResource.java
@@ -1,0 +1,24 @@
+package declared.roles;
+
+import jakarta.inject.Inject;
+import jakarta.security.enterprise.SecurityContext;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+import java.util.Set;
+
+@Path("/noroles")
+public class NoRoleResource {
+
+    @Inject
+    private SecurityContext sc;
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public Set<String> authenticate(){
+        return sc.getAllDeclaredCallerRoles();
+    }
+
+}

--- a/dev/io.openliberty.security.jakartasec.4.0.internal_fat/test-applications/declaredroles/src/declared/roles/RolesResource.java
+++ b/dev/io.openliberty.security.jakartasec.4.0.internal_fat/test-applications/declaredroles/src/declared/roles/RolesResource.java
@@ -1,0 +1,25 @@
+package declared.roles;
+
+import jakarta.annotation.security.RolesAllowed;
+import jakarta.inject.Inject;
+import jakarta.security.enterprise.SecurityContext;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+import java.util.Set;
+
+@Path("/roles")
+@RolesAllowed({"Role1", "Role2"})
+public class RolesResource {
+
+    @Inject
+    SecurityContext sc;
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public Set<String> getCallerRoles() {
+        return sc.getAllDeclaredCallerRoles();
+    }
+}

--- a/dev/io.openliberty.security.jakartasec.4.0.internal_fat/test-applications/declaredroles/src/declared/roles/RunAsBean.java
+++ b/dev/io.openliberty.security.jakartasec.4.0.internal_fat/test-applications/declaredroles/src/declared/roles/RunAsBean.java
@@ -1,0 +1,20 @@
+package declared.roles;
+
+import jakarta.annotation.security.RunAs;
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.inject.Inject;
+import jakarta.security.enterprise.SecurityContext;
+
+import java.util.Set;
+
+@RequestScoped
+@RunAs("user4")
+public class RunAsBean {
+
+    @Inject
+    SecurityContext sc;
+
+    public Set<String> getRoles(){
+        return sc.getAllDeclaredCallerRoles();
+    }
+}

--- a/dev/io.openliberty.security.jakartasec.4.0.internal_fat/test-applications/declaredroles/src/declared/roles/RunAsResource.java
+++ b/dev/io.openliberty.security.jakartasec.4.0.internal_fat/test-applications/declaredroles/src/declared/roles/RunAsResource.java
@@ -1,0 +1,25 @@
+package declared.roles;
+
+import jakarta.annotation.security.RolesAllowed;
+import jakarta.annotation.security.RunAs;
+import jakarta.inject.Inject;
+import jakarta.security.enterprise.SecurityContext;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+import java.util.Set;
+
+@Path("/runas")
+public class RunAsResource {
+
+    @Inject
+    private RunAsBean bean;
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public Set<String> getCallerRoles() {
+        return bean.getRoles();
+    }
+}


### PR DESCRIPTION
Add getAllDeclaredCallerRoles to SecurityContextImpl per Jakarta Security 4.0. This is added in the base class that is used by all appSecurity features, but only accessible for 4.0 interface onwards as it does not exist for prior releases.

Add Tests to cover range of role mapping possibilities.


- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".