### PR TITLE
Update for Jakarta Authorization 3.0

### DIFF
--- a/dev/com.ibm.ws.security.authorization.jacc.ejb/src/com/ibm/ws/security/authorization/jacc/ejb/impl/EJBJaccServiceImpl.java
+++ b/dev/com.ibm.ws.security.authorization.jacc.ejb/src/com/ibm/ws/security/authorization/jacc/ejb/impl/EJBJaccServiceImpl.java
@@ -61,8 +61,20 @@ public class EJBJaccServiceImpl implements EJBJaccService {
     private static PolicyContextHandlerImpl pch = PolicyContextHandlerImpl.getInstance();
     protected static final String KEY_JACC_SERVICE = "jaccService";
 
+    /**
+     * The HandlerProcessor centralizes the logic for setting the PolicyContext handler data with all the behaviors for each version of
+     * JACC / Jakarta Authorization. There are some behaviors that may not make sense, but for backward compatibility to maintain zero
+     * migration, the behaviors are maintained.
+     */
     enum HandlerProcessor {
-        JACC15(true, false), AUTHORIZATION20_21(false, false), AUTHORIZATION30(false, true);
+        // For JACC 1.5, all javax and jakarta named PolicyContext handler names are supported except the PrincipalMapper which is added in 3.0
+        JACC15(true, false),
+
+        // For Jakarta Authorization 2.0 and 2.1, most javax PolicyContext handlers names are removed except for the "javax.ejb.arguments" handler
+        AUTHORIZATION20_21(false, false),
+
+        // For Jakarta Authorization 3.0, the "javax.ejb.arguments" extra javax name is corrected and the new PrincipalMapper is added
+        AUTHORIZATION30(false, true);
 
         final boolean principalMapperSupported;
         final boolean javaxSupported;

--- a/dev/com.ibm.ws.security.authorization.jacc.web/src/com/ibm/ws/security/authorization/jacc/web/impl/WebJaccServiceImpl.java
+++ b/dev/com.ibm.ws.security.authorization.jacc.web/src/com/ibm/ws/security/authorization/jacc/web/impl/WebJaccServiceImpl.java
@@ -72,8 +72,20 @@ public class WebJaccServiceImpl implements WebJaccService {
 
     private static final HandlerProcessor handlerProcessor;
 
+    /**
+     * The HandlerProcessor centralizes the logic for setting the PolicyContext handler data with all the behaviors for each version of
+     * JACC / Jakarta Authorization. There are some behaviors that may not make sense, but for backward compatibility to maintain zero
+     * migration, the behaviors are maintained.
+     */
     enum HandlerProcessor {
-        JACC15(true, false), AUTHORIZATION20_21(false, false), AUTHORIZATION30(false, true);
+        // For JACC 1.5, all javax and jakarta named PolicyContext handler names are supported except the PrincipalMapper which is added in 3.0
+        JACC15(true, false),
+
+        // For Jakarta Authorization 2.0 and 2.1, the javax PolicyContext handlers names are removed
+        AUTHORIZATION20_21(false, false),
+
+        // For Jakarta Authorization 3.0, the new PrincipalMapper is added
+        AUTHORIZATION30(false, true);
 
         final boolean principalMapperSupported;
         final boolean javaxSupported;

--- a/dev/com.ibm.ws.security.authorization.jacc/resources/com/ibm/ws/security/authorization/jacc/internal/resources/JaccAuthorizationMessages.nlsprops
+++ b/dev/com.ibm.ws.security.authorization.jacc/resources/com/ibm/ws/security/authorization/jacc/internal/resources/JaccAuthorizationMessages.nlsprops
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2015 IBM Corporation and others.
+# Copyright (c) 2015, 2026 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -80,3 +80,17 @@ JACC_NO_WEB_PLUGIN=CWWKS2864E: The module for processing the Web security roles 
 JACC_NO_WEB_PLUGIN.explanation=The JACC service is unable to process the Web security roles because the required module is not available.
 JACC_NO_WEB_PLUGIN.useraction=Review the JACC provider logs and the server logs for more information.
 
+# {0} is PolicyFactory or PolicyConfigurationFactory
+JACC_AUTHORIZATION_MODULE_CREATION_FAILURE=CWWKS2865E: The Jakarta Authorization service is unable to set the {0} provider class {1} from application {2} due to the exception {3}.
+JACC_AUTHORIZATION_MODULE_CREATION_FAILURE.explanation=The Jakarta Authorization service is unable to set the provider class due to the exception.
+JACC_AUTHORIZATION_MODULE_CREATION_FAILURE.useraction=Review the provider logs and the server logs for more information.
+
+# {0} is PolicyFactory or PolicyConfigurationFactory
+JACC_AUTHORIZATION_MODULE_CONFIGURED=CWWKS2866I: The Jakarta Authorization service configured the {0} provider class {1} defined in application {2}.
+JACC_AUTHORIZATION_MODULE_CONFIGURED.explanation=This message is for informational purposes only.
+JACC_AUTHORIZATION_MODULE_CONFIGURED.useraction=No action is required.
+
+# {0} is PolicyFactory or PolicyConfigurationFactory
+JACC_AUTHORIZATION_MODULE_REMOVED=CWWKS2867I: The Jakarta Authorization service removed the {0} provider class {1} defined in application {2}.
+JACC_AUTHORIZATION_MODULE_REMOVED.explanation=This message is for informational purposes only.
+JACC_AUTHORIZATION_MODULE_REMOVED.useraction=No action is required.

--- a/dev/io.openliberty.security.authorization.internal.jacc.3.0/bnd.bnd
+++ b/dev/io.openliberty.security.authorization.internal.jacc.3.0/bnd.bnd
@@ -19,9 +19,6 @@ Bundle-Name: Security Jakarta Authorization 3.0 Service implementation
 Bundle-SymbolicName: io.openliberty.security.authorization.internal.jacc.3.0; singleton:=true
 Bundle-Description: Security Jakarta Authorization 3.0 Service implementation
 
-Export-Package: \
-  com.ibm.wsspi.security.authorization.jacc
-
 Private-Package: \
   com.ibm.ws.security.authorization.jacc.internal.resources, \
   io.openliberty.security.authorization.jacc.internal.proxy, \

--- a/dev/io.openliberty.security.authorization.internal.jacc.3.0/src/io/openliberty/security/authorization/jacc/internal/proxy/JakartaPolicyConfigFactoryProxy.java
+++ b/dev/io.openliberty.security.authorization.internal.jacc.3.0/src/io/openliberty/security/authorization/jacc/internal/proxy/JakartaPolicyConfigFactoryProxy.java
@@ -21,6 +21,15 @@ import jakarta.security.jacc.PolicyConfigurationFactory;
 import jakarta.security.jacc.PolicyContext;
 import jakarta.security.jacc.PolicyContextException;
 
+/**
+ * Stores the PolicyConfigurationFactory state so that as new PolicyConfigurationFactory instances
+ * are configured dynamically, they can be populated and committed based off of the state of each application
+ * that has started already.
+ *
+ * Only this class accesses the actual PolicyConfigurationFactory instances. All other Liberty runtime function interacts
+ * with this class when using Jakarta Authorization 3.0. The actual PolicyConfigurationFactory is accessed
+ * by the user's PolicyFactory instance to be able to get the state that this class propagates.
+ */
 public class JakartaPolicyConfigFactoryProxy extends PolicyConfigurationFactory {
 
     private final Map<String, JakartaPolicyConfigProxy> configMap = new ConcurrentHashMap<>();
@@ -71,10 +80,14 @@ public class JakartaPolicyConfigFactoryProxy extends PolicyConfigurationFactory 
             });
         }
 
+        // If we added a new PolicyConfiguration, there is no need to call reset to remove any config because it will
+        // already be an empty PolicyConfiguration in open state
         if (newProxyAdded.get()) {
             return existingConfig;
         }
 
+        // Call the actual PolicyConfigurationFactory.getPolicyConfiguration() method to drive any logic that it needs to run.
+        // Namely this will make sure that the remove flag is handled and the state is back to open state
         existingConfig.resetDelegatePolicyConfig(remove);
         return existingConfig;
     }
@@ -101,6 +114,10 @@ public class JakartaPolicyConfigFactoryProxy extends PolicyConfigurationFactory 
         return factory;
     }
 
+    /**
+     * When adding a new PolicyConfigurationFactory from a web.xml config, this method populates the new factory with the
+     * existing state and gets the PolicyConfiguration instances into the correct state.
+     */
     public void ensurePolicyConfigInitialized() {
         for (JakartaPolicyConfigProxy policyConfig : configMap.values()) {
             if (policyConfig != null) {

--- a/dev/io.openliberty.security.authorization.internal.jacc.3.0/src/io/openliberty/security/authorization/jacc/internal/proxy/JakartaPolicyConfigProxy.java
+++ b/dev/io.openliberty.security.authorization.internal.jacc.3.0/src/io/openliberty/security/authorization/jacc/internal/proxy/JakartaPolicyConfigProxy.java
@@ -25,6 +25,15 @@ import jakarta.security.jacc.PolicyConfiguration;
 import jakarta.security.jacc.PolicyConfigurationFactory;
 import jakarta.security.jacc.PolicyContextException;
 
+/**
+ * Stores the PolicyConfiguration state so that as new PolicyConfigurationFactory instances
+ * are configured dynamically, new PolicyConfiguration instances can be populated and committed 
+ * based off of the state of each application that has started already.
+ *
+ * Only instances of this class access the actual PolicyConfiguration instances. All other Liberty runtime function interacts
+ * with instances of this class when using Jakarta Authorization 3.0. The actual PolicyConfiguration instances are accessed
+ * by the user's PolicyFactory instance to be able to get the state that this class propagates.
+ */
 public class JakartaPolicyConfigProxy implements PolicyConfiguration {
 
     static enum ContextState {
@@ -55,8 +64,15 @@ public class JakartaPolicyConfigProxy implements PolicyConfiguration {
 
     private final Map<String, PermissionCollection> rolePermMap = new ConcurrentHashMap<>();
 
+    /**
+     * Stores the current PolicyConfigurationFactory so that we can know if a new one was added dynamically
+     * and can react appropriately.
+     */
     private final AtomicReference<PolicyConfigurationFactory> currentFactory = new AtomicReference<>();
 
+    /**
+     * Stores the current PolicyConfiguration to be returned if there isn't a change to the PolicyConfigurationFactory.
+     */
     private final AtomicReference<PolicyConfiguration> currentConfig = new AtomicReference<>();
 
     JakartaPolicyConfigProxy(JakartaPolicyConfigFactoryProxy factoryProxy, String contextId, boolean remove) throws PolicyContextException {
@@ -74,12 +90,21 @@ public class JakartaPolicyConfigProxy implements PolicyConfiguration {
         }
     }
 
+    /**
+     * When calling getConfiguration on the JakartaPolicyConfigFactoryProxy, this method is used
+     * to reset the state appropriately in this instance and calls the getPolicyConfiguration() method
+     * on the actual PolicyConfigurationFactory to reset the state there.
+     *
+     * @param remove whether to remove all configuration
+     * @throws PolicyContextException
+     */
     void resetDelegatePolicyConfig(boolean remove) throws PolicyContextException {
         PolicyConfigurationFactory delegateFactory = factoryProxy.getFactory();
         synchronized (this) {
             PolicyConfiguration delegateConfig = delegateFactory == null ? null : delegateFactory.getPolicyConfiguration(contextId, remove);
             if (remove) {
-                 delete(true);
+                // Only deleting our internal state and not calling delete on the delegateConfig since the getPolicyConfiguration() call above handles that
+                delete(true);
             }
             setState(ContextState.OPEN);
 
@@ -94,6 +119,10 @@ public class JakartaPolicyConfigProxy implements PolicyConfiguration {
         state = newState;
     }
 
+    /**
+     * Creates the actual PolicyConfiguration objects if it doesn't exists or there is a change
+     * in the PolicyConfigurationFactory instance because it was dynamically added.
+     */
     void ensureInitialized() {
         PolicyConfigurationFactory delegateFactory = factoryProxy.getFactory();
         if (delegateFactory != null) {
@@ -105,12 +134,27 @@ public class JakartaPolicyConfigProxy implements PolicyConfiguration {
         }
     }
 
+    /**
+     * Returns the current PolicyConfiguration or creates a new one and populates its state.
+     *
+     * Conditionally this method also checks that the PolicyConfiguration instance state
+     * matches the current state in this class. Additionally this method updates the
+     * current PolicyConfigurationFactory and PolicyConfiguration instances to point to
+     * the newly created instances if there is a factory change.
+     *
+     * @param delegateFactory the PolicyConfigurationFactory to check
+     * @param checkState      whether to check the PolicyConfiguration state to match this class
+     * @return the PolicyConfiguration
+     * @throws PolicyContextException
+     */
     private PolicyConfiguration getDelegatePolicyConfig(PolicyConfigurationFactory delegateFactory, boolean checkState) throws PolicyContextException {
         if (currentFactory.get() == delegateFactory) {
             return currentConfig.get();
         }
 
         synchronized (this) {
+            // Standard double check to validate that two threads don't both get in here and both make changes.  If one gets in and updates
+            // the other thread should get what the first thread already did.  This can be done because AtomicRefernece makes use of volatile.
             if (currentFactory.get() == delegateFactory) {
                 return currentConfig.get();
             }

--- a/dev/io.openliberty.security.authorization.internal.jacc.3.0/src/io/openliberty/security/authorization/jacc/internal/proxy/JakartaPolicyFactoryProxyImpl.java
+++ b/dev/io.openliberty.security.authorization.internal.jacc.3.0/src/io/openliberty/security/authorization/jacc/internal/proxy/JakartaPolicyFactoryProxyImpl.java
@@ -21,6 +21,10 @@ import jakarta.security.jacc.Policy;
 import jakarta.security.jacc.PolicyFactory;
 import jakarta.security.jacc.PrincipalMapper;
 
+/**
+ * Jakarta Authorization 3.0 implementation of PolicyProxy that is the interface used for interacting with
+ * the jakarta.security.jacc.PolicyFactory instead of java.security.Policy as was done in previous spec versions.
+ */
 public class JakartaPolicyFactoryProxyImpl implements PolicyProxy {
 
     private static Subject nullSubject = new Subject();
@@ -65,6 +69,14 @@ public class JakartaPolicyFactoryProxyImpl implements PolicyProxy {
         return true;
     }
 
+    /**
+     * This method is called when starting applications after the PolicyConfiguration is populated.
+     *
+     * Previously there was only a single Policy object, but now there is one per PolicyContext id
+     * so we need to call refresh on all of them that had populated PolicyConfigurations.
+     *
+     * @param contextIds the context ids of the Policy's that need to be refreshed
+     */
     @Override
     public void refresh(Set<String> contextIds) {
         PolicyFactory policyFactory = PolicyFactory.getPolicyFactory();
@@ -79,6 +91,13 @@ public class JakartaPolicyFactoryProxyImpl implements PolicyProxy {
         }
     }
 
+    /**
+     * This method is used to determine if there is a Policy configured. If there isn't
+     * one configured, the Liberty runtime will use the built-in authorization logic since there
+     * isn't a Jakarta Authorization Policy to call.
+     *
+     * @return whether there is a PolicyFactory configured or not
+     */
     @Override
     public boolean isPolicyConfigured() {
         return PolicyFactory.getPolicyFactory() != null;

--- a/dev/io.openliberty.security.authorization.internal.jacc.3.0/src/io/openliberty/security/authorization/jacc/internal/proxy/package-info.java
+++ b/dev/io.openliberty.security.authorization.internal.jacc.3.0/src/io/openliberty/security/authorization/jacc/internal/proxy/package-info.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2025, 2026 IBM Corporation and others.
+ * Copyright (c) 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -12,6 +12,6 @@
  */
 @org.osgi.annotation.versioning.Version("1.0")
 @TraceOptions(traceGroup = "Security.Authorization", messageBundle = "com.ibm.ws.security.authorization.jacc.internal.resources.JaccAuthorizationMessages")
-package io.openliberty.security.authorization.jacc.internal.web;
+package io.openliberty.security.authorization.jacc.internal.proxy;
 
 import com.ibm.websphere.ras.annotation.TraceOptions;

--- a/dev/io.openliberty.security.authorization.internal.jacc.3.0/src/io/openliberty/security/authorization/jacc/internal/web/AuthorizationServletInitializer.java
+++ b/dev/io.openliberty.security.authorization.internal.jacc.3.0/src/io/openliberty/security/authorization/jacc/internal/web/AuthorizationServletInitializer.java
@@ -16,6 +16,8 @@ import java.util.Set;
 
 import org.osgi.service.component.annotations.Component;
 
+import com.ibm.websphere.ras.Tr;
+import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.ws.ffdc.annotation.FFDCIgnore;
 
 import io.openliberty.security.authorization.jacc.internal.proxy.JakartaPolicyConfigFactoryProxy;
@@ -26,8 +28,8 @@ import jakarta.servlet.ServletContext;
 import jakarta.servlet.ServletException;
 
 /**
- * Listeners for web applications to start and reads the init parameters for the web.xml
- * to configure that policy and configuration for Jakarta Security
+ * Listener for web applications to start and reads the init parameters for the web.xml
+ * to configure that policy and configuration factories for Jakarta Authorization
  */
 @Component(
            name = "io.openliberty.security.authorization.jacc.servlet.initializer",
@@ -35,6 +37,8 @@ import jakarta.servlet.ServletException;
            configurationPolicy = IGNORE,
            immediate = true)
 public class AuthorizationServletInitializer implements ServletContainerInitializer {
+
+    private static final TraceComponent tc = Tr.register(AuthorizationServletInitializer.class);
 
     @Override
     @FFDCIgnore({ IllegalStateException.class, SecurityException.class })
@@ -48,6 +52,8 @@ public class AuthorizationServletInitializer implements ServletContainerInitiali
 
         try {
             ClassLoader appClassLoader = servletContext.getClassLoader();
+
+            // Set the PolicyFactory if there is one defined in the web.xml
             String policyFactoryName = servletContext.getInitParameter(PolicyFactory.FACTORY_NAME);
             if (policyFactoryName != null) {
                 try {
@@ -55,12 +61,15 @@ public class AuthorizationServletInitializer implements ServletContainerInitiali
                 } catch (SecurityException se) {
                 }
 
-                policyFactory = loadClass(appClassLoader, policyFactoryName, PolicyFactory.class, previousPolicyFactory);
+                policyFactory = loadClass(appClassLoader, policyFactoryName, PolicyFactory.class, previousPolicyFactory, servletContext);
                 if (policyFactory != null) {
                     PolicyFactory.setPolicyFactory(policyFactory);
+                    Tr.info(tc, "JACC_AUTHORIZATION_MODULE_CONFIGURED", "PolicyFactory", policyFactoryName, servletContext.getServletContextName());
                     policyFactoryAdded = true;
                 }
             }
+
+            // Set the PolicyConfigurationFactory if there is one defined in the web.xml
             String configFactoryName = servletContext.getInitParameter(PolicyConfigurationFactory.FACTORY_NAME);
             if (configFactoryName != null) {
                 try {
@@ -68,10 +77,11 @@ public class AuthorizationServletInitializer implements ServletContainerInitiali
                 } catch (IllegalStateException se) {
                     // expected if there isn't one configured
                 }
-                configFactory = loadClass(appClassLoader, configFactoryName, PolicyConfigurationFactory.class, previousConfigFactory);
+                configFactory = loadClass(appClassLoader, configFactoryName, PolicyConfigurationFactory.class, previousConfigFactory, servletContext);
                 if (configFactory != null) {
                     PolicyConfigurationFactory.setPolicyConfigurationFactory(configFactory);
                     configFactoryAdded = true;
+                    Tr.info(tc, "JACC_AUTHORIZATION_MODULE_CONFIGURED", "PolicyConfigurationFactory", configFactoryName, servletContext.getServletContextName());
                     JakartaPolicyConfigFactoryProxy configFactoryProxy = JakartaPolicyConfigFactoryProxy.getInstance();
                     if (configFactoryProxy != null) {
                         configFactoryProxy.ensurePolicyConfigInitialized();
@@ -88,7 +98,7 @@ public class AuthorizationServletInitializer implements ServletContainerInitiali
         }
     }
 
-    private <T> T loadClass(ClassLoader appClassLoader, String className, Class<T> classType, T factoryToWrap) {
+    private <T> T loadClass(ClassLoader appClassLoader, String className, Class<T> classType, T factoryToWrap, ServletContext servletContext) {
         try {
             Class<?> loadedClass = appClassLoader.loadClass(className);
             Constructor<?>[] ctors = loadedClass.getConstructors();
@@ -103,6 +113,8 @@ public class AuthorizationServletInitializer implements ServletContainerInitiali
                 }
             }
 
+            // If there is a constructor that wraps the previously set factory, use that one
+            // as required by the specification.
             if (wrapperCtor != null) {
                 return classType.cast(wrapperCtor.newInstance(factoryToWrap));
             } else if (defaultCtor != null) {
@@ -110,7 +122,7 @@ public class AuthorizationServletInitializer implements ServletContainerInitiali
             }
             return null;
         } catch (Throwable e) {
-            // FFDC and message
+            Tr.error(tc, "JACC_AUTHORIZATION_MODULE_CREATION_FAILURE", classType.getSimpleName(), className, servletContext.getServletContextName(), e.toString());
         }
         return null;
     }

--- a/dev/io.openliberty.security.authorization.internal.jacc.3.0/src/io/openliberty/security/authorization/jacc/internal/web/AuthorizationServletListener.java
+++ b/dev/io.openliberty.security.authorization.internal.jacc.3.0/src/io/openliberty/security/authorization/jacc/internal/web/AuthorizationServletListener.java
@@ -9,6 +9,8 @@
  *******************************************************************************/
 package io.openliberty.security.authorization.jacc.internal.web;
 
+import com.ibm.websphere.ras.Tr;
+import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.ws.ffdc.annotation.FFDCIgnore;
 
 import jakarta.security.jacc.PolicyConfigurationFactory;
@@ -16,7 +18,12 @@ import jakarta.security.jacc.PolicyFactory;
 import jakarta.servlet.ServletContextEvent;
 import jakarta.servlet.ServletContextListener;
 
+/**
+ * Listener that removes the policy and configuration factories that were added then the application was started.
+ */
 public class AuthorizationServletListener implements ServletContextListener {
+
+    private static final TraceComponent tc = Tr.register(AuthorizationServletListener.class);
 
     private final PolicyFactory policyFactory;
     private final PolicyConfigurationFactory configFactory;
@@ -48,6 +55,8 @@ public class AuthorizationServletListener implements ServletContextListener {
                     wrappedFactory = previousPolicyFactory;
                 }
                 PolicyFactory.setPolicyFactory(wrappedFactory);
+                Tr.info(tc, "JACC_AUTHORIZATION_MODULE_REMOVED", "PolicyFactory", currentFactory.getClass().getName(),
+                        sce.getServletContext().getServletContextName());
             }
         }
 
@@ -66,6 +75,8 @@ public class AuthorizationServletListener implements ServletContextListener {
                     wrappedFactory = previousConfigFactory;
                 }
                 PolicyConfigurationFactory.setPolicyConfigurationFactory(wrappedFactory);
+                Tr.info(tc, "JACC_AUTHORIZATION_MODULE_REMOVED", "PolicyConfigurationFactory", currentFactory.getClass().getName(),
+                        sce.getServletContext().getServletContextName());
             }
         }
     }


### PR DESCRIPTION
- Add message when failing to create authorization modules from web.xml configuration
- Add comments to the HandlerProcessor enums for (EJB|Web)JaccServiceImpl classes to explain what each version means
- Stop exporting com.ibm.wsspi.security.authorization.jacc package from the 3.0 bundle
- Add trace options for group and message bundle to package-info
- Add messages for when configuring or removing a PolicyFactory or PolicyConfigurationFactory


- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
