### PR TITLE
Remove remaining TODOs from com.ibm.ws.messaging.comms.client

### DIFF
--- a/dev/com.ibm.ws.messaging.comms.client/src/com/ibm/ws/sib/jfapchannel/impl/CommsOutboundChain.java
+++ b/dev/com.ibm.ws.messaging.comms.client/src/com/ibm/ws/sib/jfapchannel/impl/CommsOutboundChain.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 IBM Corporation and others.
+ * Copyright (c) 2011, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -256,7 +256,6 @@ public class CommsOutboundChain implements ApplicationPrereq {
             }
         }else {
         	// Use Netty Framework for transport
-        	// TODO: Verify Dynamic updates with SSL on Netty
         	try {
         		if (null == secureFacet) throw new ChainException(new Throwable(nls.getFormattedMessage("missingSslOptions.ChainNotStarted", new Object[] { chainName }, "Chain not started " + chainName)));
             	if (isAnyTracingEnabled() && tc.isDebugEnabled()) debug(this, tc, "JFAP Outbound secure chain" + chainName + " successfully started ");

--- a/dev/com.ibm.ws.messaging.comms.client/src/com/ibm/ws/sib/jfapchannel/netty/NettyNetworkConnectionContext.java
+++ b/dev/com.ibm.ws.messaging.comms.client/src/com/ibm/ws/sib/jfapchannel/netty/NettyNetworkConnectionContext.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022, 2023 IBM Corporation and others.
+ * Copyright (c) 2022, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -102,13 +102,6 @@ public class NettyNetworkConnectionContext implements NetworkConnectionContext{
 		if (TraceComponent.isAnyTracingEnabled() && tc.isEntryEnabled())
 			SibTr.entry(this, tc, "close", new Object[] { networkConnection, throwable });
 
-		// TODO: This needs to be verified and implemented is not. https://github.com/OpenLiberty/open-liberty/issues/24814
-		// If the server is stopping, all connections will be closed/flushed by netty bundle? Verify
-		if (FrameworkState.isStopping()) {
-			if (TraceComponent.isAnyTracingEnabled() && tc.isEntryEnabled())
-				SibTr.exit(this, tc, "close");
-			return;
-		}
 		Exception exception = null;
 		if (throwable instanceof Exception)
 		{

--- a/dev/com.ibm.ws.messaging.comms.client/src/com/ibm/ws/sib/jfapchannel/netty/NettyNetworkConnectionFactory.java
+++ b/dev/com.ibm.ws.messaging.comms.client/src/com/ibm/ws/sib/jfapchannel/netty/NettyNetworkConnectionFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022, 2023 IBM Corporation and others.
+ * Copyright (c) 2022, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -106,7 +106,6 @@ public class NettyNetworkConnectionFactory implements NetworkConnectionFactory{
 	{
 		if (tc.isEntryEnabled())
 			SibTr.entry(this, tc, "createConnection", endpoint);
-		// TODO: Verify if this is used. See https://github.com/OpenLiberty/open-liberty/issues/22692
 		throw new FrameworkException("Not implemented yet for Netty. Currently only used on tWAS not Liberty.");
 
 	}

--- a/dev/com.ibm.ws.messaging.comms.client/src/com/ibm/ws/sib/jfapchannel/richclient/framework/impl/RichClientFramework.java
+++ b/dev/com.ibm.ws.messaging.comms.client/src/com/ibm/ws/sib/jfapchannel/richclient/framework/impl/RichClientFramework.java
@@ -140,7 +140,7 @@ public class RichClientFramework extends Framework
         if (TraceComponent.isAnyTracingEnabled() && tc.isEntryEnabled())
             SibTr.entry(this, tc, "getOutboundConnectionProperties", ep);
         
-     // TODO: Check if this data path is even used see https://github.com/OpenLiberty/open-liberty/issues/22692
+	// Note: No known code paths within Liberty
 
         Map properties = null;
         if (ep instanceof CFEndPoint)


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

################################################################################################

fixes #25963


`// TODO: Verify Dynamic updates with SSL on Netty`
- Verified via keystore updates and saw the code path entered

`// TODO: Verify if this is used. See https://github.com/OpenLiberty/open-liberty/issues/22692`
- Not implemented and no known tests enter that code

`// TODO: This needs to be verified and implemented is not. https://github.com/OpenLiberty/open-liberty/issues/24814`
- The FrameworkState.isStopping() was removed. 
- Explicit closure during shutdown is cleaner than relying on Netty to forcibly terminate connections.
- Testing was performed on `com.ibm.ws.jbatch.jms.throttle_fat`'s testThrottlingJobs where the messageEngineServer was shutdown during active connections. 
   - With the check included, I saw numerous `Connection unexpectedly broken during read.` errors logged. 
   - With it removed, the connections were explicitly closed.
   
   
 There are other TODOs but they are not Netty related.
 
 I didn't much improvement for Optionals, so I left it alone. 
   