### PR TITLE
Ensure clean persistence context for lazy loading verification in `countCars` test

### DIFF
--- a/dev/com.ibm.ws.persistence_fat/test-bundles/com.ibm.ws.persistence.consumer/src/persistence_fat/consumer/ConsumerImpl.java
+++ b/dev/com.ibm.ws.persistence_fat/test-bundles/com.ibm.ws.persistence.consumer/src/persistence_fat/consumer/ConsumerImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 IBM Corporation and others.
+ * Copyright (c) 2017, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.persistence_fat/test-bundles/com.ibm.ws.persistence.consumer/src/persistence_fat/consumer/ConsumerImpl.java
+++ b/dev/com.ibm.ws.persistence_fat/test-bundles/com.ibm.ws.persistence.consumer/src/persistence_fat/consumer/ConsumerImpl.java
@@ -95,6 +95,9 @@ public class ConsumerImpl implements Consumer {
     public int getNumCars(long personId) {
         EntityManager em = _activePu.createEntityManager();
         try {
+            em.getEntityManagerFactory().getCache().evict(Person.class, personId);
+            // Clear the persistence context to ensure a clean state after cache eviction
+            em.clear();
             Person p = em.find(Person.class, personId);
             if (p == null) {
                 throw new RuntimeException("null person.id=" + personId);


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

Clear L2 cache and persistence context before loading entity to ensure fresh load with proper lazy loading.
For RTC defect 308669.