### PR TITLE
Adding hibernate property to enable dirty tracking via snapshot comparison for JPA 3.2

### DIFF
--- a/dev/com.ibm.ws.jpa.container.core/src/com/ibm/ws/jpa/AbstractJPAProviderIntegration.java
+++ b/dev/com.ibm.ws.jpa.container.core/src/com/ibm/ws/jpa/AbstractJPAProviderIntegration.java
@@ -218,19 +218,21 @@ public abstract class AbstractJPAProviderIntegration implements JPAProviderInteg
                 }
             }
             /*
-             * Disable Hibernate's dirty tracking enhancement for JPA 3.2 to make use of snapshot comparison.
+             * Disable Hibernate's dirty tracking enhancement for versions greater than
+             * or equal to JPA 3.2 so that it make use of snapshot comparison.
              * Only set this property if not already configured by the user in persistence.xml or server.xml.
              */
-            if(JPAAccessor.getJPAComponent().getJPAVersion().equals(JPAVersion.JPA32)){
+            JPAVersion jpaVersion = JPAAccessor.getJPAComponent().getJPAVersion();
+            if (jpaVersion.greaterThanOrEquals(JPAVersion.JPA32)) {
                 if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
-                    Tr.debug(this, tc, "Current JPA version is JPA 3.2");
+                    Tr.debug(this, tc, "Current JPA version is: " + jpaVersion.toString());
                 Properties properties = puInfo.getProperties();
-                if (null!= properties && !properties.containsKey("hibernate.enhancer.enableDirtyTracking")) {
+                if (null != properties && !properties.containsKey("hibernate.enhancer.enableDirtyTracking")) {
                     if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
-                    Tr.debug(this, tc, "Setting hibernate.enhancer.enableDirtyTracking to false for JPA 3.2");
+                        Tr.debug(this, tc, "Setting hibernate.enhancer.enableDirtyTracking to false.");
                     props.put("hibernate.enhancer.enableDirtyTracking", "false");
                 }
-            }  
+            }
         }
 
         // Log third party provider name and version info once per provider

--- a/dev/com.ibm.ws.jpa.container.core/src/com/ibm/ws/jpa/AbstractJPAProviderIntegration.java
+++ b/dev/com.ibm.ws.jpa.container.core/src/com/ibm/ws/jpa/AbstractJPAProviderIntegration.java
@@ -217,6 +217,20 @@ public abstract class AbstractJPAProviderIntegration implements JPAProviderInteg
                         Tr.debug(this, tc, "Unable to provide JtaPlatform for Liberty TransactionManager to Hibernate", x);
                 }
             }
+            /*
+             * Disable Hibernate's dirty tracking enhancement for JPA 3.2 to make use of snapshot comparison.
+             * Only set this property if not already configured by the user in persistence.xml or server.xml.
+             */
+            if(JPAAccessor.getJPAComponent().getJPAVersion().equals(JPAVersion.JPA32)){
+                if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
+                    Tr.debug(this, tc, "Current JPA version is JPA 3.2");
+                Properties properties = puInfo.getProperties();
+                if (null!= properties && !properties.containsKey("hibernate.enhancer.enableDirtyTracking")) {
+                    if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
+                    Tr.debug(this, tc, "Setting hibernate.enhancer.enableDirtyTracking to false for JPA 3.2");
+                    props.put("hibernate.enhancer.enableDirtyTracking", "false");
+                }
+            }  
         }
 
         // Log third party provider name and version info once per provider


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

################################################################################################