### PR TITLE
Revert "Fix async callback thread context propagation for ManagedExecutorService"

### DIFF
--- a/dev/com.ibm.ws.jaxrs.2.0.common/src/org/apache/cxf/transport/http/HTTPConduit.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.common/src/org/apache/cxf/transport/http/HTTPConduit.java
@@ -92,7 +92,6 @@ import org.apache.cxf.ws.addressing.EndpointReferenceType;
 
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
-import com.ibm.ws.cxf.jaxrs20.client.component.AsyncClientRunnableWrapperManager;
 import com.ibm.ws.ffdc.annotation.FFDCIgnore;
 
 /*
@@ -1226,11 +1225,7 @@ public abstract class HTTPConduit
 
         @FFDCIgnore(RejectedExecutionException.class)
         protected void handleResponseOnWorkqueue(boolean allowCurrentThread, boolean forceWQ) throws IOException {
-            // Liberty change Begin
-            // Capture thread context before creating the runnable
-            AsyncClientRunnableWrapperManager.prepare(outMessage);
-             // Liberty Change End
-            Runnable runnable = AsyncClientRunnableWrapperManager.wrap(outMessage, new Runnable() {
+            Runnable runnable = new Runnable() {
                 @Override
                 @FFDCIgnore(Throwable.class)
                 public void run() {
@@ -1247,7 +1242,7 @@ public abstract class HTTPConduit
                         mo.onMessage(outMessage);
                     }
                 }
-            });
+            };
             HTTPClientPolicy policy = getClient(outMessage);
             boolean exceptionSet = outMessage.getContent(Exception.class) != null;
             if (!exceptionSet) {

--- a/dev/com.ibm.ws.org.apache.cxf.cxf.rt.transports.http.3.2/src/org/apache/cxf/transport/http/HTTPConduit.java
+++ b/dev/com.ibm.ws.org.apache.cxf.cxf.rt.transports.http.3.2/src/org/apache/cxf/transport/http/HTTPConduit.java
@@ -1308,10 +1308,6 @@ public abstract class HTTPConduit
 
         @FFDCIgnore(RejectedExecutionException.class) // Liberty Change Start
         protected void handleResponseOnWorkqueue(boolean allowCurrentThread, boolean forceWQ) throws IOException {
-            // Liberty change Begin 
-            // Capture thread context before creating the runnable
-            AsyncClientRunnableWrapperManager.prepare(outMessage);
-            // Liberty Change End
             Runnable runnable = AsyncClientRunnableWrapperManager.wrap(outMessage, new Runnable() {
                 @Override
                 @FFDCIgnore(Throwable.class)


### PR DESCRIPTION
Reverts OpenLiberty/open-liberty#33999

This fix is causing issues in _com.ibm.ws.jaxrs.2.1_fat_executor,_ and it appears to be related to test_bug.