### PR TITLE
Erroneous comparison with type instead of singleType

### DIFF
--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
@@ -3911,7 +3911,6 @@ public class QueryInfo {
      * @throws MappingException if the repository method return type is incompatible with both
      *                              delete-only and find-and-delete.
      */
-    @SuppressWarnings("unlikely-arg-type")
     @Trivial
     private boolean isFindAndDelete() {
 
@@ -3926,10 +3925,10 @@ public class QueryInfo {
                                "; singleType: " + (singleType == null ? null : singleType.getSimpleName()));
 
         if (isFindAndDelete &&
-            type != null &&
-            !type.equals(entityInfo.entityClass) &&
-            !type.equals(entityInfo.recordClass) &&
-            !type.equals(Object.class) &&
+            singleType != null &&
+            !singleType.equals(entityInfo.entityClass) &&
+            !singleType.equals(entityInfo.recordClass) &&
+            !singleType.equals(Object.class) &&
             !Util.wrapperClassIfPrimitive(singleType) //
                             .equals(Util.wrapperClassIfPrimitive(entityInfo.idType)))
             throw Fail.returnTypeInvalidForDelete(this);


### PR DESCRIPTION
CWWKD1006E error was showing in logs due to an erroneous comparison of `type` field rather than `singleType`.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
