### PR TITLE
feat: add better support for TC + podman

### DIFF
--- a/dev/fattest.simplicity/src/componenttest/containers/TestContainerHelper.java
+++ b/dev/fattest.simplicity/src/componenttest/containers/TestContainerHelper.java
@@ -1,0 +1,93 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package componenttest.containers;
+
+import com.ibm.websphere.simplicity.log.Log;
+
+import componenttest.custom.junit.runner.FATRunner;
+
+public class TestContainerHelper {
+
+    private static final Class<?> c = TestContainerHelper.class;
+
+    private TestContainerHelper() {
+        //Utility class
+    }
+
+    /**
+     * Determines if we are going to attempt to run against a remote
+     * docker host, or a local docker host.
+     *
+     * Priority:
+     * 1. System Property: fat.test.use.remote.docker
+     * 2. System Property: fat.test.docker.host -> REMOTE
+     * 3. System: GITHUB_ACTIONS -> LOCAL
+     * 4. System: WINDOWS -> REMOTE
+     * 5. System: ARM -> REMOTE
+     *
+     * default (!!! fat.test.localrun)
+     *
+     * @return true, we are running against a remote docker host, false otherwise.
+     */
+    public static boolean useRemoteDocker() {
+        boolean result;
+        String reason;
+
+        do {
+            //State 1: fat.test.use.remote.docker should always be honored first
+            if (System.getProperty("fat.test.use.remote.docker") != null) {
+                result = Boolean.getBoolean("fat.test.use.remote.docker");
+                reason = "fat.test.use.remote.docker set to " + result;
+                break;
+            }
+
+            //State 2: User provided a remote docker host, assume they want to use the remote host
+            if (ExternalDockerClientFilter.instance().isForced()) {
+                result = true;
+                reason = "fat.test.docker.host was configured";
+                break;
+            }
+
+            //State 3: Github actions build should always use local
+            if (Boolean.parseBoolean(System.getenv("GITHUB_ACTIONS"))) {
+                result = false;
+                reason = "GitHub Actions Build";
+                break;
+            }
+
+            //State 4: Earlier version of TestContainers didn't support docker for windows
+            // Assume a user on windows with no other preferences will want to use a remote host.
+            if (System.getProperty("os.name", "unknown").toLowerCase().contains("windows")) {
+                result = true;
+                reason = "Local operating system is Windows. Default container support not guaranteed.";
+                break;
+            }
+
+            //State 5: ARM architecture can cause performance/starting issues with x86 containers, so also assume remote as the default.
+            if (FATRunner.ARM_ARCHITECTURE) {
+                result = true;
+                reason = "CPU architecture is ARM. x86 container support and performance not guaranteed.";
+                break;
+            }
+
+            // Default, use local docker for local runs, and remote docker for remote (RTC) runs
+            result = !FATRunner.FAT_TEST_LOCALRUN;
+            reason = "fat.test.localrun set to " + FATRunner.FAT_TEST_LOCALRUN;
+        } while (false);
+
+        reason = result ? //
+                        "Remote docker host will be the highest priority. Reason: " + reason : //
+                        "Local docker host will be the highest priority. Reason: " + reason;
+
+        Log.info(c, "useRemoteDocker", reason);
+        return result;
+    }
+
+}

--- a/dev/fattest.simplicity/src/componenttest/containers/TestContainerSuite.java
+++ b/dev/fattest.simplicity/src/componenttest/containers/TestContainerSuite.java
@@ -205,7 +205,7 @@ public class TestContainerSuite {
         }
 
         //If using remote docker then setup strategy
-        if (useRemoteDocker()) {
+        if (TestContainerHelper.useRemoteDocker()) {
             try {
                 ExternalTestService.getService("docker-engine", ExternalDockerClientFilter.instance());
             } catch (Exception e) {
@@ -265,7 +265,7 @@ public class TestContainerSuite {
 
         // Do not touch a users docker-java properties unless we intended to connect
         // to our own remote docker hosts.
-        if (!useRemoteDocker()) {
+        if (!TestContainerHelper.useRemoteDocker()) {
             Log.info(c, m, "Skipping Docker-java config updates when testing against a local docker host.");
             return;
         }
@@ -359,74 +359,5 @@ public class TestContainerSuite {
         }
 
         return true;
-    }
-
-    /**
-     * Determines if we are going to attempt to run against a remote
-     * docker host, or a local docker host.
-     *
-     * Priority:
-     * 1. System Property: fat.test.use.remote.docker
-     * 2. System Property: fat.test.docker.host -> REMOTE
-     * 3. System: GITHUB_ACTIONS -> LOCAL
-     * 4. System: WINDOWS -> REMOTE
-     * 5. System: ARM -> REMOTE
-     *
-     * default (!!! fat.test.localrun)
-     *
-     * @return true, we are running against a remote docker host, false otherwise.
-     */
-    private static boolean useRemoteDocker() {
-        boolean result;
-        String reason;
-
-        do {
-            //State 1: fat.test.use.remote.docker should always be honored first
-            if (System.getProperty("fat.test.use.remote.docker") != null) {
-                result = Boolean.getBoolean("fat.test.use.remote.docker");
-                reason = "fat.test.use.remote.docker set to " + result;
-                break;
-            }
-
-            //State 2: User provided a remote docker host, assume they want to use the remote host
-            if (ExternalDockerClientFilter.instance().isForced()) {
-                result = true;
-                reason = "fat.test.docker.host was configured";
-                break;
-            }
-
-            //State 3: Github actions build should always use local
-            if (Boolean.parseBoolean(System.getenv("GITHUB_ACTIONS"))) {
-                result = false;
-                reason = "GitHub Actions Build";
-                break;
-            }
-
-            //State 4: Earlier version of TestContainers didn't support docker for windows
-            // Assume a user on windows with no other preferences will want to use a remote host.
-            if (System.getProperty("os.name", "unknown").toLowerCase().contains("windows")) {
-                result = true;
-                reason = "Local operating system is Windows. Default container support not guaranteed.";
-                break;
-            }
-
-            //State 5: ARM architecture can cause performance/starting issues with x86 containers, so also assume remote as the default.
-            if (FATRunner.ARM_ARCHITECTURE) {
-                result = true;
-                reason = "CPU architecture is ARM. x86 container support and performance not guaranteed.";
-                break;
-            }
-
-            // Default, use local docker for local runs, and remote docker for remote (RTC) runs
-            result = !FATRunner.FAT_TEST_LOCALRUN;
-            reason = "fat.test.localrun set to " + FATRunner.FAT_TEST_LOCALRUN;
-        } while (false);
-
-        reason = result ? //
-                        "Remote docker host will be the highest priority. Reason: " + reason : //
-                        "Local docker host will be the highest priority. Reason: " + reason;
-
-        Log.info(c, "useRemoteDocker", reason);
-        return result;
     }
 }

--- a/dev/fattest.simplicity/src/componenttest/containers/substitution/LibertyImageNameSubstitutor.java
+++ b/dev/fattest.simplicity/src/componenttest/containers/substitution/LibertyImageNameSubstitutor.java
@@ -21,6 +21,7 @@ import com.ibm.websphere.simplicity.log.Log;
 
 import componenttest.containers.ImageHelper;
 import componenttest.containers.ImageVerifier;
+import componenttest.containers.TestContainerHelper;
 import componenttest.containers.registry.ArtifactoryRegistry;
 import componenttest.containers.registry.InternalRegistry;
 
@@ -61,8 +62,10 @@ public class LibertyImageNameSubstitutor extends ImageNameSubstitutor {
             // Priority 3: If a public registry was explicitly set on an image, do not substitute
             // This is now handled directly by the MIRROR substitutor
 
-            // Priority 4: Always use mirror registry if using remote docker host.
-            if (DockerClientFactory.instance().isUsing(EnvironmentAndSystemPropertyClientProviderStrategy.class)) {
+            // Priority 4: Always use mirror registry if using a non-native docker client strategy
+            // and we plan to connect to a remote docker host
+            if (DockerClientFactory.instance().isUsing(EnvironmentAndSystemPropertyClientProviderStrategy.class) &&
+                TestContainerHelper.useRemoteDocker()) {
                 ImageVerifier.collectImage(original);
                 result = REGISTRY.apply(MIRROR.apply(original));
                 reason = "Using a remote docker host, must use mirrored registry";

--- a/dev/fattest.simplicity/test/componenttest/containers/substitution/LibertyImageNameSubstitorTest.java
+++ b/dev/fattest.simplicity/test/componenttest/containers/substitution/LibertyImageNameSubstitorTest.java
@@ -59,6 +59,7 @@ public class LibertyImageNameSubstitorTest {
 
     @Test //Priority 4
     public void testRemoteDockerHost() {
+        System.setProperty("fat.test.use.remote.docker", "true");
         try (MockedStatic<DockerClientFactory> envProvider = MockedInstances.dockerClientFactory(EnvironmentAndSystemPropertyClientProviderStrategy.class)) {
             // No mirror available
             LibertyImageNameSubstitutor substitutor = new LibertyImageNameSubstitutor();
@@ -98,6 +99,8 @@ public class LibertyImageNameSubstitorTest {
                 assertEquals("Expected image to be substituted for an artifactory mirror image",
                              expected, actual);
             }
+        } finally {
+            System.clearProperty("fat.test.use.remote.docker");
         }
     }
 


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

External users that have configured testcontainers with podman will also use EnvironmentAndSystemPropertyClientProviderStrategy to connect to a local unix socket.
Therefore, do not force the use of Artifactory when we don't actually intend to connect to one of our remote docker hosts.