### PR TITLE
Avoid main path code being cluttered up by exception handling

### DIFF
--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/Fail.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/Fail.java
@@ -9,9 +9,14 @@
  *******************************************************************************/
 package io.openliberty.data.internal.persistence;
 
+import static io.openliberty.data.internal.QueryType.FIND;
+import static io.openliberty.data.internal.QueryType.FIND_AND_DELETE;
 import static io.openliberty.data.internal.persistence.cdi.DataExtension.exc;
 
+import java.lang.annotation.Annotation;
 import java.lang.reflect.Parameter;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -22,10 +27,10 @@ import com.ibm.websphere.ras.annotation.Sensitive;
 import io.openliberty.data.internal.QueryType;
 import io.openliberty.data.internal.version.DataVersionCompatibility;
 import jakarta.data.Limit;
-import jakarta.data.exceptions.DataException;
 import jakarta.data.exceptions.EmptyResultException;
 import jakarta.data.exceptions.MappingException;
 import jakarta.data.exceptions.NonUniqueResultException;
+import jakarta.data.exceptions.OptimisticLockingFailureException;
 import jakarta.data.page.CursoredPage;
 import jakarta.data.page.Page;
 import jakarta.data.page.PageRequest;
@@ -37,6 +42,53 @@ import jakarta.data.repository.Query;
  * This class consists of methods that raise exceptions.
  */
 public class Fail {
+
+    /**
+     * Raises MappingException for a result that cannot be converted to the
+     * return type of the repository count method.
+     *
+     * @param info  query information for the repository method.
+     * @param count the count of matching items obtained by the query.
+     * @throws the MappingException.
+     */
+    static MappingException countConversion(QueryInfo info, Long count) {
+        throw exc(MappingException.class,
+                  "CWWKD1049.count.convert.err",
+                  count,
+                  info.method.getName(),
+                  info.repositoryInterface.getName(),
+                  info.method.getGenericReturnType().getTypeName());
+    }
+
+    /**
+     * Raises a new MappingException when the total count of results exceeds
+     * a maximum threshold.
+     *
+     * @param info  query information for the repository method.
+     * @param count long count.
+     * @param type  Integer.class, Short.class, or Byte.class.
+     * @throws MappingException
+     */
+    static MappingException countExceedsMax(QueryInfo info,
+                                            long count,
+                                            Class<? extends Number> type) {
+        String max = type.getSimpleName() + ".MAX_VALUE (";
+        if (Integer.class.equals(type))
+            max += Integer.MAX_VALUE;
+        else if (Short.class.equals(type))
+            max += Short.MAX_VALUE;
+        else if (Byte.class.equals(type))
+            max += Byte.MAX_VALUE;
+        max += ')';
+
+        throw exc(MappingException.class,
+                  "CWWKD1048.result.exceeds.max",
+                  count,
+                  info.method.getName(),
+                  info.repositoryInterface.getName(),
+                  info.method.getGenericReturnType().getTypeName(),
+                  max);
+    }
 
     /**
      * Raises a new UnsupportedOperationException for a JPQL query that is
@@ -74,6 +126,38 @@ public class Fail {
     }
 
     /**
+     * Raises a new UnsupportedOperationException for a repository method that
+     * has two or more of the same special parameter type.
+     *
+     * @param info           query information for the repository method.
+     * @param paramClassName simple class name of the duplicate parameter.
+     * @throws UnsupportedOperationException
+     */
+    static UnsupportedOperationException duplicateSpecialParam(QueryInfo info,
+                                                               String paramClassName) {
+        throw exc(UnsupportedOperationException.class,
+                  "CWWKD1017.dup.special.param",
+                  info.method.getName(),
+                  info.repositoryInterface.getName(),
+                  paramClassName);
+    }
+
+    /**
+     * Raise IllegalArgumentException because the application supplied an empty
+     * value as the life cycle method parameter.
+     *
+     * @param info query information for the repository method.
+     * @throws the IllegalArgumentException.
+     */
+    static IllegalArgumentException emptyLifeCycleParam(QueryInfo info) {
+        throw exc(IllegalArgumentException.class,
+                  "CWWKD1092.lifecycle.arg.empty",
+                  info.method.getName(),
+                  info.repositoryInterface.getName(),
+                  info.method.getGenericParameterTypes()[0].getTypeName());
+    }
+
+    /**
      * Raise a new EmptyResultException.
      *
      * @param info query information for the repository method.
@@ -93,24 +177,182 @@ public class Fail {
     }
 
     /**
-     * Raise a new DataException for the error where the repository method has an
+     * Raises a new MappingException when an entity attribute name is not indicated
+     * for a constraint, sort, or other place in the Jakarta Data API that requires
+     * an entity attribute name.
+     *
+     * @param info  query information for the repository method.
+     * @param count long count.
+     * @param type  Integer.class, Short.class, or Byte.class.
+     * @throws MappingException
+     */
+    static MappingException entityAttributeNameMissing(QueryInfo info) {
+        throw exc(MappingException.class,
+                  "CWWKD1024.missing.entity.attr",
+                  info.method.getName(),
+                  info.repositoryInterface.getName(),
+                  info.entityInfo.getType().getName(),
+                  info.entityInfo.attributeTypes.keySet());
+    }
+
+    /**
+     * Raise IllegalArgumentException because the supplied entity does not
+     * match the expected type, or NullPointerException if the supplied entity
+     * is null.
+     *
+     * @param info   query information for the repository method.
+     * @param entity the supplied entity.
+     * @throws IllegalArgumentException.
+     * @throws NullPointerException.
+     */
+    static EmptyResultException entityMismatch(QueryInfo info,
+                                               @Sensitive Object entity) {
+        if (entity == null)
+            throw Fail.entityNull(info);
+
+        Class<?> expectedEntityClass = info.entityInfo.getType();
+
+        throw exc(IllegalArgumentException.class,
+                  "CWWKD1016.incompat.entity.param",
+                  info.method.getName(),
+                  info.repositoryInterface.getName(),
+                  expectedEntityClass.getName(),
+                  entity.getClass().getName());
+    }
+
+    /**
+     * Raises OptimisticLockingFailureException because no matching entity
+     * was found.
+     *
+     * @param info            query information for the repository method.
+     * @param entity          the entity.
+     * @param idAttributeName name of the entity's id attribute.
+     * @param id              value of the entity's id attribute.
+     * @param version         value of the entity's version attribute. Null if none.
+     * @throws the OptimisticLockingFailureException.
+     */
+    static OptimisticLockingFailureException entityNotFound(QueryInfo info,
+                                                            @Sensitive Object entity,
+                                                            String idAttributeName,
+                                                            Object id,
+                                                            Object version) {
+        List<String> entityProps = new ArrayList<>(2);
+
+        if (id != null)
+            entityProps.add(info.loggableAppend(idAttributeName,
+                                                "=",
+                                                id));
+
+        if (info.entityInfo.versionAttributeName != null && version != null)
+            entityProps.add(info.loggableAppend(info.entityInfo.versionAttributeName,
+                                                "=",
+                                                version));
+
+        throw exc(OptimisticLockingFailureException.class,
+                  "CWWKD1050.opt.lock.exc",
+                  info.method.getName(),
+                  info.repositoryInterface.getName(),
+                  entity.getClass().getName(),
+                  entityProps,
+                  Util.LIFE_CYCLE_METHODS_THAT_RETURN_ENTITIES_STATELESS);
+    }
+
+    /**
+     * Raise a NullPointerException because the supplied entity is null.
+     *
+     * @param info query information for the repository method.
+     * @throws the NullPointerException.
+     */
+    static NullPointerException entityNull(QueryInfo info) {
+        throw exc(NullPointerException.class,
+                  "CWWKD1015.null.entity.param",
+                  info.method.getName(),
+                  info.repositoryInterface.getName());
+    }
+
+    /**
+     * Raises a new MappingException when a function that is supplied to a
+     * repository method does not apply to the respective entity because it
+     * lacks an entity attribute of the required type.
+     *
+     * @param info           query information for the repository method.
+     * @param functionName   name of the function being attempted.
+     * @param entityAnnoName name of an entity annotation, such as @Id or @Version.
+     * @throws MappingException
+     */
+    static MappingException functionNotApplicable(QueryInfo info,
+                                                  String functionName,
+                                                  String entityAnnoName) {
+        throw exc(MappingException.class,
+                  "CWWKD1093.fn.not.applicable",
+                  functionName,
+                  info.entityInfo.getType().getName(),
+                  info.method.getName(),
+                  info.repositoryInterface.getName(),
+                  entityAnnoName);
+    }
+
+    /**
+     * Raise a new MappingException for the error where the repository method has an
      * extra parameter that does not apply to the query conditions and is not a
      * special parameter.
      *
      * @param info  query information for the repository method.
      * @param index index (0-based) of the repository method parameter.
-     * @throws the DataException.
+     * @throws the MappingException.
      */
-    static DataException extraMethodParam(QueryInfo info, int index) {
+    static MappingException extraMethodParam(QueryInfo info, int index) {
         validateParameterPositions(info);
 
-        throw exc(DataException.class,
+        throw exc(MappingException.class,
                   "CWWKD1023.extra.param",
                   info.method.getName(),
                   info.repositoryInterface.getName(),
                   info.specialParamsStartAt,
                   info.method.getParameterTypes()[index].getName(),
                   info.jpql);
+    }
+
+    /**
+     * Raise a new MappingException for the error where the repository method has an
+     * extra parameter that does not apply to the query conditions and is not a
+     * special parameter.
+     *
+     * @param info        query information for the repository method.
+     * @param numRequired number of parameters required by the query conditions.
+     * @param numFound    number of parameters found on the repository method.
+     * @throws the MappingException.
+     */
+    static MappingException extraMethodParams(QueryInfo info,
+                                              int numRequired,
+                                              int numFound) {
+        throw exc(UnsupportedOperationException.class,
+                  "CWWKD1022.too.many.params",
+                  info.method.getName(),
+                  info.repositoryInterface.getName(),
+                  numRequired,
+                  numFound,
+                  info.jpql);
+    }
+
+    /**
+     * Raises UnsupportedOperationException for a repository method that is not
+     * valid as a life cycle method because it has no method parameters or more
+     * than 1 method parameter.
+     *
+     * @param info     query information for the repository method.
+     * @param anooType Java class of the of repository method annotation.
+     * @throws UnsupportedOperationException.
+     */
+    static MappingException //
+                    lifeCycleMethodParamCount(QueryInfo info,
+                                              Class<? extends Annotation> annoType) {
+        throw exc(UnsupportedOperationException.class,
+                  "CWWKD1009.lifecycle.param.err",
+                  info.method.getName(),
+                  info.repositoryInterface.getName(),
+                  info.method.getParameterCount(),
+                  annoType.getSimpleName());
     }
 
     /**
@@ -128,7 +370,7 @@ public class Fail {
      * @throws UnsupportedOperationException if there is a mispositioned special
      *                                           parameter.
      */
-    static MappingException methodLacksNamedParams(QueryInfo info,
+    static RuntimeException methodLacksNamedParams(QueryInfo info,
                                                    Set<String> lacking) {
 
         validateParameterPositions(info);
@@ -151,6 +393,43 @@ public class Fail {
                   info.method.getAnnotation(Query.class).value(),
                   "@Param(\"" + first + "\")",
                   "String " + first);
+    }
+
+    /**
+     * Create a new UnsupportedOperationException for repository method parameter
+     * annotations that conflict with each other or with the type of the repository
+     * method parameter.
+     *
+     * @param info       query information for the repository method.
+     * @param errorCode  constant from DataVersionCompatibility that classifies
+     *                       the error.
+     * @param paramIndex index (0-based) of repository method parameter.
+     * @param paramType  Java class of the repository method parameter.
+     * @param paramAnnos annotations on the repository method parameter.
+     * @throws the UnsupportedOperationException
+     */
+    static UnsupportedOperationException methodParamAnnoConflict(QueryInfo info,
+                                                                 int errorCode,
+                                                                 int paramIndex,
+                                                                 Class<?> paramType,
+                                                                 Annotation[] paramAnnos) {
+        if (errorCode == DataVersionCompatibility.PARAM_ANNO_CONFLICTS_WITH_CONSTRAINT)
+            throw exc(UnsupportedOperationException.class,
+                      "CWWKD1117.anno.constraint.conflict",
+                      paramIndex + 1, // switch to 1-based
+                      info.method.getName(),
+                      info.repositoryInterface.getName(),
+                      Arrays.toString(paramAnnos),
+                      paramType.getClass().getName());
+        else if (errorCode == DataVersionCompatibility.PARAM_ANNOS_CONFLICT)
+            throw exc(UnsupportedOperationException.class,
+                      "CWWKD1118.param.anno.conflict",
+                      paramIndex + 1, // switch to 1-based
+                      info.method.getName(),
+                      info.repositoryInterface.getName(),
+                      Arrays.toString(paramAnnos));
+        else // internal error
+            throw new IllegalArgumentException("errorCode: " + errorCode);
     }
 
     /**
@@ -180,11 +459,7 @@ public class Fail {
                       type.getSimpleName());
         else if (param instanceof Limit ? limit != null : pageReq != null)
             // conflicts with another parameter of the same type
-            throw exc(UnsupportedOperationException.class,
-                      "CWWKD1017.dup.special.param",
-                      info.method.getName(),
-                      info.repositoryInterface.getName(),
-                      type.getSimpleName());
+            throw Fail.duplicateSpecialParam(info, type.getSimpleName());
         else
             // conflict between Limit and PageRequest parameters
             throw exc(UnsupportedOperationException.class,
@@ -193,6 +468,27 @@ public class Fail {
                       info.repositoryInterface.getName(),
                       Limit.class.getSimpleName(),
                       PageRequest.class.getSimpleName());
+    }
+
+    /**
+     * Create a new UnsupportedOperationException for a repository method
+     * parameter that is not valid on a repository method that has the given
+     * repository method annotation.
+     *
+     * @param info       query information for the repository method.
+     * @param paramType  Java class of the repository method parameter.
+     * @param methodAnno repository method annotation, such as Update or Delete.
+     * @throws the UnsupportedOperationException
+     */
+    static UnsupportedOperationException methodParamInvalid(QueryInfo info,
+                                                            Class<?> paramType,
+                                                            Annotation methodAnno) {
+        throw exc(UnsupportedOperationException.class,
+                  "CWWKD1020.invalid.param.type",
+                  info.method.getName(),
+                  info.repositoryInterface.getName(),
+                  paramType.getSimpleName(),
+                  methodAnno.annotationType().getSimpleName());
     }
 
     /**
@@ -320,6 +616,27 @@ public class Fail {
     }
 
     /**
+     * Raises MappingException for a repository method that has two method
+     * parameters that apply to the same JPQL named parameter.
+     *
+     * @param info           query information for the repository method.
+     * @param namedParamName name of the JPQL named parameter.
+     * @param methodParam    the method parameter.
+     * @throws MappingException.
+     */
+    static MappingException namedParamConflict(QueryInfo info,
+                                               String namedParamName,
+                                               Parameter methodParam) {
+        throw exc(MappingException.class,
+                  "CWWKD1083.dup.method.param",
+                  info.method.getName(),
+                  info.repositoryInterface.getName(),
+                  namedParamName,
+                  "@Param(\"" + namedParamName + "\")",
+                  methodParam.getType().getSimpleName() + ' ' + namedParamName);
+    }
+
+    /**
      * Raise a new NonUniqueResultException.
      *
      * @param info       query information for the repository method.
@@ -349,6 +666,82 @@ public class Fail {
     }
 
     /**
+     * Raises NullPointerException because a null value was supplied to a
+     * repository method.
+     *
+     * @param info  query information for the repository method.
+     * @param index index of repository method parameter that is null.
+     * @throws the NullPointerException.
+     */
+    static NullPointerException nullMethodParameter(QueryInfo info, int index) {
+        Class<?> paramType = info.method.getParameterTypes()[index];
+        Class<?> arrayType = paramType.componentType();
+        String paramTypeName = arrayType == null //
+                        ? paramType.getName() //
+                        : arrayType.getName() + "[]";
+        throw exc(NullPointerException.class,
+                  "CWWKD1087.null.param",
+                  paramTypeName,
+                  info.method.getName(),
+                  info.repositoryInterface.getName());
+    }
+
+    /**
+     * Raises OptimisticLockingFailureException because less entities than
+     * expected were updated.
+     *
+     * @param info        query information for the repository method.
+     * @param updateCount the observed update count.
+     * @param numExpected the expected update count.
+     * @throws the OptimisticLockingFailureException.
+     */
+    static OptimisticLockingFailureException optimisticLockConflict(QueryInfo info,
+                                                                    int updateCount,
+                                                                    int numExpected) {
+        if (numExpected == 1)
+            throw exc(OptimisticLockingFailureException.class,
+                      "CWWKD1051.single.opt.lock.exc",
+                      info.method.getName(),
+                      info.repositoryInterface.getName(),
+                      info.entityInfo.entityClass.getName(),
+                      Util.LIFE_CYCLE_METHODS_THAT_RETURN_ENTITIES_STATELESS);
+        else
+            throw exc(OptimisticLockingFailureException.class,
+                      "CWWKD1052.multi.opt.lock.exc",
+                      info.method.getName(),
+                      info.repositoryInterface.getName(),
+                      numExpected - updateCount,
+                      numExpected,
+                      info.entityInfo.entityClass.getName(),
+                      Util.LIFE_CYCLE_METHODS_THAT_RETURN_ENTITIES_STATELESS);
+    }
+
+    /**
+     * Raises UnsupportedOperationException because having an OrderBy annotation
+     * on the repository method is incompatible with also using the OrderBy keyword
+     * and with repository methods that are not find operations.
+     *
+     * @param info query information for the repository method.
+     * @throws the UnsupportedOperationException.
+     */
+    static UnsupportedOperationException orderByAnnoIncompat(QueryInfo info) {
+        // disallow on incompatible operations
+        if (info.type != FIND && info.type != FIND_AND_DELETE)
+            throw exc(UnsupportedOperationException.class,
+                      "CWWKD1096.orderby.incompat",
+                      info.method.getName(),
+                      info.repositoryInterface.getName());
+
+        if (info.sorts != null) // also has an OrderBy keyword
+            throw exc(UnsupportedOperationException.class,
+                      "CWWKD1090.orderby.conflict",
+                      info.method.getName(),
+                      info.repositoryInterface.getName());
+
+        throw new IllegalStateException(); // unreachable
+    }
+
+    /**
      * Raises an error for a type conversion failure due to a value being outside of
      * the specified range.
      *
@@ -373,9 +766,101 @@ public class Fail {
     }
 
     /**
+     * Raises IllegalArgumentException because the given PageRequest has a
+     * mode that is incompatible with the return type of the repository method.
+     *
+     * @param info    query information for the repository method.
+     * @param pageReq the page request.
+     * @throws IllegalArgumentException.
+     */
+    static IllegalArgumentException pageModeIncompatible(QueryInfo info,
+                                                         PageRequest pageReq) {
+        throw exc(IllegalArgumentException.class,
+                  "CWWKD1035.incompat.page.mode",
+                  pageReq.mode(),
+                  info.method.getName(),
+                  info.repositoryInterface.getName(),
+                  info.method.getGenericReturnType().getTypeName(),
+                  CursoredPage.class.getSimpleName());
+    }
+
+    /**
+     * Raises UnsupportedOperationException because the query is incompatible with
+     * cursor-based pagination.
+     *
+     * @param info    query information for the repository method.
+     * @param ql      a query written in query language, usually JPQL
+     *                    or the JCQL subset of JPQL.
+     * @param startAt starting index within query of the portion that
+     *                    is incompatible with cursor pagination.
+     * @param length  length of the incompatible portion of the query.
+     * @throws the UnsupportedOperationException.
+     */
+    static UnsupportedOperationException queryIncompatipleWithCursor(QueryInfo info,
+                                                                     String ql,
+                                                                     int startAt,
+                                                                     int length) {
+        throw exc(UnsupportedOperationException.class,
+                  "CWWKD1120.cursor.keyword.mismatch",
+                  info.method.getName(),
+                  info.repositoryInterface.getName(),
+                  ql.substring(startAt, startAt + length),
+                  ql);
+    }
+
+    /**
+     * Raises UnsupportedOperationException because a DELETE or UPDATE query
+     * lacks the name of the entity upon which which the query operates.
+     *
+     * @param info      query information for the repository method.
+     * @param ql        a query written in query language, usually JPQL
+     *                      or the JCQL subset of JPQL.
+     * @param queryType DELETE or UPDATE.
+     * @throws the UnsupportedOperationException.
+     */
+    static UnsupportedOperationException queryLacksEntityName(QueryInfo info,
+                                                              String ql,
+                                                              String queryType) {
+        String exampleQuery = "DELETE".equals(queryType) //
+                        ? "DELETE FROM [entity_name] WHERE [conditional_expression]" //
+                        : "UPDATE [entity_name] SET [update_items] WHERE [conditional_expression]";
+
+        throw exc(UnsupportedOperationException.class,
+                  "CWWKD1030.ql.lacks.entity",
+                  ql,
+                  info.method.getName(),
+                  info.repositoryInterface.getName(),
+                  queryType,
+                  exampleQuery);
+    }
+
+    /**
+     * Raises MappingException for a result that cannot be converted to the
+     * return type of the repository method.
+     *
+     * @param info       query information for the repository method.
+     * @param resultType name of the result class or null for a null result.
+     * @param cause      a cause exception. Null if none.
+     * @throws the MappingException.
+     */
+    static MappingException resultConversion(QueryInfo info,
+                                             String resultType,
+                                             Throwable cause) {
+        MappingException x = exc(MappingException.class,
+                                 "CWWKD1046.result.convert.err",
+                                 resultType,
+                                 info.method.getName(),
+                                 info.repositoryInterface.getName(),
+                                 info.method.getGenericReturnType().getTypeName());
+        if (cause != null)
+            x = (MappingException) x.initCause(cause);
+        throw x;
+    }
+
+    /**
      * Raises an UnsupportedOperationException for an error where the
      * repository method return type does not match the query results.
-     * On reason this might happen is when EclipseLink returns wrong values
+     * One reason this might happen is when EclipseLink returns wrong values
      * when selecting ElementCollection attributes instead of rejecting
      * it as unsupported.
      *
@@ -405,6 +890,175 @@ public class Fail {
                       info.method.getGenericReturnType().getTypeName(),
                       query instanceof String ? query : query.getClass().getName(),
                       r);
+    }
+
+    /**
+     * Raises ClassCastException for a repository method return type that does
+     * not match the number of entities returned.
+     *
+     * @param info                   query information for the repository method.
+     * @param lifeCycleMethodAnno    type of life cycle method. For example, @Insert.
+     * @param hasSingularEntityParam indicates if the method's entity parameter is
+     *                                   singular (one entity) vs multiple.
+     * @throws the ClassCastException.
+     */
+    static ClassCastException resultSizeMismatch(QueryInfo info,
+                                                 String lifeCycleMethodAnno,
+                                                 int numResults,
+                                                 boolean hasSingularEntityParam) {
+        throw exc(ClassCastException.class,
+                  "CWWKD1094.return.mismatch",
+                  info.method.getName(),
+                  info.repositoryInterface.getName(),
+                  info.method.getGenericReturnType().getTypeName(),
+                  numResults,
+                  lifeCycleMethodAnno,
+                  Util.lifeCycleReturnTypes(info.entityInfo.getType().getName(),
+                                            hasSingularEntityParam,
+                                            false));
+    }
+
+    /**
+     * Raises MappingException for a return type that is not valid for the
+     * repository method.
+     *
+     * @param info query information for the repository method.
+     * @throws the MappingException.
+     */
+    static MappingException returnTypeInvalid(QueryInfo info) {
+        // TODO add helpful information about supported result types
+        throw exc(UnsupportedOperationException.class,
+                  "CWWKD1004.general.rtrn.err",
+                  info.method.getGenericReturnType().getTypeName(),
+                  info.method.getName(),
+                  info.repositoryInterface.getName());
+    }
+
+    /**
+     * Raises UnsupportedOperationException for a return type that is not valid
+     * for the repository method.
+     *
+     * @param info                   query information for the repository method.
+     * @param lifeCycleMethodType    type of life cycle method. For example, Insert.
+     * @param hasSingularEntityParam indicates if the method's entity parameter is
+     *                                   singular (one entity) vs multiple.
+     * @param validReturnTypes       valid return types, if always the same.
+     *                                   Otherwise null.
+     * @param resultClass            resultClass from which to infer valid return
+     *                                   types. Otherwise null.
+     * @throws the UnsupportedOperationException.
+     */
+    static UnsupportedOperationException returnTypeInvalid(QueryInfo info,
+                                                           String lifeCycleMethodType,
+                                                           boolean hasSingularEntityParam,
+                                                           String validReturnTypes,
+                                                           Class<?> resultClass) {
+        if (validReturnTypes == null)
+            validReturnTypes = Util.lifeCycleReturnTypes(resultClass.getSimpleName(),
+                                                         hasSingularEntityParam,
+                                                         false).toString();
+
+        throw exc(UnsupportedOperationException.class,
+                  "CWWKD1003.rtrn.err",
+                  info.method.getGenericReturnType().getTypeName(),
+                  info.method.getName(),
+                  info.repositoryInterface.getName(),
+                  lifeCycleMethodType,
+                  validReturnTypes);
+    }
+
+    /**
+     * Raises MappingException for a return type that is not valid for a
+     * repository delete method.
+     *
+     * @param info query information for the repository method.
+     * @throws the MappingException.
+     */
+    static MappingException returnTypeInvalidForDelete(QueryInfo info) {
+        throw exc(MappingException.class,
+                  "CWWKD1006.delete.rtrn.err",
+                  info.method.getGenericReturnType().getTypeName(),
+                  info.method.getName(),
+                  info.repositoryInterface.getName(),
+                  info.entityInfo.getType().getName(),
+                  info.entityInfo.idType);
+    }
+
+    /**
+     * Raises MappingException for a return type that is not valid for a
+     * repository method that performs a SELECT query/find operation.
+     *
+     * @param info query information for the repository method.
+     * @throws the MappingException.
+     */
+    static MappingException returnTypeInvalidForFind(QueryInfo info) {
+        throw exc(MappingException.class,
+                  "CWWKD1005.find.rtrn.err",
+                  info.method.getName(),
+                  info.repositoryInterface.getName(),
+                  info.method.getGenericReturnType().getTypeName(),
+                  info.entityInfo.entityClass.getName(),
+                  List.of("List",
+                          "Optional",
+                          "Page",
+                          "CursoredPage",
+                          "Stream"));
+    }
+
+    /**
+     * Raises MappingException for an attempt to retrieve a subset of entity
+     * attributes, where at least one member of the requested subset is not
+     * an entity attribute.
+     *
+     * @param info  query information for the repository method.
+     * @param names requested entity attribute names, at least one of which
+     *                  is not valid.
+     * @param cause a cause exception to chain.
+     * @throws the MappingException.
+     */
+    static MappingException selectedAttributesMismatch(QueryInfo info,
+                                                       String[] names,
+                                                       Throwable cause) {
+        // Raise a more precise error that relates to using records
+        // for a subset of entity attributes
+        MappingException x = exc(MappingException.class,
+                                 "CWWKD1101.attr.subset.mismatch",
+                                 info.method.getGenericReturnType().getTypeName(),
+                                 info.method.getName(),
+                                 info.repositoryInterface.getName(),
+                                 info.singleType.getName(),
+                                 Arrays.toString(names),
+                                 info.entityInfo.getType().getName(),
+                                 info.entityInfo.getAttributeNames());
+        throw (MappingException) x.initCause(cause);
+    }
+
+    /**
+     * Raises MappingException because there is no known entity attribute
+     * with the given name.
+     *
+     * @param info query information for the repository method.
+     * @param name name that does not match the name of an entity attribute.
+     * @throws the MappingException.
+     */
+    static MappingException unknownEntityAttribute(QueryInfo info, String name) {
+        if (Util.hasOperationAnno(info.method, info.producer))
+            throw exc(MappingException.class,
+                      "CWWKD1010.unknown.entity.attr",
+                      name,
+                      info.entityInfo.getType().getName(),
+                      info.method.getName(),
+                      info.repositoryInterface.getName(),
+                      info.entityInfo.attributeTypes.keySet());
+        else
+            throw exc(MappingException.class,
+                      "CWWKD1091.method.name.parse.err",
+                      name,
+                      info.entityInfo.getType().getName(),
+                      info.method.getName(),
+                      info.repositoryInterface.getName(),
+                      Util.operationAnnoNames(info.producer),
+                      info.entityInfo.attributeTypes.keySet());
     }
 
     /**

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/Fail.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/Fail.java
@@ -1,0 +1,510 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.data.internal.persistence;
+
+import static io.openliberty.data.internal.persistence.cdi.DataExtension.exc;
+
+import java.lang.reflect.Parameter;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import com.ibm.websphere.ras.annotation.Sensitive;
+
+import io.openliberty.data.internal.QueryType;
+import io.openliberty.data.internal.version.DataVersionCompatibility;
+import jakarta.data.Limit;
+import jakarta.data.exceptions.DataException;
+import jakarta.data.exceptions.EmptyResultException;
+import jakarta.data.exceptions.MappingException;
+import jakarta.data.exceptions.NonUniqueResultException;
+import jakarta.data.page.CursoredPage;
+import jakarta.data.page.Page;
+import jakarta.data.page.PageRequest;
+import jakarta.data.repository.OrderBy;
+import jakarta.data.repository.Param;
+import jakarta.data.repository.Query;
+
+/**
+ * This class consists of methods that raise exceptions.
+ */
+public class Fail {
+
+    /**
+     * Raises a new UnsupportedOperationException for a JPQL query that is
+     * not compatible with cursor pagination.
+     *
+     * @param info              query information for the repository method.
+     * @param ql                the query.
+     * @param endOfWhereClause  position at which the WHERE clause ends.
+     * @param endsAtOrderClause indicates if this error is being raised because an
+     *                              ORDER BY clause was found in the query.
+     * @throws UnsupportedOperationException
+     */
+    static UnsupportedOperationException cursorQueryIncompat(QueryInfo info,
+                                                             String ql,
+                                                             int endOfWhereClause,
+                                                             boolean endsAtOrderClause) {
+
+        if (endsAtOrderClause)
+            throw exc(UnsupportedOperationException.class,
+                      "CWWKD1033.ql.orderby.disallowed",
+                      info.method.getName(),
+                      info.repositoryInterface.getName(),
+                      CursoredPage.class.getSimpleName(),
+                      OrderBy.class.getSimpleName(),
+                      ql);
+        else
+            throw exc(UnsupportedOperationException.class,
+                      "CWWKD1034.ql.req.end.in.where",
+                      info.method.getName(),
+                      info.repositoryInterface.getName(),
+                      CursoredPage.class.getSimpleName(),
+                      endOfWhereClause,
+                      ql.length(),
+                      ql);
+    }
+
+    /**
+     * Raise a new EmptyResultException.
+     *
+     * @param info query information for the repository method.
+     * @throws the EmptyResultException.
+     */
+    static EmptyResultException emptyResult(QueryInfo info) {
+        throw exc(EmptyResultException.class,
+                  "CWWKD1053.empty.result",
+                  info.method.getGenericReturnType().getTypeName(),
+                  info.method.getName(),
+                  info.repositoryInterface.getName(),
+                  List.of(List.class.getSimpleName(),
+                          Optional.class.getSimpleName(),
+                          Page.class.getSimpleName(),
+                          CursoredPage.class.getSimpleName(),
+                          Stream.class.getSimpleName()));
+    }
+
+    /**
+     * Raise a new DataException for the error where the repository method has an
+     * extra parameter that does not apply to the query conditions and is not a
+     * special parameter.
+     *
+     * @param info  query information for the repository method.
+     * @param index index (0-based) of the repository method parameter.
+     * @throws the DataException.
+     */
+    static DataException extraMethodParam(QueryInfo info, int index) {
+        validateParameterPositions(info);
+
+        throw exc(DataException.class,
+                  "CWWKD1023.extra.param",
+                  info.method.getName(),
+                  info.repositoryInterface.getName(),
+                  info.specialParamsStartAt,
+                  info.method.getParameterTypes()[index].getName(),
+                  info.jpql);
+    }
+
+    /**
+     * Check if the cause of the lacking named parameter is a mispositioned
+     * special parameter. If so, raises UnsupportedOperationException.
+     *
+     * Otherwise, raises a MappingException for the error where one or more
+     * of the named parameters required by a JPQL query are not specified
+     * by the method parameters
+     *
+     * @param info    query information for the repository method.
+     * @param lacking query named parameters for which no method parameters were
+     *                    found.
+     * @throws MappingException              for a missing named parameter.
+     * @throws UnsupportedOperationException if there is a mispositioned special
+     *                                           parameter.
+     */
+    static MappingException methodLacksNamedParams(QueryInfo info,
+                                                   Set<String> lacking) {
+
+        validateParameterPositions(info);
+
+        String first = null;
+        StringBuilder all = new StringBuilder();
+        for (String name : lacking) {
+            if (first == null)
+                first = name;
+            else
+                all.append(", ");
+            all.append(':').append(name);
+        }
+
+        throw exc(MappingException.class,
+                  "CWWKD1084.missing.named.params",
+                  info.method.getName(),
+                  info.repositoryInterface.getName(),
+                  all,
+                  info.method.getAnnotation(Query.class).value(),
+                  "@Param(\"" + first + "\")",
+                  "String " + first);
+    }
+
+    /**
+     * Create a new UnsupportedOperationException for conflicting Limit or
+     * PageRequest parameters supplied to a repository method. The conflict
+     * might be with each other, with another of the same type, or with a
+     * First keyword in the method name.
+     *
+     * @param info    query information for the repository method.
+     * @param param   method parameter that is an instance of Limit or PageRequest.
+     * @param limit   other Limit parameter value. Otherwise null.
+     * @param pageReq other PageRequest parameter value. Otherwise null.
+     * @throws the UnsupportedOperationException
+     */
+    static UnsupportedOperationException methodParamIncompat(QueryInfo info,
+                                                             Object param,
+                                                             Limit limit,
+                                                             PageRequest pageReq) {
+        Class<?> type = param instanceof Limit ? Limit.class : PageRequest.class;
+
+        if (limit == null && pageReq == null)
+            // conflicts with First keyword
+            throw exc(UnsupportedOperationException.class,
+                      "CWWKD1099.first.keyword.incompat",
+                      info.method.getName(),
+                      info.repositoryInterface.getName(),
+                      type.getSimpleName());
+        else if (param instanceof Limit ? limit != null : pageReq != null)
+            // conflicts with another parameter of the same type
+            throw exc(UnsupportedOperationException.class,
+                      "CWWKD1017.dup.special.param",
+                      info.method.getName(),
+                      info.repositoryInterface.getName(),
+                      type.getSimpleName());
+        else
+            // conflict between Limit and PageRequest parameters
+            throw exc(UnsupportedOperationException.class,
+                      "CWWKD1018.confl.special.param",
+                      info.method.getName(),
+                      info.repositoryInterface.getName(),
+                      Limit.class.getSimpleName(),
+                      PageRequest.class.getSimpleName());
+    }
+
+    /**
+     * Constructs the MappingException or UnsupportedOperationException for
+     * the error where a repository method parameter lacks an annotation that
+     * identifies the corresponding entity attribute name.
+     *
+     * @param info query information for the repository method.
+     * @param p    position (1-based) of the repository method parameter.
+     * @throws MappingException or UnsupportedOperationException.
+     */
+    static RuntimeException methodParamLacksAnno(QueryInfo info, int p) {
+        DataVersionCompatibility compat = info.producer.compat();
+
+        switch (info.type) {
+            case FIND:
+            case FIND_AND_DELETE:
+                validateParameterPositions(info);
+                String specParams = info.type == QueryType.FIND //
+                                ? compat.specialParamsForFind() //
+                                : compat.specialParamsForFindAndDelete();
+                throw exc(MappingException.class,
+                          "CWWKD1012.fd.missing.param.anno",
+                          p,
+                          info.method.getName(),
+                          info.repositoryInterface.getName(),
+                          specParams);
+            case QM_DELETE:
+            case COUNT:
+            case EXISTS:
+                throw exc(MappingException.class,
+                          "CWWKD1013.cde.missing.param.anno",
+                          p,
+                          info.method.getName(),
+                          info.repositoryInterface.getName());
+            case QM_UPDATE:
+                throw exc(UnsupportedOperationException.class,
+                          "CWWKD1014.upd.missing.param.anno",
+                          info.method.getName(),
+                          info.repositoryInterface.getName(),
+                          info.method.getParameterCount(),
+                          p,
+                          compat.paramAnnosForUpdate());
+            default: // should be unreachable
+                throw new IllegalStateException(info.type.name());
+        }
+    }
+
+    /**
+     * Raise an error because the PageRequest is missing.
+     *
+     * @param info query information for the repository method.
+     * @throws IllegalArgumentException      if the user supplied a null PageRequest
+     * @throws UnsupportedOperationException if the repository method signature
+     *                                           lacks a parameter for supplying a
+     *                                           PageRequest
+     */
+    static RuntimeException missingPageRequest(QueryInfo info) {
+        Class<?>[] paramTypes = info.method.getParameterTypes();
+
+        // Check parameter positions after those used for query parameters
+        boolean signatureHasPageReq = false;
+        for (int i = 0; i < paramTypes.length; i++)
+            signatureHasPageReq |= PageRequest.class.equals(paramTypes[i]);
+
+        if (signatureHasPageReq)
+            // NullPointerException is required by BasicRepository.findAll
+            throw exc(NullPointerException.class,
+                      "CWWKD1087.null.param",
+                      PageRequest.class.getName(),
+                      info.method.getName(),
+                      info.repositoryInterface.getName());
+        else
+            throw exc(UnsupportedOperationException.class,
+                      "CWWKD1041.rtrn.mismatch.pagereq",
+                      info.method.getName(),
+                      info.repositoryInterface.getName(),
+                      info.method.getGenericReturnType().getTypeName());
+    }
+
+    /**
+     * Raises UnsupportedOperationException for the error where a repository
+     * method intermixed named and positional parameters for a query.
+     *
+     * @param info          query information for the repository method.
+     * @param methodNPCount count of repository method parameters that indicate
+     *                          names and values of JPQL named parameters.
+     * @throws the UnsupportedOperationException.
+     */
+    static UnsupportedOperationException mixedQLParamTypes(QueryInfo info,
+                                                           int methodNPCount) {
+        String firstNamedParam = null;
+        StringBuilder allNamedParams = new StringBuilder().append('(');
+        for (String name : info.jpqlParamNames) {
+            if (firstNamedParam == null)
+                firstNamedParam = name;
+            else
+                allNamedParams.append(", ");
+            allNamedParams.append(':').append(name);
+        }
+        allNamedParams.append(')');
+
+        Class<?> firstNamedParamType = String.class;
+        for (Parameter p : info.method.getParameters()) {
+            Param param = p.getAnnotation(Param.class);
+            if (param == null //
+                            ? p.isNamePresent() &&
+                              firstNamedParam.equals(p.getName()) //
+                            : firstNamedParam.equals(param.value()))
+                firstNamedParamType = p.getType();
+            break;
+        }
+
+        throw exc(UnsupportedOperationException.class,
+                  "CWWKD1019.mixed.positional.named",
+                  info.method.getName(),
+                  info.repositoryInterface.getName(),
+                  info.jpqlParamCount - methodNPCount,
+                  methodNPCount,
+                  allNamedParams,
+                  info.method.getAnnotation(Query.class).value(),
+                  ':' + firstNamedParam,
+                  "@Param(\"" + firstNamedParam + "\")",
+                  firstNamedParamType.getSimpleName() + ' ' + firstNamedParam);
+    }
+
+    /**
+     * Raise a new NonUniqueResultException.
+     *
+     * @param info       query information for the repository method.
+     * @param numResults number of results.
+     * @throws the NonUniqueResultException.
+     */
+    static NonUniqueResultException nonUniqueResult(QueryInfo info,
+                                                    int numResults) {
+
+        String entityName = info.entityInfo.getType().getSimpleName();
+        String returnType = "Optional<" + entityName + ">";
+
+        List<String> recommendations = info.producer.compat().atLeast(1, 1) //
+                        ? List.of("@Find @First @OrderBy(...) " +
+                                  returnType + " get(...)",
+                                  returnType + " findFirstByX(...)") //
+                        : List.of(returnType + " findFirstByX(...)",
+                                  returnType + " findByX(..., Limit.of(1))");
+
+        throw exc(NonUniqueResultException.class,
+                  "CWWKD1054.non.unique.result",
+                  info.method.getName(),
+                  info.repositoryInterface.getName(),
+                  info.method.getGenericReturnType().getTypeName(),
+                  numResults,
+                  recommendations);
+    }
+
+    /**
+     * Raises an error for a type conversion failure due to a value being outside of
+     * the specified range.
+     *
+     * @param info  query information for the repository method.
+     * @param value the value that fails to convert.
+     * @param min   minimum value for range.
+     * @param max   maximum value for range.
+     * @throws MappingException for the type conversion failure.
+     */
+    static MappingException outOfRange(QueryInfo info,
+                                       @Sensitive Number value,
+                                       long min,
+                                       long max) {
+        throw exc(MappingException.class,
+                  "CWWKD1047.result.out.of.range",
+                  info.loggableAppend(value.getClass().getName(), " (", value, ")"),
+                  info.method.getName(),
+                  info.repositoryInterface.getName(),
+                  info.method.getGenericReturnType().getTypeName(),
+                  min,
+                  max);
+    }
+
+    /**
+     * Raises an UnsupportedOperationException for an error where the
+     * repository method return type does not match the query results.
+     * On reason this might happen is when EclipseLink returns wrong values
+     * when selecting ElementCollection attributes instead of rejecting
+     * it as unsupported.
+     *
+     * @param info    query information for the repository method.
+     * @param results list of at least 1 result.
+     * @param query   jakarta.persistence.Query, a String, or null.
+     * @throws UnsupportedOperationException.
+     */
+    static UnsupportedOperationException resultIncompatible(QueryInfo info,
+                                                            @Sensitive List<?> results,
+                                                            Object query) {
+        String r = results.getClass().getName() +
+                   "<" + results.get(0).getClass().getName() + ">";
+
+        if (query == null)
+            throw exc(UnsupportedOperationException.class,
+                      "CWWKD1102.incompat.query.result",
+                      info.method.getName(),
+                      info.repositoryInterface.getName(),
+                      info.method.getGenericReturnType().getTypeName(),
+                      r);
+        else
+            throw exc(UnsupportedOperationException.class,
+                      "CWWKD1103.incompat.query.result",
+                      info.method.getName(),
+                      info.repositoryInterface.getName(),
+                      info.method.getGenericReturnType().getTypeName(),
+                      query instanceof String ? query : query.getClass().getName(),
+                      r);
+    }
+
+    /**
+     * Raises UnsupportedOperationException for the general error where
+     * a repository method is unrecognized.
+     *
+     * @param info query information for the repository method.
+     * @throws the UnsupportedOperationException.
+     */
+    static UnsupportedOperationException unsupportedMethod(QueryInfo info) {
+        throw exc(UnsupportedOperationException.class,
+                  "CWWKD1011.unknown.method.pattern",
+                  info.method.getName(),
+                  info.repositoryInterface.getName(),
+                  Util.operationAnnoNames(info.producer),
+                  Util.resourceAccessorTypeNames(info.producer),
+                  Util.methodNamePrefixes(info.producer),
+                  info.entityInfo.getExampleMethodNames());
+    }
+
+    /**
+     * Raises MappingException for the error where the repository method
+     * defines extra named parameters that are not used by the JPQL query.
+     *
+     * @throws MappingException.
+     */
+    static MappingException unusedNamedParamsOnMethod(QueryInfo info,
+                                                      Set<String> extras,
+                                                      Set<String> qlRequired) {
+        String firstExtraParam = null;
+        StringBuilder extraParamNames = new StringBuilder();
+        for (String name : extras)
+            if (name.length() > 0) {
+                if (firstExtraParam == null)
+                    firstExtraParam = name;
+                else
+                    extraParamNames.append(", ");
+                extraParamNames.append(name);
+            }
+
+        if (firstExtraParam == null && !extras.isEmpty())
+            // @Param("") with empty String is not valid
+            throw exc(MappingException.class,
+                      "CWWKD1104.empty.anno.value",
+                      Param.class.getSimpleName(),
+                      info.method.getName(),
+                      info.repositoryInterface.getName());
+
+        boolean isFirst = true;
+        StringBuilder qlParamNames = new StringBuilder();
+        for (String name : qlRequired) {
+            if (!isFirst)
+                qlParamNames.append(", ");
+            qlParamNames.append(':').append(name);
+            isFirst = false;
+        }
+
+        if (qlRequired.isEmpty())
+            throw exc(MappingException.class,
+                      "CWWKD1086.named.params.unused",
+                      info.method.getName(),
+                      info.repositoryInterface.getName(),
+                      extraParamNames,
+                      info.method.getAnnotation(Query.class).value(),
+                      ':' + firstExtraParam);
+        else
+            throw exc(MappingException.class,
+                      "CWWKD1085.extra.method.params",
+                      info.method.getName(),
+                      info.repositoryInterface.getName(),
+                      extraParamNames,
+                      qlParamNames,
+                      info.method.getAnnotation(Query.class).value());
+    }
+
+    /**
+     * Confirm that special parameters are positioned after all other parameters.
+     *
+     * @throws UnupportedOperationException if a special parameter is ahead of
+     *                                          a query parameter.
+     */
+    private static void validateParameterPositions(QueryInfo info) {
+        DataVersionCompatibility compat = info.entityInfo.builder.provider.compat;
+
+        Class<?>[] paramTypes = info.method.getParameterTypes();
+        Set<Class<?>> specParamTypes = compat.specialParamTypes();
+        int specParamIndex = Integer.MAX_VALUE, otherParamIndex = -1;
+        for (int i = 0; i < paramTypes.length; i++)
+            if (specParamTypes.contains(paramTypes[i]))
+                specParamIndex = i < specParamIndex ? i : specParamIndex;
+            else
+                otherParamIndex = i;
+
+        if (specParamIndex < otherParamIndex)
+            throw exc(UnsupportedOperationException.class,
+                      "CWWKD1098.spec.param.position.err",
+                      info.method.getName(),
+                      info.repositoryInterface.getName(),
+                      paramTypes[specParamIndex].getName(),
+                      compat.specialParamsForFind());
+    }
+
+}

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/PageImpl.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/PageImpl.java
@@ -165,7 +165,7 @@ public class PageImpl<T> implements Page<T> {
         this.pageRequest = pageRequest;
 
         if (pageRequest == null)
-            missingPageRequest();
+            throw Fail.missingPageRequest(queryInfo);
 
         this.isForward = pageRequest.mode() != PageRequest.Mode.CURSOR_PREVIOUS;
     }
@@ -255,37 +255,6 @@ public class PageImpl<T> implements Page<T> {
         int size = results.size();
         int max = pageRequest.size();
         return size > max ? new ResultIterator(max) : results.iterator();
-    }
-
-    /**
-     * Raise an error because the PageRequest is missing.
-     *
-     * @throws IllegalArgumentException      if the user supplied a null PageRequest
-     * @throws UnsupportedOperationException if the repository method signature
-     *                                           lacks a parameter for supplying a
-     *                                           PageRequest
-     */
-    void missingPageRequest() {
-        Class<?>[] paramTypes = queryInfo.method.getParameterTypes();
-
-        // Check parameter positions after those used for query parameters
-        boolean signatureHasPageReq = false;
-        for (int i = 0; i < paramTypes.length; i++)
-            signatureHasPageReq |= PageRequest.class.equals(paramTypes[i]);
-
-        if (signatureHasPageReq)
-            // NullPointerException is required by BasicRepository.findAll
-            throw exc(NullPointerException.class,
-                      "CWWKD1087.null.param",
-                      PageRequest.class.getName(),
-                      queryInfo.method.getName(),
-                      queryInfo.repositoryInterface.getName());
-        else
-            throw exc(UnsupportedOperationException.class,
-                      "CWWKD1041.rtrn.mismatch.pagereq",
-                      queryInfo.method.getName(),
-                      queryInfo.repositoryInterface.getName(),
-                      queryInfo.method.getGenericReturnType().getTypeName());
     }
 
     @Override

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
@@ -26,7 +26,6 @@ import static io.openliberty.data.internal.QueryType.QM_DELETE;
 import static io.openliberty.data.internal.QueryType.QM_UPDATE;
 import static io.openliberty.data.internal.QueryType.SAVE;
 import static io.openliberty.data.internal.persistence.Util.SORT_PARAM_TYPES;
-import static io.openliberty.data.internal.persistence.Util.lifeCycleReturnTypes;
 import static io.openliberty.data.internal.persistence.cdi.DataExtension.exc;
 import static jakarta.data.repository.By.ID;
 
@@ -391,23 +390,13 @@ public class QueryInfo {
             if (++d < depth)
                 type = returnTypeAtDepth.get(d);
             else
-                // TODO add helpful information about supported result types
-                throw exc(UnsupportedOperationException.class,
-                          "CWWKD1004.general.rtrn.err",
-                          method.getGenericReturnType().getTypeName(),
-                          method.getName(),
-                          repositoryInterface.getName());
+                throw Fail.returnTypeInvalid(this);
         if (isOptional = Optional.class.equals(type)) {
             multiType = null;
             if (++d < depth)
                 type = returnTypeAtDepth.get(d);
             else
-                // TODO add helpful information about supported result types
-                throw exc(UnsupportedOperationException.class,
-                          "CWWKD1004.general.rtrn.err",
-                          method.getGenericReturnType().getTypeName(),
-                          method.getName(),
-                          repositoryInterface.getName());
+                throw Fail.returnTypeInvalid(this);
         } else {
             if (returnArrayType != null
                 || Iterator.class.equals(type)
@@ -417,12 +406,7 @@ public class QueryInfo {
                 if (++d < depth)
                     type = returnTypeAtDepth.get(d);
                 else
-                    // TODO add helpful information about supported result types
-                    throw exc(UnsupportedOperationException.class,
-                              "CWWKD1004.general.rtrn.err",
-                              method.getGenericReturnType().getTypeName(),
-                              method.getName(),
-                              repositoryInterface.getName());
+                    throw Fail.returnTypeInvalid(this);
             } else {
                 multiType = null;
             }
@@ -702,13 +686,7 @@ public class QueryInfo {
      */
     int computeOffset(PageRequest pagination) {
         if (pagination.mode() != PageRequest.Mode.OFFSET)
-            throw exc(IllegalArgumentException.class,
-                      "CWWKD1035.incompat.page.mode",
-                      pagination.mode(),
-                      method.getName(),
-                      repositoryInterface.getName(),
-                      method.getGenericReturnType().getTypeName(),
-                      CursoredPage.class.getSimpleName());
+            throw Fail.pageModeIncompatible(this, pagination);
 
         int maxPageSize = pagination.size();
         long pageIndex = pagination.page() - 1; // zero-based
@@ -740,12 +718,7 @@ public class QueryInfo {
     private Object convert(Object value, Class<?> toType, boolean failIfNotConverted) {
         if (value == null) {
             if (toType.isPrimitive())
-                throw exc(MappingException.class,
-                          "CWWKD1046.result.convert.err",
-                          null,
-                          method.getName(),
-                          repositoryInterface.getName(),
-                          method.getGenericReturnType().getTypeName());
+                throw Fail.resultConversion(this, null, null);
             else
                 return null;
         }
@@ -914,16 +887,8 @@ public class QueryInfo {
         }
 
         if (failIfNotConverted) {
-            MappingException x;
-            x = exc(MappingException.class,
-                    "CWWKD1046.result.convert.err",
-                    loggableAppend(fromType.getName(), " (", value, ")"),
-                    method.getName(),
-                    repositoryInterface.getName(),
-                    method.getGenericReturnType().getTypeName());
-            if (cause != null)
-                x = (MappingException) x.initCause(cause);
-            throw x;
+            String resultInfo = loggableAppend(fromType.getName(), " (", value, ")");
+            throw Fail.resultConversion(this, resultInfo, cause);
         } else {
             return value;
         }
@@ -965,12 +930,7 @@ public class QueryInfo {
                 // covers Set
                 list = new LinkedHashSet<>(results.size());
             else
-                throw exc(UnsupportedOperationException.class,
-                          "CWWKD1046.result.convert.err",
-                          List.class.getName(),
-                          method.getName(),
-                          repositoryInterface.getName(),
-                          method.getGenericReturnType().getTypeName());
+                throw Fail.resultConversion(this, List.class.getName(), null);
         } else {
             try {
                 @SuppressWarnings("unchecked")
@@ -1059,35 +1019,17 @@ public class QueryInfo {
         } else {
             if (int.class.equals(singleType) || Integer.class.equals(singleType))
                 if (count > Integer.MAX_VALUE)
-                    throw exc(MappingException.class,
-                              "CWWKD1048.result.exceeds.max",
-                              count,
-                              method.getName(),
-                              repositoryInterface.getName(),
-                              method.getGenericReturnType().getTypeName(),
-                              "Integer.MAX_VALUE (" + Integer.MAX_VALUE + ')');
+                    throw Fail.countExceedsMax(this, count, Integer.class);
                 else
                     returnValue = count.intValue();
             else if (short.class.equals(singleType) || Short.class.equals(singleType))
                 if (count > Short.MAX_VALUE)
-                    throw exc(MappingException.class,
-                              "CWWKD1048.result.exceeds.max",
-                              count,
-                              method.getName(),
-                              repositoryInterface.getName(),
-                              method.getGenericReturnType().getTypeName(),
-                              "Short.MAX_VALUE (" + Short.MAX_VALUE + ')');
+                    throw Fail.countExceedsMax(this, count, Short.class);
                 else
                     returnValue = count.shortValue();
             else if (byte.class.equals(singleType) || Byte.class.equals(singleType))
                 if (count > Byte.MAX_VALUE)
-                    throw exc(MappingException.class,
-                              "CWWKD1048.result.exceeds.max",
-                              count,
-                              method.getName(),
-                              repositoryInterface.getName(),
-                              method.getGenericReturnType().getTypeName(),
-                              "Byte.MAX_VALUE (" + Byte.MAX_VALUE + ')');
+                    throw Fail.countExceedsMax(this, count, Byte.class);
                 else
                     returnValue = count.byteValue();
             else if (BigInteger.class.equals(singleType))
@@ -1095,12 +1037,7 @@ public class QueryInfo {
             else if (BigDecimal.class.equals(singleType))
                 returnValue = BigDecimal.valueOf(count);
             else
-                throw exc(MappingException.class,
-                          "CWWKD1049.count.convert.err",
-                          count,
-                          method.getName(),
-                          repositoryInterface.getName(),
-                          method.getGenericReturnType().getTypeName());
+                throw Fail.countConversion(this, count);
         }
 
         Class<?> returnType = method.getReturnType();
@@ -1110,12 +1047,7 @@ public class QueryInfo {
                    CompletionStage.class.equals(returnType)) {
             returnValue = CompletableFuture.completedFuture(returnValue);
         } else if (multiType != null) {
-            throw exc(MappingException.class,
-                      "CWWKD1049.count.convert.err",
-                      count,
-                      method.getName(),
-                      repositoryInterface.getName(),
-                      method.getGenericReturnType().getTypeName());
+            throw Fail.countConversion(this, count);
         }
 
         if (trace && tc.isEntryEnabled())
@@ -1141,12 +1073,7 @@ public class QueryInfo {
 
         for (Object result : results)
             if (result == null) {
-                throw exc(DataException.class,
-                          "CWWKD1046.result.convert.err",
-                          null,
-                          method.getName(),
-                          repositoryInterface.getName(),
-                          method.getGenericReturnType().getTypeName());
+                throw Fail.resultConversion(this, null, null);
             } else if (entityInfo.entityClass.isInstance(result)) {
                 em.remove(result);
             } else if (entityInfo.idClassAttributeAccessors != null) {
@@ -1182,13 +1109,7 @@ public class QueryInfo {
                 } else if (!entityInfo.idType.isInstance(value)) {
                     value = convert(result, entityInfo.idType, false);
                     if (value == result)
-                        throw exc(MappingException.class,
-                                  "CWWKD1006.delete.rtrn.err",
-                                  method.getGenericReturnType().getTypeName(),
-                                  method.getName(),
-                                  repositoryInterface.getName(),
-                                  entityInfo.getType().getName(),
-                                  entityInfo.idType);
+                        throw Fail.returnTypeInvalidForDelete(this);
                 }
 
                 jakarta.persistence.Query delete = em.createQuery(jpqlDelete);
@@ -1242,29 +1163,10 @@ public class QueryInfo {
         }
 
         if (numExpected == 0)
-            throw exc(IllegalArgumentException.class,
-                      "CWWKD1092.lifecycle.arg.empty",
-                      method.getName(),
-                      repositoryInterface.getName(),
-                      method.getGenericParameterTypes()[0].getTypeName());
+            throw Fail.emptyLifeCycleParam(this);
 
         if (updateCount < numExpected)
-            if (numExpected == 1)
-                throw exc(OptimisticLockingFailureException.class,
-                          "CWWKD1051.single.opt.lock.exc",
-                          method.getName(),
-                          repositoryInterface.getName(),
-                          entityInfo.entityClass.getName(),
-                          Util.LIFE_CYCLE_METHODS_THAT_RETURN_ENTITIES_STATELESS);
-            else
-                throw exc(OptimisticLockingFailureException.class,
-                          "CWWKD1052.multi.opt.lock.exc",
-                          method.getName(),
-                          repositoryInterface.getName(),
-                          numExpected - updateCount,
-                          numExpected,
-                          entityInfo.entityClass.getName(),
-                          Util.LIFE_CYCLE_METHODS_THAT_RETURN_ENTITIES_STATELESS);
+            throw Fail.optimisticLockConflict(this, updateCount, numExpected);
 
         Object returnValue = toReturnValue(updateCount, method.getReturnType());
 
@@ -1289,21 +1191,8 @@ public class QueryInfo {
         if (trace && tc.isEntryEnabled())
             Tr.entry(this, tc, "deleteOne", loggable(e));
 
-        Class<?> entityClass = entityInfo.getType();
-
-        if (e == null)
-            throw exc(NullPointerException.class,
-                      "CWWKD1015.null.entity.param",
-                      method.getName(),
-                      repositoryInterface.getName());
-
-        if (!entityClass.isInstance(e))
-            throw exc(IllegalArgumentException.class,
-                      "CWWKD1016.incompat.entity.param",
-                      method.getName(),
-                      repositoryInterface.getName(),
-                      entityClass.getName(),
-                      e.getClass().getName());
+        if (!entityInfo.getType().isInstance(e))
+            throw Fail.entityMismatch(this, e);
 
         String jpql = this.jpql;
 
@@ -1359,20 +1248,7 @@ public class QueryInfo {
             if (void.class.equals(returnType) || Void.class.equals(returnType)) {
                 if (idAttributeName == null)
                     idAttributeName = ID;
-                List<String> entityProps = new ArrayList<>(2);
-                if (id != null)
-                    entityProps.add(loggableAppend(idAttributeName,
-                                                   "=", id));
-                if (entityInfo.versionAttributeName != null && version != null)
-                    entityProps.add(loggableAppend(entityInfo.versionAttributeName,
-                                                   "=", version));
-                throw exc(OptimisticLockingFailureException.class,
-                          "CWWKD1050.opt.lock.exc",
-                          method.getName(),
-                          repositoryInterface.getName(),
-                          e.getClass().getName(),
-                          entityProps,
-                          Util.LIFE_CYCLE_METHODS_THAT_RETURN_ENTITIES_STATELESS);
+                throw Fail.entityNotFound(this, e, idAttributeName, id, version);
             }
         } else if (numDeleted > 1) {
             // ought to be unreachable
@@ -1538,11 +1414,7 @@ public class QueryInfo {
                 if (restriction == null)
                     restriction = param;
                 else
-                    throw exc(UnsupportedOperationException.class,
-                              "CWWKD1017.dup.special.param",
-                              method.getName(),
-                              repositoryInterface.getName(),
-                              "Restriction");
+                    throw Fail.duplicateSpecialParam(this, "Restriction");
             } else if (param == null) {
                 // ignore null for empty Sort...
                 boolean isSort = false;
@@ -1550,11 +1422,7 @@ public class QueryInfo {
                     isSort |= sortPositions[s] == i;
                 if (!isSort)
                     // BasicRepository.findAll requires NullPointerException
-                    throw exc(NullPointerException.class,
-                              "CWWKD1087.null.param",
-                              method.getParameterTypes()[i].getName(),
-                              method.getName(),
-                              repositoryInterface.getName());
+                    throw Fail.nullMethodParameter(this, i);
             } else {
                 throw Fail.extraMethodParam(this, i);
             }
@@ -1682,13 +1550,7 @@ public class QueryInfo {
                             addedJPQLParams);
         } else if (pageReq != null &&
                    !PageRequest.Mode.OFFSET.equals(pageReq.mode())) {
-            throw exc(IllegalArgumentException.class,
-                      "CWWKD1035.incompat.page.mode",
-                      pageReq.mode(),
-                      method.getName(),
-                      repositoryInterface.getName(),
-                      method.getGenericReturnType().getTypeName(),
-                      CursoredPage.class.getSimpleName());
+            throw Fail.pageModeIncompatible(this, pageReq);
         } else {
             if (trace && tc.isDebugEnabled())
                 Tr.debug(this, tc, "createQuery",
@@ -1734,12 +1596,7 @@ public class QueryInfo {
                 else if (DoubleStream.class.equals(multiType))
                     returnValue = stream.mapToDouble(this::toDouble);
                 else
-                    throw exc(UnsupportedOperationException.class,
-                              "CWWKD1046.result.convert.err",
-                              List.class.getName(),
-                              method.getName(),
-                              repositoryInterface.getName(),
-                              method.getGenericReturnType().getTypeName());
+                    throw Fail.resultConversion(this, List.class.getName(), null);
             } else {
                 List<?> results = query.getResultList();
 
@@ -1836,13 +1693,9 @@ public class QueryInfo {
                             throw Fail.nonUniqueResult(this, size);
                         }
                     } else {
-                        throw exc(MappingException.class,
-                                  "CWWKD1046.result.convert.err",
-                                  loggableAppend(firstNonNullResult.getClass().getName(),
-                                                 " (", firstNonNullResult, ")"),
-                                  method.getName(),
-                                  repositoryInterface.getName(),
-                                  method.getGenericReturnType().getTypeName());
+                        String resultInfo = loggableAppend(firstNonNullResult.getClass().getName(),
+                                                           " (", firstNonNullResult, ")");
+                        throw Fail.resultConversion(this, resultInfo, null);
                     }
                 } else if (results.isEmpty()) {
                     throw Fail.emptyResult(this);
@@ -1920,11 +1773,7 @@ public class QueryInfo {
                    Number.class.isAssignableFrom(singleType)) {
             returnValue = convert(results.size(), singleType, true);
         } else if (results.isEmpty()) {
-            throw exc(IllegalArgumentException.class,
-                      "CWWKD1092.lifecycle.arg.empty",
-                      method.getName(),
-                      repositoryInterface.getName(),
-                      method.getGenericParameterTypes()[0].getTypeName());
+            throw Fail.emptyLifeCycleParam(this);
         } else if (void.class.equals(returnType) || Void.class.equals(returnType)) {
             returnValue = null;
         } else {
@@ -1952,15 +1801,8 @@ public class QueryInfo {
                 else if (Iterator.class.equals(multiType))
                     returnValue = results.iterator();
                 else
-                    throw exc(MappingException.class,
-                              "CWWKD1003.rtrn.err",
-                              method.getGenericReturnType().getTypeName(),
-                              method.getName(),
-                              repositoryInterface.getName(),
-                              "Update",
-                              lifeCycleReturnTypes(results.get(0).getClass().getSimpleName(),
-                                                   hasSingularEntityParam,
-                                                   false));
+                    throw Fail.returnTypeInvalid(this, "Update", hasSingularEntityParam,
+                                                 null, results.get(0).getClass());
             }
         }
 
@@ -1975,15 +1817,8 @@ public class QueryInfo {
         } else if (returnValue != null &&
                    !Util.wrapperClassIfPrimitive(returnType) //
                                    .isAssignableFrom(returnValue.getClass())) {
-            throw exc(MappingException.class,
-                      "CWWKD1003.rtrn.err",
-                      method.getGenericReturnType().getTypeName(),
-                      method.getName(),
-                      repositoryInterface.getName(),
-                      "Update",
-                      lifeCycleReturnTypes(results.get(0).getClass().getSimpleName(),
-                                           hasSingularEntityParam,
-                                           false));
+            throw Fail.returnTypeInvalid(this, "Update", hasSingularEntityParam,
+                                         null, results.get(0).getClass());
         }
 
         if (trace && tc.isEntryEnabled())
@@ -2057,21 +1892,8 @@ public class QueryInfo {
 
         List<?> results = query.getResultList();
 
-        if (results.isEmpty()) {
-            List<String> entityProps = new ArrayList<>(2);
-            if (id != null)
-                entityProps.add(loggableAppend(idAttributeName, "=", id));
-            if (entityInfo.versionAttributeName != null && version != null)
-                entityProps.add(loggableAppend(entityInfo.versionAttributeName,
-                                               "=", version));
-            throw exc(OptimisticLockingFailureException.class,
-                      "CWWKD1050.opt.lock.exc",
-                      method.getName(),
-                      repositoryInterface.getName(),
-                      e.getClass().getName(),
-                      entityProps,
-                      Util.LIFE_CYCLE_METHODS_THAT_RETURN_ENTITIES_STATELESS);
-        }
+        if (results.isEmpty())
+            throw Fail.entityNotFound(this, e, idAttributeName, id, version);
 
         if (trace && tc.isDebugEnabled())
             Tr.debug(this, tc, "found", loggable(results.get(0)));
@@ -2616,33 +2438,26 @@ public class QueryInfo {
 
         Set<Class<?>> specParamTypes = compat.specialParamTypes();
         Class<?>[] paramTypes = method.getParameterTypes();
-        int numAttributeParams = paramTypes.length;
-        while (numAttributeParams > 0 &&
-               specParamTypes.contains(paramTypes[numAttributeParams - 1])) {
-            numAttributeParams--;
-            if (!compat.isSpecialParamValid(paramTypes[numAttributeParams], type))
-                throw exc(UnsupportedOperationException.class,
-                          "CWWKD1020.invalid.param.type",
-                          method.getName(),
-                          repositoryInterface.getName(),
-                          paramTypes[numAttributeParams].getSimpleName(),
-                          methodAnno.annotationType().getSimpleName());
-        }
+        int numConstraints = paramTypes.length;
+        while (numConstraints > 0 &&
+               specParamTypes.contains(paramTypes[numConstraints - 1]))
+            if (!compat.isSpecialParamValid(paramTypes[--numConstraints], type))
+                throw Fail.methodParamInvalid(this, paramTypes[numConstraints], methodAnno);
 
         Annotation[][] annosForAllParams = method.getParameterAnnotations();
 
         // Arrays to be populated per repository method parameter
-        String[] attrNames = new String[numAttributeParams];
+        String[] attrNames = new String[numConstraints];
         AttributeConstraint[] attrConstraints = //
-                        new AttributeConstraint[numAttributeParams];
-        char[] updateOps = new char[numAttributeParams];
-        int[] numPreviousJPQLParams = new int[numAttributeParams + 1];
-        StringBuilder[] constraintJPQL = new StringBuilder[numAttributeParams];
+                        new AttributeConstraint[numConstraints];
+        char[] updateOps = new char[numConstraints];
+        int[] numPreviousJPQLParams = new int[numConstraints + 1];
+        StringBuilder[] constraintJPQL = new StringBuilder[numConstraints];
 
         // p is the repository method parameter number (0-based)
         // qp is the JPQL query parameter number (1-based)
         int numJPQLParams = 0;
-        for (int p = 0; p < numAttributeParams; p++) {
+        for (int p = 0; p < numConstraints; p++) {
             numPreviousJPQLParams[p] = numJPQLParams;
 
             Object constraint = constraints.get(p);
@@ -2654,24 +2469,9 @@ public class QueryInfo {
                                                           attrConstraints,
                                                           updateOps,
                                                           numJPQLParams);
-                if (numJPQLParams == DataVersionCompatibility //
-                                .PARAM_ANNO_CONFLICTS_WITH_CONSTRAINT)
-                    throw exc(UnsupportedOperationException.class,
-                              "CWWKD1117.anno.constraint.conflict",
-                              p + 1,
-                              method.getName(),
-                              repositoryInterface.getName(),
-                              Arrays.toString(annosForAllParams[p]),
-                              paramTypes[p].getClass().getName());
-                else if (numJPQLParams == DataVersionCompatibility //
-                                .PARAM_ANNOS_CONFLICT)
-                    throw exc(UnsupportedOperationException.class,
-                              "CWWKD1118.param.anno.conflict",
-                              p + 1,
-                              method.getName(),
-                              repositoryInterface.getName(),
-                              Arrays.toString(annosForAllParams[p]));
-
+                if (numJPQLParams < 0)
+                    Fail.methodParamAnnoConflict(this, numJPQLParams, p,
+                                                 paramTypes[p], annosForAllParams[p]);
             } else {
                 constraintJPQL[p] = new StringBuilder(50);
                 numJPQLParams = compat.generateConstraint(constraintJPQL[p],
@@ -2705,7 +2505,7 @@ public class QueryInfo {
             attrNames[p] = getAttributeName(name, true);
         }
 
-        numPreviousJPQLParams[numAttributeParams] = numJPQLParams;
+        numPreviousJPQLParams[numConstraints] = numJPQLParams;
 
         // Write new JPQL, starting with SELECT or UPDATE
         if (q == null && type == FIND) { // SELECT
@@ -2724,7 +2524,7 @@ public class QueryInfo {
             boolean needsVersionUpdate = entityInfo.versionAttributeName != null;
             boolean first = true;
             // p is the repository method parameter position (0-based)
-            for (int p = 0; p < numAttributeParams; p++) {
+            for (int p = 0; p < numConstraints; p++) {
                 char op = updateOps[p];
                 if (op != Character.MIN_VALUE) {
                     if (op != '=' &&
@@ -2798,21 +2598,15 @@ public class QueryInfo {
                 first = false;
             }
 
-            if (first)
-                // No parameters are annotated to indicate update.
-                throw exc(UnsupportedOperationException.class,
-                          "CWWKD1009.lifecycle.param.err",
-                          method.getName(),
-                          repositoryInterface.getName(),
-                          method.getParameterCount(),
-                          Update.class.getSimpleName());
+            if (first) // No parameters are annotated to indicate update.
+                throw Fail.lifeCycleMethodParamCount(this, Update.class);
         }
 
         int startIndexForWhereClause = q.length();
 
         // append the WHERE clause
         // p is the repository method parameter position (0-based)
-        for (int p = 0; p < numAttributeParams; p++) {
+        for (int p = 0; p < numConstraints; p++) {
             if (attrConstraints[p] != null || constraintJPQL[p] != null) {
                 if (hasWhere) {
                     q.append(" AND ");
@@ -2850,7 +2644,7 @@ public class QueryInfo {
             q.append(')');
 
         if (countPages && type == FIND)
-            generateCount(numAttributeParams == 0 ? null : q.substring(startIndexForWhereClause));
+            generateCount(numConstraints == 0 ? null : q.substring(startIndexForWhereClause));
 
         if (type == FIND || type == FIND_AND_DELETE)
             specialParamsStartAt = locateFirstSpecialParameter(paramTypes, true);
@@ -2901,13 +2695,7 @@ public class QueryInfo {
         if (type == FIND_AND_DELETE &&
             !(singleType.isAssignableFrom(Util.wrapperClassIfPrimitive(entityInfo.idType)) ||
               singleType.isAssignableFrom(entityInfo.getType()))) {
-            throw exc(MappingException.class,
-                      "CWWKD1006.delete.rtrn.err",
-                      method.getGenericReturnType().getTypeName(),
-                      method.getName(),
-                      repositoryInterface.getName(),
-                      entityInfo.getType().getName(),
-                      entityInfo.idType.getName());
+            throw Fail.returnTypeInvalidForDelete(this);
         }
 
         if (cols == null || cols.length == 0) {
@@ -2928,15 +2716,7 @@ public class QueryInfo {
                 RecordComponent[] recordComponents = singleType.getRecordComponents();
                 if (recordComponents == null) {
                     // not a record, not an entity, and app did not use @Select
-                    throw exc(MappingException.class,
-                              "CWWKD1005.find.rtrn.err",
-                              method.getName(),
-                              repositoryInterface.getName(),
-                              method.getGenericReturnType().getTypeName(),
-                              entityInfo.entityClass.getName(),
-                              List.of("List", "Optional",
-                                      "Page", "CursoredPage",
-                                      "Stream"));
+                    throw Fail.returnTypeInvalidForFind(this);
                 } else {
                     // Construct new instance for record
                     q.append("SELECT NEW ").append(singleType.getName()).append('(');
@@ -2962,19 +2742,7 @@ public class QueryInfo {
                             first = false;
                         }
                     } catch (RuntimeException x) {
-                        // Raise a more precise error that relates to using records
-                        // for a subset of entity attributes
-                        MappingException mx;
-                        mx = exc(MappingException.class,
-                                 "CWWKD1101.attr.subset.mismatch",
-                                 method.getGenericReturnType().getTypeName(),
-                                 method.getName(),
-                                 repositoryInterface.getName(),
-                                 singleType.getName(),
-                                 Arrays.toString(names),
-                                 entityInfo.getType().getName(),
-                                 entityInfo.getAttributeNames());
-                        throw (MappingException) mx.initCause(x);
+                        throw Fail.selectedAttributesMismatch(this, names, x);
                     }
                     q.append(')');
                 }
@@ -3206,23 +2974,11 @@ public class QueryInfo {
                     // id(this)
                     attributeName = entityInfo.attributeNames.get(By.ID);
                     if (attributeName == null && failIfNotFound)
-                        throw exc(MappingException.class,
-                                  "CWWKD1093.fn.not.applicable",
-                                  name,
-                                  entityInfo.getType().getName(),
-                                  method.getName(),
-                                  repositoryInterface.getName(),
-                                  "@Id");
+                        throw Fail.functionNotApplicable(this, name, "@Id");
                 } else if (len == 13 && name.regionMatches(true, 0, "version", 0, 7)) {
                     // version(this)
                     if (entityInfo.versionAttributeName == null && failIfNotFound)
-                        throw exc(MappingException.class,
-                                  "CWWKD1093.fn.not.applicable",
-                                  name,
-                                  entityInfo.getType().getName(),
-                                  method.getName(),
-                                  repositoryInterface.getName(),
-                                  "@Version");
+                        throw Fail.functionNotApplicable(this, name, "@Version");
                     else
                         attributeName = entityInfo.versionAttributeName;
                 } else {
@@ -3238,12 +2994,7 @@ public class QueryInfo {
                 // allow functions, such as LENGTH(name)
                 attributeName = name;
         } else if (len == 0) {
-            throw exc(MappingException.class,
-                      "CWWKD1024.missing.entity.attr",
-                      method.getName(),
-                      repositoryInterface.getName(),
-                      entityInfo.getType().getName(),
-                      entityInfo.attributeTypes.keySet());
+            throw Fail.entityAttributeNameMissing(this);
         } else {
             String lowerName = name.toLowerCase();
             attributeName = entityInfo.attributeNames.get(lowerName);
@@ -3264,25 +3015,8 @@ public class QueryInfo {
                             // allow functions, such as: length * width
                             attributeName = name;
 
-                        if (nameCharsOnly && failIfNotFound) {
-                            if (Util.hasOperationAnno(method, producer))
-                                throw exc(MappingException.class,
-                                          "CWWKD1010.unknown.entity.attr",
-                                          name,
-                                          entityInfo.getType().getName(),
-                                          method.getName(),
-                                          repositoryInterface.getName(),
-                                          entityInfo.attributeTypes.keySet());
-                            else
-                                throw exc(MappingException.class,
-                                          "CWWKD1091.method.name.parse.err",
-                                          name,
-                                          entityInfo.getType().getName(),
-                                          method.getName(),
-                                          repositoryInterface.getName(),
-                                          Util.operationAnnoNames(producer),
-                                          entityInfo.attributeTypes.keySet());
-                        }
+                        if (nameCharsOnly && failIfNotFound)
+                            throw Fail.unknownEntityAttribute(this, name);
                     }
                 }
             }
@@ -3478,30 +3212,14 @@ public class QueryInfo {
                 if (type == FIND_AND_DELETE
                     && multiType != null
                     && Stream.class.isAssignableFrom(multiType)) {
-                    throw exc(UnsupportedOperationException.class,
-                              "CWWKD1006.delete.rtrn.err",
-                              method.getGenericReturnType().getTypeName(),
-                              method.getName(),
-                              repositoryInterface.getName(),
-                              entityInfo.getType().getName(),
-                              entityInfo.idType.getName());
+                    throw Fail.returnTypeInvalidForDelete(this);
                 }
             }
 
             // The @OrderBy annotation from Jakarta Data provides sort criteria statically
             if (orderBy.length > 0) {
-                // disallow on incompatible operations
-                if (type != FIND && type != FIND_AND_DELETE)
-                    throw exc(UnsupportedOperationException.class,
-                              "CWWKD1096.orderby.incompat",
-                              method.getName(),
-                              repositoryInterface.getName());
-
-                if (sorts != null) // also has an OrderBy keyword
-                    throw exc(UnsupportedOperationException.class,
-                              "CWWKD1090.orderby.conflict",
-                              method.getName(),
-                              repositoryInterface.getName());
+                if (type != FIND && type != FIND_AND_DELETE || sorts != null)
+                    throw Fail.orderByAnnoIncompat(this);
 
                 sorts = new ArrayList<>(orderBy.length);
                 if (q == null)
@@ -3638,11 +3356,7 @@ public class QueryInfo {
                     specialParamsStartAt = i;
                 if ("jakarta.data.restrict.Restriction".equals(paramType.getName())) // TODO 1.1
                     if (addsToWHERE)
-                        throw exc(UnsupportedOperationException.class,
-                                  "CWWKD1017.dup.special.param",
-                                  method.getName(),
-                                  repositoryInterface.getName(),
-                                  "Restriction");
+                        throw Fail.duplicateSpecialParam(this, "Restriction");
                     else
                         addsToWHERE = true;
             } else if (i > specialParamsStartAt) {
@@ -3696,13 +3410,7 @@ public class QueryInfo {
             if (entityName.length() > 0)
                 setEntityInfo(entityName.toString(), entityInfos, ql);
             else
-                throw exc(UnsupportedOperationException.class,
-                          "CWWKD1030.ql.lacks.entity",
-                          ql,
-                          method.getName(),
-                          repositoryInterface.getName(),
-                          "UPDATE",
-                          "UPDATE [entity_name] SET [update_items] WHERE [conditional_expression]");
+                throw Fail.queryLacksEntityName(this, ql, "UPDATE");
 
             entityVar = parseIdentificationVariable(startAt, length, ql);
             entityVar_ = entityVar + '.';
@@ -3756,13 +3464,7 @@ public class QueryInfo {
                 boolean isDuplicate = !jpqlParamNames.add(paramName);
                 if (qlParamNames.contains(paramName)) {
                     if (isDuplicate) // duplicate of a valid name
-                        throw exc(MappingException.class,
-                                  "CWWKD1083.dup.method.param",
-                                  method.getName(),
-                                  repositoryInterface.getName(),
-                                  paramName,
-                                  "@Param(\"" + paramName + "\")",
-                                  params[i].getType().getSimpleName() + ' ' + paramName);
+                        throw Fail.namedParamConflict(this, paramName, params[i]);
                 } else {
                     hasExtraParam = true;
                 }
@@ -4039,11 +3741,7 @@ public class QueryInfo {
         }
 
         if (entityCount == 0)
-            throw exc(IllegalArgumentException.class,
-                      "CWWKD1092.lifecycle.arg.empty",
-                      method.getName(),
-                      repositoryInterface.getName(),
-                      method.getGenericParameterTypes()[0].getTypeName());
+            throw Fail.emptyLifeCycleParam(this);
 
         if (trace && tc.isDebugEnabled())
             Tr.debug(this, tc, "flush");
@@ -4069,16 +3767,8 @@ public class QueryInfo {
                     else if (results.isEmpty())
                         returnValue = null;
                     else
-                        throw exc(ClassCastException.class,
-                                  "CWWKD1094.return.mismatch",
-                                  method.getName(),
-                                  repositoryInterface.getName(),
-                                  method.getGenericReturnType().getTypeName(),
-                                  results.size(),
-                                  "@Insert",
-                                  lifeCycleReturnTypes(entityInfo.getType().getName(),
-                                                       hasSingularEntityParam,
-                                                       false));
+                        throw Fail.resultSizeMismatch(this, "@Insert", results.size(),
+                                                      hasSingularEntityParam);
                 else if (multiType.isInstance(results))
                     returnValue = results;
                 else if (Stream.class.equals(multiType))
@@ -4088,15 +3778,8 @@ public class QueryInfo {
                 else if (Iterator.class.equals(multiType))
                     returnValue = results.iterator();
                 else
-                    throw exc(MappingException.class,
-                              "CWWKD1003.rtrn.err",
-                              method.getGenericReturnType().getTypeName(),
-                              method.getName(),
-                              repositoryInterface.getName(),
-                              "Insert",
-                              lifeCycleReturnTypes(results.get(0).getClass().getSimpleName(),
-                                                   hasSingularEntityParam,
-                                                   false));
+                    throw Fail.returnTypeInvalid(this, "Insert", hasSingularEntityParam,
+                                                 null, results.get(0).getClass());
             }
         }
 
@@ -4105,15 +3788,8 @@ public class QueryInfo {
             // useful for @Asynchronous
             returnValue = CompletableFuture.completedFuture(returnValue);
         } else if (!resultVoid && !returnType.isInstance(returnValue)) {
-            throw exc(MappingException.class,
-                      "CWWKD1003.rtrn.err",
-                      method.getGenericReturnType().getTypeName(),
-                      method.getName(),
-                      repositoryInterface.getName(),
-                      "Insert",
-                      lifeCycleReturnTypes(results.get(0).getClass().getSimpleName(),
-                                           hasSingularEntityParam,
-                                           false));
+            throw Fail.returnTypeInvalid(this, "Insert", hasSingularEntityParam,
+                                         null, results.get(0).getClass());
         }
 
         if (trace && tc.isEntryEnabled())
@@ -4249,21 +3925,14 @@ public class QueryInfo {
                                "; multiType: " + (multiType == null ? null : multiType.getSimpleName()) +
                                "; singleType: " + (singleType == null ? null : singleType.getSimpleName()));
 
-        if (isFindAndDelete)
-            if (type != null
-                && !type.equals(entityInfo.entityClass)
-                && !type.equals(entityInfo.recordClass)
-                && !type.equals(Object.class)
-                && !Util.wrapperClassIfPrimitive(singleType) //
-                                .equals(Util.wrapperClassIfPrimitive(entityInfo.idType))) {
-                throw exc(MappingException.class,
-                          "CWWKD1006.delete.rtrn.err",
-                          method.getGenericReturnType().getTypeName(),
-                          method.getName(),
-                          repositoryInterface.getName(),
-                          entityInfo.getType().getName(),
-                          entityInfo.idType.getName());
-            }
+        if (isFindAndDelete &&
+            type != null &&
+            !type.equals(entityInfo.entityClass) &&
+            !type.equals(entityInfo.recordClass) &&
+            !type.equals(Object.class) &&
+            !Util.wrapperClassIfPrimitive(singleType) //
+                            .equals(Util.wrapperClassIfPrimitive(entityInfo.idType)))
+            throw Fail.returnTypeInvalidForDelete(this);
 
         return isFindAndDelete;
     }
@@ -4617,13 +4286,7 @@ public class QueryInfo {
                             if (entityName.length() > 0)
                                 setEntityInfo(entityName.toString(), entityInfos, ql);
                             else if (type != FIND) // a DELETE query
-                                throw exc(UnsupportedOperationException.class,
-                                          "CWWKD1030.ql.lacks.entity",
-                                          ql,
-                                          method.getName(),
-                                          repositoryInterface.getName(),
-                                          "DELETE",
-                                          "DELETE FROM [entity_name] WHERE [conditional_expression]");
+                                throw Fail.queryLacksEntityName(this, ql, "DELETE");
 
                             entityVar = parseIdentificationVariable(i, length, ql);
                             entityVar_ = entityVar + '.';
@@ -4653,16 +4316,9 @@ public class QueryInfo {
                             if (isOrder)
                                 restrictAt = i;
                             if (isCursoredPage && !isSelect && !isWhere && !isOrder)
-                                // ORDER BY isn't allowed with cursored pagination
-                                // either, nor is SELECT positioned after WHERE,
-                                // but those patterns have a better error message
-                                // elsewhere that points out the correct usage
-                                throw exc(UnsupportedOperationException.class,
-                                          "CWWKD1120.cursor.keyword.mismatch",
-                                          method.getName(),
-                                          repositoryInterface.getName(),
-                                          ql.substring(i, i + l),
-                                          ql);
+                                // ORDER BY and SELECT positioned after WHERE are
+                                // also incompatible but are handled better elsewhere
+                                throw Fail.queryIncompatipleWithCursor(this, ql, i, l);
                             if (hasTopLevelSelectClause &&
                                 countReplacesFirstSelectEndingAt < 0) {
                                 countReplacesFirstSelectEndingAt = i;
@@ -5026,11 +4682,7 @@ public class QueryInfo {
                     if (args[p] == null)
                         // BasicRepository.findAll(PageRequest, Order) requires
                         // NullPointerException when Order is null.
-                        throw exc(NullPointerException.class,
-                                  "CWWKD1087.null.param",
-                                  paramTypeName,
-                                  method.getName(),
-                                  repositoryInterface.getName());
+                        throw Fail.nullMethodParameter(this, p);
                     else
                         throw exc(IllegalArgumentException.class,
                                   "CWWKD1088.empty.sorts",
@@ -5098,11 +4750,7 @@ public class QueryInfo {
         }
 
         if (entityCount == 0)
-            throw exc(IllegalArgumentException.class,
-                      "CWWKD1092.lifecycle.arg.empty",
-                      method.getName(),
-                      repositoryInterface.getName(),
-                      method.getGenericParameterTypes()[0].getTypeName());
+            throw Fail.emptyLifeCycleParam(this);
 
         if (trace && tc.isDebugEnabled())
             Tr.debug(this, tc, "flush");
@@ -5127,16 +4775,8 @@ public class QueryInfo {
                     else if (results.isEmpty())
                         returnValue = null;
                     else
-                        throw exc(ClassCastException.class,
-                                  "CWWKD1094.return.mismatch",
-                                  method.getName(),
-                                  repositoryInterface.getName(),
-                                  method.getGenericReturnType().getTypeName(),
-                                  results.size(),
-                                  "@Save",
-                                  lifeCycleReturnTypes(entityInfo.getType().getName(),
-                                                       hasSingularEntityParam,
-                                                       false));
+                        throw Fail.resultSizeMismatch(this, "@Save", results.size(),
+                                                      hasSingularEntityParam);
                 else if (multiType.isInstance(results))
                     returnValue = results;
                 else if (Stream.class.equals(multiType))
@@ -5146,15 +4786,8 @@ public class QueryInfo {
                 else if (Iterator.class.equals(multiType))
                     returnValue = results.iterator();
                 else
-                    throw exc(MappingException.class,
-                              "CWWKD1003.rtrn.err",
-                              method.getGenericReturnType().getTypeName(),
-                              method.getName(),
-                              repositoryInterface.getName(),
-                              "Save",
-                              lifeCycleReturnTypes(results.get(0).getClass().getSimpleName(),
-                                                   hasSingularEntityParam,
-                                                   false));
+                    throw Fail.returnTypeInvalid(this, "Save", hasSingularEntityParam,
+                                                 null, results.get(0).getClass());
             }
         }
 
@@ -5163,15 +4796,8 @@ public class QueryInfo {
             // useful for @Asynchronous
             returnValue = CompletableFuture.completedFuture(returnValue);
         } else if (!resultVoid && !returnType.isInstance(returnValue)) {
-            throw exc(MappingException.class,
-                      "CWWKD1003.rtrn.err",
-                      method.getGenericReturnType().getTypeName(),
-                      method.getName(),
-                      repositoryInterface.getName(),
-                      "Save",
-                      lifeCycleReturnTypes(results.get(0).getClass().getSimpleName(),
-                                           hasSingularEntityParam,
-                                           false));
+            throw Fail.returnTypeInvalid(this, "Save", hasSingularEntityParam,
+                                         null, results.get(0).getClass());
         }
 
         if (trace && tc.isEntryEnabled())
@@ -5367,13 +4993,7 @@ public class QueryInfo {
             Iterator<String> paramNames = jpqlParamNames.iterator();
             for (int a = 0; a < specialParamsStartAt; a++) {
                 if (!paramNames.hasNext())
-                    throw exc(UnsupportedOperationException.class,
-                              "CWWKD1022.too.many.params",
-                              method.getName(),
-                              repositoryInterface.getName(),
-                              a + 1,
-                              specialParamsStartAt + 1,
-                              jpql);
+                    throw Fail.extraMethodParams(this, a + 1, specialParamsStartAt + 1);
                 String paramName = paramNames.next();
                 if (trace && tc.isDebugEnabled())
                     Tr.debug(this, tc, "[m] set :" + paramName + ' ' + loggable(args[a]));
@@ -5527,10 +5147,7 @@ public class QueryInfo {
     @Trivial
     private final Object toEntity(Object o, EntityManager em) {
         if (o == null)
-            throw exc(NullPointerException.class,
-                      "CWWKD1015.null.entity.param",
-                      method.getName(),
-                      repositoryInterface.getName());
+            throw Fail.entityNull(this);
 
         Object entity = o;
         Class<?> oClass = o.getClass();
@@ -5704,29 +5321,10 @@ public class QueryInfo {
         em.flush();
 
         if (numExpected == 0)
-            throw exc(IllegalArgumentException.class,
-                      "CWWKD1092.lifecycle.arg.empty",
-                      method.getName(),
-                      repositoryInterface.getName(),
-                      method.getGenericParameterTypes()[0].getTypeName());
+            throw Fail.emptyLifeCycleParam(this);
 
         if (updateCount < numExpected)
-            if (numExpected == 1)
-                throw exc(OptimisticLockingFailureException.class,
-                          "CWWKD1051.single.opt.lock.exc",
-                          method.getName(),
-                          repositoryInterface.getName(),
-                          entityInfo.entityClass.getName(),
-                          Util.LIFE_CYCLE_METHODS_THAT_RETURN_ENTITIES_STATELESS);
-            else
-                throw exc(OptimisticLockingFailureException.class,
-                          "CWWKD1052.multi.opt.lock.exc",
-                          method.getName(),
-                          repositoryInterface.getName(),
-                          numExpected - updateCount,
-                          numExpected,
-                          entityInfo.entityClass.getName(),
-                          Util.LIFE_CYCLE_METHODS_THAT_RETURN_ENTITIES_STATELESS);
+            throw Fail.optimisticLockConflict(this, updateCount, numExpected);
 
         Object returnValue = toReturnValue(updateCount, method.getReturnType());
 
@@ -5750,21 +5348,8 @@ public class QueryInfo {
         if (trace && tc.isEntryEnabled())
             Tr.entry(this, tc, "updateOne", loggable(e));
 
-        Class<?> entityClass = entityInfo.getType();
-
-        if (e == null)
-            throw exc(NullPointerException.class,
-                      "CWWKD1015.null.entity.param",
-                      method.getName(),
-                      repositoryInterface.getName());
-
-        if (!entityClass.isInstance(e))
-            throw exc(IllegalArgumentException.class,
-                      "CWWKD1016.incompat.entity.param",
-                      method.getName(),
-                      repositoryInterface.getName(),
-                      entityClass.getName(),
-                      e.getClass().getName());
+        if (!entityInfo.getType().isInstance(e))
+            throw Fail.entityMismatch(this, e);
 
         String jpql = this.jpql;
         Set<String> attrsToUpdate = entityInfo.attributeNamesForEntityUpdate;
@@ -5859,13 +5444,7 @@ public class QueryInfo {
                                   paramTypes[i].getSimpleName());
             }
 
-            throw exc(UnsupportedOperationException.class,
-                      "CWWKD1022.too.many.params",
-                      method.getName(),
-                      repositoryInterface.getName(),
-                      jpqlParamCount,
-                      methodParamCount,
-                      jpql);
+            throw Fail.extraMethodParams(this, jpqlParamCount, methodParamCount);
         }
 
         if (type == FIND &&
@@ -5966,13 +5545,7 @@ public class QueryInfo {
              !CompletableFuture.class.equals(multiType) &&
              !CompletionStage.class.equals(multiType)))
 
-            throw exc(UnsupportedOperationException.class,
-                      "CWWKD1003.rtrn.err",
-                      method.getGenericReturnType().getTypeName(),
-                      method.getName(),
-                      repositoryInterface.getName(),
-                      "exists",
-                      "boolean, Boolean");
+            throw Fail.returnTypeInvalid(this, "exists", false, "boolean, Boolean", null);
     }
 
     /**

--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
@@ -824,19 +824,19 @@ public class QueryInfo {
                         if (v >= Integer.MIN_VALUE && v <= Integer.MAX_VALUE)
                             return n.intValue();
                         else
-                            convertFail(n, Integer.MIN_VALUE, Integer.MAX_VALUE);
+                            throw Fail.outOfRange(this, n, Integer.MIN_VALUE, Integer.MAX_VALUE);
                     } else if (short.class.equals(toType) ||
                                Short.class.equals(toType)) {
                         if (v >= Short.MIN_VALUE && v <= Short.MAX_VALUE)
                             return n.shortValue();
                         else
-                            convertFail(n, Short.MIN_VALUE, Short.MAX_VALUE);
+                            throw Fail.outOfRange(this, n, Short.MIN_VALUE, Short.MAX_VALUE);
                     } else if (byte.class.equals(toType) ||
                                Byte.class.equals(toType)) {
                         if (v >= Byte.MIN_VALUE && v <= Byte.MAX_VALUE)
                             return n.byteValue();
                         else
-                            convertFail(n, Byte.MIN_VALUE, Byte.MAX_VALUE);
+                            throw Fail.outOfRange(this, n, Byte.MIN_VALUE, Byte.MAX_VALUE);
                     } else if (BigInteger.class.equals(toType)) {
                         return BigInteger.valueOf(v);
                     } else if (BigDecimal.class.equals(toType)) {
@@ -930,28 +930,6 @@ public class QueryInfo {
     }
 
     /**
-     * Raises an error for a type conversion failure due to a value being outside of
-     * the specified range.
-     *
-     * @param queryInfo query information for the repository method.
-     * @param value     the value that fails to convert.
-     * @param min       minimum value for range.
-     * @param max       maximum value for range.
-     * @throws MappingException for the type conversion failure.
-     */
-    @Trivial
-    private void convertFail(Number value, long min, long max) {
-        throw exc(MappingException.class,
-                  "CWWKD1047.result.out.of.range",
-                  loggableAppend(value.getClass().getName(), " (", value, ")"),
-                  method.getName(),
-                  repositoryInterface.getName(),
-                  method.getGenericReturnType().getTypeName(),
-                  min,
-                  max);
-    }
-
-    /**
      * Convert the results list into an Iterable of the specified type.
      *
      * @param results      results of a find or save operation.
@@ -1038,7 +1016,7 @@ public class QueryInfo {
                     // ElementCollection attributes instead of rejecting it as
                     // unsupported. Raise an error instead.
                     if (converted == element)
-                        throw excIncompatibleQueryResult(results, query);
+                        throw Fail.resultIncompatible(this, results, query);
                 }
                 list.add(element);
             }
@@ -1426,354 +1404,6 @@ public class QueryInfo {
     }
 
     /**
-     * Create a new UnsupportedOperationException for a conflicting Limit or
-     * PageRequest parameter.
-     *
-     * @param ql                the query.
-     * @param endOfWhereClause  position at which the WHERE clause ends.
-     * @param endsAtOrderClause indicates if this error is being raised because an
-     *                              ORDER BY clause was found in the query.
-     * @return UnsupportedOperationException
-     */
-    @Trivial
-    private UnsupportedOperationException //
-                    excCursorPaginationNotAllowed(String ql,
-                                                  int endOfWhereClause,
-                                                  boolean endsAtOrderClause) {
-
-        if (endsAtOrderClause)
-            throw exc(UnsupportedOperationException.class,
-                      "CWWKD1033.ql.orderby.disallowed",
-                      method.getName(),
-                      repositoryInterface.getName(),
-                      CursoredPage.class.getSimpleName(),
-                      OrderBy.class.getSimpleName(),
-                      ql);
-        else
-            throw exc(UnsupportedOperationException.class,
-                      "CWWKD1034.ql.req.end.in.where",
-                      method.getName(),
-                      repositoryInterface.getName(),
-                      CursoredPage.class.getSimpleName(),
-                      endOfWhereClause,
-                      ql.length(),
-                      ql);
-    }
-
-    /**
-     * Create a new EmptyResultException.
-     *
-     * @return the EmptyResultException.
-     */
-    @Trivial
-    private EmptyResultException excEmptyResult() {
-        return exc(EmptyResultException.class,
-                   "CWWKD1053.empty.result",
-                   method.getGenericReturnType().getTypeName(),
-                   method.getName(),
-                   repositoryInterface.getName(),
-                   List.of(List.class.getSimpleName(),
-                           Optional.class.getSimpleName(),
-                           Page.class.getSimpleName(),
-                           CursoredPage.class.getSimpleName(),
-                           Stream.class.getSimpleName()));
-    }
-
-    /**
-     * Constructs the MappingException for the error where the repository method
-     * defines extra named parameters that are not used by the JDQL or JPQL query.
-     *
-     * @return MappingException.
-     */
-    @Trivial
-    private MappingException excExtraMethodArgNamedParams(Set<String> extras,
-                                                          Set<String> qlRequired) {
-        String firstExtraParam = null;
-        StringBuilder extraParamNames = new StringBuilder();
-        for (String name : extras)
-            if (name.length() > 0) {
-                if (firstExtraParam == null)
-                    firstExtraParam = name;
-                else
-                    extraParamNames.append(", ");
-                extraParamNames.append(name);
-            }
-
-        if (firstExtraParam == null && !extras.isEmpty())
-            // @Param("") with empty String is not valid
-            return exc(MappingException.class,
-                       "CWWKD1104.empty.anno.value",
-                       Param.class.getSimpleName(),
-                       method.getName(),
-                       repositoryInterface.getName());
-
-        boolean isFirst = true;
-        StringBuilder qlParamNames = new StringBuilder();
-        for (String name : qlRequired) {
-            if (!isFirst)
-                qlParamNames.append(", ");
-            qlParamNames.append(':').append(name);
-            isFirst = false;
-        }
-
-        if (qlRequired.isEmpty())
-            return exc(MappingException.class,
-                       "CWWKD1086.named.params.unused",
-                       method.getName(),
-                       repositoryInterface.getName(),
-                       extraParamNames,
-                       method.getAnnotation(Query.class).value(),
-                       ':' + firstExtraParam);
-        else
-            return exc(MappingException.class,
-                       "CWWKD1085.extra.method.params",
-                       method.getName(),
-                       repositoryInterface.getName(),
-                       extraParamNames,
-                       qlParamNames,
-                       method.getAnnotation(Query.class).value());
-    }
-
-    /**
-     * Create a new UnsupportedOperationException for a conflicting Limit or
-     * PageRequest parameter.
-     *
-     * @param param   method parameter that is an instance of Limit or PageRequest.
-     * @param limit   other Limit parameter value. Otherwise null.
-     * @param pageReq other PageRequest parameter value. Otherwise null.
-     * @param method  repository method
-     * @return UnsupportedOperationException
-     */
-    @Trivial
-    private UnsupportedOperationException excIncompatible(Object param,
-                                                          Limit limit,
-                                                          PageRequest pageReq,
-                                                          Method method) {
-        Class<?> type = param instanceof Limit ? Limit.class : PageRequest.class;
-
-        if (limit == null && pageReq == null)
-            // conflicts with First keyword
-            return exc(UnsupportedOperationException.class,
-                       "CWWKD1099.first.keyword.incompat",
-                       method.getName(),
-                       repositoryInterface.getName(),
-                       type.getSimpleName());
-        else if (param instanceof Limit ? limit != null : pageReq != null)
-            // conflicts with another parameter of the same time
-            return exc(UnsupportedOperationException.class,
-                       "CWWKD1017.dup.special.param",
-                       method.getName(),
-                       repositoryInterface.getName(),
-                       type.getSimpleName());
-        else
-            // conflict between Limit and PageRequest parameters
-            throw exc(UnsupportedOperationException.class,
-                      "CWWKD1018.confl.special.param",
-                      method.getName(),
-                      repositoryInterface.getName(),
-                      Limit.class.getSimpleName(),
-                      PageRequest.class.getSimpleName());
-    }
-
-    /**
-     * Constructs an UnsupportedOperationException for an error where the
-     * repository method return type does not match the query results.
-     * On reason this might happen is when EclipseLink returns wrong values
-     * when selecting ElementCollection attributes instead of rejecting
-     * it as unsupported.
-     *
-     * @param results list of at least 1 result.
-     * @param query   jakarta.persistence.Query, a String, or null.
-     * @return UnsupportedOperationException.
-     */
-    @Trivial
-    private UnsupportedOperationException excIncompatibleQueryResult(List<?> results,
-                                                                     Object query) {
-        String r = results.getClass().getName() +
-                   "<" + results.get(0).getClass().getName() + ">";
-
-        if (query == null)
-            return exc(UnsupportedOperationException.class,
-                       "CWWKD1102.incompat.query.result",
-                       method.getName(),
-                       repositoryInterface.getName(),
-                       method.getGenericReturnType().getTypeName(),
-                       r);
-        else
-            return exc(UnsupportedOperationException.class,
-                       "CWWKD1103.incompat.query.result",
-                       method.getName(),
-                       repositoryInterface.getName(),
-                       method.getGenericReturnType().getTypeName(),
-                       query instanceof String ? query : query.getClass().getName(),
-                       r);
-    }
-
-    /**
-     * Check if the cause of the lacking named parameter is a mispositioned
-     * special parameter. If so, raises UnsupportedOperationException.
-     *
-     * Otherwise, constructs a MappingException for the error where one or more
-     * of the named parameters required by a JDQL or JPQL query are not specified
-     * by the method parameters
-     *
-     * @param lacking query named parameters for which no method parameters were
-     *                    found.
-     * @return MappingException for a missing named parameter.
-     * @throws UnsupportedOperationException if there is a mispositioned special
-     *                                           parameter.
-     */
-    @Trivial
-    private MappingException excLackingMethodArgNamedParams(Set<String> lacking) {
-
-        validateParameterPositions();
-
-        String first = null;
-        StringBuilder all = new StringBuilder();
-        for (String name : lacking) {
-            if (first == null)
-                first = name;
-            else
-                all.append(", ");
-            all.append(':').append(name);
-        }
-
-        return exc(MappingException.class,
-                   "CWWKD1084.missing.named.params",
-                   method.getName(),
-                   repositoryInterface.getName(),
-                   all,
-                   method.getAnnotation(Query.class).value(),
-                   "@Param(\"" + first + "\")",
-                   "String " + first);
-    }
-
-    /**
-     * Constructs the MappingException or UnsupportedOoperationException for
-     * the error where a repository method parameter lacks an annotation that
-     * identifies the corresponding entity attribute name.
-     *
-     * @param p position (1-based) of the repository method parameter.
-     * @return MappingException or UnsupportedOperationException.
-     */
-    @Trivial
-    private RuntimeException excMissingParamAnno(int p) {
-        DataVersionCompatibility compat = producer.compat();
-
-        switch (type) {
-            case FIND:
-            case FIND_AND_DELETE:
-                validateParameterPositions();
-                String specParams = type == FIND //
-                                ? compat.specialParamsForFind() //
-                                : compat.specialParamsForFindAndDelete();
-                throw exc(MappingException.class,
-                          "CWWKD1012.fd.missing.param.anno",
-                          p,
-                          method.getName(),
-                          repositoryInterface.getName(),
-                          specParams);
-            case QM_DELETE:
-            case COUNT:
-            case EXISTS:
-                throw exc(MappingException.class,
-                          "CWWKD1013.cde.missing.param.anno",
-                          p,
-                          method.getName(),
-                          repositoryInterface.getName());
-            case QM_UPDATE:
-                throw exc(UnsupportedOperationException.class,
-                          "CWWKD1014.upd.missing.param.anno",
-                          method.getName(),
-                          repositoryInterface.getName(),
-                          method.getParameterCount(),
-                          p,
-                          compat.paramAnnosForUpdate());
-            default: // should be unreachable
-                throw new IllegalStateException(type.name());
-        }
-    }
-
-    /**
-     * Constructs the UnsupportedOperationException for the error where a repository
-     * method intermixed named and positional parameters for a query.
-     *
-     * @return UnsupportedOperationException.
-     */
-    @Trivial
-    private UnsupportedOperationException excMixedQLParamTypes(int methodNPCount) {
-        String firstNamedParam = null;
-        StringBuilder allNamedParams = new StringBuilder().append('(');
-        for (String name : jpqlParamNames) {
-            if (firstNamedParam == null)
-                firstNamedParam = name;
-            else
-                allNamedParams.append(", ");
-            allNamedParams.append(':').append(name);
-        }
-        allNamedParams.append(')');
-
-        Class<?> firstNamedParamType = String.class;
-        for (Parameter p : method.getParameters()) {
-            Param param = p.getAnnotation(Param.class);
-            if (param == null //
-                            ? p.isNamePresent() && firstNamedParam.equals(p.getName()) //
-                            : firstNamedParam.equals(param.value()))
-                firstNamedParamType = p.getType();
-            break;
-        }
-
-        return exc(UnsupportedOperationException.class,
-                   "CWWKD1019.mixed.positional.named",
-                   method.getName(),
-                   repositoryInterface.getName(),
-                   jpqlParamCount - methodNPCount,
-                   methodNPCount,
-                   allNamedParams,
-                   method.getAnnotation(Query.class).value(),
-                   ':' + firstNamedParam,
-                   "@Param(\"" + firstNamedParam + "\")",
-                   firstNamedParamType.getSimpleName() + ' ' + firstNamedParam);
-    }
-
-    /**
-     * Create a new NonUniqueResultException.
-     *
-     * @param numResults number of results.
-     * @return the NonUniqueResultException.
-     */
-    @Trivial
-    private NonUniqueResultException excNonUniqueResult(int numResults) {
-        throw exc(NonUniqueResultException.class,
-                  "CWWKD1054.non.unique.result",
-                  method.getName(),
-                  repositoryInterface.getName(),
-                  method.getGenericReturnType().getTypeName(),
-                  numResults,
-                  List.of(// In a future release: @Find @First findByX(...)
-                          "findFirstByX(...)",
-                          "findByX(..., Limit.of(1))"));
-    }
-
-    /**
-     * Constructs the UnsupportedOperationException for the general error where
-     * a repository method is unrecognized and log the error.
-     *
-     * @return UnsupportedOperationException.
-     */
-    @Trivial
-    private UnsupportedOperationException excUnsupportedMethod() {
-        return exc(UnsupportedOperationException.class,
-                   "CWWKD1011.unknown.method.pattern",
-                   method.getName(),
-                   repositoryInterface.getName(),
-                   Util.operationAnnoNames(producer),
-                   Util.resourceAccessorTypeNames(producer),
-                   Util.methodNamePrefixes(producer),
-                   entityInfo.getExampleMethodNames());
-    }
-
-    /**
      * Execute JPQL for a repository delete or update query.
      *
      * @param em   entity manager.
@@ -1886,7 +1516,7 @@ public class QueryInfo {
                 if (max == 0 && limit == null && pageReq == null)
                     max = (limit = (Limit) param).maxResults();
                 else
-                    throw excIncompatible(param, limit, pageReq, method);
+                    throw Fail.methodParamIncompat(this, param, limit, pageReq);
             } else if (param instanceof Order) {
                 @SuppressWarnings("unchecked")
                 Iterable<Sort<Object>> order = (Iterable<Sort<Object>>) param;
@@ -1895,7 +1525,7 @@ public class QueryInfo {
                 if (max == 0 && pageReq == null && limit == null)
                     max = (pageReq = (PageRequest) param).size();
                 else
-                    throw excIncompatible(param, limit, pageReq, method);
+                    throw Fail.methodParamIncompat(this, param, limit, pageReq);
             } else if (param instanceof Sort) {
                 @SuppressWarnings("unchecked")
                 List<Sort<Object>> newList = supplySorts(sortList, (Sort<Object>) param);
@@ -1926,15 +1556,7 @@ public class QueryInfo {
                               method.getName(),
                               repositoryInterface.getName());
             } else {
-                validateParameterPositions();
-
-                throw exc(DataException.class,
-                          "CWWKD1023.extra.param",
-                          method.getName(),
-                          repositoryInterface.getName(),
-                          specialParamsStartAt,
-                          method.getParameterTypes()[i].getName(),
-                          jpql);
+                throw Fail.extraMethodParam(this, i);
             }
         }
 
@@ -2211,7 +1833,7 @@ public class QueryInfo {
                         } else {
                             // List<Object[]> with multiple Object[] elements
                             // cannot convert to a one dimensional array
-                            throw excNonUniqueResult(size);
+                            throw Fail.nonUniqueResult(this, size);
                         }
                     } else {
                         throw exc(MappingException.class,
@@ -2223,7 +1845,7 @@ public class QueryInfo {
                                   method.getGenericReturnType().getTypeName());
                     }
                 } else if (results.isEmpty()) {
-                    throw excEmptyResult();
+                    throw Fail.emptyResult(this);
                 } else { // single result of other type
                     if (Iterable.class.isAssignableFrom(singleType) &&
                         !(results.get(0) instanceof Iterable))
@@ -2320,7 +1942,7 @@ public class QueryInfo {
                     else if (results.isEmpty())
                         returnValue = null;
                     else
-                        throw excNonUniqueResult(results.size());
+                        throw Fail.nonUniqueResult(this, results.size());
                 else if (multiType.isInstance(results))
                     returnValue = results;
                 else if (Stream.class.equals(multiType))
@@ -2562,7 +2184,7 @@ public class QueryInfo {
         String attribute = methodName.substring(start, endBefore);
 
         if (attribute.length() == 0)
-            throw excUnsupportedMethod();
+            throw Fail.unsupportedMethod(this);
 
         String name = getAttributeName(attribute, true);
 
@@ -3078,7 +2700,7 @@ public class QueryInfo {
                 if (Boolean.TRUE.equals(isNamePresent))
                     name = params[p].getName();
                 else
-                    throw excMissingParamAnno(p + 1);
+                    throw Fail.methodParamLacksAnno(this, p + 1);
             }
             attrNames[p] = getAttributeName(name, true);
         }
@@ -3701,22 +3323,6 @@ public class QueryInfo {
     }
 
     /**
-     * Determine if the index of the text ignoring case if it is the next non-whitespace characters.
-     *
-     * @parma text the text to match.
-     * @param ql      query language.
-     * @param startAt starting position in the query language string.
-     * @return position of the text ignoring case if it is the next non-whitespace characters. Otherwise -1;
-     */
-    @Trivial
-    private static int indexOfAfterWhitespace(String text, String ql, int startAt) {
-        int length = ql.length();
-        while (startAt < length && Character.isWhitespace(ql.charAt(startAt)))
-            startAt++;
-        return ql.regionMatches(true, startAt, text, 0, 2) ? startAt : -1;
-    }
-
-    /**
      * Infer the selection value to use for a COUNT query.
      * Typically, the best we can do is to use the entity identifier variable,
      * For example, COUNT(o). This works for:
@@ -4174,18 +3780,18 @@ public class QueryInfo {
             LinkedHashSet<String> lacking = new LinkedHashSet<>(qlParamNames);
             lacking.removeAll(jpqlParamNames);
             if (!lacking.isEmpty())
-                throw excLackingMethodArgNamedParams(lacking);
+                throw Fail.methodLacksNamedParams(this, lacking);
 
             // Does the method supply any named parameters not needed by the query?
             Set<String> extras = new LinkedHashSet<>(jpqlParamNames);
             extras.removeAll(qlParamNames);
             if (!extras.isEmpty())
-                throw excExtraMethodArgNamedParams(extras, qlParamNames);
+                throw Fail.unusedNamedParamsOnMethod(this, extras, qlParamNames);
         }
 
         // Does the method supply a mixture of named and positional parameters?
         if (paramNamesCount > 0 && paramNamesCount < jpqlParamCount)
-            throw excMixedQLParamTypes(paramNamesCount);
+            throw Fail.mixedQLParamTypes(this, paramNamesCount);
     }
 
     /**
@@ -4279,7 +3885,7 @@ public class QueryInfo {
             type = EXISTS;
             validateReturnForExists();
         } else {
-            throw excUnsupportedMethod();
+            throw Fail.unsupportedMethod(this);
         }
 
         if (trace && tc.isDebugEnabled())
@@ -4687,7 +4293,7 @@ public class QueryInfo {
      * @return loggable value.
      */
     @Trivial
-    private final String loggableAppend(String prefix, Object... possibleSuffix) {
+    final String loggableAppend(String prefix, Object... possibleSuffix) {
         return entityInfo.builder.provider.loggableAppend(repositoryInterface,
                                                           method,
                                                           prefix,
@@ -4708,9 +4314,9 @@ public class QueryInfo {
         if (size == 1)
             return results.get(0);
         else if (size == 0)
-            throw excEmptyResult();
+            throw Fail.emptyResult(this);
         else
-            throw excNonUniqueResult(results.size());
+            throw Fail.nonUniqueResult(this, results.size());
     }
 
     /**
@@ -5071,7 +4677,7 @@ public class QueryInfo {
                             }
                             if (encloseWhereBeginAt > 0) {
                                 if (isCursoredPage)
-                                    throw excCursorPaginationNotAllowed(ql, i, isOrder);
+                                    throw Fail.cursorQueryIncompat(this, ql, i, isOrder);
                                 int p = i - 1;
                                 while (p > 0 && Character.isWhitespace(ql.charAt(p)))
                                     p--;
@@ -6219,7 +5825,7 @@ public class QueryInfo {
     @Trivial
     private void validate(boolean validateNumberOfMethodArgs) {
         if (type == null)
-            throw excUnsupportedMethod();
+            throw Fail.unsupportedMethod(this);
 
         int methodParamCount = method.getParameterCount();
         if (validateNumberOfMethodArgs &&
@@ -6346,34 +5952,6 @@ public class QueryInfo {
                         : iusdce == 1 //
                                         ? (delete != null ? delete : count != null ? count : exists) //
                                         : (q == 1 ? query : f == 1 ? find : null);
-    }
-
-    /**
-     * Confirm that special parameters are positioned after all other parameters.
-     *
-     * @throws UnupportedOperationException if a special parameter is ahead of
-     *                                          a query parameter.
-     */
-    @Trivial
-    private void validateParameterPositions() {
-        DataVersionCompatibility compat = entityInfo.builder.provider.compat;
-
-        Class<?>[] paramTypes = method.getParameterTypes();
-        Set<Class<?>> specParamTypes = compat.specialParamTypes();
-        int specParamIndex = Integer.MAX_VALUE, otherParamIndex = -1;
-        for (int i = 0; i < paramTypes.length; i++)
-            if (specParamTypes.contains(paramTypes[i]))
-                specParamIndex = i < specParamIndex ? i : specParamIndex;
-            else
-                otherParamIndex = i;
-
-        if (specParamIndex < otherParamIndex)
-            throw exc(UnsupportedOperationException.class,
-                      "CWWKD1098.spec.param.position.err",
-                      method.getName(),
-                      repositoryInterface.getName(),
-                      paramTypes[specParamIndex].getName(),
-                      compat.specialParamsForFind());
     }
 
     /**


### PR DESCRIPTION
Jakarta Data code has lots of good exception/error reporting that is excellent for serviceability and helping users figure out their problems, but it significantly clutters up the main code path making it hard to understand.  This PR adds a separate class where a lot of the processing and collecting of information can be put, leaving the main path code with usually only a single line of code per exception.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
