### PR TITLE
Update auth cache for performance and other issues

### DIFF
--- a/dev/com.ibm.ws.security.authentication.builtin/src/com/ibm/ws/security/authentication/internal/cache/AuthCache.java
+++ b/dev/com.ibm.ws.security.authentication.builtin/src/com/ibm/ws/security/authentication/internal/cache/AuthCache.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2022 IBM Corporation and others.
+ * Copyright (c) 2021, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -32,7 +32,7 @@ public interface AuthCache {
      * @param key The key to look for the value for.
      * @return The value mapped to the specified key, or null if no mapping exists.
      */
-    public Object get(Object key);
+    public CacheObject get(Object key);
 
     /**
      * Remove the value for the specified from the cache.

--- a/dev/com.ibm.ws.security.authentication.builtin/src/com/ibm/ws/security/authentication/internal/cache/AuthCacheServiceImpl.java
+++ b/dev/com.ibm.ws.security.authentication.builtin/src/com/ibm/ws/security/authentication/internal/cache/AuthCacheServiceImpl.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2022 IBM Corporation and others.
+ * Copyright (c) 2011, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -71,8 +71,8 @@ public class AuthCacheServiceImpl implements AuthCacheService, UserRegistryChang
     @Override
     public void insert(Subject subject, String userid, @Sensitive String password) {
         try {
+            CacheContext cacheContext = new CacheContext(authCacheConfig, subject, userid, password);
             CacheObject cacheObject = new CacheObject(subject);
-            CacheContext cacheContext = new CacheContext(authCacheConfig, cacheObject, userid, password);
             commonInsert(cacheContext, cacheObject);
         } catch (Exception e) {
             if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
@@ -86,8 +86,8 @@ public class AuthCacheServiceImpl implements AuthCacheService, UserRegistryChang
     @Override
     public void insert(Subject subject, X509Certificate[] certChain) {
         try {
+            CacheContext cacheContext = new CacheContext(authCacheConfig, subject, certChain);
             CacheObject cacheObject = new CacheObject(subject);
-            CacheContext cacheContext = new CacheContext(authCacheConfig, cacheObject, certChain);
             commonInsert(cacheContext, cacheObject);
         } catch (Exception e) {
             if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
@@ -103,8 +103,8 @@ public class AuthCacheServiceImpl implements AuthCacheService, UserRegistryChang
     @Override
     public void insert(Subject subject) {
         try {
+            CacheContext cacheContext = new CacheContext(authCacheConfig, subject);
             CacheObject cacheObject = new CacheObject(subject);
-            CacheContext cacheContext = new CacheContext(authCacheConfig, cacheObject);
             commonInsert(cacheContext, cacheObject);
         } catch (Exception e) {
             if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
@@ -190,7 +190,7 @@ public class AuthCacheServiceImpl implements AuthCacheService, UserRegistryChang
         if (cacheKey instanceof byte[]) {
             cacheKey = new ByteArray((byte[]) cacheKey);
         }
-        return (CacheObject) cache.get(cacheKey);
+        return cache.get(cacheKey);
     }
 
     protected void activate(ComponentContext componentContext, Map<String, Object> newProperties) {

--- a/dev/com.ibm.ws.security.authentication.builtin/src/com/ibm/ws/security/authentication/internal/cache/InMemoryAuthCache.java
+++ b/dev/com.ibm.ws.security.authentication.builtin/src/com/ibm/ws/security/authentication/internal/cache/InMemoryAuthCache.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 1997, 2022 IBM Corporation and others.
+ * Copyright (c) 1997, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -122,7 +122,7 @@ public class InMemoryAuthCache implements AuthCache, FFDCSelfIntrospectable {
      * Find and return the object associated with the specified key.
      */
     @Override
-    public synchronized Object get(Object key) {
+    public synchronized CacheObject get(Object key) {
         ConcurrentHashMap<Object, Object> tableRef = primaryTable;
         Entry curEntry = (Entry) primaryTable.get(key);
 
@@ -261,12 +261,12 @@ public class InMemoryAuthCache implements AuthCache, FFDCSelfIntrospectable {
 
     public static class Entry {
 
-        public Object value;
+        public CacheObject value;
 
         public Entry() {
         }
 
-        public Entry(Object value) {
+        public Entry(CacheObject value) {
             this.value = value;
         }
     }

--- a/dev/com.ibm.ws.security.authentication.builtin/src/com/ibm/ws/security/authentication/internal/cache/JCacheAuthCache.java
+++ b/dev/com.ibm.ws.security.authentication.builtin/src/com/ibm/ws/security/authentication/internal/cache/JCacheAuthCache.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2022 IBM Corporation and others.
+ * Copyright (c) 2021, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -117,7 +117,7 @@ public class JCacheAuthCache implements AuthCache {
     }
 
     @Override
-    public Object get(Object key) {
+    public CacheObject get(Object key) {
         Object value = null;
 
         /*
@@ -167,7 +167,7 @@ public class JCacheAuthCache implements AuthCache {
             }
         }
 
-        return value;
+        return (CacheObject) value;
     }
 
     @Override

--- a/dev/com.ibm.ws.security.authentication.builtin/src/com/ibm/ws/security/authentication/internal/cache/keyproviders/BasicAuthCacheKeyProvider.java
+++ b/dev/com.ibm.ws.security.authentication.builtin/src/com/ibm/ws/security/authentication/internal/cache/keyproviders/BasicAuthCacheKeyProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 IBM Corporation and others.
+ * Copyright (c) 2011, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -122,10 +122,13 @@ public class BasicAuthCacheKeyProvider implements CacheKeyProvider {
 
     private void addKeys(Set<Object> keys, String realm, String userid, @Sensitive String hashedPassword) {
         String keyWithoutPassword = createLookupKey(realm, userid);
-        addKey(keys, keyWithoutPassword);
-        if (keyWithoutPassword != null && hashedPassword != null) {
-            String keyWithPassword = keyWithoutPassword + KEY_SEPARATOR + hashedPassword;
-            addKey(keys, keyWithPassword);
+        if (keyWithoutPassword != null) {
+            if (hashedPassword == null) {
+                addKey(keys, keyWithoutPassword);
+            } else {
+                String keyWithPassword = keyWithoutPassword + KEY_SEPARATOR + hashedPassword;
+                addKey(keys, keyWithPassword);
+            }
         }
     }
 

--- a/dev/com.ibm.ws.security.authentication.builtin/test/com/ibm/ws/security/authentication/internal/cache/AuthCacheServiceTest.java
+++ b/dev/com.ibm.ws.security.authentication.builtin/test/com/ibm/ws/security/authentication/internal/cache/AuthCacheServiceTest.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2022 IBM Corporation and others.
+ * Copyright (c) 2011, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -12,9 +12,10 @@
  *******************************************************************************/
 package com.ibm.ws.security.authentication.internal.cache;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -173,7 +174,8 @@ public class AuthCacheServiceTest {
 
             Subject actualSubject = authCacheService.getSubject(getSSOTokenCacheKey(testSubject));
 
-            assertSame("The subject must be found in the cache by its SSO token.", testSubject, actualSubject);
+            assertEquals("The subject must be found in the cache by its SSO token.", testSubject, actualSubject);
+            assertNotSame("The subject must be a new instance when returned from the cache.", testSubject, actualSubject);
         } catch (Throwable t) {
             outputMgr.failWithThrowable(methodName, t);
         }
@@ -220,7 +222,8 @@ public class AuthCacheServiceTest {
 
             Subject actualSubject = authCacheService.getSubject(basicAuthCacheKey);
 
-            assertSame("The subject must be found in the cache by its <realm>:<userid>:<hashedPassword>", testSubject, actualSubject);
+            assertEquals("The subject must be found in the cache by its <realm>:<userid>:<hashedPassword>.", testSubject, actualSubject);
+            assertNotSame("The subject must be a new instance when returned from the cache.", testSubject, actualSubject);
         } catch (Throwable t) {
             outputMgr.failWithThrowable(methodName, t);
         }
@@ -251,8 +254,8 @@ public class AuthCacheServiceTest {
             Subject actualSubject = null;
             for (Object lookupKey : lookupKeys) {
                 actualSubject = authCacheService.getSubject(lookupKey);
-                assertSame("The subject must be found in the cache when using the " + lookupKey + " key.",
-                           testSubject, actualSubject);
+                assertEquals("The subject must be found in the cache when using the " + lookupKey + " key.", testSubject, actualSubject);
+                assertNotSame("The subject must be a new instance when returned from the cache.", testSubject, actualSubject);
             }
         } catch (Throwable t) {
             outputMgr.failWithThrowable(methodName, t);
@@ -289,7 +292,8 @@ public class AuthCacheServiceTest {
             authCacheService.insert(testSubject, testUser, testPassword);
             actualSubject = authCacheService.getSubject(basicAuthCacheKey);
 
-            assertSame("The subject must be found in the cache.", testSubject, actualSubject);
+            assertEquals("The subject must be found in the cache.", testSubject, actualSubject);
+            assertNotSame("The subject must be a new instance when returned from the cache.", testSubject, actualSubject);
         } catch (Throwable t) {
             outputMgr.failWithThrowable(methodName, t);
         }
@@ -330,7 +334,8 @@ public class AuthCacheServiceTest {
 
             SingleSignonToken ssoToken = getSSOToken(testSubject);
             Subject actualSubject = authCacheService.getSubject(getSSOTokenCacheKey(ssoToken));
-            assertSame("The subject must still be found in the cache.", testSubject, actualSubject);
+            assertEquals("The subject must still be found in the cache.", testSubject, actualSubject);
+            assertNotSame("The subject must be a new instance when returned from the cache.", testSubject, actualSubject);
         } catch (Throwable t) {
             outputMgr.failWithThrowable(methodName, t);
         }
@@ -405,7 +410,8 @@ public class AuthCacheServiceTest {
 
             Subject actualSubject = authCacheService.getSubject(invalidSubjectLookupKey);
 
-            assertSame("The subject must still be found in the cache.", invalidSubject, actualSubject);
+            assertEquals("The subject must still be found in the cache.", invalidSubject, actualSubject);
+            assertNotSame("The subject must be a new instance when returned from the cache.", invalidSubject, actualSubject);
         } catch (Throwable t) {
             outputMgr.failWithThrowable(methodName, t);
         }

--- a/dev/com.ibm.ws.security.authentication.builtin/test/com/ibm/ws/security/authentication/internal/cache/CacheContextTest.java
+++ b/dev/com.ibm.ws.security.authentication.builtin/test/com/ibm/ws/security/authentication/internal/cache/CacheContextTest.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2011 IBM Corporation and others.
+ * Copyright (c) 2011, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -25,11 +25,10 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import test.common.SharedOutputManager;
-
 import com.ibm.ws.security.authentication.cache.AuthCacheConfig;
 import com.ibm.ws.security.authentication.cache.CacheContext;
-import com.ibm.ws.security.authentication.cache.CacheObject;
+
+import test.common.SharedOutputManager;
 
 /**
  *
@@ -47,26 +46,25 @@ public class CacheContextTest {
 
     /**
      * Capture stdout/stderr output to the manager.
-     * 
+     *
      * @throws Exception
      */
     @BeforeClass
     public static void setUpBeforeClass() throws Exception {
-        // There are variations of this constructor: 
+        // There are variations of this constructor:
         // e.g. to specify a log location or an enabled trace spec. Ctrl-Space for suggestions
         outputMgr = SharedOutputManager.getInstance();
         outputMgr.captureStreams();
 
         testSubject = new Subject();
-        CacheObject cacheObject = new CacheObject(testSubject);
         config = mockery.mock(AuthCacheConfig.class);
-        simpleCacheContext = new CacheContext(config, cacheObject);
-        cacheContextWithUseridPassword = new CacheContext(config, cacheObject, testUser, testPassword);
+        simpleCacheContext = new CacheContext(config, testSubject);
+        cacheContextWithUseridPassword = new CacheContext(config, testSubject, testUser, testPassword);
     }
 
     /**
      * Final teardown work when class is exiting.
-     * 
+     *
      * @throws Exception
      */
     @AfterClass
@@ -77,7 +75,7 @@ public class CacheContextTest {
 
     /**
      * Individual teardown after each test.
-     * 
+     *
      * @throws Exception
      */
     @After

--- a/dev/com.ibm.ws.security.authentication.builtin/test/com/ibm/ws/security/authentication/internal/cache/keyproviders/BasicAuthCacheKeyProviderTest.java
+++ b/dev/com.ibm.ws.security.authentication.builtin/test/com/ibm/ws/security/authentication/internal/cache/keyproviders/BasicAuthCacheKeyProviderTest.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2022 IBM Corporation and others.
+ * Copyright (c) 2011, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -37,7 +37,6 @@ import com.ibm.ws.common.encoder.Base64Coder;
 import com.ibm.ws.security.authentication.cache.AuthCacheConfig;
 import com.ibm.ws.security.authentication.cache.CacheContext;
 import com.ibm.ws.security.authentication.cache.CacheKeyProvider;
-import com.ibm.ws.security.authentication.cache.CacheObject;
 
 import test.common.SharedOutputManager;
 
@@ -49,7 +48,7 @@ public class BasicAuthCacheKeyProviderTest {
     private static SharedOutputManager outputMgr;
     private static Mockery mockery = new JUnit4Mockery();
     private static CacheContext cacheContext;
-    private static CacheObject cacheObject;
+    private static Subject testSubject;
     private static String testRealm = "BasicRealm";
     private static String testUser = "user1";
     private static String testUserSecurityName = "user1SecurityName";
@@ -67,20 +66,14 @@ public class BasicAuthCacheKeyProviderTest {
         outputMgr = SharedOutputManager.getInstance();
         outputMgr.captureStreams();
 
-        createCacheObject();
+        createTestSubject();
         createCacheContext();
         createExpectedKeys();
     }
 
-    private static void createCacheObject() throws Exception {
-        Subject testSubject = createTestSubject();
-        cacheObject = new CacheObject(testSubject);
-    }
-
-    private static Subject createTestSubject() throws Exception {
-        Subject subject = new Subject();
-        addCredentialToSubject(subject);
-        return subject;
+    private static void createTestSubject() throws Exception {
+        testSubject = new Subject();
+        addCredentialToSubject(testSubject);
     }
 
     private static void addCredentialToSubject(Subject subject) throws Exception {
@@ -111,7 +104,7 @@ public class BasicAuthCacheKeyProviderTest {
                 will(returnValue(true));
             }
         });
-        cacheContext = new CacheContext(config, cacheObject, testUser, testPassword);
+        cacheContext = new CacheContext(config, testSubject, testUser, testPassword);
     }
 
     private static void createExpectedKeys() throws NoSuchAlgorithmException {
@@ -173,9 +166,12 @@ public class BasicAuthCacheKeyProviderTest {
             assertTrue("The key must be the <realm>:<userid>:<hashedPassword>.", keys.contains(realmUseridAndHashedPassword));
             assertTrue("The key must be the <realm>:<securityName>:<hashedPassword>.", keys.contains(realmSecurityNameAndHashedPassword));
             assertTrue("The key must be the <realm>:<uniqueSecurityName>:<hashedPassword>.", keys.contains(realmUniqueSecurityNameAndHashedPassword));
-            assertTrue("The key must be the <realm>:<userid>.", keys.contains(realmAndUserid));
-            assertTrue("The key must be the <realm>:<securityName>.", keys.contains(realmAndSecurityName));
-            assertTrue("The key must be the <realm>:<uniqueSecurityName>.", keys.contains(realmAndUniqueSecurityName));
+
+            // If the CacheContext has the userid and password, there should not be a key with just the userid.
+            // This is a change that was done because we cannot treat providing only the userid as the same as providing both the userid and password.
+            assertFalse("The key must be the <realm>:<userid>.", keys.contains(realmAndUserid));
+            assertFalse("The key must be the <realm>:<securityName>.", keys.contains(realmAndSecurityName));
+            assertFalse("The key must be the <realm>:<uniqueSecurityName>.", keys.contains(realmAndUniqueSecurityName));
         } catch (Throwable t) {
             outputMgr.failWithThrowable(methodName, t);
         }
@@ -208,7 +204,7 @@ public class BasicAuthCacheKeyProviderTest {
                 will(returnValue(false));
             }
         });
-        CacheContext contextWithConfigBasicAuthLookupFalse = new CacheContext(config, cacheObject, testUser, testPassword);
+        CacheContext contextWithConfigBasicAuthLookupFalse = new CacheContext(config, testSubject, testUser, testPassword);
         return contextWithConfigBasicAuthLookupFalse;
     }
 

--- a/dev/com.ibm.ws.security.authentication.builtin/test/com/ibm/ws/security/authentication/internal/cache/keyproviders/CustomCacheKeyProviderTest.java
+++ b/dev/com.ibm.ws.security.authentication.builtin/test/com/ibm/ws/security/authentication/internal/cache/keyproviders/CustomCacheKeyProviderTest.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2011 IBM Corporation and others.
+ * Copyright (c) 2011, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -27,14 +27,13 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import test.common.SharedOutputManager;
-
 import com.ibm.ws.security.authentication.cache.AuthCacheConfig;
 import com.ibm.ws.security.authentication.cache.CacheContext;
 import com.ibm.ws.security.authentication.cache.CacheKeyProvider;
-import com.ibm.ws.security.authentication.cache.CacheObject;
 import com.ibm.wsspi.security.token.AttributeNameConstants;
 import com.ibm.wsspi.security.token.SingleSignonToken;
+
+import test.common.SharedOutputManager;
 
 /**
  *
@@ -52,20 +51,19 @@ public class CustomCacheKeyProviderTest {
 
     /**
      * Capture stdout/stderr output to the manager.
-     * 
+     *
      * @throws Exception
      */
     @BeforeClass
     public static void setUpBeforeClass() throws Exception {
-        // There are variations of this constructor: 
+        // There are variations of this constructor:
         // e.g. to specify a log location or an enabled trace spec. Ctrl-Space for suggestions
         outputMgr = SharedOutputManager.getInstance();
         outputMgr.captureStreams();
 
         ssoToken = createSSOToken();
         testSubject = new Subject();
-        CacheObject cacheObject = new CacheObject(testSubject);
-        cacheContext = new CacheContext(config, cacheObject);
+        cacheContext = new CacheContext(config, testSubject);
     }
 
     private static SingleSignonToken createSSOToken() {
@@ -87,7 +85,7 @@ public class CustomCacheKeyProviderTest {
 
     /**
      * Final teardown work when class is exiting.
-     * 
+     *
      * @throws Exception
      */
     @AfterClass
@@ -98,7 +96,7 @@ public class CustomCacheKeyProviderTest {
 
     /**
      * Individual teardown after each test.
-     * 
+     *
      * @throws Exception
      */
     @After
@@ -133,8 +131,7 @@ public class CustomCacheKeyProviderTest {
     public void testProvideKeyFromHashtable() {
         final String methodName = "testProvideKeyFromHashtable";
         Subject subject = createTestSubjectWithCustomCacheKey();
-        CacheObject cacheObject = new CacheObject(subject);
-        cacheContext = new CacheContext(config, cacheObject);
+        cacheContext = new CacheContext(config, subject);
         try {
             CacheKeyProvider provider = new CustomCacheKeyProvider();
             Object cacheKey = provider.provideKey(cacheContext);

--- a/dev/com.ibm.ws.security.authentication.builtin/test/com/ibm/ws/security/authentication/internal/cache/keyproviders/SSOTokenBytesCacheKeyProviderTest.java
+++ b/dev/com.ibm.ws.security.authentication.builtin/test/com/ibm/ws/security/authentication/internal/cache/keyproviders/SSOTokenBytesCacheKeyProviderTest.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2022 IBM Corporation and others.
+ * Copyright (c) 2011, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -26,14 +26,13 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import test.common.SharedOutputManager;
-
 import com.ibm.ws.common.encoder.Base64Coder;
 import com.ibm.ws.security.authentication.cache.AuthCacheConfig;
 import com.ibm.ws.security.authentication.cache.CacheContext;
 import com.ibm.ws.security.authentication.cache.CacheKeyProvider;
-import com.ibm.ws.security.authentication.cache.CacheObject;
 import com.ibm.wsspi.security.token.SingleSignonToken;
+
+import test.common.SharedOutputManager;
 
 /**
  *
@@ -50,21 +49,20 @@ public class SSOTokenBytesCacheKeyProviderTest {
 
     /**
      * Capture stdout/stderr output to the manager.
-     * 
+     *
      * @throws Exception
      */
     @BeforeClass
     public static void setUpBeforeClass() throws Exception {
-        // There are variations of this constructor: 
+        // There are variations of this constructor:
         // e.g. to specify a log location or an enabled trace spec. Ctrl-Space for suggestions
         outputMgr = SharedOutputManager.getInstance();
         outputMgr.captureStreams();
 
         ssoToken = createSSOToken();
         testSubject = createTestSubject();
-        CacheObject cacheObject = new CacheObject(testSubject);
         authCacheConfig = mockery.mock(AuthCacheConfig.class);
-        cacheContext = new CacheContext(authCacheConfig, cacheObject);
+        cacheContext = new CacheContext(authCacheConfig, testSubject);
     }
 
     private static SingleSignonToken createSSOToken() {
@@ -90,7 +88,7 @@ public class SSOTokenBytesCacheKeyProviderTest {
 
     /**
      * Final teardown work when class is exiting.
-     * 
+     *
      * @throws Exception
      */
     @AfterClass
@@ -101,7 +99,7 @@ public class SSOTokenBytesCacheKeyProviderTest {
 
     /**
      * Individual teardown after each test.
-     * 
+     *
      * @throws Exception
      */
     @After
@@ -139,8 +137,7 @@ public class SSOTokenBytesCacheKeyProviderTest {
         final String methodName = "testProvideKeyWithNoTokenReturnsNull";
         try {
             CacheKeyProvider provider = new SSOTokenBytesCacheKeyProvider();
-            CacheObject cacheObject = new CacheObject(new Subject());
-            CacheContext cacheContext = new CacheContext(authCacheConfig, cacheObject);
+            CacheContext cacheContext = new CacheContext(authCacheConfig, new Subject());
             Object cacheKey = provider.provideKey(cacheContext);
             assertNull("There must not be a key.", cacheKey);
         } catch (Throwable t) {

--- a/dev/com.ibm.ws.security.authentication/src/com/ibm/ws/security/authentication/cache/CacheContext.java
+++ b/dev/com.ibm.ws.security.authentication/src/com/ibm/ws/security/authentication/cache/CacheContext.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2011 IBM Corporation and others.
+ * Copyright (c) 2011, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -24,8 +24,8 @@ import com.ibm.websphere.ras.annotation.Sensitive;
  */
 public class CacheContext {
 
-    private final CacheObject cacheObject;
     private final AuthCacheConfig config;
+    private final Subject subject;
     private String userid;
     private String password;
     private X509Certificate[] certChain = null;
@@ -34,9 +34,9 @@ public class CacheContext {
      * @param config
      * @param cacheObject
      */
-    public CacheContext(AuthCacheConfig config, CacheObject cacheObject) {
+    public CacheContext(AuthCacheConfig config, Subject subject) {
         this.config = config;
-        this.cacheObject = cacheObject;
+        this.subject = subject;
     }
 
     /**
@@ -44,15 +44,15 @@ public class CacheContext {
      * @param userid
      * @param password
      */
-    public CacheContext(AuthCacheConfig config, CacheObject cacheObject, String userid, @Sensitive String password) {
-        this(config, cacheObject);
+    public CacheContext(AuthCacheConfig config, Subject subject, String userid, @Sensitive String password) {
+        this(config, subject);
         this.userid = userid;
         this.password = password;
     }
 
-    public CacheContext(AuthCacheConfig config, CacheObject cacheObject, X509Certificate[] certChain) {
+    public CacheContext(AuthCacheConfig config, Subject subject, X509Certificate[] certChain) {
         this.config = config;
-        this.cacheObject = cacheObject;
+        this.subject = subject;
         this.certChain = certChain;
     }
 
@@ -71,7 +71,7 @@ public class CacheContext {
      * @return
      */
     public Subject getSubject() {
-        return cacheObject.getSubject();
+        return subject;
     }
 
     /**

--- a/dev/com.ibm.ws.security.authentication/src/com/ibm/ws/security/authentication/cache/CacheObject.java
+++ b/dev/com.ibm.ws.security.authentication/src/com/ibm/ws/security/authentication/cache/CacheObject.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2022 IBM Corporation and others.
+ * Copyright (c) 2011, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -36,7 +36,15 @@ public class CacheObject implements Serializable {
 
     private static final long serialVersionUID = -2299564519252837462L;
 
+    private transient boolean isReadOnly;
+
     private transient Subject subject;
+
+    private transient Set<Principal> principals;
+
+    private transient Set<Object> publicCredentials;
+
+    private transient Set<Object> privateCredentials;
 
     private final List<Object> lookupKeys = Collections.synchronizedList(new ArrayList<Object>(8));
 
@@ -54,6 +62,14 @@ public class CacheObject implements Serializable {
      */
     public CacheObject(Subject subject) {
         this.subject = subject;
+        // save off the principals and credentials so that we are not doing synchronization logic when returning
+        // the Subject in the getSubject() method
+        if (subject != null) {
+            isReadOnly = subject.isReadOnly();
+            principals = Collections.unmodifiableSet(new HashSet<Principal>(subject.getPrincipals()));
+            publicCredentials = Collections.unmodifiableSet(new HashSet<Object>(subject.getPublicCredentials()));
+            privateCredentials = Collections.unmodifiableSet(new HashSet<Object>(subject.getPrivateCredentials()));
+        }
     }
 
     /**
@@ -84,12 +100,22 @@ public class CacheObject implements Serializable {
     }
 
     /**
-     * Get the {@link Subject} stored in this {@link CacheObject}.
+     * Gets a {@link Subject} with the stored state in this {@link CacheObject}.
      *
-     * @return The subject.
+     * Returns a new Subject instance each time for 2 reasons.
+     *
+     * The Subject class is heavily synchronized so if multiple threads are using the login information,
+     * they will end up bottlenecking on the same Subject instance instead of being able to run in parallel.
+     *
+     * If we returned the actual Subject instance, any changes to the Subject would modify the cached value
+     * as well which is a problem if multiple threads are using the same Subject instance. Where this is
+     * most notably a problem is when calling logout which ends up clearing the Subject and suddenly the other
+     * thread would have no state in their Subject.
+     *
+     * @return A new Subject with the cached content in it
      */
     public Subject getSubject() {
-        return this.subject;
+        return subject == null ? null : new Subject(isReadOnly, principals, publicCredentials, privateCredentials);
     }
 
     @SuppressWarnings("unchecked")
@@ -102,15 +128,15 @@ public class CacheObject implements Serializable {
         /*
          * Read the fields comprising the Subject.
          */
-        boolean subjectReadOnly = input.readBoolean();
-        Set<Principal> subjectPrincipals = (Set<Principal>) input.readObject();
-        Set<Object> subjectPubCreds = (Set<Object>) input.readObject();
-        Set<Object> subjectPrivCreds = (Set<Object>) input.readObject();
+        isReadOnly = input.readBoolean();
+        principals = (Set<Principal>) input.readObject();
+        publicCredentials = (Set<Object>) input.readObject();
+        privateCredentials = (Set<Object>) input.readObject();
 
         /*
          * Create the subject from the subject fields.
          */
-        subject = new Subject(subjectReadOnly, subjectPrincipals, subjectPubCreds, subjectPrivCreds);
+        subject = new Subject(isReadOnly, principals, publicCredentials, privateCredentials);
     }
 
     private void writeObject(ObjectOutputStream output) throws IOException {
@@ -125,9 +151,9 @@ public class CacheObject implements Serializable {
          * Use new sets since the the SecureSet implementation in Subject was not intended for
          * serialization.
          */
-        output.writeBoolean(subject.isReadOnly());
-        output.writeObject(new HashSet<Principal>(subject.getPrincipals()));
-        output.writeObject(new HashSet<Object>(subject.getPublicCredentials()));
-        output.writeObject(new HashSet<Object>(subject.getPrivateCredentials()));
+        output.writeBoolean(isReadOnly);
+        output.writeObject(principals);
+        output.writeObject(publicCredentials);
+        output.writeObject(privateCredentials);
     }
 }


### PR DESCRIPTION
Fixes #34054

- Do most of what was done in #33981 with the get() signature updates done in #34143 to relatively do the same thing that was done before to have the AuthCache return a copy of the Subject from get() instead of the exact Subject that was inserted.  This is done to avoid synchronizing on the returned Subject across threads and also to not have the cached Subject be modified after it is returned from get().  Now if it is modified after being returned, it won't affect the cached value. 
- Update the BasicAuthCacheKeyProvider so that when a userid and password are passed we do not add a key with just the userid. These need to be treated differently since they go down different authentication paths when passed just a userid vs being passed both a userid and password.  When authenticating with just the userid, the request should not get the Subject from a previous login with both a userid and password.
- Update CacheContext to maintain the same contract to return the same Subject instance.  Previously it used the Subject from the CacheObject, but since CacheObject.getSubject now returns a copy it was not the same contract.  Now CacheContext constructor does not take a CacheObject, but instead is just passed the Subject

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
