### PR TITLE
throw IllegalStateException when trying to set RecordRoute on a started proxy branch

### DIFF
--- a/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/container/proxy/ProxyBranchImpl.java
+++ b/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/container/proxy/ProxyBranchImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2003, 2024 IBM Corporation and others.
+ * Copyright (c) 2003, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -1773,9 +1773,14 @@ public class ProxyBranchImpl extends BranchManager
 	}
 
 	/**
-	 * @see javax.servlet.sip.ProxyBranch#setRecordRoute(boolean) 
-	 */	
+	 * @see javax.servlet.sip.ProxyBranch#setRecordRoute(boolean)
+	 */
 	public void setRecordRoute(boolean includeRecordRoute) {
+		//throw IllegalStateException if proxy branch has been already started
+		if (isStarted()) {
+			throw new IllegalStateException(
+				"Cannot set record-route: proxy branch has already been started");
+		}
 		_isRecordRoute = includeRecordRoute;
 	}
 


### PR DESCRIPTION
- [x ] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

################################################################################################
The JSR289 API javadoc specifies that calling setRecordRoute on a proxy branch that was already started should generate an IllegaStateException 


Fixes #34280