### PR TITLE
Netty do not close a connection or send an error response at generated exception caught from codec

### DIFF
--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/channel/internal/inbound/HttpInboundServiceContextImpl.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/channel/internal/inbound/HttpInboundServiceContextImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2004, 2025 IBM Corporation and others.
+ * Copyright (c) 2004, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -10,6 +10,7 @@
 package com.ibm.ws.http.channel.internal.inbound;
 
 import java.io.IOException;
+import java.net.InetSocketAddress;
 import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -2284,8 +2285,9 @@ public class HttpInboundServiceContextImpl extends HttpServiceContextImpl implem
         Pattern pattern = getHttpConfig().getForwardedProxiesRegex();
         Matcher matcher = null;
 
-        String remoteIp = nettyContext.channel().remoteAddress().toString();
-        remoteIp = remoteIp.substring(1, remoteIp.indexOf(':'));
+        // The remoteAddress API is meant to be cast down to a specific type. Since we are using HTTP this
+        // should be a cast down to InetSocketAddress
+        String remoteIp = ((InetSocketAddress)nettyContext.channel().remoteAddress()).getAddress().getHostAddress();
 
         String attribute;
 

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/netty/pipeline/CRLFValidationHandler.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/netty/pipeline/CRLFValidationHandler.java
@@ -9,6 +9,8 @@
  *******************************************************************************/
 package com.ibm.ws.http.netty.pipeline;
 
+import java.text.ParseException;
+
 import com.ibm.ws.http.netty.NettyHttpConstants;
 
 import io.netty.buffer.ByteBuf;
@@ -49,7 +51,7 @@ public class CRLFValidationHandler extends ChannelInboundHandlerAdapter {
 
             if (++leadingCRLFCount > MAX_CRLF_ALLOWED) {
                 ctx.channel().attr(NettyHttpConstants.THROW_FFDC).set(true);
-                throw new IllegalArgumentException("Too many leading CRLF characters");
+                throw new ParseException("Too many leading CRLF characters", MAX_CRLF_ALLOWED);
             }
         }
 

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/netty/pipeline/inbound/HttpDispatcherHandler.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/netty/pipeline/inbound/HttpDispatcherHandler.java
@@ -11,6 +11,7 @@ package com.ibm.ws.http.netty.pipeline.inbound;
 
 import java.net.InetSocketAddress;
 import java.nio.charset.StandardCharsets;
+import java.text.ParseException;
 import java.util.Objects;
 
 import com.ibm.websphere.ras.Tr;
@@ -32,7 +33,7 @@ import com.ibm.wsspi.http.channel.values.StatusCodes;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.SimpleChannelInboundHandler;
-import  io.netty.handler.codec.TooLongFrameException;
+import io.netty.handler.codec.TooLongFrameException;
 import io.netty.handler.codec.http.DefaultFullHttpResponse;
 import io.netty.handler.codec.http.FullHttpRequest;
 import io.netty.handler.codec.http.HttpResponseStatus;
@@ -112,8 +113,16 @@ public class HttpDispatcherHandler extends SimpleChannelInboundHandler<FullHttpR
                 }
             });
         } else {
-            if (request.decoderResult().cause() != null) {
-                request.decoderResult().cause().printStackTrace();
+            if(context.channel().isActive()) {
+                if (request.decoderResult().cause() != null) {
+                    sendErrorMessage(request.decoderResult().cause());
+                } else {
+                    sendErrorMessage(new Exception("HTTP request decoding failure!"));
+                }
+            } else {
+                if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                    Tr.debug(tc, "Failed decode request on closed channel: " + context.channel());
+                }
             }
         }
 
@@ -158,15 +167,19 @@ public class HttpDispatcherHandler extends SimpleChannelInboundHandler<FullHttpR
                 return;
             }
         } else if (cause instanceof IllegalArgumentException) {
+            if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                Tr.debug(tc, "Ignoring exceptionCaught while decoding request of IllegalArgumentException: " + cause);
+            }
+            // We assume the IllegalArgumentException comes from the Netty codec. From here we assume that the codecs
+            // will still send an http request but with a decoding exception. And we will use that to handle with an 
+            // appropriate response. Return for now
+            return;
+        } else if (cause instanceof ParseException) {
             //Legacy doesnt throw ffdc on processNewInformation
             if (context.channel().attr(NettyHttpConstants.THROW_FFDC).get() != null) {
                 context.channel().attr(NettyHttpConstants.THROW_FFDC).set(null);
-            } else if (!cause.getMessage().contains("possibly HTTP/0.9")) {
+            } else {
                 FFDCFilter.processException(cause, HttpDispatcherHandler.class.getName() + ".exceptionCaught(ChannelHandlerContext, Throwable)", "1", context);
-            }
-
-            if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-                Tr.debug(tc, "exceptionCaught encountered an IllegalArgumentException : " + cause);
             }
             sendErrorMessage(cause);
             return;

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/netty/pipeline/inbound/LibertyHttpObjectAggregator.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/netty/pipeline/inbound/LibertyHttpObjectAggregator.java
@@ -9,6 +9,10 @@
  *******************************************************************************/
 package com.ibm.ws.http.netty.pipeline.inbound;
 
+import com.ibm.websphere.ras.Tr;
+import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.ws.http.channel.internal.HttpMessages;
+
 import io.netty.buffer.CompositeByteBuf;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.SimpleChannelInboundHandler;
@@ -23,6 +27,8 @@ import io.netty.util.AttributeKey;
 import io.netty.util.ReferenceCountUtil;
 
 public class LibertyHttpObjectAggregator extends SimpleChannelInboundHandler<HttpObject> {
+
+    private static final TraceComponent tc = Tr.register(LibertyHttpObjectAggregator.class, HttpMessages.HTTP_TRACE_NAME, HttpMessages.HTTP_BUNDLE);
 
     private long maxContentLength = Long.MAX_VALUE;
 
@@ -41,9 +47,6 @@ public class LibertyHttpObjectAggregator extends SimpleChannelInboundHandler<Htt
 
     @Override
     protected void channelRead0(ChannelHandlerContext ctx, HttpObject msg) throws Exception {
-        if (msg.decoderResult().isFinished() && msg.decoderResult().isFailure()) {
-            exceptionCaught(ctx, msg.decoderResult().cause());
-        }
         if (msg instanceof FullHttpRequest) {
             // Already have a Full HTTP Request so just need to forward here
             ctx.fireChannelRead(ReferenceCountUtil.retain(msg, 1));
@@ -54,6 +57,15 @@ public class LibertyHttpObjectAggregator extends SimpleChannelInboundHandler<Htt
         }
         if (msg instanceof HttpRequest) {
             HttpRequest request = (HttpRequest) msg;
+            if(msg.decoderResult().isFinished() && msg.decoderResult().isFailure()) {
+                if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                    Tr.debug(tc, "Found http request with decoding failure!");
+                }
+                FullHttpRequest fullRequest = new DefaultFullHttpRequest(request.protocolVersion(), request.method(), request.uri());
+                fullRequest.setDecoderResult(request.decoderResult());
+                ctx.fireChannelRead(fullRequest);
+                return;
+            }
             ctx.channel().attr(CURRENT_REQUEST).set(request);
 
             CompositeByteBuf content = ctx.alloc().compositeBuffer();
@@ -85,6 +97,7 @@ public class LibertyHttpObjectAggregator extends SimpleChannelInboundHandler<Htt
                 if (msg instanceof LastHttpContent) {
                     HttpRequest request = ctx.channel().attr(CURRENT_REQUEST).get();
                     FullHttpRequest fullRequest = new DefaultFullHttpRequest(request.protocolVersion(), request.method(), request.uri(), content, request.headers(), ((LastHttpContent) msg).trailingHeaders());
+                    fullRequest.setDecoderResult(httpContent.decoderResult());
 
                     ctx.fireChannelRead(fullRequest);
 

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/netty/pipeline/inbound/LibertyHttpRequestHandler.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/netty/pipeline/inbound/LibertyHttpRequestHandler.java
@@ -95,14 +95,6 @@ public class LibertyHttpRequestHandler extends ChannelDuplexHandler {
     public void channelRead(ChannelHandlerContext context, Object msg) throws Exception {
         if (msg instanceof FullHttpRequest) {
             FullHttpRequest request = (FullHttpRequest) msg;
-            if (!(request.decoderResult().isFinished() && request.decoderResult().isSuccess())) {
-                if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-                    Tr.debug(this, tc, "Bad decode result, close connection. Cause: " + request.decoderResult().cause());
-                }
-                ReferenceCountUtil.safeRelease(request);
-                context.close();
-                return;
-            }
             if (closeAfterDrain || (hasMaxRequests && acceptedRequests >= maxRequests)) {
                 if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
                     Tr.debug(this, tc, "Pausing read for channel " + context.channel());


### PR DESCRIPTION

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

fixes #29677