### PR TITLE
Simplify InjectionScopeData by replacing the use of Map.Entry with a Long

### DIFF
--- a/dev/com.ibm.ws.injection/src/com/ibm/ws/injectionengine/osgi/internal/OSGiInjectionScopeData.java
+++ b/dev/com.ibm.ws.injection/src/com/ibm/ws/injectionengine/osgi/internal/OSGiInjectionScopeData.java
@@ -14,7 +14,6 @@ package com.ibm.ws.injectionengine.osgi.internal;
 
 import java.io.PrintWriter;
 import java.lang.annotation.Annotation;
-import java.util.AbstractMap.SimpleEntry;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -136,11 +135,11 @@ public class OSGiInjectionScopeData extends InjectionScopeData implements Deferr
     /**
      * The result of {@link #processDeferredReferenceData} for the list of reference contexts
      * that were registered for deferred processing if a non-java:comp request is made. The
-     * result includes a boolean indicating whether or not deferred reference data was processed
-     * and an expiration for the result (1 minute after completion; nanoseconds).
+     * result is an expiration (30 seconds after completion; nanoseconds) or Long.MIN_VALUE
+     * if there was no deferred metadata processed.
      *
      * This field is initialized lazily and cleared if no reference data was processed or
-     * 1 minute after reference data was processed.
+     * 30 seconds after reference data was processed.
      *
      * JNDI lookups are attempted first without deferred reference data and retried if
      * deferred reference data is processed, so the result should be kept a reasonable
@@ -148,7 +147,7 @@ public class OSGiInjectionScopeData extends InjectionScopeData implements Deferr
      *
      * @see #deferredReferenceDatas
      */
-    private CompletableFuture<Map.Entry<Boolean, Long>> deferredReferenceDatasFuture;
+    private CompletableFuture<Long> deferredReferenceDatasFuture;
 
     public OSGiInjectionScopeData(J2EEName j2eeName, NamingConstants.JavaColonNamespace namespace, OSGiInjectionScopeData parent, ReentrantReadWriteLock nonCompEnvLock) {
         super(j2eeName);
@@ -540,7 +539,7 @@ public class OSGiInjectionScopeData extends InjectionScopeData implements Deferr
         deferredReferenceDatas = null;
 
         if (deferredReferenceDatasFuture != null) {
-            deferredReferenceDatasFuture.complete(new SimpleEntry<Boolean, Long>(false, 0L));
+            deferredReferenceDatasFuture.complete(Long.MIN_VALUE);
             deferredReferenceDatasFuture = null;
         }
     }
@@ -555,7 +554,7 @@ public class OSGiInjectionScopeData extends InjectionScopeData implements Deferr
 
         if (deferredReferenceDatas == null) {
             deferredReferenceDatas = new LinkedHashMap<DeferredReferenceData, Boolean>();
-            deferredReferenceDatasFuture = new CompletableFuture<Map.Entry<Boolean, Long>>();
+            deferredReferenceDatasFuture = new CompletableFuture<Long>();
             if (parent != null && deferredReferenceDataEnabled) {
                 parent.addDeferredReferenceData(this);
             }
@@ -577,6 +576,15 @@ public class OSGiInjectionScopeData extends InjectionScopeData implements Deferr
 
         if (deferredReferenceDatas != null) {
             deferredReferenceDatas.remove(refData);
+
+            if (deferredReferenceDatas.isEmpty()) {
+                deferredReferenceDatas = null;
+
+                if (deferredReferenceDatasFuture != null) {
+                    deferredReferenceDatasFuture.complete(Long.MIN_VALUE);
+                    deferredReferenceDatasFuture = null;
+                }
+            }
         }
 
         if (TraceComponent.isAnyTracingEnabled() && tc.isEntryEnabled()) {
@@ -597,7 +605,7 @@ public class OSGiInjectionScopeData extends InjectionScopeData implements Deferr
         }
 
         Map<DeferredReferenceData, Boolean> deferredReferenceDatas;
-        CompletableFuture<Map.Entry<Boolean, Long>> currentFuture;
+        CompletableFuture<Long> currentFuture;
         synchronized (this) {
             deferredReferenceDatas = this.deferredReferenceDatas;
             this.deferredReferenceDatas = null;
@@ -630,7 +638,7 @@ public class OSGiInjectionScopeData extends InjectionScopeData implements Deferr
 
                 // Unblock any concurrent access and clear the future if no longer required.
                 if (deferredReferenceDatasFuture != null) {
-                    deferredReferenceDatasFuture.complete(new SimpleEntry<Boolean, Long>(any, System.nanoTime() + TimeUnit.SECONDS.toNanos(60)));
+                    deferredReferenceDatasFuture.complete(any ? System.nanoTime() + TimeUnit.SECONDS.toNanos(30) : Long.MIN_VALUE);
 
                     // If there was no deferred reference data processed, no need to keep future.
                     if (!any) {
@@ -643,12 +651,12 @@ public class OSGiInjectionScopeData extends InjectionScopeData implements Deferr
                 // Wait a reasonable amount of time for deferred processing to complete
                 if (isTraceOn && tc.isDebugEnabled())
                     Tr.debug(tc, "waiting up to 60 seconds for completion of " + currentFuture);
-                Entry<Boolean, Long> result = currentFuture.get(60, TimeUnit.SECONDS);
+                Long result = currentFuture.get(60, TimeUnit.SECONDS);
 
                 // Return the result for a reasonable amount of time after processing has
-                // completed (60s); then just remove the future as it is no longer needed.
-                if (result.getValue() > System.nanoTime()) {
-                    any = result.getKey();
+                // completed (30s); then just remove the future as it is no longer needed.
+                if (result != Long.MIN_VALUE && result > System.nanoTime()) {
+                    any = true;
                 } else {
                     synchronized (this) {
                         deferredReferenceDatasFuture = null;

--- a/dev/com.ibm.ws.injection/src/com/ibm/ws/injectionengine/osgi/internal/OSGiInjectionScopeData.java
+++ b/dev/com.ibm.ws.injection/src/com/ibm/ws/injectionengine/osgi/internal/OSGiInjectionScopeData.java
@@ -58,6 +58,13 @@ public class OSGiInjectionScopeData extends InjectionScopeData implements Deferr
     private static final TraceComponent tc = Tr.register(OSGiInjectionScopeData.class);
 
     /**
+     * Deferred reference data processing results expiration interval in nanoseconds.
+     * Determines how long after deferred reference data processing completes that
+     * threads will attempt a second lookup of java:app and java:module scopes.
+     */
+    private static final long DEFERRED_RESULT_EXPIRATION = TimeUnit.SECONDS.toNanos(30);
+
+    /**
      * The "primary" namespace for this scope data, which corresponds to this
      * scope data's storage location:
      * <ul>
@@ -135,8 +142,8 @@ public class OSGiInjectionScopeData extends InjectionScopeData implements Deferr
     /**
      * The result of {@link #processDeferredReferenceData} for the list of reference contexts
      * that were registered for deferred processing if a non-java:comp request is made. The
-     * result is an expiration (30 seconds after completion; nanoseconds) or Long.MIN_VALUE
-     * if there was no deferred metadata processed.
+     * result is the nanoTime when deferred processing completed or Long.MIN_VALUE if there
+     * was no deferred metadata processed.
      *
      * This field is initialized lazily and cleared if no reference data was processed or
      * 30 seconds after reference data was processed.
@@ -638,7 +645,7 @@ public class OSGiInjectionScopeData extends InjectionScopeData implements Deferr
 
                 // Unblock any concurrent access and clear the future if no longer required.
                 if (deferredReferenceDatasFuture != null) {
-                    deferredReferenceDatasFuture.complete(any ? System.nanoTime() + TimeUnit.SECONDS.toNanos(30) : Long.MIN_VALUE);
+                    deferredReferenceDatasFuture.complete(any ? System.nanoTime() : Long.MIN_VALUE);
 
                     // If there was no deferred reference data processed, no need to keep future.
                     if (!any) {
@@ -655,7 +662,8 @@ public class OSGiInjectionScopeData extends InjectionScopeData implements Deferr
 
                 // Return the result for a reasonable amount of time after processing has
                 // completed (30s); then just remove the future as it is no longer needed.
-                if (result != Long.MIN_VALUE && result > System.nanoTime()) {
+                // Result is true if the future returned a nanoTime other than MIN_VALUE.
+                if (result != Long.MIN_VALUE && System.nanoTime() - result < DEFERRED_RESULT_EXPIRATION) {
                     any = true;
                 } else {
                     synchronized (this) {


### PR DESCRIPTION
This is a simplified implementation of PR #34131 from last week that fixes a Jakarta Data lookup problem with `java:module` for EJB modules. This latest PR does a few of things:
- Replaces the use of `Map.Entry<Boolean, Long>` with just `Long`. The prior PR saved a composite result with 1) `Boolean` to indicate whether deferred meta data was actually processed, and 2) `Long` - expiration time of the result (60s after completion). The new approach is to just store `Long`, which is either MIN_VALUE to indicate the old "false", or the completion nanoTime.  So a value that is NOT MIN_VALUE means true.
- Correctly handles nanoTime rollover.  The old code pre-added 60 seconds to the "start" time.  The proper way to handle rollover is to just take current nanoTime - start nanoTime and then compare it to the desired difference (lowered to 30s)... so the new code uses this approach.
- Clears the reference data and reference data future variables if all reference data are removed (empty list).

These changes should
- reduce the number and complexity of objects created
- eliminate the calls to System.nanoTime() for some scenarios
- properly handles nanoTime rollowver

If System.nanoTime() were to return exactly MIN_VALUE (seems extremely unlikely), then the original timing window would be exposed again.  But even then, it would be no worse and still very hard to hit. Additional checking could be performed to account for this, but I think the probability of MIN_VALUE being returned is so unlikely it is not worth the effort.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".