### PR TITLE
Fix for RTC 308675

### DIFF
--- a/dev/com.ibm.ws.security.oauth.oidc_fat.common/src/com/ibm/ws/security/oauth_oidc/fat/commonTest/CommonValidationTools.java
+++ b/dev/com.ibm.ws.security.oauth.oidc_fat.common/src/com/ibm/ws/security/oauth_oidc/fat/commonTest/CommonValidationTools.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2025 IBM Corporation and others.
+ * Copyright (c) 2020, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -1058,7 +1058,7 @@ public class CommonValidationTools {
 
             String tokenLine = getTokenLineFromResponse(response);
             if (tokenLine != null) {
-                String[] responseLines = tokenLine.split(System.getProperty("line.separator"));
+                String[] responseLines = tokenLine.split("\\r?\\n");
                 if (responseLines.length == 1) {
 
                     String[] entries = tokenLine.split(",");


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

---

Tests fail intermittently on Windows with invalid_grant OAuth errors (CWOAU0029E) due to corrupted refresh tokens containing embedded newlines and extra credential text.

```
{"error_description":"CWOAU0029E: The token with key: WgQz07btjv1sEldWtfKcBA69SJ1sBDZzsb14HTlhFbyL8iYksk%7D%0A%09Private+Credential%3A+com.ibm.ws.security.token.internal.SingleSignonTokenImpl%403d2e4c65 type: authorization_grant subType: refresh_token was not found in the token cache.","error":"invalid_grant"}
```

The refresh_token should only be `WgQz07btjv1sEldWtfKcBA69SJ1sBDZzsb14HTlhFbyL8iYksk`, but `%7D%0A%09Private+Credential%3A+com.ibm.ws.security.token.internal.SingleSignonTokenImpl%403d2e4c65` is being appended.

The refresh_token is parsed from an HTTP response and will append the subsequent line to it if one exists. Typically, the line of the response containing the refresh_token is the last line, however when it is not this error seems to occur. Currently, the code splits the lines using `line.separator` which on Windows is `\r\n` however the response body contains `\n` as shown in the error as an encoding `%0A` and therefore the line splitting fails.

