### PR TITLE
Remove metrics exporter from container tests

### DIFF
--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/internal/suite/FATSuite.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/internal/suite/FATSuite.java
@@ -18,12 +18,6 @@ import org.junit.runners.Suite.SuiteClasses;
 
 import componenttest.containers.TestContainerSuite;
 import componenttest.custom.junit.runner.AlwaysPassesTest;
-import io.openliberty.microprofile.telemetry.internal.tests.Agent129Test;
-import io.openliberty.microprofile.telemetry.internal.tests.Agent214Test;
-import io.openliberty.microprofile.telemetry.internal.tests.Agent250Test;
-import io.openliberty.microprofile.telemetry.internal.tests.AgentConfigMultiAppTest;
-import io.openliberty.microprofile.telemetry.internal.tests.AgentConfigTest;
-import io.openliberty.microprofile.telemetry.internal.tests.AgentTest;
 import io.openliberty.microprofile.telemetry.internal.tests.CrossFeatureJaegerTest;
 import io.openliberty.microprofile.telemetry.internal.tests.CrossFeatureZipkinTest;
 import io.openliberty.microprofile.telemetry.internal.tests.JaegerLegacyTest;
@@ -41,12 +35,12 @@ import io.openliberty.microprofile.telemetry.internal.tests.ZipkinTest;
 @SuiteClasses({
 
                 AlwaysPassesTest.class, //Must keep this test to run something in the Java 6 builds.
-                AgentTest.class,
-                Agent129Test.class,
-                Agent214Test.class,
-                Agent250Test.class,
-                AgentConfigTest.class,
-                AgentConfigMultiAppTest.class,
+//                AgentTest.class,
+//                Agent129Test.class,
+//                Agent214Test.class,
+//                Agent250Test.class,
+//                AgentConfigTest.class,
+//                AgentConfigMultiAppTest.class,
                 CrossFeatureJaegerTest.class,
                 CrossFeatureZipkinTest.class,
                 JaegerSecureOtelCollectorTest.class,

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/internal/tests/CrossFeatureJaegerTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/internal/tests/CrossFeatureJaegerTest.java
@@ -97,7 +97,8 @@ public class CrossFeatureJaegerTest {
         telemetryServer.addEnvVar(TestConstants.ENV_OTEL_EXPORTER_OTLP_ENDPOINT, jaegerContainer.getOtlpGrpcUrl());
         telemetryServer.addEnvVar(TestConstants.ENV_OTEL_BSP_SCHEDULE_DELAY, "100"); // Wait no more than 100ms to send traces to the server
         telemetryServer.addEnvVar(TestConstants.ENV_OTEL_SDK_DISABLED, "false"); //Enable tracing
-        telemetryServer.addEnvVar(TestConstants.ENV_OTEL_LOGS_EXPORTER, "none"); //Disable logging
+        telemetryServer.addEnvVar(TestConstants.ENV_OTEL_LOGS_EXPORTER, "none"); //Disable logging exporting
+        telemetryServer.addEnvVar(TestConstants.ENV_OTEL_LOGS_EXPORTER, "none"); //Disable metrics exporting
         telemetryServer.addEnvVar("OTEL_PROPAGATORS", "tracecontext, baggage, jaeger"); // Include the jaeger propagation headers
         telemetryServer.addEnvVar("IO_OPENLIBERTY_MICROPROFILE_TELEMETRY_INTERNAL_APPS_CROSSFEATURE_TELEMETRY_CROSSFEATURECLIENT_MP_REST_URL", getUrl(opentracingServer));
 

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/internal/tests/CrossFeatureJaegerTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/internal/tests/CrossFeatureJaegerTest.java
@@ -95,10 +95,13 @@ public class CrossFeatureJaegerTest {
         opentracingServer.useSecondaryHTTPPort();
 
         telemetryServer.addEnvVar(TestConstants.ENV_OTEL_EXPORTER_OTLP_ENDPOINT, jaegerContainer.getOtlpGrpcUrl());
-        telemetryServer.addEnvVar(TestConstants.ENV_OTEL_BSP_SCHEDULE_DELAY, "100"); // Wait no more than 100ms to send traces to the server
         telemetryServer.addEnvVar(TestConstants.ENV_OTEL_SDK_DISABLED, "false"); //Enable tracing
         telemetryServer.addEnvVar(TestConstants.ENV_OTEL_LOGS_EXPORTER, "none"); //Disable logging exporting
         telemetryServer.addEnvVar(TestConstants.ENV_OTEL_LOGS_EXPORTER, "none"); //Disable metrics exporting
+
+        telemetryServer.addEnvVar("OTEL_EXPORTER_OTLP_TIMEOUT", "30000"); //Add delays and extend timeouts
+        telemetryServer.addEnvVar(TestConstants.ENV_OTEL_BSP_SCHEDULE_DELAY, "5000");
+
         telemetryServer.addEnvVar("OTEL_PROPAGATORS", "tracecontext, baggage, jaeger"); // Include the jaeger propagation headers
         telemetryServer.addEnvVar("IO_OPENLIBERTY_MICROPROFILE_TELEMETRY_INTERNAL_APPS_CROSSFEATURE_TELEMETRY_CROSSFEATURECLIENT_MP_REST_URL", getUrl(opentracingServer));
 

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/internal/tests/CrossFeatureZipkinTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/internal/tests/CrossFeatureZipkinTest.java
@@ -88,7 +88,8 @@ public class CrossFeatureZipkinTest {
         telemetryServer.addEnvVar(TestConstants.ENV_OTEL_EXPORTER_ZIPKIN_ENDPOINT, zipkinContainer.getApiBaseUrl() + "/spans");
         telemetryServer.addEnvVar(TestConstants.ENV_OTEL_BSP_SCHEDULE_DELAY, "100"); // Wait no more than 100ms to send traces to the server
         telemetryServer.addEnvVar(TestConstants.ENV_OTEL_SDK_DISABLED, "false"); //Enable tracing
-        telemetryServer.addEnvVar(TestConstants.ENV_OTEL_LOGS_EXPORTER, "none"); //Disable logging
+        telemetryServer.addEnvVar(TestConstants.ENV_OTEL_LOGS_EXPORTER, "none"); //Disable logging exporting
+        telemetryServer.addEnvVar(TestConstants.ENV_OTEL_LOGS_EXPORTER, "none"); //Disable metrics exporting
         telemetryServer.addEnvVar("OTEL_PROPAGATORS", "tracecontext, b3"); // Include the b3 propagation header for Zipkin
         telemetryServer.addEnvVar("IO_OPENLIBERTY_MICROPROFILE_TELEMETRY_INTERNAL_APPS_CROSSFEATURE_TELEMETRY_CROSSFEATURECLIENT_MP_REST_URL", getUrl(opentracingServer));
 

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/internal/tests/CrossFeatureZipkinTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/internal/tests/CrossFeatureZipkinTest.java
@@ -86,13 +86,14 @@ public class CrossFeatureZipkinTest {
 
         telemetryServer.addEnvVar(TestConstants.ENV_OTEL_TRACES_EXPORTER, "zipkin");
         telemetryServer.addEnvVar(TestConstants.ENV_OTEL_EXPORTER_ZIPKIN_ENDPOINT, zipkinContainer.getApiBaseUrl() + "/spans");
-        telemetryServer.addEnvVar(TestConstants.ENV_OTEL_BSP_SCHEDULE_DELAY, "100"); // Wait no more than 100ms to send traces to the server
         telemetryServer.addEnvVar(TestConstants.ENV_OTEL_SDK_DISABLED, "false"); //Enable tracing
         telemetryServer.addEnvVar(TestConstants.ENV_OTEL_LOGS_EXPORTER, "none"); //Disable logging exporting
         telemetryServer.addEnvVar(TestConstants.ENV_OTEL_LOGS_EXPORTER, "none"); //Disable metrics exporting
         telemetryServer.addEnvVar("OTEL_PROPAGATORS", "tracecontext, b3"); // Include the b3 propagation header for Zipkin
         telemetryServer.addEnvVar("IO_OPENLIBERTY_MICROPROFILE_TELEMETRY_INTERNAL_APPS_CROSSFEATURE_TELEMETRY_CROSSFEATURECLIENT_MP_REST_URL", getUrl(opentracingServer));
 
+        telemetryServer.addEnvVar("OTEL_EXPORTER_OTLP_TIMEOUT", "30000"); //Add delays and extend timeouts
+        telemetryServer.addEnvVar(TestConstants.ENV_OTEL_BSP_SCHEDULE_DELAY, "5000");
         opentracingServer.addEnvVar("zipkinPortName", Integer.toString(zipkinContainer.getHttpPort()));
         opentracingServer.addEnvVar("zipkinHostName", zipkinContainer.getHost());
         opentracingServer.addEnvVar("ZIPKIN_SAMPLER_TYPE", "const"); // Trace every call

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/internal/tests/JaegerLegacyTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/internal/tests/JaegerLegacyTest.java
@@ -21,7 +21,6 @@ import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.rules.RuleChain;
 import org.junit.runner.RunWith;
-import org.testcontainers.containers.GenericContainer;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
 
@@ -29,7 +28,6 @@ import componenttest.containers.SimpleLogConsumer;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
-import componenttest.custom.junit.runner.RepeatTestFilter;
 import componenttest.rules.repeater.RepeatTests;
 import io.openliberty.microprofile.telemetry.internal.apps.spanTest.TestResource;
 import io.openliberty.microprofile.telemetry.internal.utils.KeyPairs;
@@ -47,14 +45,13 @@ public class JaegerLegacyTest extends JaegerBaseTest {
 
     private static KeyPairs keyPairs = new KeyPairs(server);
 
-    public static JaegerContainer jaegerContainer = new JaegerContainer(keyPairs.getCertificate(), keyPairs.getKey()
-                                                                        ).withLogConsumer(new SimpleLogConsumer(JaegerLegacyTest.class, "jaeger"));
+    public static JaegerContainer jaegerContainer = new JaegerContainer(keyPairs.getCertificate(), keyPairs.getKey()).withLogConsumer(new SimpleLogConsumer(JaegerLegacyTest.class,
+                                                                                                                                                            "jaeger"));
     //The native Jaeger exporter has been discontinued and is not supported in MpTelemetry-2.0. OTLP is used for Jaeger instead
     public static RepeatTests repeat = TelemetryActions.telemetry10and11Repeats(SERVER_NAME);
 
     @ClassRule
     public static RuleChain chain = RuleChain.outerRule(jaegerContainer).around(repeat);
-
 
     public static JaegerQueryClient client;
 
@@ -69,6 +66,8 @@ public class JaegerLegacyTest extends JaegerBaseTest {
         server.addEnvVar(TestConstants.ENV_OTEL_BSP_SCHEDULE_DELAY, "100"); // Wait no more than 100ms to send traces to the server
         server.addEnvVar(TestConstants.ENV_OTEL_SDK_DISABLED, "false"); //Enable tracing
 
+        server.addEnvVar("OTEL_EXPORTER_OTLP_TIMEOUT", "30000"); //Add delays and extend timeouts
+        server.addEnvVar(TestConstants.ENV_OTEL_BSP_SCHEDULE_DELAY, "5000");
         // Construct the test application
         WebArchive jaegerTest = ShrinkWrap.create(WebArchive.class, "spanTest.war")
                                           .addPackage(TestResource.class.getPackage());

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/internal/tests/JaegerOtelCollectorTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/internal/tests/JaegerOtelCollectorTest.java
@@ -85,6 +85,7 @@ public class JaegerOtelCollectorTest extends JaegerBaseTest {
         server.addEnvVar(TestConstants.ENV_OTEL_BSP_SCHEDULE_DELAY, "100"); // Wait no more than 100ms to send traces to the server
         server.addEnvVar(TestConstants.ENV_OTEL_SDK_DISABLED, "false"); //Enable tracing
         server.addEnvVar(TestConstants.ENV_OTEL_LOGS_EXPORTER, "none"); //Disable logging
+        server.addEnvVar(TestConstants.ENV_OTEL_METRICS_EXPORTER, "none"); //Disable metrics exporting
 
         // Construct the test application
         WebArchive jaegerTest = ShrinkWrap.create(WebArchive.class, "spanTest.war")

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/internal/tests/JaegerOtelCollectorTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/internal/tests/JaegerOtelCollectorTest.java
@@ -82,10 +82,12 @@ public class JaegerOtelCollectorTest extends JaegerBaseTest {
         server.addEnvVar(TestConstants.ENV_OTEL_TRACES_EXPORTER, "otlp");
         server.addEnvVar(TestConstants.ENV_OTEL_EXPORTER_OTLP_ENDPOINT, otelCollectorContainer.getOtlpGrpcUrl());
         server.addEnvVar(TestConstants.ENV_OTEL_SERVICE_NAME, "Test service");
-        server.addEnvVar(TestConstants.ENV_OTEL_BSP_SCHEDULE_DELAY, "100"); // Wait no more than 100ms to send traces to the server
         server.addEnvVar(TestConstants.ENV_OTEL_SDK_DISABLED, "false"); //Enable tracing
         server.addEnvVar(TestConstants.ENV_OTEL_LOGS_EXPORTER, "none"); //Disable logging
         server.addEnvVar(TestConstants.ENV_OTEL_METRICS_EXPORTER, "none"); //Disable metrics exporting
+
+        server.addEnvVar("OTEL_EXPORTER_OTLP_TIMEOUT", "30000"); //Add delays and extend timeouts
+        server.addEnvVar(TestConstants.ENV_OTEL_BSP_SCHEDULE_DELAY, "5000");
 
         // Construct the test application
         WebArchive jaegerTest = ShrinkWrap.create(WebArchive.class, "spanTest.war")

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/internal/tests/JaegerOtlpTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/internal/tests/JaegerOtlpTest.java
@@ -60,10 +60,12 @@ public class JaegerOtlpTest extends JaegerBaseTest {
         server.addEnvVar(TestConstants.ENV_OTEL_EXPORTER_OTLP_ENDPOINT, jaegerContainer.getOtlpGrpcUrl());
 
         server.addEnvVar(TestConstants.ENV_OTEL_SERVICE_NAME, "Test service");
-        server.addEnvVar(TestConstants.ENV_OTEL_BSP_SCHEDULE_DELAY, "100"); // Wait no more than 100ms to send traces to the server
         server.addEnvVar(TestConstants.ENV_OTEL_SDK_DISABLED, "false"); //Enable tracing
         server.addEnvVar(TestConstants.ENV_OTEL_LOGS_EXPORTER, "none"); //Disable logging exporting
         server.addEnvVar(TestConstants.ENV_OTEL_METRICS_EXPORTER, "none"); //Disable metrics exporting
+
+        server.addEnvVar("OTEL_EXPORTER_OTLP_TIMEOUT", "30000"); //Add delays and extend timeouts
+        server.addEnvVar(TestConstants.ENV_OTEL_BSP_SCHEDULE_DELAY, "5000");
 
         // Construct the test application
         WebArchive jaegerTest = ShrinkWrap.create(WebArchive.class, "spanTest.war")

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/internal/tests/JaegerOtlpTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/internal/tests/JaegerOtlpTest.java
@@ -62,7 +62,8 @@ public class JaegerOtlpTest extends JaegerBaseTest {
         server.addEnvVar(TestConstants.ENV_OTEL_SERVICE_NAME, "Test service");
         server.addEnvVar(TestConstants.ENV_OTEL_BSP_SCHEDULE_DELAY, "100"); // Wait no more than 100ms to send traces to the server
         server.addEnvVar(TestConstants.ENV_OTEL_SDK_DISABLED, "false"); //Enable tracing
-        server.addEnvVar(TestConstants.ENV_OTEL_LOGS_EXPORTER, "none"); //Disable logging
+        server.addEnvVar(TestConstants.ENV_OTEL_LOGS_EXPORTER, "none"); //Disable logging exporting
+        server.addEnvVar(TestConstants.ENV_OTEL_METRICS_EXPORTER, "none"); //Disable metrics exporting
 
         // Construct the test application
         WebArchive jaegerTest = ShrinkWrap.create(WebArchive.class, "spanTest.war")

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/internal/tests/JaegerSecureOtelCollectorTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/internal/tests/JaegerSecureOtelCollectorTest.java
@@ -87,12 +87,13 @@ public class JaegerSecureOtelCollectorTest extends JaegerBaseTest {
         server.addEnvVar(TestConstants.ENV_OTEL_TRACES_EXPORTER, "otlp");
         server.addEnvVar(TestConstants.ENV_OTEL_EXPORTER_OTLP_ENDPOINT, otelCollectorContainer.getSecureOtlpGrpcUrl());
         server.addEnvVar(TestConstants.ENV_OTEL_SERVICE_NAME, "Test service");
-        server.addEnvVar(TestConstants.ENV_OTEL_BSP_SCHEDULE_DELAY, "100"); // Wait no more than 100ms to send traces to the server
         server.addEnvVar(TestConstants.ENV_OTEL_SDK_DISABLED, "false"); //Enable tracing
         server.addEnvVar(TestConstants.ENV_OTEL_LOGS_EXPORTER, "none"); //Disable logging exporting
         server.addEnvVar(TestConstants.ENV_OTEL_METRICS_EXPORTER, "none"); //Disable metrics exporting
         server.addEnvVar(TestConstants.ENV_OTEL_EXPORTER_OTLP_CERTIFICATE, otelCollectorKeyPairs.certificateFilePath());
 
+        server.addEnvVar("OTEL_EXPORTER_OTLP_TIMEOUT", "30000"); //Add delays and extend timeouts
+        server.addEnvVar(TestConstants.ENV_OTEL_BSP_SCHEDULE_DELAY, "5000");
         // Construct the test application
         WebArchive jaegerTest = ShrinkWrap.create(WebArchive.class, "spanTest.war")
                                           .addPackage(TestResource.class.getPackage());

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/internal/tests/JaegerSecureOtelCollectorTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/internal/tests/JaegerSecureOtelCollectorTest.java
@@ -89,7 +89,8 @@ public class JaegerSecureOtelCollectorTest extends JaegerBaseTest {
         server.addEnvVar(TestConstants.ENV_OTEL_SERVICE_NAME, "Test service");
         server.addEnvVar(TestConstants.ENV_OTEL_BSP_SCHEDULE_DELAY, "100"); // Wait no more than 100ms to send traces to the server
         server.addEnvVar(TestConstants.ENV_OTEL_SDK_DISABLED, "false"); //Enable tracing
-        server.addEnvVar(TestConstants.ENV_OTEL_LOGS_EXPORTER, "none"); //Disable logging
+        server.addEnvVar(TestConstants.ENV_OTEL_LOGS_EXPORTER, "none"); //Disable logging exporting
+        server.addEnvVar(TestConstants.ENV_OTEL_METRICS_EXPORTER, "none"); //Disable metrics exporting
         server.addEnvVar(TestConstants.ENV_OTEL_EXPORTER_OTLP_CERTIFICATE, otelCollectorKeyPairs.certificateFilePath());
 
         // Construct the test application

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/internal/tests/JaegerSecureOtlpTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/internal/tests/JaegerSecureOtlpTest.java
@@ -63,11 +63,13 @@ public class JaegerSecureOtlpTest extends JaegerBaseTest {
         server.addEnvVar(TestConstants.ENV_OTEL_EXPORTER_OTLP_ENDPOINT, jaegerContainer.getSecureOtlpGrpcUrl());
 
         server.addEnvVar(TestConstants.ENV_OTEL_SERVICE_NAME, "Test service");
-        server.addEnvVar(TestConstants.ENV_OTEL_BSP_SCHEDULE_DELAY, "100"); // Wait no more than 100ms to send traces to the server
         server.addEnvVar(TestConstants.ENV_OTEL_SDK_DISABLED, "false"); //Enable tracing
         server.addEnvVar(TestConstants.ENV_OTEL_LOGS_EXPORTER, "none"); //Disable logging exporting
         server.addEnvVar(TestConstants.ENV_OTEL_METRICS_EXPORTER, "none"); //Disable metrics exporting
         server.addEnvVar(TestConstants.ENV_OTEL_EXPORTER_OTLP_CERTIFICATE, otelCollectorKeyPairs.certificateFilePath());
+
+        server.addEnvVar("OTEL_EXPORTER_OTLP_TIMEOUT", "30000"); //Add delays and extend timeouts
+        server.addEnvVar(TestConstants.ENV_OTEL_BSP_SCHEDULE_DELAY, "5000");
         // Construct the test application
         WebArchive jaegerTest = ShrinkWrap.create(WebArchive.class, "spanTest.war")
                                           .addPackage(TestResource.class.getPackage());

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/internal/tests/JaegerSecureOtlpTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/internal/tests/JaegerSecureOtlpTest.java
@@ -65,7 +65,8 @@ public class JaegerSecureOtlpTest extends JaegerBaseTest {
         server.addEnvVar(TestConstants.ENV_OTEL_SERVICE_NAME, "Test service");
         server.addEnvVar(TestConstants.ENV_OTEL_BSP_SCHEDULE_DELAY, "100"); // Wait no more than 100ms to send traces to the server
         server.addEnvVar(TestConstants.ENV_OTEL_SDK_DISABLED, "false"); //Enable tracing
-        server.addEnvVar(TestConstants.ENV_OTEL_LOGS_EXPORTER, "none"); //Disable logging
+        server.addEnvVar(TestConstants.ENV_OTEL_LOGS_EXPORTER, "none"); //Disable logging exporting
+        server.addEnvVar(TestConstants.ENV_OTEL_METRICS_EXPORTER, "none"); //Disable metrics exporting
         server.addEnvVar(TestConstants.ENV_OTEL_EXPORTER_OTLP_CERTIFICATE, otelCollectorKeyPairs.certificateFilePath());
         // Construct the test application
         WebArchive jaegerTest = ShrinkWrap.create(WebArchive.class, "spanTest.war")

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/internal/tests/JvmMetricsOtelCollectorTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/internal/tests/JvmMetricsOtelCollectorTest.java
@@ -79,6 +79,9 @@ public class JvmMetricsOtelCollectorTest {
         server.addEnvVar(TestConstants.ENV_OTEL_SERVICE_NAME, "PrometheusOtelCollectorTest");
         server.addEnvVar(TestConstants.ENV_OTEL_SDK_DISABLED, "false");
 
+        server.addEnvVar("OTEL_EXPORTER_OTLP_TIMEOUT", "30000"); //Add delays and extend timeouts
+        server.addEnvVar(TestConstants.ENV_OTEL_BSP_SCHEDULE_DELAY, "5000");
+
         // Construct the test application
         WebArchive spanTest = ShrinkWrap.create(WebArchive.class, "spanTest.war")
                                         .addPackage(TestResource.class.getPackage());

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/internal/tests/JvmMetricsOtelCollectorTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/internal/tests/JvmMetricsOtelCollectorTest.java
@@ -27,9 +27,8 @@ import org.junit.rules.RuleChain;
 import org.junit.runner.RunWith;
 import org.testcontainers.containers.Network;
 
-import com.ibm.websphere.simplicity.ShrinkHelper;
-
 import com.ibm.websphere.simplicity.OperatingSystem;
+import com.ibm.websphere.simplicity.ShrinkHelper;
 
 import componenttest.annotation.Server;
 import componenttest.containers.SimpleLogConsumer;
@@ -53,10 +52,10 @@ public class JvmMetricsOtelCollectorTest {
 
     public static Network network = Network.newNetwork();
     public static OtelCollectorContainer otelCollectorContainer = new OtelCollectorContainer(new File("lib/LibertyFATTestFiles/otel-collector-config-metrics.yaml"), 3131)
-                                                                                                                                                                   .withNetwork(network)
-                                                                                                                                                                   .withNetworkAliases("otel-collector-metrics")
-                                                                                                                                                                   .withLogConsumer(new SimpleLogConsumer(JvmMetricsOtelCollectorTest.class,
-                                                                                                                                                                                                          "otelCol"));
+                                                                                                                                                                          .withNetwork(network)
+                                                                                                                                                                          .withNetworkAliases("otel-collector-metrics")
+                                                                                                                                                                          .withLogConsumer(new SimpleLogConsumer(JvmMetricsOtelCollectorTest.class,
+                                                                                                                                                                                                                 "otelCol"));
     public static RepeatTests repeat = TelemetryActions.telemetry20Repeats(SERVER_NAME);
 
     @ClassRule
@@ -101,7 +100,7 @@ public class JvmMetricsOtelCollectorTest {
 
         //JVM Metrics are not found on AIX. Upstream issue: https://bugs.openjdk.org/browse/JDK-8030957
         OperatingSystem os = server.getMachine().getOperatingSystem();
-        if(os == OperatingSystem.AIX){
+        if (os == OperatingSystem.AIX) {
             return;
         }
 

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/internal/tests/MetricsApiOtelCollectorTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/internal/tests/MetricsApiOtelCollectorTest.java
@@ -84,6 +84,9 @@ public class MetricsApiOtelCollectorTest {
         server.addEnvVar(TestConstants.ENV_OTEL_SERVICE_NAME, "PrometheusOtelCollectorTest");
         server.addEnvVar(TestConstants.ENV_OTEL_SDK_DISABLED, "false");
 
+        server.addEnvVar("OTEL_EXPORTER_OTLP_TIMEOUT", "30000"); //Add delays and extend timeouts
+        server.addEnvVar(TestConstants.ENV_OTEL_BSP_SCHEDULE_DELAY, "5000");
+
         // Construct the test application
         WebArchive spanTest = ShrinkWrap.create(WebArchive.class, "spanTest.war")
                                         .addPackage(TestResource.class.getPackage());
@@ -144,20 +147,20 @@ public class MetricsApiOtelCollectorTest {
 
     /**
      * Gets metrics from otelcollector:3131/metrics in the prometheus format.
-     * For more info on the Prometheus metrics format: 
+     * For more info on the Prometheus metrics format:
      * https://github.com/prometheus/docs/blob/main/content/docs/instrumenting/exposition_formats.md#text-format-details
      */
     public void getApiMetrics(String name, String type, String value) throws Exception {
-        
+
         waitForApiMetrics();
-        
+
         String result = client.dumpMetrics();
         // Add null check for result before using it
         if (result == null) {
             fail("No metrics data returned from collector");
             return;
         }
-        
+
         List<String> splits = Arrays.asList(result.split("((?=# HELP))"));
         for (String s : splits) {
             if (s.contains(name)) {

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/internal/tests/TracingNotEnabledTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/internal/tests/TracingNotEnabledTest.java
@@ -90,6 +90,9 @@ public class TracingNotEnabledTest {
         server.addEnvVar(TestConstants.ENV_OTEL_BSP_SCHEDULE_DELAY, "100"); // Wait no more than 100ms to send traces to the server
         // server.addEnvVar(TestConstants.ENV_OTEL_SDK_DISABLED, "false"); // Do not enable tracing
 
+        server.addEnvVar(TestConstants.ENV_OTEL_LOGS_EXPORTER, "none"); //Disable logging exporting
+        server.addEnvVar(TestConstants.ENV_OTEL_METRICS_EXPORTER, "none"); //Disable metrics exporting
+
         // Construct the test application
         WebArchive jaegerTest = ShrinkWrap.create(WebArchive.class, "spanTest.war")
                                           .addPackage(TestResource.class.getPackage());

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/internal/tests/TracingNotEnabledTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/internal/tests/TracingNotEnabledTest.java
@@ -87,7 +87,9 @@ public class TracingNotEnabledTest {
         server.addEnvVar(TestConstants.ENV_OTEL_EXPORTER_OTLP_ENDPOINT, jaegerContainer.getOtlpGrpcUrl());
 
         server.addEnvVar(TestConstants.ENV_OTEL_SERVICE_NAME, SERVICE_NAME);
-        server.addEnvVar(TestConstants.ENV_OTEL_BSP_SCHEDULE_DELAY, "100"); // Wait no more than 100ms to send traces to the server
+
+        server.addEnvVar("OTEL_EXPORTER_OTLP_TIMEOUT", "30000"); //Add delays and extend timeouts
+        server.addEnvVar(TestConstants.ENV_OTEL_BSP_SCHEDULE_DELAY, "5000");
         // server.addEnvVar(TestConstants.ENV_OTEL_SDK_DISABLED, "false"); // Do not enable tracing
 
         server.addEnvVar(TestConstants.ENV_OTEL_LOGS_EXPORTER, "none"); //Disable logging exporting

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/internal/tests/ZipkinOtelCollectorTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/internal/tests/ZipkinOtelCollectorTest.java
@@ -114,11 +114,12 @@ public class ZipkinOtelCollectorTest {
 
         // Service + BSP batching config
         server.addEnvVar(TestConstants.ENV_OTEL_SERVICE_NAME, "Test service");
-        server.addEnvVar(TestConstants.ENV_OTEL_BSP_SCHEDULE_DELAY, "100");
         server.addEnvVar(TestConstants.ENV_OTEL_BSP_MAX_EXPORT_BATCH_SIZE, "1");
         server.addEnvVar(TestConstants.ENV_OTEL_SDK_DISABLED, "false");
         server.addEnvVar(TestConstants.ENV_OTEL_TRACES_SAMPLER, "always_on");
 
+        server.addEnvVar("OTEL_EXPORTER_OTLP_TIMEOUT", "30000"); //Add delays and extend timeouts
+        server.addEnvVar(TestConstants.ENV_OTEL_BSP_SCHEDULE_DELAY, "5000");
         // Deploy app
         WebArchive spanTest = ShrinkWrap.create(WebArchive.class, "spanTest.war")
                                         .addPackage(TestResource.class.getPackage());

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/internal/tests/ZipkinOtelCollectorTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/internal/tests/ZipkinOtelCollectorTest.java
@@ -105,7 +105,8 @@ public class ZipkinOtelCollectorTest {
 
         // Configure exporter → collector (gRPC)
         server.addEnvVar(TestConstants.ENV_OTEL_TRACES_EXPORTER, "otlp");
-        server.addEnvVar(TestConstants.ENV_OTEL_LOGS_EXPORTER, "none");
+        server.addEnvVar(TestConstants.ENV_OTEL_LOGS_EXPORTER, "none"); //Disable logging exporting
+        server.addEnvVar(TestConstants.ENV_OTEL_METRICS_EXPORTER, "none"); //Disable metrics exporting
         server.addEnvVar(TestConstants.ENV_OTEL_EXPORTER_OTLP_ENDPOINT, otelCollectorContainer.getOtlpGrpcUrl());
         server.addEnvVar(TestConstants.ENV_OTEL_EXPORTER_OTLP_PROTOCOL, "grpc");
         // Some older agents only honor the per-signal endpoint:

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/internal/tests/ZipkinTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/internal/tests/ZipkinTest.java
@@ -88,9 +88,11 @@ public class ZipkinTest {
         server.addEnvVar(TestConstants.ENV_OTEL_EXPORTER_ZIPKIN_ENDPOINT, zipkinContainer.getApiBaseUrl() + "/spans");
 
         server.addEnvVar(TestConstants.ENV_OTEL_SERVICE_NAME, "Test service");
-        server.addEnvVar(TestConstants.ENV_OTEL_BSP_SCHEDULE_DELAY, "100"); // Wait no more than 100ms to send traces to the server
         server.addEnvVar(TestConstants.ENV_OTEL_SDK_DISABLED, "false"); //Enable tracing
         server.addEnvVar(TestConstants.ENV_OTEL_TRACES_SAMPLER, "always_on");
+
+        server.addEnvVar("OTEL_EXPORTER_OTLP_TIMEOUT", "30000"); //Add delays and extend timeouts
+        server.addEnvVar(TestConstants.ENV_OTEL_BSP_SCHEDULE_DELAY, "5000");
 
         // Construct the test application
         WebArchive spanTest = ShrinkWrap.create(WebArchive.class, "spanTest.war")


### PR DESCRIPTION
For z/os failure investigation

