### PR TITLE
Netty Camel case Content-Length and Transfer-Encoding

### DIFF
--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/channel/internal/HttpServiceContextImpl.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/channel/internal/HttpServiceContextImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2004, 2025 IBM Corporation and others.
+ * Copyright (c) 2004, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution,  and is available at
@@ -117,6 +117,7 @@ import io.netty.handler.codec.http.DefaultFullHttpResponse;
 import io.netty.handler.codec.http.DefaultHttpContent;
 import io.netty.handler.codec.http.DefaultLastHttpContent;
 import io.netty.handler.codec.http.FullHttpRequest;
+import io.netty.handler.codec.http.HttpHeaderValues;
 import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpResponse;
@@ -3005,7 +3006,9 @@ public abstract class HttpServiceContextImpl implements HttpServiceContext, FFDC
             if (!isPartialBody() && !getRequest().getMethod().equals(MethodValues.HEAD.getName())) {
                 msg.setContentLength(GenericUtils.sizeOf(buffers));
             } else if (addedCompressionContentLength || (!msg.isChunkedEncodingSet() && msg.getContentLength() == HttpGenerics.NOT_SET)) {
-                HttpUtil.setTransferEncodingChunked(nettyResponse, true);
+                nettyResponse.headers().set(HttpHeaderKeys.HDR_TRANSFER_ENCODING.getName(), HttpHeaderValues.CHUNKED);
+                nettyResponse.headers().remove(HttpHeaderKeys.HDR_CONTENT_LENGTH.getName());
+
                 if (nettyContext.channel().hasAttr(NettyHttpConstants.CONTENT_LENGTH)) {
                     nettyContext.channel().attr(NettyHttpConstants.CONTENT_LENGTH).set(null);
                 }
@@ -3122,7 +3125,7 @@ public abstract class HttpServiceContextImpl implements HttpServiceContext, FFDC
         DefaultFullHttpRequest newRequest = new DefaultFullHttpRequest(nettyRequest.protocolVersion(), HttpMethod.GET, uri);
         newRequest.headers().set(HttpConversionUtil.ExtensionHeaderNames.STREAM_ID.text(), nextPromisedStreamId);
         newRequest.headers().set(HttpConversionUtil.ExtensionHeaderNames.SCHEME.text(), scheme);
-        HttpUtil.setContentLength(newRequest, 0);
+        newRequest.headers().set(HttpHeaderKeys.HDR_CONTENT_LENGTH.getName(), 0);
 
         HttpDispatcher.getExecutorService().execute(() -> {
             try {
@@ -3339,7 +3342,8 @@ public abstract class HttpServiceContextImpl implements HttpServiceContext, FFDC
                 complete = true;
                 getResponse().setContentLength(GenericUtils.sizeOf(buffers));
             } else if (!msg.isChunkedEncodingSet() && msg.getContentLength() == HttpGenerics.NOT_SET) {
-                HttpUtil.setTransferEncodingChunked(nettyResponse, true);
+                nettyResponse.headers().set(HttpHeaderKeys.HDR_TRANSFER_ENCODING.getName(), HttpHeaderValues.CHUNKED);
+                nettyResponse.headers().remove(HttpHeaderKeys.HDR_CONTENT_LENGTH.getName());
             }
 
             if (msg.isBodyExpected()) {

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/netty/message/NettyBaseMessage.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/netty/message/NettyBaseMessage.java
@@ -9,11 +9,6 @@
  *******************************************************************************/
 package com.ibm.ws.http.netty.message;
 
-import static com.ibm.ws.http.netty.message.NettyBaseMessage.MessageType.REQUEST;
-
-import java.io.IOException;
-import java.io.ObjectInput;
-import java.io.ObjectOutput;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -26,19 +21,14 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Set;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.ws.http.channel.internal.HttpChannelConfig;
-import com.ibm.ws.http.channel.internal.HttpConfigConstants;
 import com.ibm.ws.http.channel.internal.HttpMessages;
 import com.ibm.ws.http.channel.internal.HttpTrailersImpl;
 import com.ibm.ws.http.channel.internal.cookies.CookieCacheData;
 import com.ibm.ws.http.channel.internal.cookies.CookieHeaderByteParser;
-import com.ibm.ws.http.channel.internal.cookies.CookieUtils;
-import com.ibm.ws.http.channel.internal.cookies.SameSiteCookieUtils;
 import com.ibm.wsspi.genericbnf.BNFHeaders;
 import com.ibm.wsspi.genericbnf.HeaderField;
 import com.ibm.wsspi.genericbnf.HeaderKeys;
@@ -55,6 +45,7 @@ import com.ibm.wsspi.http.channel.values.TransferEncodingValues;
 import com.ibm.wsspi.http.channel.values.VersionValues;
 
 import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.HttpHeaderValues;
 import io.netty.handler.codec.http.HttpMessage;
 import io.netty.handler.codec.http.HttpUtil;
 import io.netty.handler.codec.http2.HttpConversionUtil;
@@ -655,9 +646,30 @@ public class NettyBaseMessage implements HttpBaseMessage {
 
     @Override
     public void setContentLength(long length) {
-        if (HttpUtil.isTransferEncodingChunked(message))
-            HttpUtil.setTransferEncodingChunked(message, false);
-        HttpUtil.setContentLength(message, length);
+        if(isChunkedEncodingSet()) {
+            //retain HttpUtil.setTransferEncodingChunked false case logic
+            String temp = HttpHeaderKeys.HDR_TRANSFER_ENCODING.getName();
+            List<String> encodings = headers.getAll(temp);
+            if (!encodings.isEmpty()) {
+                List<CharSequence> values = new ArrayList(encodings);
+                Iterator<CharSequence> valuesIt = values.iterator();
+
+                while (valuesIt.hasNext()) {
+                    CharSequence value = valuesIt.next();
+                    if (HttpHeaderValues.CHUNKED.contentEqualsIgnoreCase(value)) {
+                        valuesIt.remove();
+                    }
+                }
+
+                if (values.isEmpty()) {
+                    headers.remove(temp);
+                } else {
+                    headers.set(temp, values);
+                }
+            }
+        }
+
+        headers.set(HttpHeaderKeys.HDR_CONTENT_LENGTH.getName(), length);
     }
 
     @Override

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/netty/message/NettyResponseMessage.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/netty/message/NettyResponseMessage.java
@@ -9,13 +9,8 @@
  *******************************************************************************/
 package com.ibm.ws.http.netty.message;
 
-import java.io.IOException;
-import java.io.ObjectInput;
-import java.io.ObjectOutput;
-import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map.Entry;
 import java.util.Objects;
@@ -25,12 +20,10 @@ import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.ws.http.channel.internal.HttpChannelConfig;
 import com.ibm.ws.http.channel.internal.HttpMessages;
-import com.ibm.ws.http.channel.internal.HttpTrailersImpl;
 import com.ibm.ws.http.channel.internal.inbound.HttpInboundServiceContextImpl;
 import com.ibm.ws.http.dispatcher.internal.HttpDispatcher;
 import com.ibm.wsspi.genericbnf.HeaderField;
 import com.ibm.wsspi.genericbnf.HeaderKeys;
-import com.ibm.wsspi.genericbnf.exception.UnsupportedProtocolVersionException;
 import com.ibm.wsspi.http.HttpCookie;
 import com.ibm.wsspi.http.channel.HttpResponseMessage;
 import com.ibm.wsspi.http.channel.HttpServiceContext;
@@ -38,14 +31,12 @@ import com.ibm.wsspi.http.channel.HttpTrailers;
 import com.ibm.wsspi.http.channel.inbound.HttpInboundServiceContext;
 import com.ibm.wsspi.http.channel.values.ConnectionValues;
 import com.ibm.wsspi.http.channel.values.ContentEncodingValues;
-import com.ibm.wsspi.http.channel.values.ExpectValues;
 import com.ibm.wsspi.http.channel.values.HttpHeaderKeys;
 import com.ibm.wsspi.http.channel.values.StatusCodes;
 import com.ibm.wsspi.http.channel.values.TransferEncodingValues;
 import com.ibm.wsspi.http.channel.values.VersionValues;
 
 import io.netty.handler.codec.http.DefaultHttpHeaders;
-import io.netty.handler.codec.http.DefaultHttpResponse;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpHeaderValues;
 import io.netty.handler.codec.http.HttpHeaders;
@@ -151,14 +142,14 @@ public class NettyResponseMessage extends NettyBaseMessage implements HttpRespon
     @Override
     public void setConnection(ConnectionValues value) {
         if (value.getName().equalsIgnoreCase(HttpHeaderValues.CLOSE.toString()))
-            nettyResponse.headers().set(HttpHeaderNames.CONNECTION, HttpHeaderValues.CLOSE);
+            headers.set(HttpHeaderKeys.HDR_CONNECTION.getName(), HttpHeaderValues.CLOSE);
         else if (value.getName().equalsIgnoreCase(HttpHeaderValues.KEEP_ALIVE.toString()))
-            nettyResponse.headers().set(HttpHeaderNames.CONNECTION, HttpHeaderValues.KEEP_ALIVE);
+            headers.set(HttpHeaderKeys.HDR_CONNECTION.getName(), HttpHeaderValues.KEEP_ALIVE);
     }
 
     @Override
     public void setConnection(ConnectionValues[] values) {
-        nettyResponse.headers().set(HttpHeaderNames.CONNECTION, values);
+        headers.set(HttpHeaderKeys.HDR_CONNECTION.getName(), values);
     }
 
     @Override
@@ -183,14 +174,16 @@ public class NettyResponseMessage extends NettyBaseMessage implements HttpRespon
 
     @Override
     public void setContentEncoding(ContentEncodingValues value) {
-        headers.set(HttpHeaderNames.CONTENT_ENCODING, value.getName());
+        headers.set(HttpHeaderKeys.HDR_CONTENT_ENCODING.getName(), value.getName());
     }
 
     @Override
     public void setContentEncoding(ContentEncodingValues[] values) {
-        headers.remove(HttpHeaderNames.CONTENT_ENCODING);
+        String temp = HttpHeaderKeys.HDR_CONTENT_ENCODING.getName();
+        
+        headers.remove(temp);
         for(ContentEncodingValues value : values){
-            headers.add(HttpHeaderNames.CONTENT_ENCODING, value.getName());
+            headers.add(temp, value.getName());
         }
     }
 

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/netty/pipeline/outbound/HeaderHandler.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/netty/pipeline/outbound/HeaderHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023, 2025 IBM Corporation and others.
+ * Copyright (c) 2023, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -10,6 +10,8 @@
 package com.ibm.ws.http.netty.pipeline.outbound;
 
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -22,6 +24,8 @@ import com.ibm.ws.http.channel.internal.HttpMessages;
 import com.ibm.ws.http.dispatcher.internal.HttpDispatcher;
 import com.ibm.wsspi.http.channel.values.HttpHeaderKeys;
 
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpHeaderValues;
 import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.HttpResponse;
 import io.netty.handler.codec.http.HttpResponseStatus;
@@ -64,23 +68,42 @@ public class HeaderHandler {
         if (!headers.contains(HttpHeaderKeys.HDR_DATE.getName())) {
             byte[] date = HttpDispatcher.getDateFormatter().getRFC1123TimeAsBytes(config.getDateHeaderRange());
             headers.set(HttpHeaderKeys.HDR_DATE.getName(),
-                            new String(date, StandardCharsets.UTF_8));
+                        new String(date, StandardCharsets.UTF_8));
         }
 
         // If HTTP 1.0 remove the Transfer-Encoding header if it exists.
         if (response.protocolVersion().equals(HttpVersion.HTTP_1_0)) {
             if (headers.contains(HttpHeaderKeys.HDR_TRANSFER_ENCODING.getName())) {
-                response.headers().remove(HttpHeaderKeys.HDR_TRANSFER_ENCODING.getName());
+                headers.remove(HttpHeaderKeys.HDR_TRANSFER_ENCODING.getName());
             }
         } else if (!HttpUtil.isContentLengthSet(response) && !headers.contains(HttpConversionUtil.ExtensionHeaderNames.STREAM_ID.text())) {
             if (response.status().equals(HttpResponseStatus.SWITCHING_PROTOCOLS)) {
+                headers.remove(HttpHeaderNames.CONTENT_LENGTH);
 
-                HttpUtil.setContentLength(response, 0);
-                HttpUtil.setTransferEncodingChunked(response, false);
+                //from HttpUtil.setTransferEncodingChunked false case
+                List<String> encodings = headers.getAll(HttpHeaderNames.TRANSFER_ENCODING);
+                if (!encodings.isEmpty()) {
+                    List<CharSequence> values = new ArrayList(encodings);
+                    Iterator<CharSequence> valuesIt = values.iterator();
 
+                    while (valuesIt.hasNext()) {
+                        CharSequence value = valuesIt.next();
+                        if (HttpHeaderValues.CHUNKED.contentEqualsIgnoreCase(value)) {
+                            valuesIt.remove();
+                        }
+                    }
+
+                    if (values.isEmpty()) {
+                        headers.remove(HttpHeaderNames.TRANSFER_ENCODING);
+                    } else {
+                        headers.set(HttpHeaderKeys.HDR_TRANSFER_ENCODING.getName(), values);
+                    }
+                }
             } else {
-                HttpUtil.setTransferEncodingChunked(response, true);
+                headers.set(HttpHeaderKeys.HDR_TRANSFER_ENCODING.getName(), HttpHeaderValues.CHUNKED);
             }
+        } else if (HttpUtil.isContentLengthSet(response)) { //set camel case
+            headers.set(HttpHeaderKeys.HDR_CONTENT_LENGTH.getName(), HttpUtil.getContentLength(response));
         }
 
         if (config.removeServerHeader()) {

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/netty/pipeline/outbound/HeaderHandler.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/netty/pipeline/outbound/HeaderHandler.java
@@ -78,7 +78,7 @@ public class HeaderHandler {
             }
         } else if (!HttpUtil.isContentLengthSet(response) && !headers.contains(HttpConversionUtil.ExtensionHeaderNames.STREAM_ID.text())) {
             if (response.status().equals(HttpResponseStatus.SWITCHING_PROTOCOLS)) {
-                headers.remove(HttpHeaderNames.CONTENT_LENGTH);
+                headers.set(HttpHeaderKeys.HDR_CONTENT_LENGTH.getName(), 0);
 
                 //from HttpUtil.setTransferEncodingChunked false case
                 List<String> encodings = headers.getAll(HttpHeaderNames.TRANSFER_ENCODING);
@@ -101,6 +101,7 @@ public class HeaderHandler {
                 }
             } else {
                 headers.set(HttpHeaderKeys.HDR_TRANSFER_ENCODING.getName(), HttpHeaderValues.CHUNKED);
+                headers.remove(HttpHeaderNames.CONTENT_LENGTH);
             }
         } else if (HttpUtil.isContentLengthSet(response)) { //set camel case
             headers.set(HttpHeaderKeys.HDR_CONTENT_LENGTH.getName(), HttpUtil.getContentLength(response));

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/netty/pipeline/outbound/HeaderHandler.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/netty/pipeline/outbound/HeaderHandler.java
@@ -101,11 +101,9 @@ public class HeaderHandler {
                 }
             } else {
                 headers.set(HttpHeaderKeys.HDR_TRANSFER_ENCODING.getName(), HttpHeaderValues.CHUNKED);
-                headers.remove(HttpHeaderNames.CONTENT_LENGTH);
+                headers.remove(HttpHeaderKeys.HDR_CONTENT_LENGTH.getName());
             }
-        } else if (HttpUtil.isContentLengthSet(response)) { //set camel case
-            headers.set(HttpHeaderKeys.HDR_CONTENT_LENGTH.getName(), HttpUtil.getContentLength(response));
-        }
+        } 
 
         if (config.removeServerHeader()) {
             if (headers.contains(HttpHeaderKeys.HDR_SERVER.getName())) {

--- a/dev/com.ibm.ws.webcontainer.servlet.4.0_fat.2/fat/src/com/ibm/ws/fat/wc/tests/WCResponseContentLengthChunkedEncodingTest.java
+++ b/dev/com.ibm.ws.webcontainer.servlet.4.0_fat.2/fat/src/com/ibm/ws/fat/wc/tests/WCResponseContentLengthChunkedEncodingTest.java
@@ -325,12 +325,12 @@ public class WCResponseContentLengthChunkedEncodingTest {
                 LOG.info("\n>>>>>> Response Headers: >>>>>>");
                 for (Header header : headers) {
                     LOG.info(header.toString());
-                    if (header.getName().equalsIgnoreCase(LENGTH)) {
+                    if (header.getName().equals(LENGTH)) {
                         responseCL = Integer.valueOf(header.getValue());
                         LOG.info("\n Found Content-Length = " + responseCL);
                     }
 
-                    if (header.getName().equalsIgnoreCase(TRANSFER_ENC)) {
+                    if (header.getName().equals(TRANSFER_ENC)) {
                         chunkedResponse = true;
                         LOG.info("\n Found " + TRANSFER_ENC + " = " + header.getValue());
                     }


### PR DESCRIPTION
fixes https://github.com/OpenLiberty/open-liberty/issues/33983

Keep response `Content-Length` and `Transfer-Encoding` consistent with all other  response headers