### PR TITLE
Updates for Java 2 Security with Java 17 and EE 11

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/test/src/com/ibm/ws/feature/tests/SymbolicNameTest.java
+++ b/dev/com.ibm.websphere.appserver.features/test/src/com/ibm/ws/feature/tests/SymbolicNameTest.java
@@ -80,8 +80,7 @@ public class SymbolicNameTest {
             }
             String symbolicName = featureInfo.getName();
             // javaeePlatform and appSecurity are special because they have dependencies on each other.
-            if (symbolicName.startsWith("io.openliberty.jakartaeePlatform")
-                || symbolicName.startsWith("com.ibm.websphere.appserver.javaeePlatform")
+            if (symbolicName.startsWith("com.ibm.websphere.appserver.javaeePlatform")
                 || symbolicName.startsWith("com.ibm.websphere.appserver.appSecurity")
                 || symbolicName.startsWith("io.openliberty.jandex.internal")) { //Jandex internal was once incorrectly placed in kernelCore.mf, this led to dependencies on multiple versions of Jandex being active at once which has been grandfathered in
                 continue;

--- a/dev/com.ibm.websphere.appserver.features/visibility/auto/com.ibm.websphere.appserver.javaeePlatform7.0-jndi1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/auto/com.ibm.websphere.appserver.javaeePlatform7.0-jndi1.0.feature
@@ -3,7 +3,7 @@ symbolicName=com.ibm.websphere.appserver.javaeePlatform7.0-jndi1.0
 visibility=private
 IBM-Process-Types: client, \
  server
-IBM-Provision-Capability: osgi.identity; filter:="(&(type=osgi.subsystem.feature)(osgi.identity=com.ibm.websphere.appserver.javaeePlatform-7.0))", \
+IBM-Provision-Capability: osgi.identity; filter:="(&(type=osgi.subsystem.feature)(osgi.identity=io.openliberty.eePlatform.7.0.internal-1.0))", \
  osgi.identity; filter:="(&(type=osgi.subsystem.feature)(osgi.identity=com.ibm.websphere.appserver.jndi-1.0))"
 -bundles=com.ibm.ws.javaee.platform.v7.jndi
 IBM-Install-Policy: when-satisfied

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.eeCompatible-10.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.eeCompatible-10.0.feature
@@ -3,8 +3,9 @@ symbolicName=com.ibm.websphere.appserver.eeCompatible-10.0
 visibility=private
 singleton=true
 Subsystem-Version: 10.0.0
--bundles=com.ibm.ws.javaee.version, \
-  io.openliberty.java11.internal
+-bundles=io.openliberty.jakartaee.platform.v10, \
+ com.ibm.ws.javaee.version, \
+ io.openliberty.java11.internal
 kind=ga
 edition=core
 WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.eeCompatible-11.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.eeCompatible-11.0.feature
@@ -3,8 +3,8 @@ symbolicName=com.ibm.websphere.appserver.eeCompatible-11.0
 visibility=private
 singleton=true
 Subsystem-Version: 11.0.0
--bundles=com.ibm.ws.javaee.version, \
-  io.openliberty.java17.internal
+-bundles=io.openliberty.jakartaee.platform.v11, \
+ com.ibm.ws.javaee.version
 kind=beta
 edition=core
 WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.eeCompatible-8.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.eeCompatible-8.0.feature
@@ -4,7 +4,8 @@ WLP-DisableAllFeatures-OnConflict: false
 visibility=private
 singleton=true
 Subsystem-Version: 8.0.0
--bundles=com.ibm.ws.javaee.version
+-bundles=com.ibm.ws.javaee.platform.v8, \
+ com.ibm.ws.javaee.version
 kind=ga
 edition=core
 WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.eeCompatible-9.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.eeCompatible-9.0.feature
@@ -3,7 +3,8 @@ symbolicName=com.ibm.websphere.appserver.eeCompatible-9.0
 visibility=private
 singleton=true
 Subsystem-Version: 9.0.0
--bundles=com.ibm.ws.javaee.version
+-bundles=io.openliberty.jakartaee.platform.v9, \
+ com.ibm.ws.javaee.version
 kind=ga
 edition=core
 WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.javaeePlatform-8.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/com.ibm.websphere.appserver.javaeePlatform-8.0.feature
@@ -2,9 +2,8 @@
 symbolicName=com.ibm.websphere.appserver.javaeePlatform-8.0
 WLP-DisableAllFeatures-OnConflict: false
 IBM-Process-Types: client, server
--features=com.ibm.websphere.appserver.javaeePlatform-7.0
--bundles=com.ibm.ws.javaee.platform.v8, \
- com.ibm.ws.javaee.version
+-features=io.openliberty.eePlatform.7.0.internal-1.0, \
+ com.ibm.websphere.appserver.eeCompatible-8.0
 kind=ga
 edition=core
 WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.appclient.appClient-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.appclient.appClient-2.0.feature
@@ -1,7 +1,7 @@
 -include= ~${workspace}/cnf/resources/bnd/feature.props
 symbolicName=io.openliberty.appclient.appClient-2.0
 visibility=private
--features=io.openliberty.jakartaeePlatform-9.0, \
+-features=io.openliberty.jakartaeePlatform-9.0; ibm.tolerates:="10.0, 11.0", \
   com.ibm.websphere.appserver.eeCompatible-9.0; ibm.tolerates:="10.0, 11.0", \
   com.ibm.websphere.appserver.iiopclient-1.0, \
   com.ibm.websphere.appclient.client-1.0, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.eePlatform.7.0.internal-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.eePlatform.7.0.internal-1.0.feature
@@ -1,9 +1,9 @@
 -include= ~${workspace}/cnf/resources/bnd/feature.props
-symbolicName=com.ibm.websphere.appserver.javaeePlatform-7.0
+symbolicName=io.openliberty.eePlatform.7.0.internal-1.0
 WLP-DisableAllFeatures-OnConflict: false
 IBM-Process-Types: client, server
--features=io.openliberty.eePlatform.7.0.internal-1.0
--bundles=com.ibm.ws.javaee.platform.v7
+-features=com.ibm.websphere.appserver.javaeePlatform-6.0
+-bundles=com.ibm.ws.javaee.platform.defaultresource
 kind=ga
 edition=core
 WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.ejbCore-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.ejbCore-2.0.feature
@@ -3,7 +3,7 @@ symbolicName=io.openliberty.ejbCore-2.0
 IBM-API-Package: jakarta.ejb; type="spec", \
  jakarta.ejb.embeddable; type="spec", \
  jakarta.ejb.spi; type="spec"
--features=io.openliberty.jakartaeePlatform-9.0, \
+-features=io.openliberty.jakartaeePlatform-9.0; ibm.tolerates:="10.0, 11.0", \
   com.ibm.websphere.appserver.javaeeddSchema-1.0, \
   io.openliberty.managedBeansCore-2.0
 -bundles=com.ibm.ws.app.manager.war.jakarta, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.jakartaeePlatform-10.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.jakartaeePlatform-10.0.feature
@@ -1,9 +1,9 @@
 -include= ~${workspace}/cnf/resources/bnd/feature.props
 symbolicName=io.openliberty.jakartaeePlatform-10.0
+singleton=true
 IBM-Process-Types: client, server
--features=io.openliberty.jakartaeePlatform-9.0
--bundles=io.openliberty.jakartaee.platform.v10, \
- com.ibm.ws.javaee.version
+-features=io.openliberty.eePlatform.7.0.internal-1.0, \
+ com.ibm.websphere.appserver.eeCompatible-10.0
 kind=ga
 edition=core
 WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.jakartaeePlatform-11.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.jakartaeePlatform-11.0.feature
@@ -1,9 +1,12 @@
 -include= ~${workspace}/cnf/resources/bnd/feature.props
 symbolicName=io.openliberty.jakartaeePlatform-11.0
+singleton=true
 IBM-Process-Types: client, server
--features=io.openliberty.jakartaeePlatform-10.0
--bundles=io.openliberty.jakartaee.platform.v11, \
- com.ibm.ws.javaee.version
+-features=com.ibm.websphere.appserver.appmanager-1.0, \
+ com.ibm.websphere.appserver.eeCompatible-11.0
+# com.ibm.ws.security.java2sec is removed for EE 11
+-bundles=com.ibm.ws.app.manager.module, \
+ com.ibm.ws.javaee.platform.defaultresource
 kind=beta
 edition=core
 WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.jakartaeePlatform-9.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.jakartaeePlatform-9.0.feature
@@ -1,9 +1,9 @@
 -include= ~${workspace}/cnf/resources/bnd/feature.props
 symbolicName=io.openliberty.jakartaeePlatform-9.0
+singleton=true
 IBM-Process-Types: client, server
--features=com.ibm.websphere.appserver.javaeePlatform-8.0
--bundles=io.openliberty.jakartaee.platform.v9, \
- com.ibm.ws.javaee.version
+-features=io.openliberty.eePlatform.7.0.internal-1.0, \
+ com.ibm.websphere.appserver.eeCompatible-9.0
 kind=ga
 edition=core
 WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.messaging.internal-3.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.messaging.internal-3.1.feature
@@ -3,7 +3,7 @@ symbolicName=io.openliberty.messaging.internal-3.1
 singleton=true
 IBM-App-ForceRestart: uninstall
 IBM-API-Package: jakarta.jms; version="3.1"; type="spec"
--features=io.openliberty.jakartaeePlatform-10.0, \
+-features=io.openliberty.jakartaeePlatform-10.0; ibm.tolerates:="11.0", \
   io.openliberty.connectors.internal-2.1, \
   io.openliberty.jakarta.messaging-3.1, \
   com.ibm.websphere.appserver.transaction-2.0, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/cdi-2.0/com.ibm.websphere.appserver.cdi-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/cdi-2.0/com.ibm.websphere.appserver.cdi-2.0.feature
@@ -45,7 +45,7 @@ Subsystem-Name: Contexts and Dependency Injection 2.0
   com.ibm.websphere.appserver.javax.annotation-1.3, \
   com.ibm.websphere.appserver.internal.slf4j-1.7, \
   com.ibm.websphere.appserver.javax.persistence-2.2, \
-  com.ibm.websphere.appserver.javaeePlatform-7.0
+  com.ibm.websphere.appserver.javaeePlatform-8.0
 -bundles=com.ibm.ws.org.jboss.weld3, \
  com.ibm.ws.org.jboss.jdeparser.1.0.0, \
  com.ibm.ws.managedobject, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/connectors-2.1/io.openliberty.connectors-2.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/connectors-2.1/io.openliberty.connectors-2.1.feature
@@ -15,7 +15,7 @@ WLP-AlsoKnownAs: jca-2.1
 Subsystem-Name: Jakarta Connectors 2.1
 Subsystem-Category: JakartaEE10Application
 -features= com.ibm.websphere.appserver.eeCompatible-10.0; ibm.tolerates:="11.0", \
-  io.openliberty.jakartaeePlatform-10.0, \
+  io.openliberty.jakartaeePlatform-10.0; ibm.tolerates:="11.0", \
   io.openliberty.appserver.connectors-2.1, \
   io.openliberty.connectors.internal-2.1, \
   com.ibm.websphere.appserver.transaction-2.0

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/springBoot-3.0/io.openliberty.springBoot-3.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/springBoot-3.0/io.openliberty.springBoot-3.0.feature
@@ -7,7 +7,7 @@ IBM-ShortName: springBoot-3.0
 IBM-Process-Types: server
 Subsystem-Name: Spring Boot Support 3.0
 -features=io.openliberty.springBootHandler-3.0, \
-  com.ibm.websphere.appserver.eeCompatible-10.0; ibm.tolerates:="11.0"
+  com.ibm.websphere.appserver.eeCompatible-10.0
 -bundles=io.openliberty.java17.internal
 kind=ga
 edition=core

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/springBoot-4.0/io.openliberty.springBoot-4.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/springBoot-4.0/io.openliberty.springBoot-4.0.feature
@@ -7,6 +7,5 @@ IBM-Process-Types: server
 Subsystem-Name: Spring Boot Support 4.0
 -features=io.openliberty.springBootHandler-4.0, \
   com.ibm.websphere.appserver.eeCompatible-11.0
--bundles=io.openliberty.java17.internal
 kind=beta
 edition=core

--- a/dev/com.ibm.ws.app.manager.module/src/com/ibm/ws/app/manager/module/internal/DeployedAppInfoBase.java
+++ b/dev/com.ibm.ws.app.manager.module/src/com/ibm/ws/app/manager/module/internal/DeployedAppInfoBase.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2025 IBM Corporation and others.
+ * Copyright (c) 2012, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -570,14 +570,20 @@ public abstract class DeployedAppInfoBase extends SimpleDeployedAppInfoBase impl
         this.libraryConfigHelper = new ClassLoaderConfigHelper(getConfigHelper(), configAdmin, classLoadingService);
         this.isDelegateLast = libraryConfigHelper.isDelegateLast();
         this.permissionManager = deployedAppServices.getPermissionManager();
-        try {
-            this.permissionsConfig = getContainer().adapt(PermissionsConfig.class); // throws UnableToAdaptException
-        } catch (UnableToAdaptException e) {
-            // error.application.parse.descriptor=
-            // CWWKZ0113E: Application {0}: Parse error for application descriptor {1}: {2}
-            Tr.error(_tc, "error.application.parse.descriptor", getName(), "META-INF/permissions.xml", e);
-            throw e;
+
+        if (!java2SecurityEnabled()) {
+            this.permissionsConfig = null;
+        } else {
+            try {
+                this.permissionsConfig = getContainer().adapt(PermissionsConfig.class); // throws UnableToAdaptException
+            } catch (UnableToAdaptException e) {
+                // error.application.parse.descriptor=
+                // CWWKZ0113E: Application {0}: Parse error for application descriptor {1}: {2}
+                Tr.error(_tc, "error.application.parse.descriptor", getName(), "META-INF/permissions.xml", e);
+                throw e;
+            }
         }
+
         String parentPid = (String) applicationInformation.getConfigProperty(Constants.SERVICE_PID);
         String sourcePid = (String) applicationInformation.getConfigProperty("ibm.extends.source.pid");
         if (sourcePid != null) {
@@ -742,10 +748,6 @@ public abstract class DeployedAppInfoBase extends SimpleDeployedAppInfoBase impl
     }
 
     private boolean java2SecurityEnabled() {
-        SecurityManager sm = System.getSecurityManager();
-        if (sm != null)
-            return true;
-        else
-            return false;
+        return System.getSecurityManager() != null;
     }
 }

--- a/dev/com.ibm.ws.classloading/bnd.bnd
+++ b/dev/com.ibm.ws.classloading/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017, 2019 IBM Corporation and others.
+# Copyright (c) 2017, 2026 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -53,6 +53,7 @@ Private-Package: \
   com.ibm.ws.classloading.internal.ClassLoadingServiceImpl,\
   com.ibm.ws.classloading.internal.NativeLibraryAdapter,\
   com.ibm.ws.classloading.internal.util.ClassRedefiner,\
+  com.ibm.ws.classloading.java2sec.PermissionManager,\
   com.ibm.ws.library.internal.SharedLibraryFactory
 
 Service-Component: \
@@ -60,19 +61,6 @@ Service-Component: \
     configuration-policy:=require; \
     implementation:=com.ibm.ws.classloading.java2sec.JavaPermissionsConfiguration; \
     provide:=com.ibm.ws.classloading.java2sec.JavaPermissionsConfiguration; \
-    properties:="service.vendor=IBM", \
-  com.ibm.ws.classloading.java2sec.PermissionManager; \
-    configuration-policy:=ignore; \
-    immediate:=true;\
-    implementation:=com.ibm.ws.classloading.java2sec.PermissionManager; \
-    provide:=com.ibm.ws.classloading.java2sec.PermissionManager; \
-    permission=com.ibm.ws.classloading.java2sec.JavaPermissionsConfiguration; \
-    classLoadingService=com.ibm.wsspi.classloading.ClassLoadingService; \
-    wsjarURLStreamHandler='org.osgi.service.url.URLStreamHandlerService(url.handler.protocol=wsjar)'; \
-    dynamic:='permission'; \
-    multiple:='permission'; \
-    greedy:='permission'; \
-    optional:='permission'; \
     properties:="service.vendor=IBM"
 
 instrument.classesExcludes: com/ibm/ws/classloading/internal/resources/*.class

--- a/dev/com.ibm.ws.classloading/src/com/ibm/ws/classloading/java2sec/PermissionManager.java
+++ b/dev/com.ibm.ws.classloading/src/com/ibm/ws/classloading/java2sec/PermissionManager.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2019, 2020, 2022 IBM Corporation and others.
+ * Copyright (c) 2015, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -13,7 +13,6 @@
 package com.ibm.ws.classloading.java2sec;
 
 import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -34,15 +33,14 @@ import java.security.cert.Certificate;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-
-import java.util.zip.ZipFile;
 import java.util.zip.ZipEntry;
-import java.util.Enumeration;
+import java.util.zip.ZipFile;
 
 import javax.security.auth.AuthPermission;
 
@@ -55,7 +53,13 @@ import org.osgi.framework.wiring.BundleWiring;
 import org.osgi.framework.wiring.FrameworkWiring;
 import org.osgi.service.component.ComponentContext;
 import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ConfigurationPolicy;
 import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceCardinality;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 import org.osgi.service.url.URLStreamHandlerService;
 
 import com.ibm.websphere.ras.Tr;
@@ -65,6 +69,7 @@ import com.ibm.ws.kernel.boot.security.WLPDynamicPolicy;
 import com.ibm.wsspi.classloading.ClassLoadingService;
 import com.ibm.wsspi.kernel.service.utils.ConcurrentServiceReferenceSet;
 
+@Component(service = PermissionManager.class, immediate = true, configurationPolicy = ConfigurationPolicy.IGNORE, property = "service.vendor=IBM")
 public class PermissionManager implements PermissionsCombiner {
 
     /**
@@ -102,7 +107,7 @@ public class PermissionManager implements PermissionsCombiner {
 
     private boolean isServer = true;
     private boolean wsjarUrlStreamHandlerAvailable = false;
-    
+
     private static final String LOGGING_PERMISSION = "java.util.logging.LoggingPermission";
 
     /**
@@ -185,6 +190,7 @@ public class PermissionManager implements PermissionsCombiner {
         setAsDynamicPolicyPermissionCombiner(null);
     }
 
+    @Reference(name = KEY_PERMISSION, cardinality = ReferenceCardinality.MULTIPLE, policy = ReferencePolicy.DYNAMIC, policyOption = ReferencePolicyOption.GREEDY)
     protected void setPermission(ServiceReference<JavaPermissionsConfiguration> permission) {
         permissions.addReference(permission);
     }
@@ -200,6 +206,7 @@ public class PermissionManager implements PermissionsCombiner {
         }
     }
 
+    @Reference(name = "wsjarURLStreamHandler", service = URLStreamHandlerService.class, target = "(url.handler.protocol=wsjar)")
     protected synchronized void setWsjarURLStreamHandler(ServiceReference<URLStreamHandlerService> urlStreamHandlerServiceRef) {
         wsjarUrlStreamHandlerAvailable = true;
     }
@@ -223,6 +230,7 @@ public class PermissionManager implements PermissionsCombiner {
         codeBasePermissionMap.clear();
     }
 
+    @Reference(name = "classLoadingService")
     protected void setClassLoadingService(ClassLoadingService service) {
         classLoadingService = service;
     }

--- a/dev/com.ibm.ws.clientcontainer.beanvalidation_fat/bnd.bnd
+++ b/dev/com.ibm.ws.clientcontainer.beanvalidation_fat/bnd.bnd
@@ -1,14 +1,11 @@
 #*******************************************************************************
-# Copyright (c) 2017, 2022 IBM Corporation and others.
+# Copyright (c) 2017, 2026 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-2.0/
 # 
 # SPDX-License-Identifier: EPL-2.0
-#
-# Contributors:
-#     IBM Corporation - initial API and implementation
 #*******************************************************************************
 -include= ~../cnf/resources/bnd/bundle.props
 bVersion=1.0
@@ -25,7 +22,8 @@ fat.project: true
 
 tested.features: \
   jakartaeeClient-9.1, \
-  jakartaeeClient-10.0
+  jakartaeeClient-10.0, \
+  jakartaeeClient-11.0
 
 # Dependencies may be local bundles (e.g. com.ibm.websphere.javaee.servlet.3.1)
 #      or binaries from Artifactory (e.g. commons-logging:commons-logging)

--- a/dev/com.ibm.ws.clientcontainer.beanvalidation_fat/fat/src/com/ibm/ws/clientcontainer/fat/BvalAppClientTest_11.java
+++ b/dev/com.ibm.ws.clientcontainer.beanvalidation_fat/fat/src/com/ibm/ws/clientcontainer/fat/BvalAppClientTest_11.java
@@ -1,14 +1,11 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2022 IBM Corporation and others.
+ * Copyright (c) 2017, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
  * 
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package com.ibm.ws.clientcontainer.fat;
 
@@ -25,7 +22,7 @@ import componenttest.annotation.SkipForRepeat;
 public class BvalAppClientTest_11 extends AbstractAppClientTest {
     
 	@Test
-	@SkipForRepeat({SkipForRepeat.EE9_FEATURES, SkipForRepeat.EE10_FEATURES})
+	@SkipForRepeat({SkipForRepeat.EE9_FEATURES, SkipForRepeat.EE10_FEATURES, SkipForRepeat.EE11_FEATURES})
 	public void testApacheBvalConfig_11_AppClient() throws Exception {
 		String testClientName = "com.ibm.ws.clientcontainer.beanvalidation.fat.ApacheBvalConfig_11";
 		client = LibertyClientFactory.getLibertyClient(testClientName);
@@ -38,7 +35,7 @@ public class BvalAppClientTest_11 extends AbstractAppClientTest {
 	}
 	
 	@Test
-    @SkipForRepeat({SkipForRepeat.EE9_FEATURES, SkipForRepeat.EE10_FEATURES})
+    @SkipForRepeat({SkipForRepeat.EE9_FEATURES, SkipForRepeat.EE10_FEATURES, SkipForRepeat.EE11_FEATURES})
 	public void testBeanvalidation_11_AppClient() throws Exception {
 		String testClientName = "com.ibm.ws.clientcontainer.beanvalidation.fat.beanvalidation_11";
 		client = LibertyClientFactory.getLibertyClient(testClientName);
@@ -52,7 +49,7 @@ public class BvalAppClientTest_11 extends AbstractAppClientTest {
 	}
 	
 	@Test
-    @SkipForRepeat({SkipForRepeat.EE9_FEATURES, SkipForRepeat.EE10_FEATURES})
+    @SkipForRepeat({SkipForRepeat.EE9_FEATURES, SkipForRepeat.EE10_FEATURES, SkipForRepeat.EE11_FEATURES})
 	public void testBeanValidationCDI_11_AppClient() throws Exception {
 		String testClientName = "com.ibm.ws.clientcontainer.beanvalidation.fat.BeanValidationCDI_11";
 		client = LibertyClientFactory.getLibertyClient(testClientName);
@@ -66,7 +63,7 @@ public class BvalAppClientTest_11 extends AbstractAppClientTest {
 	}
 	
 	@Test
-    @SkipForRepeat({SkipForRepeat.EE9_FEATURES, SkipForRepeat.EE10_FEATURES})
+    @SkipForRepeat({SkipForRepeat.EE9_FEATURES, SkipForRepeat.EE10_FEATURES, SkipForRepeat.EE11_FEATURES})
 	public void testDefaultbeanvalidation_11_AppClient() throws Exception {
 		String testClientName = "com.ibm.ws.clientcontainer.beanvalidation.fat.defaultbeanvalidation_11";
 		client = LibertyClientFactory.getLibertyClient(testClientName);
@@ -80,7 +77,7 @@ public class BvalAppClientTest_11 extends AbstractAppClientTest {
 	}
 	
 	@Test
-    @SkipForRepeat({SkipForRepeat.EE9_FEATURES, SkipForRepeat.EE10_FEATURES})
+    @SkipForRepeat({SkipForRepeat.EE9_FEATURES, SkipForRepeat.EE10_FEATURES, SkipForRepeat.EE11_FEATURES})
 	public void testDefaultBeanValidationCDI_11_AppClient() throws Exception {
 		String testClientName = "com.ibm.ws.clientcontainer.beanvalidation.fat.DefaultBeanValidationCDI_11";
 		client = LibertyClientFactory.getLibertyClient(testClientName);

--- a/dev/com.ibm.ws.clientcontainer.beanvalidation_fat/fat/src/com/ibm/ws/clientcontainer/fat/BvalAppClientTest_20.java
+++ b/dev/com.ibm.ws.clientcontainer.beanvalidation_fat/fat/src/com/ibm/ws/clientcontainer/fat/BvalAppClientTest_20.java
@@ -1,14 +1,11 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2022 IBM Corporation and others.
+ * Copyright (c) 2017, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
  * 
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package com.ibm.ws.clientcontainer.fat;
 
@@ -25,7 +22,7 @@ import componenttest.annotation.SkipForRepeat;
 public class BvalAppClientTest_20 extends AbstractAppClientTest {
 	
 	@Test
-    @SkipForRepeat({SkipForRepeat.EE9_FEATURES, SkipForRepeat.EE10_FEATURES})
+    @SkipForRepeat({SkipForRepeat.EE9_FEATURES, SkipForRepeat.EE10_FEATURES, SkipForRepeat.EE11_FEATURES})
 	public void testBeanvalidation_20_AppClient() throws Exception {
 		String testClientName = "com.ibm.ws.clientcontainer.beanvalidation.fat.beanvalidation_20";
 		client = LibertyClientFactory.getLibertyClient(testClientName);

--- a/dev/com.ibm.ws.clientcontainer.beanvalidation_fat/fat/src/com/ibm/ws/clientcontainer/fat/FATSuite.java
+++ b/dev/com.ibm.ws.clientcontainer.beanvalidation_fat/fat/src/com/ibm/ws/clientcontainer/fat/FATSuite.java
@@ -1,14 +1,11 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2022 IBM Corporation and others.
+ * Copyright (c) 2017, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
  * 
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package com.ibm.ws.clientcontainer.fat;
 
@@ -24,10 +21,7 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
 
-import componenttest.custom.junit.runner.AlwaysPassesTest;
 import componenttest.rules.repeater.FeatureReplacementAction;
-import componenttest.rules.repeater.JakartaEE10Action;
-import componenttest.rules.repeater.JakartaEE9Action;
 import componenttest.rules.repeater.RepeatTests;
 
 
@@ -43,8 +37,9 @@ public class FATSuite {
 
 	@ClassRule
     public static RepeatTests r = RepeatTests.withoutModification()
-                    .andWith(new JakartaEE9Action())
-                    .andWith(new JakartaEE10Action());
+                    .andWith(FeatureReplacementAction.EE9_FEATURES())
+                    .andWith(FeatureReplacementAction.EE10_FEATURES())
+                    .andWith(FeatureReplacementAction.EE11_FEATURES().alwaysAddFeature("xmlBinding-4.0"));
 
 	public static EnterpriseArchive apacheBvalConfigApp;
 	public static EnterpriseArchive beanValidationApp;

--- a/dev/com.ibm.ws.kernel.boot.nested/src/com/ibm/ws/kernel/launch/internal/FrameworkManager.java
+++ b/dev/com.ibm.ws.kernel.boot.nested/src/com/ibm/ws/kernel/launch/internal/FrameworkManager.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010, 2025 IBM Corporation and others.
+ * Copyright (c) 2010, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -240,14 +240,7 @@ public class FrameworkManager {
             // Save the bootstrap config locally
             this.config = config;
 
-            boolean j2secManager = false;
             if (config.get(BootstrapConstants.JAVA_2_SECURITY_PROPERTY) != null) {
-                j2secManager = true;
-            }
-
-            String j2secNoRethrow = config.get(BootstrapConstants.JAVA_2_SECURITY_NORETHROW);
-
-            if (j2secManager) {
                 // OLGH#20289 -- Java 2 Security Manager is no longer supported with Java 18+
                 if (javaVersion() >= 18) {
                     Tr.error(tc, "error.set.securitymanager.jdk18", javaVersion());
@@ -259,6 +252,8 @@ public class FrameworkManager {
                             throw new IllegalStateException(Tr.formatMessage(tc, "error.checkpoint.securitymanager.not.supported"));
                         }
                     });
+                    String j2secNoRethrow = config.get(BootstrapConstants.JAVA_2_SECURITY_NORETHROW);
+
                     if (j2secNoRethrow == null || j2secNoRethrow.equals("false")) {
                         try {
                             AccessController.doPrivileged(new java.security.PrivilegedExceptionAction<Void>() {

--- a/dev/com.ibm.ws.kernel.boot/resources/com/ibm/ws/kernel/boot/resources/LauncherMessages.nlsprops
+++ b/dev/com.ibm.ws.kernel.boot/resources/com/ibm/ws/kernel/boot/resources/LauncherMessages.nlsprops
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2010, 2025 IBM Corporation and others.
+# Copyright (c) 2010, 2026 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -798,7 +798,15 @@ warning.manual.PPV.env.var.useraction=To retain the PREFERRED_PLATFORM_VERSION e
 
 error.read.server.env=CWWKE0970E: Unable to read the server.env file at the {} location.
 error.read.server.env.explanation=Failure to read the server.env file.
-error.read.server.env.useraction=Unable to read the server.env file.  Check file permissions and retry the operation.
+error.read.server.env.useraction=Unable to read the server.env file. Check file permissions and retry the operation.
+
+warning.java2security.stopped=CWWKE0971W: Java 2 Security is disabled because Jakarta EE 11 does not support it.
+warning.java2security.stopped.explanation=Jakarta EE 11 removed support for Java 2 Security.
+warning.java2security.stopped.useraction=Disable Java 2 Security in the server configuration when you are using Jakarta EE 11 features.
+
+info.java2security.restarted=CWWKE0972I: Java 2 Security is re-enabled because Jakarta EE 11 features were removed.
+info.java2security.restarted.explanation=This message is for informational purposes only.
+info.java2security.restarted.useraction=No action is required.
 
 info.serverStarting=Starting server {0}.
 info.serverStarted=Server {0} started.

--- a/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyClient.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyClient.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2025 IBM Corporation and others.
+ * Copyright (c) 2011, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -71,6 +71,7 @@ import componenttest.common.apiservices.Bootstrap;
 import componenttest.common.apiservices.LocalMachine;
 import componenttest.custom.junit.runner.LogPolice;
 import componenttest.exception.TopologyException;
+import componenttest.rules.repeater.JakartaEEAction;
 import componenttest.topology.impl.JavaInfo.Vendor;
 import componenttest.topology.impl.LibertyFileManager.LogSearchResult;
 import componenttest.topology.utils.FileUtils;
@@ -562,7 +563,6 @@ public class LibertyClient {
         if (preClean)
             preStartClientLogsTidy();
 
-
         Properties useEnvVars = new Properties();
         useEnvVars.putAll(envVars);
         if (!useEnvVars.isEmpty())
@@ -629,6 +629,8 @@ public class LibertyClient {
             JVM_ARGS += " " + MAC_RUN;
         }
 
+        boolean startedWithJavaSecurity = false;
+
         // if we have java 2 security enabled, add java.security.manager and java.security.policy
         if (GLOBAL_JAVA2SECURITY) {
             RemoteFile f = getClientBootstrapPropertiesFile();
@@ -637,11 +639,12 @@ public class LibertyClient {
             if (clientNeedsToRunWithJava2Security()) {
                 addJava2SecurityPropertiesToBootstrapFile(f);
                 Log.info(c, "startClientWithArgs", "Java 2 Security enabled for client " + getClientName() + " because GLOBAL_JAVA2SECURITY=true");
+                startedWithJavaSecurity = true;
             } else {
                 LOG.warning("The build is configured to run FAT tests with Java 2 Security enabled, but the FAT client " + getClientName() +
                             " is exempt from Java 2 Security regression testing.");
             }
-        } else if (javaInfo.majorVersion() >= 18) {
+        } else {
             // Check if "websphere.java.security" has been added to bootstrapping.properties
             // as some tests will add it for their own security enable tests
             boolean bootstrapHasJava2SecProps = false;
@@ -664,16 +667,18 @@ public class LibertyClient {
                     reader.close();
             }
 
+            startedWithJavaSecurity = bootstrapHasJava2SecProps;
+
             if (bootstrapHasJava2SecProps) {
                 if (javaInfo.majorVersion() >= 24) {
                     // Security manager is permanently disabled starting in Java 24
                     LOG.severe("The build is configured to run FAT tests with Java 2 security enabled, but the security manager is permanently disabled in Java versions 24 and later.  The security manager cannot be set!");
                     throw new RuntimeException("The security manager is permanently disabled in Java versions 24 and later.  When running FATs, use @MaximumJavaLevel(javaLevel = 23) or disable Java 2 security to prevent this test from failing running in Java 24 or later.");
+                } else if (javaInfo.majorVersion() >= 18) {
+                    // If we are running on Java 18 through 23, then we need to explicitly enable the security manager
+                    Log.info(c, method, "Java 18 + Java2Sec requested, setting -Djava.security.manager=allow");
+                    JVM_ARGS += " -Djava.security.manager=allow";
                 }
-
-                // If we are running on Java 18 through 23, then we need to explicitly enable the security manager
-                Log.info(c, method, "Java 18 + Java2Sec requested, setting -Djava.security.manager=allow");
-                JVM_ARGS += " -Djava.security.manager=allow";
             }
         }
 
@@ -688,23 +693,25 @@ public class LibertyClient {
                 Properties clientEnv = getClientEnv();
                 Properties defaultEnv = getDefaultEnv();
                 Map<String, String> opts = getJvmOptionsAsMap();
-                if (clientEnv.containsKey("ENABLE_FIPS140_3") || defaultEnv.containsKey("ENABLE_FIPS140_3") || opts.containsKey("-Xenablefips140-3") || opts.containsKey("-Dsemeru.fips")) {
+                if (clientEnv.containsKey("ENABLE_FIPS140_3") || defaultEnv.containsKey("ENABLE_FIPS140_3") || opts.containsKey("-Xenablefips140-3")
+                    || opts.containsKey("-Dsemeru.fips")) {
                     Log.info(c, method, "Test has defined its own settings for FIPS140-3");
                 } else {
                     Log.info(c, "startClientWithArgs", "The JDK version: " + javaInfo.majorVersion() + " and vendor: " + JavaInfo.Vendor.IBM);
 
                     if (javaInfo.majorVersion() >= 11) {
                         Log.info(c, "startClientWithArgs", "FIPS 140-3 global build properties is set for Client " + getClientName()
-                                + " with IBM Java " + javaInfo.majorVersion() + ", adding required JVM arguments to run with FIPS 140-3 enabled");
+                                                           + " with IBM Java " + javaInfo.majorVersion() + ", adding required JVM arguments to run with FIPS 140-3 enabled");
 
                         JVM_ARGS += " -Dsemeru.fips=true";
                         JVM_ARGS += " -Dsemeru.customprofile=OpenJCEPlusFIPS.FIPS140-3-Custom";
-                        JVM_ARGS += " -Djava.security.propertiesList=" + getLibertySemeruFips140_3ProfileLocationAndPrintFileContents() + File.pathSeparator + getSemeruFips140_3CustomProfileLocationAndPrintFileContents();
+                        JVM_ARGS += " -Djava.security.propertiesList=" + getLibertySemeruFips140_3ProfileLocationAndPrintFileContents() + File.pathSeparator
+                                    + getSemeruFips140_3CustomProfileLocationAndPrintFileContents();
                         JVM_ARGS += " -Dcom.ibm.fips.mode=140-3";
                         // JVM_ARGS += " -Djavax.net.debug=all";  // Uncomment as needed for additional debugging
                     } else if (javaInfo.majorVersion() == 8) {
                         Log.info(c, "startClientWithArgs", "FIPS 140-3 global build properties is set for Client " + getClientName()
-                                + " with IBM Java 8, adding JVM arguments -Xenablefips140-3, ...,  to run with FIPS 140-3 enabled");
+                                                           + " with IBM Java 8, adding JVM arguments -Xenablefips140-3, ...,  to run with FIPS 140-3 enabled");
 
                         JVM_ARGS += " -Xenablefips140-3";
                         JVM_ARGS += " -Dcom.ibm.jsse2.usefipsprovider=true";
@@ -870,11 +877,50 @@ public class LibertyClient {
         // Create a marker file to indicate client is started
         createClientMarkerFile();
 
+        if (startedWithJavaSecurity && isEE11Enabled()) {
+            final String JAVA2_SECURITY_DISABLED = "CWWKE0971W";
+            fixedIgnoreErrorsList.add(JAVA2_SECURITY_DISABLED);
+        }
+
         if ("run".equals(clientCmd)) {
             validateClientStopped(output, expectStartFailure);
         }
         postStopClientArchive();
         return output;
+    }
+
+    private boolean isEE11Enabled() throws Exception {
+        if (JakartaEEAction.isEE9Active() || JakartaEEAction.isEE10Active()) {
+            return false;
+        }
+
+        // EE 11 which doesn't support Java security manager can run with Java 17.
+
+        RemoteFile serverXML = machine.getFile(getClientConfigurationPath());
+        InputStreamReader in = new InputStreamReader(serverXML.openForReading());
+        try (Scanner s = new Scanner(in)) {
+            while (s.hasNextLine()) {
+                String line = s.nextLine();
+                if (line.contains("<featureManager>")) {//So has reached featureSets
+                    while (s.hasNextLine()) {
+                        line = s.nextLine();
+                        if (line.contains("</featureManager>"))
+                            break;
+
+                        line = line.replaceAll("<feature>", "");
+                        line = line.replaceAll("</feature>", "");
+                        line = line.trim();
+                        String lowerCaseFeatureName = line.toLowerCase();
+
+                        if ("jakartaeeclient-11.0".equals(lowerCaseFeatureName)) {
+                            return true;
+                        }
+                    }
+                }
+            }
+        }
+
+        return false;
     }
 
     private String getLibertySemeruFips140_3ProfileLocationAndPrintFileContents() throws Exception {
@@ -4038,8 +4084,8 @@ public class LibertyClient {
     public void addEnvVar(String key, String value) {
         if (!Pattern.matches("[a-zA-Z_]+[a-zA-Z0-9_]*", key)) {
             throw new IllegalArgumentException("Invalid environment variable key '" + key +
-                    "'. Environment variable keys must consist of characers [a-zA-Z0-9_] " +
-                    "in order to work on all OSes.");
+                                               "'. Environment variable keys must consist of characers [a-zA-Z0-9_] " +
+                                               "in order to work on all OSes.");
         }
         if (isStarted())
             throw new RuntimeException("Cannot add env vars to a running server");

--- a/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyServer.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyServer.java
@@ -1578,8 +1578,8 @@ public class LibertyServer implements LogMonitorClient {
         Log.info(c, methodName, ">>> STARTING SERVER: " + getServerName());
         Log.info(c, methodName,
                  "Starting " + getServerName() + "; preClean=" + preClean + ", clean=" + cleanStart + ", validateApps=" + useValidateApps + ", expectStartFailure="
-                            + expectStartFailure
-                            + ", cmd=" + serverCmd + ", args=" + args);
+                                + expectStartFailure
+                                + ", cmd=" + serverCmd + ", args=" + args);
 
         if (serverCleanupProblem) {
             throw new Exception("The server was not cleaned up on the previous test.");
@@ -1691,9 +1691,8 @@ public class LibertyServer implements LogMonitorClient {
 
         // If Java 2 security is enabled, add java.security.manager and java.security.policy.
         //
-        // Java 2 security is not enabled for servers that have Jakarta EE 11 or later features
-        // or if testing InstantOn function since neither one of them support Java 2 security
-        if (isJava2SecurityEnabled() && !isEE11OrLaterEnabled() && checkpointInfo == null) {
+        // Java 2 security is not enabled for servers if testing InstantOn function since it does not support it.
+        if (isJava2SecurityEnabled() && checkpointInfo == null) {
             RemoteFile f = getServerBootstrapPropertiesFile();
             addJava2SecurityPropertiesToBootstrapFile(f, GLOBAL_DEBUG_JAVA2SECURITY);
             String reason = GLOBAL_JAVA2SECURITY ? "GLOBAL_JAVA2SECURITY" : "GLOBAL_DEBUG_JAVA2SECURITY";
@@ -1740,7 +1739,8 @@ public class LibertyServer implements LogMonitorClient {
         // if we have FIPS 140-3 enabled, and the matched java/platform, add JVM Arg
         if (isFIPS140_3EnabledAndSupported(info) || isFIPS140_2EnabledAndSupported(info)) {
             Map<String, String> opts = getJvmOptionsAsMap();
-            if (getServerEnv().containsKey("ENABLE_FIPS140_3") || getDefaultEnv().containsKey("ENABLE_FIPS140_3") || useEnvVars.containsKey("ENABLE_FIPS140_3") || opts.containsKey("-Xenablefips140-3") || opts.containsKey("-Dsemeru.fips")) {
+            if (getServerEnv().containsKey("ENABLE_FIPS140_3") || getDefaultEnv().containsKey("ENABLE_FIPS140_3") || useEnvVars.containsKey("ENABLE_FIPS140_3")
+                || opts.containsKey("-Xenablefips140-3") || opts.containsKey("-Dsemeru.fips")) {
                 Log.info(c, methodName, "Test has defined its own settings for FIPS140-3");
             } else {
                 if (!GLOBAL_ENHANCED_ALGO) {
@@ -3463,6 +3463,22 @@ public class LibertyServer implements LogMonitorClient {
             for (String regex : fixedIgnoreErrorsList) {
                 ignorePatterns.add(Pattern.compile(regex));
             }
+        }
+
+        if (startedWithJavaSecurity && isEE11Enabled()) {
+            final String JAVA2_SECURITY_DISABLED = "CWWKE0971W";
+
+            List<String> message = findStringsInLogs(JAVA2_SECURITY_DISABLED);
+            if (message == null || message.isEmpty()) {
+                String errorMessage = "The warning messsage about Jakarta 2 Security being disabled when starting server with Jakarta EE 11 was not found.";
+                Log.info(c, method, "ERROR: " + errorMessage);
+
+                TopologyException serverStartException = new TopologyException(errorMessage);
+                Log.error(c, method, serverStartException, "ERROR: " + errorMessage);
+
+                throw serverStartException;
+            }
+            ignorePatterns.add(Pattern.compile(JAVA2_SECURITY_DISABLED));
         }
 
         // Remove any ignored warnings or patterns
@@ -7820,43 +7836,32 @@ public class LibertyServer implements LogMonitorClient {
         return !"true".equalsIgnoreCase(getBootstrapProperties().getProperty("websphere.java.security.exempt"));
     }
 
-    private boolean isEE11OrLaterEnabled() throws Exception {
-        if (JakartaEEAction.isEE11OrLaterActive()) {
-            return true;
-        }
-
-        if (JakartaEEAction.isEE9OrLaterActive()) {
+    private boolean isEE11Enabled() throws Exception {
+        if (JakartaEEAction.isEE9Active() || JakartaEEAction.isEE10Active()) {
             return false;
         }
 
-        // EE 11 which doesn't support Java security manager can run with Java 17.  As such we need to return false even if we are running
-        // with Java security enabled in the build.
+        // EE 11 which doesn't support Java security manager can run with Java 17.
+        List<Set<String>> installedFeatures;
+        try {
+            installedFeatures = getInstalledFeatures();
+        } catch (Exception e) {
+            // Will get FileNotFoundException if there is no messages.log file
+            installedFeatures = null;
+        }
 
-        RemoteFile serverXML = machine.getFile(serverRoot + "/" + SERVER_CONFIG_FILE_NAME);
-        InputStreamReader in = new InputStreamReader(serverXML.openForReading());
-        try (Scanner s = new Scanner(in)) {
-            while (s.hasNextLine()) {
-                String line = s.nextLine();
-                if (line.contains("<featureManager>")) {//So has reached featureSets
-                    while (s.hasNextLine()) {
-                        line = s.nextLine();
-                        if (line.contains("</featureManager>"))
-                            break;
-
-                        line = line.replaceAll("<feature>", "");
-                        line = line.replaceAll("</feature>", "");
-                        line = line.trim();
-                        String lowerCaseFeatureName = line.toLowerCase();
-
-                        // special case data-1.1 until JakartaEE12Action is created when EE 12 is more of a thing.
-                        if (JakartaEE11Action.EE11_ONLY_FEATURE_SET_LOWERCASE.contains(lowerCaseFeatureName) || "data-1.1".equals(lowerCaseFeatureName)) {
-                            return true;
-                        }
+        if (installedFeatures != null) {
+            for (Set<String> installedFeatureSet : installedFeatures) {
+                for (String installedFeature : installedFeatureSet) {
+                    String lowerCaseFeatureName = installedFeature.toLowerCase();
+                    if (JakartaEE11Action.EE11_ONLY_FEATURE_SET_LOWERCASE.contains(lowerCaseFeatureName)) {
+                        return true;
+                    } else if ("springboot-4.0".equals(lowerCaseFeatureName)) {
+                        return true;
                     }
                 }
             }
         }
-
         return false;
     }
 
@@ -8181,7 +8186,8 @@ public class LibertyServer implements LogMonitorClient {
                                                  + " with IBM Java " + info.majorVersion() + ", adding required JVM arguments to run with FIPS 140-3 enabled");
                 opts.put("-Dsemeru.fips", "true");
                 opts.put("-Dsemeru.customprofile", "OpenJCEPlusFIPS.FIPS140-3-Custom");
-                opts.put("-Djava.security.propertiesList", getLibertySemeruFips140_3ProfileLocationAndPrintFileContents() + File.pathSeparator + getSemeruFips140_3CustomProfileLocationAndPrintFileContents());
+                opts.put("-Djava.security.propertiesList",
+                         getLibertySemeruFips140_3ProfileLocationAndPrintFileContents() + File.pathSeparator + getSemeruFips140_3CustomProfileLocationAndPrintFileContents());
             } else if (info.majorVersion() == 8) {
                 Log.info(c, "getFipsJvmOptions", "FIPS 140-3 global build properties is set for server "
                                                  + getServerName()

--- a/dev/io.openliberty.jakartaee.platform.v11/.classpath
+++ b/dev/io.openliberty.jakartaee.platform.v11/.classpath
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
+	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
 	<classpathentry kind="output" path="bin"/>

--- a/dev/io.openliberty.jakartaee.platform.v11/bnd.bnd
+++ b/dev/io.openliberty.jakartaee.platform.v11/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2023, 2024 IBM Corporation and others.
+# Copyright (c) 2023, 2026 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -19,9 +19,22 @@ Bundle-Name: Jakarta EE API service for Runtime version
 Bundle-SymbolicName: io.openliberty.jakartaee.platform.v11
 Bundle-Description: Jakarta EE 11.0 API service for runtime, version ${bVersion}
 
+Bundle-Activator: io.openliberty.jakartaee.internal.platform.v11.Jakarta11Activator
+
+-privatepackage: \
+  io.openliberty.jakartaee.internal.platform.v11, \
+  com.ibm.ws.kernel.boot.resources
+
 # Register a marker service to enable 11.0 Jakarta EE.
 Service-Component: \
   io.openliberty.jakartaee.platform.v11; \
     implementation:=com.ibm.ws.javaee.version.JavaEEVersion; \
     provide:=com.ibm.ws.javaee.version.JavaEEVersion; \
     properties:="version=11.0,service.ranking:Integer=11"
+
+-buildpath: \
+ com.ibm.websphere.org.osgi.core;version=latest,\
+ com.ibm.websphere.org.osgi.service.component;version=latest,\
+ com.ibm.ws.logging.core;version=latest,\
+ com.ibm.ws.kernel.service;version=latest, \
+ com.ibm.ws.kernel.boot;version=latest

--- a/dev/io.openliberty.jakartaee.platform.v11/src/io/openliberty/jakartaee/internal/platform/v11/Jakarta11Activator.java
+++ b/dev/io.openliberty.jakartaee.platform.v11/src/io/openliberty/jakartaee/internal/platform/v11/Jakarta11Activator.java
@@ -1,0 +1,51 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.jakartaee.internal.platform.v11;
+
+import org.osgi.framework.BundleActivator;
+import org.osgi.framework.BundleContext;
+
+import com.ibm.websphere.ras.Tr;
+import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.ws.kernel.service.util.JavaInfo;
+import com.ibm.wsspi.kernel.service.utils.FrameworkState;
+
+/**
+ * Disables Java SecurityManager if it is enabled since Jakarta EE 11 does not support it.
+ */
+@SuppressWarnings("removal")
+public class Jakarta11Activator implements BundleActivator {
+
+    private static final TraceComponent tc = Tr.register(Jakarta11Activator.class, "bootstrap", "com.ibm.ws.kernel.boot.resources.LauncherMessages");
+
+    private SecurityManager securityManager = null;
+
+    @Override
+    public void start(BundleContext arg0) throws Exception {
+        if (JavaInfo.majorVersion() == 17) {
+            securityManager = System.getSecurityManager();
+            if (securityManager != null) {
+                System.setSecurityManager(null);
+                Tr.warning(tc, "warning.java2security.stopped");
+            }
+        }
+    }
+
+    @Override
+    public void stop(BundleContext arg0) throws Exception {
+        // If stopping EE 11 features to replace them with older EE features,
+        // re-enable the SecurityManager and put out an informational message.
+        if (securityManager != null && !FrameworkState.isStopping()) {
+            System.setSecurityManager(securityManager);
+            Tr.info(tc, "info.java2security.restarted");
+        }
+    }
+
+}

--- a/dev/io.openliberty.jakartaee11.internal_fat/fat/src/io/openliberty/jakartaee11/internal/tests/EE11Features.java
+++ b/dev/io.openliberty.jakartaee11.internal_fat/fat/src/io/openliberty/jakartaee11/internal/tests/EE11Features.java
@@ -232,6 +232,7 @@ public class EE11Features {
         features.remove("sipServlet-1.1"); // purposely not supporting EE 11
         features.remove("springBoot-1.5");
         features.remove("springBoot-2.0");
+        features.remove("springBoot-3.0");
 
         // Stabilized features were changed to not support EE 11 even though
         // they do not depend on Java / Jakarta EE features.
@@ -323,10 +324,6 @@ public class EE11Features {
         // remove logAnalysis-1.0.  It depends on hpel being configured
         features.remove("logAnalysis-1.0");
         features.remove("audit-2.0");
-
-        //Removing springBoot-3.0 here because springBoot-4.0 and 3.0 cannot be loaded at the same time.
-        //Also removing the feature would mean springBoot-3.0 is not being tested for EE11 compatibility giving priority to test the springBoot-4.0 feature for EE11 compatibility.
-        features.remove("springBoot-3.0");
 
         return features;
     }


### PR DESCRIPTION
- Update springBoot-3.0 to not support running with Jakarta EE 11

**Update eePlatform features**
- Update the jakartaeePlatform features to not depend on each other by using a private feature that they can all depend on
- Update the 9.0, 10.0 and 11.0 to be singleton and update features that depend on these features to have the appropriate tolerates
- Update 8.0, 9.0, 10.0, and 11.0 to depend on eeCompatible for that release and move the bundles from eePlatform to eeComaptible
- Update unit test and other features for the changes
- 6.0, 7.0 and 8.0 are not made singleton due to how the EE 6 and 7 features do not do blocking always and don't want to break zero migration
- 6.0 and 7.0 are not update to depend on eeCompatible for the same reason

**Disable Java SecurityManager when using EE 11**
- Update LibertyServer FAT function to start with Java security with EE 11 now so that we test it
- Validate the warning comes out in LibertyClient and LibertyServer

- [ ] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [ ] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
