### PR TITLE
Updates to not enable Java 2 security when testing InstantOn

### DIFF
--- a/dev/com.ibm.ws.security.utility_fat/fat/src/com/ibm/ws/security/utility/test/SecurityUtilityCreateLTPAKeysTest.java
+++ b/dev/com.ibm.ws.security.utility_fat/fat/src/com/ibm/ws/security/utility/test/SecurityUtilityCreateLTPAKeysTest.java
@@ -473,8 +473,10 @@ public class SecurityUtilityCreateLTPAKeysTest {
                       ltpaTestServer.waitForStringInLogUsingMark("CWWKS4105I", 5000));
         ltpaTestServer.stopServer();
 
-        if (!JavaInfo.forCurrentVM().isCriuSupported()) {
-            // skip testing InstantOn if CRIU is not supported on this platform
+        if (!JavaInfo.forCurrentVM().isCriuSupported() || ltpaTestServer.isJava2SecurityEnabled()) {
+            // skip testing InstantOn if CRIU is not supported on this platform or Java 2 security is enabled.
+            // There are non-InstantOn tests that will run with Java 2 security being enabled in the bootstrap.properites
+            // and the server will still have it configured since the server instance is shared.
             return;
         }
 
@@ -545,8 +547,10 @@ public class SecurityUtilityCreateLTPAKeysTest {
                       ltpaTestServer.waitForStringInLogUsingMark("CWWKS4105I", 5000));
         ltpaTestServer.stopServer();
 
-        if (!JavaInfo.forCurrentVM().isCriuSupported()) {
-            // skip testing InstantOn if CRIU is not supported on this platform
+        if (!JavaInfo.forCurrentVM().isCriuSupported() || ltpaTestServer.isJava2SecurityEnabled()) {
+            // skip testing InstantOn if CRIU is not supported on this platform or Java 2 security is enabled.
+            // There are non-InstantOn tests that will run with Java 2 security being enabled in the bootstrap.properites
+            // and the server will still have it configured since the server instance is shared.
             return;
         }
 

--- a/dev/com.ibm.ws.security.utility_fat/fat/src/com/ibm/ws/security/utility/test/SecurityUtilityCreateSSLCertificateTest.java
+++ b/dev/com.ibm.ws.security.utility_fat/fat/src/com/ibm/ws/security/utility/test/SecurityUtilityCreateSSLCertificateTest.java
@@ -438,8 +438,10 @@ public class SecurityUtilityCreateSSLCertificateTest {
      */
     private void runCheckpointServer(ProgramOutput commandOutput, LibertyServer server, String aesKey) throws Exception {
         try {
-            if (!JavaInfo.forCurrentVM().isCriuSupported()) {
-                // skip testing InstantOn if CRIU is not supported on this platform
+            if (!JavaInfo.forCurrentVM().isCriuSupported() || server.isJava2SecurityEnabled()) {
+                // skip testing InstantOn if CRIU is not supported on this platform or Java 2 security is enabled.
+                // There are non-InstantOn tests that will run with Java 2 security being enabled in the bootstrap.properites
+                // and the server will still have it configured since the server instance is shared.
                 return;
             }
             // clean up previous overrides file before checkpoint

--- a/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyServer.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyServer.java
@@ -1689,8 +1689,11 @@ public class LibertyServer implements LogMonitorClient {
             JVM_ARGS += " " + MAC_RUN;
         }
 
-        // if we have java 2 security enabled, add java.security.manager and java.security.policy
-        if (isJava2SecurityEnabled() && !isEE11OrLaterEnabled()) {
+        // If Java 2 security is enabled, add java.security.manager and java.security.policy.
+        //
+        // Java 2 security is not enabled for servers that have Jakarta EE 11 or later features
+        // or if testing InstantOn function since neither one of them support Java 2 security
+        if (isJava2SecurityEnabled() && !isEE11OrLaterEnabled() && checkpointInfo == null) {
             RemoteFile f = getServerBootstrapPropertiesFile();
             addJava2SecurityPropertiesToBootstrapFile(f, GLOBAL_DEBUG_JAVA2SECURITY);
             String reason = GLOBAL_JAVA2SECURITY ? "GLOBAL_JAVA2SECURITY" : "GLOBAL_DEBUG_JAVA2SECURITY";
@@ -1736,7 +1739,7 @@ public class LibertyServer implements LogMonitorClient {
         //FIPS 140-3
         // if we have FIPS 140-3 enabled, and the matched java/platform, add JVM Arg
         if (isFIPS140_3EnabledAndSupported(info) || isFIPS140_2EnabledAndSupported(info)) {
-            Map<String,String> opts = getJvmOptionsAsMap();
+            Map<String, String> opts = getJvmOptionsAsMap();
             if (getServerEnv().containsKey("ENABLE_FIPS140_3") || getDefaultEnv().containsKey("ENABLE_FIPS140_3") || useEnvVars.containsKey("ENABLE_FIPS140_3") || opts.containsKey("-Xenablefips140-3") || opts.containsKey("-Dsemeru.fips")) {
                 Log.info(c, methodName, "Test has defined its own settings for FIPS140-3");
             } else {


### PR DESCRIPTION
- When testing with Java 2 security enabled, checkpoint tests that test InstantOn function were failing since InstantOn function does not support Java 2 security being enabled.
- Similar to servers with EE 11 or later features being in a server.xml, LibertyServer is updated to not enable Java 2 security when testing with InstantOn
- For the com.ibm.ws.security.utilility_fat, update to not run tests with Java 2 security is enabled because the FAT class includes both InstantOn and non-InstantOn tests using the same server, so the Java 2 security settings will be set when it gets to the InstantOn tests.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
