### PR TITLE
Modifying the assertion for testUntrustedForwardedForAndPortWithIPv4AndIPv6RemoteIpConfig

### DIFF
--- a/dev/com.ibm.ws.transport.http.remoteip_fat/fat/src/com/ibm/ws/transport/http/HttpXForwardedAndForwardedHeaderTests.java
+++ b/dev/com.ibm.ws.transport.http.remoteip_fat/fat/src/com/ibm/ws/transport/http/HttpXForwardedAndForwardedHeaderTests.java
@@ -1,20 +1,18 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2022 IBM Corporation and others.
+ * Copyright (c) 2018, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
  * 
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package com.ibm.ws.transport.http;
 
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
 
 import java.io.IOException;
 import java.net.InetAddress;
@@ -895,7 +893,7 @@ public class HttpXForwardedAndForwardedHeaderTests {
 
         assertTrue("Response does not contain Endpoint Information Servlet Test message", response.contains("Endpoint Information Servlet Test"));
         assertTrue("Response does contain the expected Remote Address", !response.contains("Remote Address: 2001:db9:cafe::17"));
-        assertTrue("Response does contain the expected Remote Port", !response.contains("Remote Port: 943"));
+        assertFalse("Response should not contain the untrusted Remote Port: 943", response.matches("(?s).*Remote Port: 943\\b.*"));
     }
 
     /**


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves 

Fixes #34285 