### PR TITLE
Fix up compile and test issues

### DIFF
--- a/dev/com.ibm.ws.anno_fat/.classpath
+++ b/dev/com.ibm.ws.anno_fat/.classpath
@@ -17,6 +17,6 @@
 	<classpathentry kind="src" path="test-applications/SpringAnnoTest/SpringAnnoTestSharedLib.jar/src"/>
 	<classpathentry kind="src" path="test-applications/SpringAnnoTest/SpringAnnoTestManifestLib.jar/src"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/dev/com.ibm.ws.anno_fat/.settings/org.eclipse.jdt.core.prefs
+++ b/dev/com.ibm.ws.anno_fat/.settings/org.eclipse.jdt.core.prefs
@@ -1,12 +1,12 @@
 eclipse.preferences.version=1
 org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
 org.eclipse.jdt.core.compiler.codegen.methodParameters=do not generate
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=17
 org.eclipse.jdt.core.compiler.codegen.unusedLocal=preserve
-org.eclipse.jdt.core.compiler.compliance=1.8
+org.eclipse.jdt.core.compiler.compliance=17
 org.eclipse.jdt.core.compiler.debug.lineNumber=generate
 org.eclipse.jdt.core.compiler.debug.localVariable=generate
 org.eclipse.jdt.core.compiler.debug.sourceFile=generate
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
-org.eclipse.jdt.core.compiler.source=1.8
+org.eclipse.jdt.core.compiler.source=17

--- a/dev/com.ibm.ws.anno_fat/bnd.bnd
+++ b/dev/com.ibm.ws.anno_fat/bnd.bnd
@@ -14,6 +14,7 @@
 bVersion=1.0
 
 javac.source: 17
+javac.target: 17
 
 src: \
     fat/src, \

--- a/dev/com.ibm.ws.jca.1.7_cdi_fat/fat/src/com/ibm/ws/jca/cdi/fat/FATSuite.java
+++ b/dev/com.ibm.ws.jca.1.7_cdi_fat/fat/src/com/ibm/ws/jca/cdi/fat/FATSuite.java
@@ -18,12 +18,13 @@ import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
 import componenttest.custom.junit.runner.AlwaysPassesTest;
+import componenttest.rules.repeater.EmptyAction;
 import componenttest.rules.repeater.FeatureReplacementAction;
 import componenttest.rules.repeater.RepeatTests;
 
 @RunWith(Suite.class)
 @SuiteClasses({
-                AlwaysPassesTest.class, // Java 8 no tests will run
+                AlwaysPassesTest.class,
                 JCA17CDITest.class
 })
 public class FATSuite {
@@ -31,7 +32,7 @@ public class FATSuite {
     @ClassRule
     public static RepeatTests r = RepeatTests
                     .with(FeatureReplacementAction.NO_REPLACEMENT()
-                                    .fullFATOnly())
+                                    .conditionalFullFATOnly(EmptyAction.GREATER_THAN_OR_EQUAL_JAVA_11))
                     .andWith(FeatureReplacementAction.EE10_FEATURES()
                                     .conditionalFullFATOnly(FeatureReplacementAction.GREATER_THAN_OR_EQUAL_JAVA_17)
                                     .setSkipTransformation(true))

--- a/dev/com.ibm.ws.jca.1.7_cdi_fat/fat/src/com/ibm/ws/jca/cdi/fat/JCA17CDITest.java
+++ b/dev/com.ibm.ws.jca.1.7_cdi_fat/fat/src/com/ibm/ws/jca/cdi/fat/JCA17CDITest.java
@@ -26,7 +26,6 @@ import com.ibm.websphere.simplicity.ShrinkHelper;
 import com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions;
 
 import componenttest.annotation.ExpectedFFDC;
-import componenttest.annotation.MinimumJavaLevel;
 import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
@@ -43,7 +42,6 @@ import lib.cdi.CDIExtension;
  * resource adapter bundle.
  */
 @RunWith(FATRunner.class)
-@MinimumJavaLevel(javaLevel = 11)
 public class JCA17CDITest extends FATServletClient {
 
     private static final String WEB_MODULE_NAME = "web";

--- a/dev/io.openliberty.security.jakartasec.4.0.internal_fat/.classpath
+++ b/dev/io.openliberty.security.jakartasec.4.0.internal_fat/.classpath
@@ -4,6 +4,7 @@
 	<classpathentry kind="src" path="test-applications/ham/src"/>
 	<classpathentry kind="src" path="test-applications/inmemory/src"/>
     <classpathentry kind="src" path="test-applications/inmemory/WEB-INF"/>
+    <classpathentry kind="src" path="test-applications/declaredroles/src"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17/">
 		<attributes>


### PR DESCRIPTION
- Temporarily set everything to Java 17 for com.ibm.ws.annot_fat since it requires it in bnd.bnd and it won't build in Eclipse without the settings.  The fat should be updated to still be able to run on Java 8 and 11 to not lose that test coverage, but this change is a stop gap until that happens
- Update com.ibm.ws.jca.1.7_cdi_fat so that it runs tests on Java 8.  EE 9 supports Java 8 so no reason to mark the test to have a minimum of Java 11 and then having to make the entire test be Java 11 minimum.
- Add missing test-applications source path to .classpath for io.openliberty.security.jakartasec.4.0.internal_fat that causes things not to build in eclipse.


- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".