### PR TITLE
temporarily disable Hibernate test on Java 26

### DIFF
--- a/dev/io.openliberty.data.internal_fat_1_1/fat/src/test/jakarta/data/v1_1/Data_1_1_HibernateTest.java
+++ b/dev/io.openliberty.data.internal_fat_1_1/fat/src/test/jakarta/data/v1_1/Data_1_1_HibernateTest.java
@@ -21,6 +21,7 @@ import org.testcontainers.containers.JdbcDatabaseContainer;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
 
+import componenttest.annotation.MaximumJavaLevel;
 import componenttest.annotation.MinimumJavaLevel;
 import componenttest.annotation.Server;
 import componenttest.annotation.TestServlet;
@@ -34,6 +35,7 @@ import test.jakarta.data.v1_1.web.Data_1_1_Servlet;
 
 @RunWith(FATRunner.class)
 @MinimumJavaLevel(javaLevel = 21)
+@MaximumJavaLevel(javaLevel = 25) // TODO remove once RTC 309096 updates Byte Buddy to a version that supports java 26+
 public class Data_1_1_HibernateTest extends FATServletClient {
     /**
      * Error messages, typically for invalid repository methods, that are


### PR DESCRIPTION
Temporarily disable a Jakarta Data test bucket from running against Hibernate when Java SE 26 is used due to Byte Buddy (which is used by Hibernate) being at a level that does not support Java 26.  After the version of byte buddy is updated in 309096, the test can be re-enabled against Hibernate.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
