### PR TITLE
Add restoreServer() to tests where the default server is stopped in ConsoleFormatTest FAT

### DIFF
--- a/dev/com.ibm.ws.logging_fat/fat/src/com/ibm/ws/logging/fat/ConsoleFormatTest.java
+++ b/dev/com.ibm.ws.logging_fat/fat/src/com/ibm/ws/logging/fat/ConsoleFormatTest.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -28,9 +28,7 @@ import java.util.List;
 import java.util.Properties;
 import java.util.regex.Pattern;
 
-import org.junit.After;
 import org.junit.AfterClass;
-import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -466,11 +464,14 @@ public class ConsoleFormatTest {
             // Restore the initial contents of bootstrap.properties
             FileOutputStream out = getFileOutputStreamForRemoteFile(bootstrapFile, false);
             writeProperties(initialBootstrapProps, out);
-        }
 
-        // Stop the serverEnv
-        if (serverEnv != null && serverEnv.isStarted()) {
-            serverEnv.stopServer(EXPECTED_FAILURES);
+            // Stop the serverEnv here, to ensure proper clean up when failures occur.
+            if (serverEnv != null && serverEnv.isStarted()) {
+                serverEnv.stopServer(EXPECTED_FAILURES);
+            }
+
+            // Start the default server, to ensure other tests are run correctly.
+            restoreServer();
         }
     }
 

--- a/dev/com.ibm.ws.logging_fat/fat/src/com/ibm/ws/logging/fat/ConsoleFormatTest.java
+++ b/dev/com.ibm.ws.logging_fat/fat/src/com/ibm/ws/logging/fat/ConsoleFormatTest.java
@@ -404,16 +404,22 @@ public class ConsoleFormatTest {
         // Start the server with the server.env file configured with the consoleFormat=simple
         serverEnv.startServer();
 
-        // Retrieve the consoleLogFile RemoteFile
-        RemoteFile consoleLogFile = serverEnv.getConsoleLogFile();
+        try {
+            // Retrieve the consoleLogFile RemoteFile
+            RemoteFile consoleLogFile = serverEnv.getConsoleLogFile();
 
-        // Verify if the console logging format is not in the default dev format, and is in the simple format
-        List<String> lines = serverEnv.findStringsInLogs(SIMPLE_FORMAT_REGEX_PATTERN, consoleLogFile);
-        assertTrue("The console log is not in simple format.", lines.size() > 0);
+            // Verify if the console logging format is not in the default dev format, and is in the simple format
+            List<String> lines = serverEnv.findStringsInLogs(SIMPLE_FORMAT_REGEX_PATTERN, consoleLogFile);
+            assertTrue("The console log is not in simple format.", lines.size() > 0);
 
-        // Stop the serverEnv
-        if (serverEnv != null && serverEnv.isStarted()) {
-            serverEnv.stopServer(EXPECTED_FAILURES);
+        } finally {
+            // Stop the serverEnv here, to ensure proper clean up when failures occur.
+            if (serverEnv != null && serverEnv.isStarted()) {
+                serverEnv.stopServer(EXPECTED_FAILURES);
+            }
+
+            // Start the default server, to ensure other tests are run correctly.
+            restoreServer();
         }
     }
 


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

fixes #34210
- Test run order is not guaranteed, ensured that the default server used in the FAT is restored properly, whenever specific tests that use multiple servers stop the default one.