### PR TITLE
Ignore initial quiesce warning in EJB FAT

### DIFF
--- a/dev/com.ibm.ws.ejbcontainer.async_fat/fat/src/com/ibm/ws/ejbcontainer/async/fat/tests/AsyncSecureTests.java
+++ b/dev/com.ibm.ws.ejbcontainer.async_fat/fat/src/com/ibm/ws/ejbcontainer/async/fat/tests/AsyncSecureTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2025 IBM Corporation and others.
+ * Copyright (c) 2019, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -110,6 +110,7 @@ public class AsyncSecureTests extends AbstractTest {
 
     @AfterClass
     public static void afterClass() throws Exception {
-        server.stopServer();
+        // CWWKE1102W - ignore the initial quiesce timeout warning
+        server.stopServer("CWWKE1102W");
     }
 }

--- a/dev/com.ibm.ws.ejbcontainer.async_fat/publish/servers/com.ibm.ws.ejbcontainer.async.fat.AsyncSecureServer/server.xml
+++ b/dev/com.ibm.ws.ejbcontainer.async_fat/publish/servers/com.ibm.ws.ejbcontainer.async.fat.AsyncSecureServer/server.xml
@@ -1,4 +1,4 @@
-<server>
+<server quiesceTimeout="90s">
     <featureManager>
         <feature>servlet-3.1</feature>
         <feature>ejbLite-3.2</feature>

--- a/dev/com.ibm.ws.ejbcontainer.timer.calendar_fat/fat/src/com/ibm/ws/ejbcontainer/timer/calendar/fat/tests/NextTimeoutNonPersistentTest.java
+++ b/dev/com.ibm.ws.ejbcontainer.timer.calendar_fat/fat/src/com/ibm/ws/ejbcontainer/timer/calendar/fat/tests/NextTimeoutNonPersistentTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2023 IBM Corporation and others.
+ * Copyright (c) 2021, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -70,7 +70,8 @@ public class NextTimeoutNonPersistentTest extends FATServletClient {
             FATServletClient.runTest(server, EARLY_TIMEOUT_SERVLET, "cleanup");
         } finally {
             if (server != null && server.isStarted()) {
-                server.stopServer();
+                // CWWKE1102W - ignore the initial quiesce timeout warning
+                server.stopServer("CWWKE1102W");
             }
         }
     }

--- a/dev/com.ibm.ws.ejbcontainer.timer.calendar_fat/fat/src/com/ibm/ws/ejbcontainer/timer/calendar/fat/tests/NextTimeoutPersistentTest.java
+++ b/dev/com.ibm.ws.ejbcontainer.timer.calendar_fat/fat/src/com/ibm/ws/ejbcontainer/timer/calendar/fat/tests/NextTimeoutPersistentTest.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2021, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -113,6 +113,11 @@ public class NextTimeoutPersistentTest extends FATServletClient {
             // persistent.internal.InvokerTask run starts for a persistent timer during server shutdown,
             // but EJB timer service throws exception due to server stopping.
 
+            // CWWKE1102W: The quiesce operation did not complete.
+            //
+            // ignore this warning as it is often due to limited resource; if there is really a
+            // problem with server quiesce then a subsequent more meaningful warning will be logged
+
             if (server != null && server.isStarted()) {
                 server.stopServer("CNTR0092W",
                                   "DSRA0304E",
@@ -120,7 +125,8 @@ public class NextTimeoutPersistentTest extends FATServletClient {
                                   "DSRA0230E.*TRANSACTION_FAIL",
                                   "J2CA0027E",
                                   "CWWKC1501W.*server is stopping",
-                                  "CWWKC1503W.*server is stopping");
+                                  "CWWKC1503W.*server is stopping",
+                                  "CWWKE1102W");
             }
         }
     }

--- a/dev/com.ibm.ws.ejbcontainer.timer.calendar_fat/fat/src/com/ibm/ws/ejbcontainer/timer/calendar/fat/tests/ScheduleExpressionTest.java
+++ b/dev/com.ibm.ws.ejbcontainer.timer.calendar_fat/fat/src/com/ibm/ws/ejbcontainer/timer/calendar/fat/tests/ScheduleExpressionTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2023 IBM Corporation and others.
+ * Copyright (c) 2021, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -66,7 +66,8 @@ public class ScheduleExpressionTest extends FATServletClient {
             FATServletClient.runTest(server, SERVLET, "cleanup");
         } finally {
             if (server != null && server.isStarted()) {
-                server.stopServer();
+                // CWWKE1102W - ignore the initial quiesce timeout warning
+                server.stopServer("CWWKE1102W");
             }
         }
     }

--- a/dev/com.ibm.ws.ejbcontainer.timer.calendar_fat/publish/servers/com.ibm.ws.ejbcontainer.timer.cal.fat.NpTimerServer/server.xml
+++ b/dev/com.ibm.ws.ejbcontainer.timer.calendar_fat/publish/servers/com.ibm.ws.ejbcontainer.timer.cal.fat.NpTimerServer/server.xml
@@ -1,4 +1,4 @@
-<server>
+<server quiesceTimeout="90s">
     <include location="../fatTestPorts.xml"/>
 
     <featureManager>

--- a/dev/com.ibm.ws.ejbcontainer.timer.calendar_fat/publish/servers/com.ibm.ws.ejbcontainer.timer.cal.fat.PersistentTimerServer/server.xml
+++ b/dev/com.ibm.ws.ejbcontainer.timer.calendar_fat/publish/servers/com.ibm.ws.ejbcontainer.timer.cal.fat.PersistentTimerServer/server.xml
@@ -1,4 +1,4 @@
-<server>
+<server quiesceTimeout="90s">
     <include location="../fatTestPorts.xml"/>
 
     <featureManager>

--- a/dev/com.ibm.ws.ejbcontainer.timer.np.config_fat/fat/src/com/ibm/ws/ejbcontainer/timer/np/config/fat/tests/NpTimerConfigRetryTest.java
+++ b/dev/com.ibm.ws.ejbcontainer.timer.np.config_fat/fat/src/com/ibm/ws/ejbcontainer/timer/np/config/fat/tests/NpTimerConfigRetryTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2023 IBM Corporation and others.
+ * Copyright (c) 2014, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -81,8 +81,9 @@ public class NpTimerConfigRetryTest extends FATServletClient {
         // CNTR0020E: EJB threw an unexpected (non-declared) exception
         // CNTR0179W: Non-persistent timer maximum number of retries x was reached.
         // CNTR0333W: EJB timer ... started later than expected.
+        // CWWKE1102W: ignore the initial quiesce timeout warning
         if (server != null && server.isStarted()) {
-            server.stopServer("CNTR0020E", "CNTR0179W", "CNTR0333W");
+            server.stopServer("CNTR0020E", "CNTR0179W", "CNTR0333W", "CWWKE1102W");
         }
     }
 

--- a/dev/com.ibm.ws.ejbcontainer.timer.np.config_fat/publish/servers/com.ibm.ws.ejbcontainer.timer.np.config.NpTimerConfigServer/server.xml
+++ b/dev/com.ibm.ws.ejbcontainer.timer.np.config_fat/publish/servers/com.ibm.ws.ejbcontainer.timer.np.config.NpTimerConfigServer/server.xml
@@ -1,4 +1,4 @@
-<server>
+<server quiesceTimeout="90s">
     <include location="../fatTestPorts.xml"/>
     
     <featureManager>

--- a/dev/com.ibm.ws.ejbcontainer.timer.np_fat/fat/src/com/ibm/ws/ejbcontainer/timer/np/fat/tests/NpTimerLifecycleTest.java
+++ b/dev/com.ibm.ws.ejbcontainer.timer.np_fat/fat/src/com/ibm/ws/ejbcontainer/timer/np/fat/tests/NpTimerLifecycleTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2023 IBM Corporation and others.
+ * Copyright (c) 2021, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -80,7 +80,8 @@ public class NpTimerLifecycleTest extends FATServletClient {
     @AfterClass
     public static void afterClass() throws Exception {
         if (server != null && server.isStarted()) {
-            server.stopServer();
+            // CWWKE1102W - ignore the initial quiesce timeout warning
+            server.stopServer("CWWKE1102W");
         }
     }
 

--- a/dev/com.ibm.ws.ejbcontainer.timer.np_fat/fat/src/com/ibm/ws/ejbcontainer/timer/np/fat/tests/NpTimerOperationsTest.java
+++ b/dev/com.ibm.ws.ejbcontainer.timer.np_fat/fat/src/com/ibm/ws/ejbcontainer/timer/np/fat/tests/NpTimerOperationsTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2023 IBM Corporation and others.
+ * Copyright (c) 2021, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -124,8 +124,9 @@ public class NpTimerOperationsTest extends FATServletClient {
     @AfterClass
     public static void afterClass() throws Exception {
         // CNTR0020E: EJB threw an unexpected (non-declared) exception
+        // CWWKE1102W: ignore the initial quiesce timeout warning
         if (server != null && server.isStarted()) {
-            server.stopServer("CNTR0020E");
+            server.stopServer("CNTR0020E", "CWWKE1102W");
         }
     }
 

--- a/dev/com.ibm.ws.ejbcontainer.timer.np_fat/publish/servers/com.ibm.ws.ejbcontainer.timer.np.fat.TimerLifecycleServer/server.xml
+++ b/dev/com.ibm.ws.ejbcontainer.timer.np_fat/publish/servers/com.ibm.ws.ejbcontainer.timer.np.fat.TimerLifecycleServer/server.xml
@@ -1,4 +1,4 @@
-<server>
+<server quiesceTimeout="90s">
     <include location="../fatTestPorts.xml"/>
 
     <featureManager>

--- a/dev/com.ibm.ws.ejbcontainer.timer.np_fat/publish/servers/com.ibm.ws.ejbcontainer.timer.np.fat.TimerServer/server.xml
+++ b/dev/com.ibm.ws.ejbcontainer.timer.np_fat/publish/servers/com.ibm.ws.ejbcontainer.timer.np.fat.TimerServer/server.xml
@@ -1,4 +1,4 @@
-<server>
+<server quiesceTimeout="90s">
     <include location="../fatTestPorts.xml"/>
 
     <featureManager>

--- a/dev/com.ibm.ws.ejbcontainer.timer.v32_fat/fat/src/com/ibm/ws/ejbcontainer/timer/v32/fat/tests/NpTimerV32ApiTest.java
+++ b/dev/com.ibm.ws.ejbcontainer.timer.v32_fat/fat/src/com/ibm/ws/ejbcontainer/timer/v32/fat/tests/NpTimerV32ApiTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2023 IBM Corporation and others.
+ * Copyright (c) 2021, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -81,7 +81,8 @@ public class NpTimerV32ApiTest extends FATServletClient {
     @AfterClass
     public static void afterClass() throws Exception {
         if (server != null && server.isStarted()) {
-            server.stopServer();
+            // CWWKE1102W - ignore the initial quiesce timeout warning
+            server.stopServer("CWWKE1102W");
         }
     }
 

--- a/dev/com.ibm.ws.ejbcontainer.timer.v32_fat/publish/servers/com.ibm.ws.ejbcontainer.timer.v32.fat.NpTimerServer/server.xml
+++ b/dev/com.ibm.ws.ejbcontainer.timer.v32_fat/publish/servers/com.ibm.ws.ejbcontainer.timer.v32.fat.NpTimerServer/server.xml
@@ -1,4 +1,4 @@
-<server>
+<server quiesceTimeout="90s">
     <include location="../fatTestPorts.xml"/>
     
     <featureManager>


### PR DESCRIPTION
- Ignore CWWKE1102W; more specific warning will occur later if a real problem
- Update quiesceTimeout to 90s for slow systems

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".