### PR TITLE
Remove unused applications from test

### DIFF
--- a/dev/com.ibm.ws.webcontainer.security.jacc.1.5_fat/fat/src/com/ibm/ws/webcontainer/security/jacc15/fat/BasicAuthTest.java
+++ b/dev/com.ibm.ws.webcontainer.security.jacc.1.5_fat/fat/src/com/ibm/ws/webcontainer/security/jacc15/fat/BasicAuthTest.java
@@ -65,7 +65,7 @@ public class BasicAuthTest extends CommonServletTestScenarios {
         myServer = LibertyServerFactory.getLibertyServer("com.ibm.ws.webcontainer.security.fat.basicauth");
         JACCFatUtils.installJaccUserFeature(myServer);
         myServer.setServerConfigurationFile(DEFAULT_CONFIG_FILE);
-        JACCFatUtils.transformApps(myServer, "basicauth.war", "basicauthXMI.ear", "basicauthXMInoAuthz.ear", "basicauthXML.ear", "basicauthXMLnoAuthz.ear");
+        JACCFatUtils.transformApps(myServer, "basicauth.war", "basicauthXMInoAuthz.ear", "basicauthXMLnoAuthz.ear");
         myClient = new BasicAuthClient(myServer);
         mySSLClient = new SSLBasicAuthClient(myServer);
         myClient.setJaccValidation(true);


### PR DESCRIPTION
Occasionally we are getting errors saying some of the applications in BasicAuthTest do not have any modules. Upon testing their removal no errors seem to be occuring with the tests.

Fixes [#308704](https://wasrtc.hursley.ibm.com:9443/jazz/web/projects/WS-CD#action=com.ibm.team.workitem.viewWorkItem&id=308704)


- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

################################################################################################
