### PR TITLE
Remove defunct 'Design Review Request' step from feature template

### DIFF
--- a/.github/ISSUE_TEMPLATE/03_feature.md
+++ b/.github/ISSUE_TEMPLATE/03_feature.md
@@ -102,10 +102,8 @@ Design preliminaries determine whether a formal design, which will be provided b
 - [ ] Performance testing requirements identified, or N/A. (Feature owner and [Performance focal point](https://github.com/orgs/OpenLiberty/teams/performance-approvers))
 
 ### **Design**
-- [ ] POC Design / UFO review requested.
-  - Feature owner adds label `Design Review Request`
 - [ ] POC Design / UFO review scheduled.
-  - Follow the instructions in POC-Forum repo
+  - Follow the instructions in the [README in the POC-Forum repo](https://github.ibm.com/websphere/POC-Forum?tab=readme-ov-file#adding-an-agenda-item).
 - [ ] POC Design / UFO review completed.
 - [ ] POC / UFO Review follow-ons completed.
 - [ ] POC Design / UFO approval requested.


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".