### PR TITLE
Disable dynamic config updates for stress test server (RTC issue 302196)

### DIFF
--- a/dev/com.ibm.ws.microprofile.config.1.1_fat/publish/servers/StressServer/server.xml
+++ b/dev/com.ibm.ws.microprofile.config.1.1_fat/publish/servers/StressServer/server.xml
@@ -11,4 +11,10 @@
     </featureManager>
     
     <logging traceSpecification="com.ibm.ws.artifact*=FINER" />
+    <!--
+        Unexpected configuration changes are showing in the test while the test server is running;
+        This is causing itermittent errors.
+        This is not a test for dynamic configuration changes; disabling dynamic config updates.
+    -->
+    <config updateTrigger="disabled"/>
 </server>


### PR DESCRIPTION
- [ ] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [ ] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

