### PR TITLE
Temporarily Disable fips ec private key Tests part 1

### DIFF
--- a/dev/com.ibm.ws.security.fat.common.backchannelLogout/fat/src/com/ibm/ws/security/backchannelLogout/fat/CommonTests/BasicBCLTests.java
+++ b/dev/com.ibm.ws.security.fat.common.backchannelLogout/fat/src/com/ibm/ws/security/backchannelLogout/fat/CommonTests/BasicBCLTests.java
@@ -21,7 +21,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import componenttest.rules.SkipJavaSemeruWithFipsEnabled;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestRule;
@@ -51,6 +53,7 @@ import componenttest.custom.junit.runner.TestModeFilter;
 import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServerWrapper;
 
+
 /**
  * This test class contains tests that validate the proper behavior in end-to-end end_session requests.
  * These tests will focus on the proper logout/end_session behavior based on the OP and OAuth registered client
@@ -62,6 +65,7 @@ import componenttest.topology.impl.LibertyServerWrapper;
 @LibertyServerWrapper
 @Mode(TestMode.FULL)
 @AllowedFFDC({ "org.apache.http.NoHttpResponseException", "com.ibm.oauth.core.api.error.oauth20.OAuth20InvalidTokenException" })
+@SkipJavaSemeruWithFipsEnabled.SkipJavaSemeruWithFipsEnabledRule
 public class BasicBCLTests extends BackChannelLogoutCommonTests {
 
     protected static Class<?> thisClass = BasicBCLTests.class;
@@ -70,6 +74,9 @@ public class BasicBCLTests extends BackChannelLogoutCommonTests {
 
     @Rule
     public static final TestRule conditIgnoreRule = new ConditionalIgnoreRule();
+
+    @ClassRule
+    public static final SkipJavaSemeruWithFipsEnabled skipJavaSemeruWithFipsEnabled = new SkipJavaSemeruWithFipsEnabled();
 
     /**
      * Repeat tests using OIDC (with a Local or Custom Store) or OIDC with SAML OP's, OIDC and Social clients, end_session or http

--- a/dev/com.ibm.ws.security.jwt_fat.builder/fat/src/com/ibm/ws/security/jwt/fat/builder/JwkEndpointValidationUrlTests.java
+++ b/dev/com.ibm.ws.security.jwt_fat.builder/fat/src/com/ibm/ws/security/jwt/fat/builder/JwkEndpointValidationUrlTests.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import javax.servlet.http.HttpServletResponse;
 
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestRule;
@@ -68,12 +69,13 @@ import componenttest.topology.impl.LibertyServer;
 
 @Mode(TestMode.FULL)
 @RunWith(FATRunner.class)
+@SkipJavaSemeruWithFipsEnabledRule
 public class JwkEndpointValidationUrlTests extends CommonSecurityFat {
 
     @Rule
     public static final TestRule conditIgnoreRule = new ConditionalIgnoreRule();
 
-    @Rule
+    @ClassRule
     public static final SkipJavaSemeruWithFipsEnabled skipJavaSemeruWithFipsEnabled = new SkipJavaSemeruWithFipsEnabled("com.ibm.ws.security.jwt_fat.builder");
 
     public static class skipIfAddressDoesNotResolve extends MySkipRule {

--- a/dev/com.ibm.ws.security.jwt_fat.builder/fat/src/com/ibm/ws/security/jwt/fat/builder/JwtBuilderAPIConfigTests.java
+++ b/dev/com.ibm.ws.security.jwt_fat.builder/fat/src/com/ibm/ws/security/jwt/fat/builder/JwtBuilderAPIConfigTests.java
@@ -17,6 +17,7 @@ import java.util.Arrays;
 import javax.json.JsonObject;
 
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestRule;
@@ -61,6 +62,7 @@ import componenttest.topology.impl.LibertyServer;
 
 @Mode(TestMode.FULL)
 @RunWith(FATRunner.class)
+@SkipJavaSemeruWithFipsEnabledRule
 public class JwtBuilderAPIConfigTests extends CommonSecurityFat {
 
     @Server("com.ibm.ws.security.jwt_fat.builder")
@@ -69,7 +71,7 @@ public class JwtBuilderAPIConfigTests extends CommonSecurityFat {
     @Rule
     public static final TestRule conditIgnoreRule = new ConditionalIgnoreRule();
 
-    @Rule
+    @ClassRule
     public static final SkipJavaSemeruWithFipsEnabled skipJavaSemeruWithFipsEnabled = new SkipJavaSemeruWithFipsEnabled("com.ibm.ws.security.jwt_fat.builder");
 
     private static final JwtBuilderActions actions = new JwtBuilderActions();

--- a/dev/com.ibm.ws.security.jwt_fat.builder/fat/src/com/ibm/ws/security/jwt/fat/builder/JwtBuilderApiBasicTests.java
+++ b/dev/com.ibm.ws.security.jwt_fat.builder/fat/src/com/ibm/ws/security/jwt/fat/builder/JwtBuilderApiBasicTests.java
@@ -85,6 +85,7 @@ import componenttest.topology.impl.LibertyServer;
 
 @Mode(TestMode.FULL)
 @RunWith(FATRunner.class)
+@SkipJavaSemeruWithFipsEnabledRule
 public class JwtBuilderApiBasicTests extends CommonSecurityFat {
 
     @Server("com.ibm.ws.security.jwt_fat.builder")
@@ -102,7 +103,7 @@ public class JwtBuilderApiBasicTests extends CommonSecurityFat {
     @Rule
     public static final TestRule conditIgnoreRule = new ConditionalIgnoreRule();
 
-    @Rule
+    @ClassRule
     public static final SkipJavaSemeruWithFipsEnabled skipJavaSemeruWithFipsEnabled = new SkipJavaSemeruWithFipsEnabled("com.ibm.ws.security.jwt_fat.builder");
 
     private static final JwtBuilderActions actions = new JwtBuilderActions();

--- a/dev/com.ibm.ws.security.jwt_fat.consumer/fat/src/com/ibm/ws/security/jwt/fat/consumer/JwtConsumerApiConfigTests.java
+++ b/dev/com.ibm.ws.security.jwt_fat.consumer/fat/src/com/ibm/ws/security/jwt/fat/consumer/JwtConsumerApiConfigTests.java
@@ -15,10 +15,7 @@ import java.util.List;
 
 import javax.servlet.http.HttpServletResponse;
 
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.*;
 import org.junit.runner.RunWith;
 
 import com.gargoylesoftware.htmlunit.Page;
@@ -58,6 +55,7 @@ import componenttest.topology.impl.LibertyServer;
 
 @Mode(TestMode.FULL)
 @RunWith(FATRunner.class)
+@SkipJavaSemeruWithFipsEnabled.SkipJavaSemeruWithFipsEnabledRule
 public class JwtConsumerApiConfigTests extends CommonSecurityFat {
 
     @Server("com.ibm.ws.security.jwt_fat.consumer")
@@ -74,7 +72,7 @@ public class JwtConsumerApiConfigTests extends CommonSecurityFat {
 
     protected JWTTokenBuilder builder = null;
 
-    @Rule
+    @ClassRule
     public static final SkipJavaSemeruWithFipsEnabled skipJavaSemeruWithFipsEnabled = new SkipJavaSemeruWithFipsEnabled("com.ibm.ws.security.jwt_fat.consumer");
 
     @BeforeClass

--- a/dev/com.ibm.ws.security.jwtsso_fat.commonTest/fat/src/com/ibm/ws/security/jwtsso/fat/SigAlgTests.java
+++ b/dev/com.ibm.ws.security.jwtsso_fat.commonTest/fat/src/com/ibm/ws/security/jwtsso/fat/SigAlgTests.java
@@ -12,7 +12,9 @@
  *******************************************************************************/
 package com.ibm.ws.security.jwtsso.fat;
 
+import componenttest.rules.SkipJavaSemeruWithFipsEnabled;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -45,9 +47,13 @@ import componenttest.topology.impl.LibertyServer;
 
 @Mode(TestMode.FULL)
 @RunWith(FATRunner.class)
+@SkipJavaSemeruWithFipsEnabled.SkipJavaSemeruWithFipsEnabledRule
 public class SigAlgTests extends CommonJwtssoFat {
 
     protected static Class<?> thisClass = SigAlgTests.class;
+
+    @ClassRule
+    public static final SkipJavaSemeruWithFipsEnabled skipJavaSemeruWithFipsEnabled = new SkipJavaSemeruWithFipsEnabled();
 
     @Server("com.ibm.ws.security.jwtsso.fat")
     public static LibertyServer server;

--- a/dev/com.ibm.ws.security.mp.jwt.1.1_fat.commonTest/fat/src/com/ibm/ws/security/mp/jwt11/fat/envVarsTests/MPJwtGoodMPConfigAsEnvVars_NoPublicKey_UseKeyLocES256RelativeFile.java
+++ b/dev/com.ibm.ws.security.mp.jwt.1.1_fat.commonTest/fat/src/com/ibm/ws/security/mp/jwt11/fat/envVarsTests/MPJwtGoodMPConfigAsEnvVars_NoPublicKey_UseKeyLocES256RelativeFile.java
@@ -12,7 +12,9 @@
  *******************************************************************************/
 package com.ibm.ws.security.mp.jwt11.fat.envVarsTests;
 
+import componenttest.rules.SkipJavaSemeruWithFipsEnabled;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -40,9 +42,13 @@ import componenttest.topology.impl.LibertyServer;
 
 @Mode(TestMode.FULL)
 @RunWith(FATRunner.class)
+@SkipJavaSemeruWithFipsEnabled.SkipJavaSemeruWithFipsEnabledRule
 public class MPJwtGoodMPConfigAsEnvVars_NoPublicKey_UseKeyLocES256RelativeFile extends MPJwtWithGoodAltSigAlgMPConfig {
 
     public static Class<?> thisClass = MPJwtGoodMPConfigAsEnvVars_NoPublicKey_UseKeyLocES256RelativeFile.class;
+
+    @ClassRule
+    public static final SkipJavaSemeruWithFipsEnabled skipJavaSemeruWithFipsEnabled = new SkipJavaSemeruWithFipsEnabled();
 
     @Server("com.ibm.ws.security.mp.jwt.1.1.fat")
     public static LibertyServer envVarsResourceServer;

--- a/dev/com.ibm.ws.security.mp.jwt.1.1_fat.commonTest/fat/src/com/ibm/ws/security/mp/jwt11/fat/envVarsTests/MPJwtGoodMPConfigAsEnvVars_NoPublicKey_UseKeyLocES512JwksUri.java
+++ b/dev/com.ibm.ws.security.mp.jwt.1.1_fat.commonTest/fat/src/com/ibm/ws/security/mp/jwt11/fat/envVarsTests/MPJwtGoodMPConfigAsEnvVars_NoPublicKey_UseKeyLocES512JwksUri.java
@@ -12,7 +12,9 @@
  *******************************************************************************/
 package com.ibm.ws.security.mp.jwt11.fat.envVarsTests;
 
+import componenttest.rules.SkipJavaSemeruWithFipsEnabled;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -39,9 +41,13 @@ import componenttest.topology.impl.LibertyServer;
 
 @Mode(TestMode.FULL)
 @RunWith(FATRunner.class)
+@SkipJavaSemeruWithFipsEnabled.SkipJavaSemeruWithFipsEnabledRule
 public class MPJwtGoodMPConfigAsEnvVars_NoPublicKey_UseKeyLocES512JwksUri extends MPJwtWithGoodAltSigAlgMPConfig {
 
     public static Class<?> thisClass = MPJwtGoodMPConfigAsEnvVars_NoPublicKey_UseKeyLocES512JwksUri.class;
+
+    @ClassRule
+    public static final SkipJavaSemeruWithFipsEnabled skipJavaSemeruWithFipsEnabled = new SkipJavaSemeruWithFipsEnabled();
 
     @Server("com.ibm.ws.security.mp.jwt.1.1.fat")
     public static LibertyServer envVarsResourceServer;

--- a/dev/com.ibm.ws.security.mp.jwt.1.1_fat.commonTest/fat/src/com/ibm/ws/security/mp/jwt11/fat/envVarsTests/MPJwtGoodMPConfigAsEnvVars_UseES384PublicKey_NoKeyLoc.java
+++ b/dev/com.ibm.ws.security.mp.jwt.1.1_fat.commonTest/fat/src/com/ibm/ws/security/mp/jwt11/fat/envVarsTests/MPJwtGoodMPConfigAsEnvVars_UseES384PublicKey_NoKeyLoc.java
@@ -12,7 +12,9 @@
  *******************************************************************************/
 package com.ibm.ws.security.mp.jwt11.fat.envVarsTests;
 
+import componenttest.rules.SkipJavaSemeruWithFipsEnabled;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -40,9 +42,13 @@ import componenttest.topology.impl.LibertyServer;
 
 @Mode(TestMode.FULL)
 @RunWith(FATRunner.class)
+@SkipJavaSemeruWithFipsEnabled.SkipJavaSemeruWithFipsEnabledRule
 public class MPJwtGoodMPConfigAsEnvVars_UseES384PublicKey_NoKeyLoc extends MPJwtWithGoodAltSigAlgMPConfig {
 
     public static Class<?> thisClass = MPJwtGoodMPConfigAsEnvVars_UseES384PublicKey_NoKeyLoc.class;
+
+    @ClassRule
+    public static final SkipJavaSemeruWithFipsEnabled skipJavaSemeruWithFipsEnabled = new SkipJavaSemeruWithFipsEnabled();
 
     @Server("com.ibm.ws.security.mp.jwt.1.1.fat")
     public static LibertyServer envVarsResourceServer;

--- a/dev/com.ibm.ws.security.mp.jwt.1.1_fat.commonTest/fat/src/com/ibm/ws/security/mp/jwt11/fat/systemPropertiesTests/MPJwtGoodMPConfigAsSystemProperties_NoPublicKey_UseKeyLocES2564Url.java
+++ b/dev/com.ibm.ws.security.mp.jwt.1.1_fat.commonTest/fat/src/com/ibm/ws/security/mp/jwt11/fat/systemPropertiesTests/MPJwtGoodMPConfigAsSystemProperties_NoPublicKey_UseKeyLocES2564Url.java
@@ -12,7 +12,9 @@
  *******************************************************************************/
 package com.ibm.ws.security.mp.jwt11.fat.systemPropertiesTests;
 
+import componenttest.rules.SkipJavaSemeruWithFipsEnabled;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -40,9 +42,13 @@ import componenttest.topology.impl.LibertyServer;
 
 @Mode(TestMode.FULL)
 @RunWith(FATRunner.class)
+@SkipJavaSemeruWithFipsEnabled.SkipJavaSemeruWithFipsEnabledRule
 public class MPJwtGoodMPConfigAsSystemProperties_NoPublicKey_UseKeyLocES2564Url extends MPJwtWithGoodAltSigAlgMPConfig {
 
     public static Class<?> thisClass = MPJwtGoodMPConfigAsSystemProperties_NoPublicKey_UseKeyLocES2564Url.class;
+
+    @ClassRule
+    public static final SkipJavaSemeruWithFipsEnabled skipJavaSemeruWithFipsEnabled = new SkipJavaSemeruWithFipsEnabled();
 
     @Server("com.ibm.ws.security.mp.jwt.1.1.fat.jvmOptions")
     public static LibertyServer sysPropResourceServer;

--- a/dev/com.ibm.ws.security.mp.jwt.1.1_fat.commonTest/fat/src/com/ibm/ws/security/mp/jwt11/fat/systemPropertiesTests/MPJwtGoodMPConfigAsSystemProperties_NoPublicKey_UseKeyLocES384File.java
+++ b/dev/com.ibm.ws.security.mp.jwt.1.1_fat.commonTest/fat/src/com/ibm/ws/security/mp/jwt11/fat/systemPropertiesTests/MPJwtGoodMPConfigAsSystemProperties_NoPublicKey_UseKeyLocES384File.java
@@ -12,7 +12,9 @@
  *******************************************************************************/
 package com.ibm.ws.security.mp.jwt11.fat.systemPropertiesTests;
 
+import componenttest.rules.SkipJavaSemeruWithFipsEnabled;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -40,9 +42,13 @@ import componenttest.topology.impl.LibertyServer;
 
 @Mode(TestMode.FULL)
 @RunWith(FATRunner.class)
+@SkipJavaSemeruWithFipsEnabled.SkipJavaSemeruWithFipsEnabledRule
 public class MPJwtGoodMPConfigAsSystemProperties_NoPublicKey_UseKeyLocES384File extends MPJwtWithGoodAltSigAlgMPConfig {
 
     public static Class<?> thisClass = MPJwtGoodMPConfigAsSystemProperties_NoPublicKey_UseKeyLocES384File.class;
+
+    @ClassRule
+    public static final SkipJavaSemeruWithFipsEnabled skipJavaSemeruWithFipsEnabled = new SkipJavaSemeruWithFipsEnabled();
 
     @Server("com.ibm.ws.security.mp.jwt.1.1.fat.jvmOptions")
     public static LibertyServer sysPropResourceServer;

--- a/dev/com.ibm.ws.security.mp.jwt.1.1_fat.commonTest/fat/src/com/ibm/ws/security/mp/jwt11/fat/systemPropertiesTests/MPJwtGoodMPConfigAsSystemProperties_NoPublicKey_UseKeyLocES512RelativeFile.java
+++ b/dev/com.ibm.ws.security.mp.jwt.1.1_fat.commonTest/fat/src/com/ibm/ws/security/mp/jwt11/fat/systemPropertiesTests/MPJwtGoodMPConfigAsSystemProperties_NoPublicKey_UseKeyLocES512RelativeFile.java
@@ -12,7 +12,9 @@
  *******************************************************************************/
 package com.ibm.ws.security.mp.jwt11.fat.systemPropertiesTests;
 
+import componenttest.rules.SkipJavaSemeruWithFipsEnabled;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -40,9 +42,13 @@ import componenttest.topology.impl.LibertyServer;
 
 @Mode(TestMode.FULL)
 @RunWith(FATRunner.class)
+@SkipJavaSemeruWithFipsEnabled.SkipJavaSemeruWithFipsEnabledRule
 public class MPJwtGoodMPConfigAsSystemProperties_NoPublicKey_UseKeyLocES512RelativeFile extends MPJwtWithGoodAltSigAlgMPConfig {
 
     public static Class<?> thisClass = MPJwtGoodMPConfigAsSystemProperties_NoPublicKey_UseKeyLocES512RelativeFile.class;
+
+    @ClassRule
+    public static final SkipJavaSemeruWithFipsEnabled skipJavaSemeruWithFipsEnabled = new SkipJavaSemeruWithFipsEnabled();
 
     @Server("com.ibm.ws.security.mp.jwt.1.1.fat.jvmOptions")
     public static LibertyServer sysPropResourceServer;

--- a/dev/com.ibm.ws.security.oidc.client_fat.backchannelLogout.1/fat/src/com/ibm/ws/security/backchannelLogout/fat/BasicBCLTests.java
+++ b/dev/com.ibm.ws.security.oidc.client_fat.backchannelLogout.1/fat/src/com/ibm/ws/security/backchannelLogout/fat/BasicBCLTests.java
@@ -13,6 +13,7 @@
 
 package com.ibm.ws.security.backchannelLogout.fat;
 
+import componenttest.rules.SkipJavaSemeruWithFipsEnabled;
 import org.junit.ClassRule;
 import org.junit.runner.RunWith;
 
@@ -35,9 +36,13 @@ import componenttest.topology.impl.LibertyServerWrapper;
 @LibertyServerWrapper
 @Mode(TestMode.FULL)
 @AllowedFFDC({ "org.apache.http.NoHttpResponseException", "com.ibm.oauth.core.api.error.oauth20.OAuth20InvalidTokenException" })
+@SkipJavaSemeruWithFipsEnabled.SkipJavaSemeruWithFipsEnabledRule
 public class BasicBCLTests extends com.ibm.ws.security.backchannelLogout.fat.CommonTests.BasicBCLTests {
 
     @ClassRule
     public static RepeatTests repeat = createRepeats1(Constants.OIDC);
+
+    @ClassRule
+    public static final SkipJavaSemeruWithFipsEnabled skipJavaSemeruWithFipsEnabled = new SkipJavaSemeruWithFipsEnabled();
 
 }

--- a/dev/com.ibm.ws.security.oidc.client_fat.backchannelLogout.1/fat/src/com/ibm/ws/security/backchannelLogout/fat/HttpMethodsTests.java
+++ b/dev/com.ibm.ws.security.oidc.client_fat.backchannelLogout.1/fat/src/com/ibm/ws/security/backchannelLogout/fat/HttpMethodsTests.java
@@ -13,6 +13,7 @@
 
 package com.ibm.ws.security.backchannelLogout.fat;
 
+import componenttest.rules.SkipJavaSemeruWithFipsEnabled;
 import org.junit.ClassRule;
 import org.junit.runner.RunWith;
 
@@ -37,10 +38,14 @@ import componenttest.topology.impl.LibertyServerWrapper;
 @LibertyServerWrapper
 @Mode(TestMode.FULL)
 @AllowedFFDC({ "org.apache.http.NoHttpResponseException" })
+@SkipJavaSemeruWithFipsEnabled.SkipJavaSemeruWithFipsEnabledRule
 public class HttpMethodsTests extends com.ibm.ws.security.backchannelLogout.fat.CommonTests.HttpMethodsTests {
 
     // Repeat tests using the OIDC endpoints
     @ClassRule
     public static RepeatTests repeat = RepeatTests.with(new SecurityTestRepeatAction(Constants.OIDC));
+
+    @ClassRule
+    public static final SkipJavaSemeruWithFipsEnabled skipJavaSemeruWithFipsEnabled = new SkipJavaSemeruWithFipsEnabled();
 
 }

--- a/dev/com.ibm.ws.security.oidc.client_fat.backchannelLogout.1/fat/src/com/ibm/ws/security/backchannelLogout/fat/LogoutTokenValidationTests.java
+++ b/dev/com.ibm.ws.security.oidc.client_fat.backchannelLogout.1/fat/src/com/ibm/ws/security/backchannelLogout/fat/LogoutTokenValidationTests.java
@@ -13,6 +13,7 @@
 
 package com.ibm.ws.security.backchannelLogout.fat;
 
+import componenttest.rules.SkipJavaSemeruWithFipsEnabled;
 import org.junit.ClassRule;
 import org.junit.runner.RunWith;
 
@@ -36,6 +37,7 @@ import componenttest.topology.impl.LibertyServerWrapper;
 @LibertyServerWrapper
 @Mode(TestMode.FULL)
 @AllowedFFDC({ "org.apache.http.NoHttpResponseException" })
+@SkipJavaSemeruWithFipsEnabled.SkipJavaSemeruWithFipsEnabledRule
 public class LogoutTokenValidationTests extends com.ibm.ws.security.backchannelLogout.fat.CommonTests.LogoutTokenValidationTests {
 
     public static Class<?> thisClass = LogoutTokenValidationTests.class;
@@ -43,4 +45,6 @@ public class LogoutTokenValidationTests extends com.ibm.ws.security.backchannelL
     @ClassRule
     public static RepeatTests repeat = RepeatTests.with(new SecurityTestRepeatAction(Constants.OIDC));
 
+    @ClassRule
+    public static final SkipJavaSemeruWithFipsEnabled skipJavaSemeruWithFipsEnabled = new SkipJavaSemeruWithFipsEnabled();
 }

--- a/dev/com.ibm.ws.security.oidc.server_fat.jaxrs.config.commonTest/fat/src/com/ibm/ws/security/openidconnect/server/fat/jaxrs/config/noOP/NoOPEncryptionRSServerTests.java
+++ b/dev/com.ibm.ws.security.oidc.server_fat.jaxrs.config.commonTest/fat/src/com/ibm/ws/security/openidconnect/server/fat/jaxrs/config/noOP/NoOPEncryptionRSServerTests.java
@@ -16,6 +16,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -50,6 +51,7 @@ import componenttest.rules.SkipJavaSemeruWithFipsEnabled.SkipJavaSemeruWithFipsE
  */
 @Mode(TestMode.FULL)
 @RunWith(FATRunner.class)
+@SkipJavaSemeruWithFipsEnabledRule
 public class NoOPEncryptionRSServerTests extends MangleJWTTestTools {
 
     private static final Class<?> thisClass = NoOPEncryptionRSServerTests.class;
@@ -60,7 +62,7 @@ public class NoOPEncryptionRSServerTests extends MangleJWTTestTools {
     private static final JwtTokenActions actions = new JwtTokenActions();
     public static final JwtTokenBuilderUtils tokenBuilderHelpers = new JwtTokenBuilderUtils();
 
-    @Rule
+    @ClassRule
     public static final SkipJavaSemeruWithFipsEnabled skipJavaSemeruWithFipsEnabled = new SkipJavaSemeruWithFipsEnabled(OPServerName);
 
     @BeforeClass

--- a/dev/com.ibm.ws.security.oidc.server_fat.jaxrs.config.commonTest/fat/src/com/ibm/ws/security/openidconnect/server/fat/jaxrs/config/noOP/NoOPSignatureRSServerTests.java
+++ b/dev/com.ibm.ws.security.oidc.server_fat.jaxrs.config.commonTest/fat/src/com/ibm/ws/security/openidconnect/server/fat/jaxrs/config/noOP/NoOPSignatureRSServerTests.java
@@ -16,6 +16,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -47,6 +48,7 @@ import componenttest.rules.SkipJavaSemeruWithFipsEnabled.SkipJavaSemeruWithFipsE
  */
 @Mode(TestMode.FULL)
 @RunWith(FATRunner.class)
+@SkipJavaSemeruWithFipsEnabledRule
 public class NoOPSignatureRSServerTests extends MangleJWTTestTools {
 
     private static final Class<?> thisClass = NoOPSignatureRSServerTests.class;
@@ -56,7 +58,7 @@ public class NoOPSignatureRSServerTests extends MangleJWTTestTools {
     private static final JwtTokenActions actions = new JwtTokenActions();
     public static final JwtTokenBuilderUtils tokenBuilderHelpers = new JwtTokenBuilderUtils();
 
-    @Rule
+    @ClassRule
     public static final SkipJavaSemeruWithFipsEnabled skipJavaSemeruWithFipsEnabled = new SkipJavaSemeruWithFipsEnabled(OPServerName);
 
     @BeforeClass

--- a/dev/com.ibm.ws.security.social_fat.commonTest.LibertyOP/fat/src/com/ibm/ws/security/social/fat/LibertyOP/LibertyOP_BasicTests_oidc_usingSocialDiscoveryConfig.java
+++ b/dev/com.ibm.ws.security.social_fat.commonTest.LibertyOP/fat/src/com/ibm/ws/security/social/fat/LibertyOP/LibertyOP_BasicTests_oidc_usingSocialDiscoveryConfig.java
@@ -16,6 +16,7 @@ package com.ibm.ws.security.social.fat.LibertyOP;
 import java.util.ArrayList;
 import java.util.List;
 
+import componenttest.rules.SkipJavaSemeruWithFipsEnabled;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;

--- a/dev/com.ibm.ws.security.social_fat.commonTest.LibertyOP/fat/src/com/ibm/ws/security/social/fat/LibertyOP/LibertyOP_Encryption_oidc_usingSocialConfig.java
+++ b/dev/com.ibm.ws.security.social_fat.commonTest.LibertyOP/fat/src/com/ibm/ws/security/social/fat/LibertyOP/LibertyOP_Encryption_oidc_usingSocialConfig.java
@@ -39,6 +39,7 @@ import componenttest.topology.impl.LibertyServerWrapper;
 @RunWith(FATRunner.class)
 @LibertyServerWrapper
 @Mode(TestMode.FULL)
+@SkipJavaSemeruWithFipsEnabledRule
 public class LibertyOP_Encryption_oidc_usingSocialConfig extends Social_EncryptionTests {
 
     public static Class<?> thisClass = LibertyOP_Encryption_oidc_usingSocialConfig.class;
@@ -48,8 +49,8 @@ public class LibertyOP_Encryption_oidc_usingSocialConfig extends Social_Encrypti
     @ClassRule
     public static RepeatTests r = RepeatTests.withoutModification();
 
-    @Rule
-    public static final SkipJavaSemeruWithFipsEnabled skipJavaSemeruWithFipsEnabled = new SkipJavaSemeruWithFipsEnabled(SocialConstants.SERVER_NAME + ".LibertyOP.opWithStub");
+    @ClassRule
+    public static final SkipJavaSemeruWithFipsEnabled skipJavaSemeruWithFipsEnabled = new SkipJavaSemeruWithFipsEnabled();
 
     @BeforeClass
     public static void setUp() throws Exception {

--- a/dev/com.ibm.ws.security.social_fat.commonTest.LibertyOP/fat/src/com/ibm/ws/security/social/fat/LibertyOP/LibertyOP_SignatureAlg_oidc_usingSocialConfig.java
+++ b/dev/com.ibm.ws.security.social_fat.commonTest.LibertyOP/fat/src/com/ibm/ws/security/social/fat/LibertyOP/LibertyOP_SignatureAlg_oidc_usingSocialConfig.java
@@ -15,7 +15,9 @@ package com.ibm.ws.security.social.fat.LibertyOP;
 import java.util.ArrayList;
 import java.util.List;
 
+import componenttest.rules.SkipJavaSemeruWithFipsEnabled;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.runner.RunWith;
 
 import com.ibm.ws.security.oauth_oidc.fat.commonTest.Constants;
@@ -47,9 +49,13 @@ import componenttest.custom.junit.runner.Mode.TestMode;
 
 @Mode(TestMode.FULL)
 @RunWith(FATRunner.class)
+@SkipJavaSemeruWithFipsEnabled.SkipJavaSemeruWithFipsEnabledRule
 public class LibertyOP_SignatureAlg_oidc_usingSocialConfig extends Social_SignatureAlgTests {
 
     public static Class<?> thisClass = LibertyOP_SignatureAlg_oidc_usingSocialConfig.class;
+
+    @ClassRule
+    public static final SkipJavaSemeruWithFipsEnabled skipJavaSemeruWithFipsEnabled = new SkipJavaSemeruWithFipsEnabled();
 
     @BeforeClass
     public static void setUp() throws Exception {

--- a/dev/fattest.simplicity/src/componenttest/rules/SkipJavaSemeruWithFipsEnabled.java
+++ b/dev/fattest.simplicity/src/componenttest/rules/SkipJavaSemeruWithFipsEnabled.java
@@ -65,6 +65,20 @@ public class SkipJavaSemeruWithFipsEnabled implements TestRule {
 
     }
 
+    // constructor that inspects the local jvm where LibertyServer is not available
+    public SkipJavaSemeruWithFipsEnabled(){
+        this.server = null;
+        String buildInfo = System.getProperty("java.runtime.name");
+        this.IS_SEMERU_JAVA = buildInfo.contains("Semeru");
+        String version = System.getProperty("java.version");
+        String[] versionElements = version.split("\\D"); // split on non-digits
+
+        // Pre-JDK 9 the java.version is 1.MAJOR.MINOR
+        // Post-JDK 9 the java.version is MAJOR.MINOR
+        int i = Integer.valueOf(versionElements[0]) == 1 ? 1 : 0;
+        this.majorVersion = Integer.valueOf(versionElements[i++]);
+    }
+
     @Override
     public Statement apply(Statement statement, Description description) {
         if (description.getAnnotation(SkipJavaSemeruWithFipsEnabledRule.class) != null) {


### PR DESCRIPTION
Where a `@Rule` might have been applicable before, the nature of the issue leads to errors/warnings in the logs relating to the issue, so these need to skip the entire class of tests, so is elevated to `@ClassRule` with the Skip being added to the class.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

Initial updates to reduce volume of instances of [308738](https://wasrtc.hursley.ibm.com:9443/jazz/web/projects/WS-CD#action=com.ibm.team.workitem.viewWorkItem&id=308738)