### PR TITLE
Fix shutdown race condition in PersistentExecutorImpl causing IllegalStateException

### DIFF
--- a/dev/com.ibm.ws.concurrent.persistent/src/com/ibm/ws/concurrent/persistent/internal/PersistentExecutorImpl.java
+++ b/dev/com.ibm.ws.concurrent.persistent/src/com/ibm/ws/concurrent/persistent/internal/PersistentExecutorImpl.java
@@ -309,6 +309,12 @@ public class PersistentExecutorImpl implements ApplicationRecycleComponent, DDLG
     private final AtomicBoolean pollingStartSignalReceived = new AtomicBoolean();
 
     /**
+     * Indicates if the polling task is currently executing.
+     * Used to prevent race condition during deactivation.
+     */
+    private final AtomicBoolean pollingTaskRunning = new AtomicBoolean(false);
+
+    /**
      * Liberty scheduled executor.
      */
     @Reference(target = "(deferrable=false)")
@@ -507,6 +513,25 @@ public class PersistentExecutorImpl implements ApplicationRecycleComponent, DDLG
      */
     protected void deactivate(ComponentContext context) throws Exception {
         deactivated = true;
+        
+        // Cancel the polling future to stop background tasks before closing resources 
+        // product bug fix 308877
+        ScheduledFuture<?> pollingFuture = pollingFutureRef.get();
+        if (pollingFuture != null) {
+            pollingFuture.cancel(false);
+            // Wait for the polling task to actually finish to avoid race condition with resource cleanup
+            // Cannot use get() or isDone() on cancelled future, so check our own flag
+            long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5);
+            while (pollingTaskRunning.get() && System.nanoTime() < deadline) {
+                try {
+                    Thread.sleep(50);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    break;
+                }
+            }
+        }
+        
         if (mbean != null) {
             mbean.unregister();
             mbean = null;
@@ -2593,7 +2618,10 @@ public class PersistentExecutorImpl implements ApplicationRecycleComponent, DDLG
             if (trace && tc.isEntryEnabled())
                 Tr.entry(PersistentExecutorImpl.this, tc, "run[poll]");
 
-            Config config = configRef.get();
+            // Claim execution state BEFORE checking deactivated to prevent race condition
+            pollingTaskRunning.set(true);
+            try {
+                Config config = configRef.get();
 
             if (deactivated || !config.enableTaskExecution || config != initialConfig) {
                 if (trace && tc.isEntryEnabled())
@@ -2638,6 +2666,9 @@ public class PersistentExecutorImpl implements ApplicationRecycleComponent, DDLG
 
             if (trace && tc.isEntryEnabled())
                 Tr.exit(PersistentExecutorImpl.this, tc, "run[poll]", failure);
+            } finally {
+                pollingTaskRunning.set(false);
+            }
         }
     }
 


### PR DESCRIPTION
fixes #34287
Problem:
A race condition exists in PersistentExecutorImpl where background polling tasks (FinderTask) continue running during server shutdown after database resources are closed, resulting in IllegalStateException: Attempting to execute an operation on a closed EntityManager.

Root Cause:
The deactivate() method sets deactivated = true and closes resources but does not cancel the scheduled polling future. This allows FinderTask to continue executing in the background and attempt to access closed resources. Scheduled futures run independently until explicitly cancelled.

Solution:
Modified the deactivate() method to:

Cancel the polling future BEFORE closing any resources
Wait up to 5 seconds for the polling task to complete gracefully
############################################################################################


- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

############################################################################################
