### PR TITLE
Use same HttpChannelConfig during HttpServiceContextImpl initialization

### DIFF
--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/channel/internal/inbound/HttpInboundServiceContextImpl.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/channel/internal/inbound/HttpInboundServiceContextImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2004, 2025 IBM Corporation and others.
+ * Copyright (c) 2004, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -130,6 +130,23 @@ public class HttpInboundServiceContextImpl extends HttpServiceContextImpl implem
         this.setHeadersParsed();
         setVC(vc);
 
+    }
+
+    /*
+     *. Key difference is that setHttpConfig is set prior to the init call. This ensure the same config is used throughout initialization. 
+     */
+    public HttpInboundServiceContextImpl(ChannelHandlerContext context, VirtualConnection vc, HttpChannelConfig config) {
+        super();
+        nettyContext = context;
+        
+        super.setHttpConfig(config); // Must be called before init!
+
+        TCPConnectionContext tsc = new NettyTCPConnectionContext(context.channel(), vc);
+
+        super.init(tsc, context);
+
+        this.setHeadersParsed();
+        setVC(vc);
     }
 
     /**

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/dispatcher/internal/channel/HttpDispatcherLink.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/dispatcher/internal/channel/HttpDispatcherLink.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009, 2025 IBM Corporation and others.
+ * Copyright (c) 2009, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -200,8 +200,7 @@ public class HttpDispatcherLink extends InboundApplicationLink implements HttpIn
         }
         NettyVirtualConnectionImpl nettyVc = NettyVirtualConnectionImpl.createVC();
         nettyContext = context;
-        this.isc = new HttpInboundServiceContextImpl(context, nettyVc);
-        this.isc.setHttpConfig(config);
+        this.isc = new HttpInboundServiceContextImpl(context, nettyVc, config);
         this.isc.setStartTime();
 
         nettyRequest = request;

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/netty/pipeline/inbound/HttpDispatcherHandler.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/netty/pipeline/inbound/HttpDispatcherHandler.java
@@ -42,6 +42,7 @@ import io.netty.handler.codec.http.TooLongHttpHeaderException;
 import io.netty.handler.codec.http2.Http2Connection;
 import io.netty.handler.codec.http2.Http2Exception.StreamException;
 import io.netty.handler.timeout.ReadTimeoutException;
+import io.netty.handler.timeout.WriteTimeoutException;
 import io.netty.handler.codec.http2.Http2Error;
 import io.netty.handler.codec.http2.Http2Stream;
 import io.netty.handler.codec.http2.HttpConversionUtil;
@@ -176,13 +177,12 @@ public class HttpDispatcherHandler extends SimpleChannelInboundHandler<FullHttpR
             }
             sendErrorMessage(cause);
             return;
-        } else if(cause instanceof TimeoutException){
+        } else if(cause instanceof TimeoutException || cause instanceof WriteTimeoutException){
+         
             if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-                Tr.debug(tc, "The connection closed due to idle timeout");
+                Tr.debug(tc, "The connection closed due to timeout exception : " + cause);
             }
-            if(cause instanceof ReadTimeoutException){
-                sendErrorMessage(cause);
-            }
+            sendErrorMessage(cause);
              
         } else if(cause instanceof TooLongFrameException) { 
             if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {


### PR DESCRIPTION
- [ ] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [ ] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

Added a new HttpInboundServiceContextImpl constructor.

In the `super.init(tsc, context);`, the read and write timeouts are set, but the problem is that HttpConfig is not yet configured, so a new HttpConfig is created with default settings.  See here:

https://github.com/OpenLiberty/open-liberty/blob/892dbeae1e757ecd8543c2eb501de8835860e3eb/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/channel/internal/HttpServiceContextImpl.java#L1029-L1030