### PR TITLE
Update security FATs to expect CWWKS1865W

### DIFF
--- a/dev/com.ibm.ws.security.client_fat/publish/clients/myTestClient/configs/client_aesPassword.xml
+++ b/dev/com.ibm.ws.security.client_fat/publish/clients/myTestClient/configs/client_aesPassword.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2020 IBM Corporation and others.
+    Copyright (c) 2020, 2026 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -19,10 +19,12 @@
 
 	<application id="myCalc" name="BasicCalculatorClient" type="ear" location="BasicCalculatorClient.ear" />
 
+	<variable name="wlp.password.encryption.key" value="customEncryptionKey" />
+
 	<orb id="defaultOrb">
 		<clientPolicy.clientContainerCsiv2>
 			<layers>
-				<authenticationLayer user="user2" password="{aes}ARBy65pibvbPX/1iYmgWRTBNi8Xh1kAKrYlL8F2+2qRT7xRGDTc/GvOjgQs4SyOKmJuY53aMpjtD0YTT4ykbFbD3qKsi5DETQzkc2Qdqi5YdhtQrnhWsFst97XWhqILiWwD94uqXk638eZs=" />
+				<authenticationLayer user="user2" password="{aes}ARD8RSrwJe7SG6X9zBVJIUi0FPTCH6g/2dTc989kzFXjjaAj+TzMOaMntmNSFG5nDfAGnutvKS5Ra5+Whf1xghEG0GRja6SSnF86MeqXBq0dj4LKEDEJr/v3H8gwsr2f+1D9tSOxPwQBan0=" />
 				<!-- This is a client configuration file selected to explicitly configure the default SSL config to
 				make sure the default SSL config works when configured explicitly -->
 				<transportLayer sslRef="defaultSSLConfig" />

--- a/dev/com.ibm.ws.security.registry.basic_fat/fat/src/com/ibm/ws/security/registry/basic/fat/FATTest.java
+++ b/dev/com.ibm.ws.security.registry.basic_fat/fat/src/com/ibm/ws/security/registry/basic/fat/FATTest.java
@@ -69,6 +69,8 @@ public class FATTest {
     private static boolean CWWKS1864wAlreadyLoggedForHash = false;
     /** CWWKS1864w is only logged one time for AES-128 {aes} passwords per server start */
     private static boolean CWWKS1864wAlreadyLoggedForAES = false;
+    /** CWWKS1865w is only logged one time for {aes} passwords without a custom encryption key per server start */
+    private static boolean CWWKS1865wAlreadyLoggedForAES = false;
 
     
     @ClassRule
@@ -189,8 +191,13 @@ public class FATTest {
                 CWWKS1864wAlreadyLoggedForAES = true;
             }
 
-            // Add CWWKS1865W for AES passwords without custom encryption key
-            expectedErrors.add(CWWKS1865W_AES_NO_CUSTOM_KEY_WARNING);
+            //Note: CWWKS1865W will be output after CWWKS1864W
+            if (!!!CWWKS1865wAlreadyLoggedForAES) {
+                assertNotNull("AES password without custom encryption key should cause CWWKS1865W",
+                              server.waitForStringInLog(CWWKS1865W_AES_NO_CUSTOM_KEY_WARNING));
+                expectedErrors.add(CWWKS1865W_AES_NO_CUSTOM_KEY_WARNING);
+                CWWKS1865wAlreadyLoggedForAES = true;
+            }
 
             assertEquals("Authentication should succeed.",
                          "defaultUser", servlet.checkPassword("defaultUser", password));
@@ -230,6 +237,14 @@ public class FATTest {
                               server.waitForStringInLog(CWWKS1864W_WEAK_ALGORITHM_WARNING));
                 expectedErrors.add(CWWKS1864W_WEAK_ALGORITHM_WARNING);
                 CWWKS1864wAlreadyLoggedForAES = true;
+            }
+
+            //Note: CWWKS1865W will be output after CWWKS1864W
+            if (!!!CWWKS1865wAlreadyLoggedForAES) {
+                assertNotNull("AES password without custom encryption key should cause CWWKS1865W",
+                              server.waitForStringInLog(CWWKS1865W_AES_NO_CUSTOM_KEY_WARNING));
+                expectedErrors.add(CWWKS1865W_AES_NO_CUSTOM_KEY_WARNING);
+                CWWKS1865wAlreadyLoggedForAES = true;
             }
         }
 


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

################################################################################################

Fixes build break [RTC#308890](https://wasrtc.hursley.ibm.com:9443/jazz/web/projects/WS-CD#action=com.ibm.team.workitem.viewWorkItem&id=308890)

Test Failure Info
```
testValidAesPasswordTest_EE10_FEATURES:junit.framework.AssertionFailedError: 2026-03-02-21:34:37:957 
Exception was thrown: java.lang.Exception: Errors/warnings were found in client logs:
    at com.ibm.ws.security.client.fat.BasicTest.testValidAesPasswordTest(BasicTest.java:283)
    
Exception was thrown: java.lang.Exception: Errors/warnings were found in client logs: 
[3/6/26, 7:08:03:764 CST] 00000001 com.ibm.ws.crypto.util.PasswordCipherUtil W CWWKS1865W: One or more of your AES-encrypted passwords were encrypted without a custom encryption key. To improve the security of your stored credentials, re-encrypt them by using a custom encryption key. Be sure to store this key in a secure location. 
```
