### PR TITLE
Fix SSL keystore path resolution issue

### DIFF
--- a/dev/com.ibm.ws.ssl/src/com/ibm/ws/ssl/config/WSKeyStore.java
+++ b/dev/com.ibm.ws.ssl/src/com/ibm/ws/ssl/config/WSKeyStore.java
@@ -520,7 +520,7 @@ public class WSKeyStore extends Properties {
                 }
             }
             this.location = res;
-            if (res != null && resFile.isFile()) {
+            if (resFile != null && resFile.isFile()) {
                 if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
                     Tr.debug(tc, "Found store under [" + location + "]");
                 }

--- a/dev/com.ibm.ws.ssl/src/com/ibm/ws/ssl/config/WSKeyStore.java
+++ b/dev/com.ibm.ws.ssl/src/com/ibm/ws/ssl/config/WSKeyStore.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2005, 2025 IBM Corporation and others.
+ * Copyright (c) 2005, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -506,12 +506,30 @@ public class WSKeyStore extends Properties {
 
         // reset location w/ resolved value
         // isDefault tested because the default path's file may not exists (and that's OK)
-        if ((res != null && resFile.isFile()) || isDefault) {
-            this.location = res;
-            if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-                Tr.debug(tc, "Found store under [" + location + "]");
+        if(res !=null) {
+            try{
+                // We want to ensure consistent path handling across all the platforms
+                // since it may be assumed that this is an absolute path. 
+                if(resFile != null && !resFile.isAbsolute()){
+                    res = resFile.getAbsolutePath();
+                    resFile = new File(res);
+                }
+            }catch (Exception e){
+                if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()){
+                    Tr.debug(tc, "Unable to convert path to absolute path");
+                }
             }
-        } else {
+            this.location = res;
+            if (res != null && resFile.isFile()) {
+                if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                    Tr.debug(tc, "Found store under [" + location + "]");
+                }
+            }else{
+                if(TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()){
+                    Tr.debug(tc, "The KeyStore was not found during the path resolution: " + res);
+                }
+            }
+        } else if (!isDefault) {
             // If it wasn't found then it's likely going to trigger
             // the load.error later. Issue a warning to explain the file
             // could not be found.

--- a/dev/com.ibm.ws.ssl/test/com/ibm/ws/ssl/config/WSKeyStoreTest.java
+++ b/dev/com.ibm.ws.ssl/test/com/ibm/ws/ssl/config/WSKeyStoreTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2020 IBM Corporation and others.
+ * Copyright (c) 2012, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -529,4 +529,109 @@ public class WSKeyStoreTest {
         }
     }
 
+    /**
+     * This test verifies scenarios where the path resolution returns
+     * a relative path initially, but subsequent resolution attempts 
+     * succeed in converting it to an absolute path. 
+     */
+    @Test
+    public void fileCheckFailsButResolutionIsSuccessful() throws Exception {
+        final String relativePath = "nonExistentKeyStoreTest.jks";
+        final String resolvedPath = new File("build/tmp", relativePath).getAbsolutePath();
+        final String keyStore = LibertyConstants.DEFAULT_OUTPUT_LOCATION + LibertyConstants.DEFAULT_FALLBACK_KEY_STORE_FILE;
+        final File keyStoreJKS = new File(keyStore);
+        final String keyStoreName = LibertyConstants.DEFAULT_OUTPUT_LOCATION + LibertyConstants.DEFAULT_KEY_STORE_FILE;
+        final File keyStorePKCS12 = new File(keyStoreName);
+
+        mock.checking(new Expectations()
+        {
+            {
+                one(locMgr).resolveString(keyStore);
+                will(returnValue(keyStoreJKS.getAbsolutePath()));
+                one(locMgr).resolveString(keyStoreName);
+                will(returnValue(keyStorePKCS12.getAbsolutePath()));
+                one(locMgr).resolveString(relativePath);
+                will(returnValue(relativePath));
+                allowing(locMgr).resolveString(with(any(String.class)));
+                will(returnValue(resolvedPath));
+            }
+        });
+
+        Hashtable<String, Object> props = new Hashtable<String, Object>();
+        props.put("location", relativePath);
+        props.put("type", "JKS");
+        props.put("password", "mypassword");
+        props.put("id", "keyStoreTest");
+
+        WSKeyStore keyStoreTest = new WSKeyStoreTestDoubleReturn("keyStoreTest", props, testConfigService);
+        String keyStoreTestLocation = keyStoreTest.getLocation();
+        assertEquals("Location should be resolved to absolute path", resolvedPath, keyStoreTestLocation);
+    }
+
+    /**
+     * This test verifies successful handle of the file system 
+     * caching when files are temporarily created and deleted. 
+     */
+    @Test
+    public void fileSystemCaching() throws Exception {
+        File tempKeyStore = new File("../com.ibm.ws.ssl/build/tmp/temp.jks");
+        tempKeyStore.createNewFile();
+        tempKeyStore.delete();
+
+        final String keyStore = LibertyConstants.DEFAULT_OUTPUT_LOCATION + LibertyConstants.DEFAULT_FALLBACK_KEY_STORE_FILE;
+        final File keyStoreJKS = new File(keyStore);
+        final String keyStoreName = LibertyConstants.DEFAULT_OUTPUT_LOCATION + LibertyConstants.DEFAULT_KEY_STORE_FILE;
+        final File keyStorePKCS12 = new File(keyStoreName);
+
+        mock.checking(new Expectations()
+        {
+            {
+                one(locMgr).resolveString(keyStore);
+                will(returnValue(keyStoreJKS.getAbsolutePath()));
+                one(locMgr).resolveString(keyStoreName);
+                will(returnValue(keyStorePKCS12.getAbsolutePath()));
+                allowing(locMgr).resolveString(with(any(String.class)));
+                will(returnValue(tempKeyStore.getAbsolutePath()));
+            }
+        });
+
+        Hashtable<String, Object> props = new Hashtable<String, Object>();
+        props.put("location", "temp.jks");
+        props.put("type", "JKS");
+        props.put("password", "mypassword");
+        props.put("id", "keyStoreTest");
+
+        WSKeyStore keyStoreTest = new WSKeyStoreTestDoubleReturn("testKeyStore", props, testConfigService);
+
+        String keyStoreTestLocation = keyStoreTest.getLocation();
+        assertTrue("Location should be absolute path", new File(keyStoreTestLocation).isAbsolute());
+    }
+    /**
+     * This test verifies that absolute path conversion is enforced 
+     * even when the location resolution service returns a relative
+     * path.
+     */
+    @Test
+    public void pathResolutionWithRelativePathConversion() throws Exception{
+        final String relativePath = "nonExistentKeyStoreTest.jks";
+        final String resolvedRelativePath = "nonExistentKeyStoreTest.jks";
+
+        mock.checking(new Expectations() {
+            {
+                allowing(locMgr).resolveString(with(any(String.class)));
+                will(returnValue(resolvedRelativePath));
+            }
+        });
+        Hashtable<String, Object> props = new Hashtable<String, Object>();
+        props.put("location", "temp.jks");
+        props.put("type", "JKS");
+        props.put("password", "mypassword");
+        props.put("id", "keyStoreTest");
+
+        WSKeyStore keyStoreTest = new WSKeyStoreTestDoubleReturn("testKeyStore", props, testConfigService);
+
+        String location = keyStoreTest.getLocation();
+        assertTrue("Location should be converted to absolute path", new File(location).isAbsolute());
+
+    }
 }


### PR DESCRIPTION
Addresses an issue that occurs when the WSKeyStore fails to update the keystore location to its resolved absolute path. This causes subsequent keystore loading operations to use incorrect file data, which can lead to SSL communication errors.


- [X] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [X] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [X] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
