### PR TITLE
Differentiate between IBM Java 8 and Semeru expected results when FIPS140-3 is enabled

### DIFF
--- a/dev/com.ibm.ws.security.saml.sso_fat.2/fat/src/com/ibm/ws/security/saml/fat/common/BasicEncryptionTests.java
+++ b/dev/com.ibm.ws.security.saml.sso_fat.2/fat/src/com/ibm/ws/security/saml/fat/common/BasicEncryptionTests.java
@@ -237,12 +237,15 @@ public class BasicEncryptionTests extends SAMLCommonTest {
         updatedTestSettings.setSamlTokenValidationData(updatedTestSettings.getSamlTokenValidationData().getNameId(), updatedTestSettings.getSamlTokenValidationData().getIssuer(), updatedTestSettings.getSamlTokenValidationData().getInResponseTo(), SAMLConstants.BAD_TOKEN_EXCHANGE, updatedTestSettings.getSamlTokenValidationData().getEncryptionKeyUser(), updatedTestSettings.getSamlTokenValidationData().getRecipient(), SAMLConstants.AES128);
         
         String failureMessage = null;
-        if (!fips140_3Enabled) {
-            failureMessage = SAMLMessageConstants.CWWKS5007E_INTERNAL_SERVER_ERROR + ".+the signature method provided is weaker than the required.*";
-        } else {
+        // IBM Java 8
+        if (testSAMLServer.getServer().isIbmJdk8FIPS140_3EnabledAndSupported()) {
+            failureMessage = SAMLMessageConstants.CWWKS5007E_INTERNAL_SERVER_ERROR + ".+server is configured with FIPS 140-3 enabled mode, but the received SAML assertion is signed with RSA-SHA1.*";
+        } else if (testSAMLServer.getServer().isSemeruFIPS140_3EnabledAndSupported()) {
             // failureMessage = ".+The requested algorithm http://www.w3.org/2000/09/xmldsig#rsa-sha1 does not exist.*";
             failureMessage = SAMLMessageConstants.CWWKS5018E_SAML_RESPONSE_CANNOT_BE_DECODED + ".+Error unmarshalling message from input stream.*";
-            // failureMessage = SAMLMessageConstants.CWWKS5007E_INTERNAL_SERVER_ERROR + ".+server is configured with FIPS 140-3 enabled mode, but the received SAML assertion is signed with RSA-SHA1.*";
+        } else {
+            failureMessage = SAMLMessageConstants.CWWKS5007E_INTERNAL_SERVER_ERROR + ".+the signature method provided is weaker than the required.*";
+
         }
         String sp = SP_ENCRYPTION_SHA_1_SIGNATURE;
         String logMessage = "Did not find message: " + failureMessage;

--- a/dev/com.ibm.ws.security.saml.sso_fat.2/fat/src/com/ibm/ws/security/saml/fat/common/BasicEncryptionTests.java
+++ b/dev/com.ibm.ws.security.saml.sso_fat.2/fat/src/com/ibm/ws/security/saml/fat/common/BasicEncryptionTests.java
@@ -235,9 +235,9 @@ public class BasicEncryptionTests extends SAMLCommonTest {
         testSAMLServer.reconfigServer(buildSPServerName("server_enc_noKeyAlias_singleCertKeyStore_defaultKeyAliasCert_sha1Fips140-3Enabled.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
         SAMLTestSettings updatedTestSettings = getTestSettings(testSettings, SP_ENCRYPTION_SHA_1_SIGNATURE);
         updatedTestSettings.setSamlTokenValidationData(updatedTestSettings.getSamlTokenValidationData().getNameId(), updatedTestSettings.getSamlTokenValidationData().getIssuer(), updatedTestSettings.getSamlTokenValidationData().getInResponseTo(), SAMLConstants.BAD_TOKEN_EXCHANGE, updatedTestSettings.getSamlTokenValidationData().getEncryptionKeyUser(), updatedTestSettings.getSamlTokenValidationData().getRecipient(), SAMLConstants.AES128);
-
+        
         String failureMessage = null;
-        if (!fips140_3SemeruEnabled) {
+        if (!fips140_3Enabled) {
             failureMessage = SAMLMessageConstants.CWWKS5007E_INTERNAL_SERVER_ERROR + ".+the signature method provided is weaker than the required.*";
         } else {
             // failureMessage = ".+The requested algorithm http://www.w3.org/2000/09/xmldsig#rsa-sha1 does not exist.*";

--- a/dev/com.ibm.ws.security.saml.sso_fat.2/fat/src/com/ibm/ws/security/saml/fat/common/BasicEncryptionTests.java
+++ b/dev/com.ibm.ws.security.saml.sso_fat.2/fat/src/com/ibm/ws/security/saml/fat/common/BasicEncryptionTests.java
@@ -235,9 +235,9 @@ public class BasicEncryptionTests extends SAMLCommonTest {
         testSAMLServer.reconfigServer(buildSPServerName("server_enc_noKeyAlias_singleCertKeyStore_defaultKeyAliasCert_sha1Fips140-3Enabled.xml"), _testName, SAMLConstants.NO_EXTRA_MSGS, SAMLConstants.JUNIT_REPORTING);
         SAMLTestSettings updatedTestSettings = getTestSettings(testSettings, SP_ENCRYPTION_SHA_1_SIGNATURE);
         updatedTestSettings.setSamlTokenValidationData(updatedTestSettings.getSamlTokenValidationData().getNameId(), updatedTestSettings.getSamlTokenValidationData().getIssuer(), updatedTestSettings.getSamlTokenValidationData().getInResponseTo(), SAMLConstants.BAD_TOKEN_EXCHANGE, updatedTestSettings.getSamlTokenValidationData().getEncryptionKeyUser(), updatedTestSettings.getSamlTokenValidationData().getRecipient(), SAMLConstants.AES128);
-        
+
         String failureMessage = null;
-        if (!fips140_3Enabled) {
+        if (!fips140_3SemeruEnabled) {
             failureMessage = SAMLMessageConstants.CWWKS5007E_INTERNAL_SERVER_ERROR + ".+the signature method provided is weaker than the required.*";
         } else {
             // failureMessage = ".+The requested algorithm http://www.w3.org/2000/09/xmldsig#rsa-sha1 does not exist.*";

--- a/dev/com.ibm.ws.security.saml.sso_fat.common/src/com/ibm/ws/security/saml20/fat/commonTest/SAMLCommonTest.java
+++ b/dev/com.ibm.ws.security.saml.sso_fat.common/src/com/ibm/ws/security/saml20/fat/commonTest/SAMLCommonTest.java
@@ -77,11 +77,11 @@ public class SAMLCommonTest extends CommonTest {
     public static class skipIfFips140_3Enabled extends MySkipRule {
         @Override
         public Boolean callSpecificCheck() {
-            Log.info(thisClass, "skipIfFips140_3Enabled", "Should we skip the test: " + fips140_3SemeruEnabled);
-            if (fips140_3SemeruEnabled) {
+            Log.info(thisClass, "skipIfFips140_3Enabled", "Should we skip the test: " + fips140_3Enabled);
+            if (fips140_3Enabled) {
                 testSkipped();
             }
-            return fips140_3SemeruEnabled;
+            return fips140_3Enabled;
         }
     }
 
@@ -124,7 +124,7 @@ public class SAMLCommonTest extends CommonTest {
     protected static List<CommonLocalLDAPServerSuite> ldapRefList = new ArrayList<CommonLocalLDAPServerSuite>();
     protected static boolean cipherMayExceed128 = false;
     public static boolean usingExternalLDAPServer = false;
-    public static boolean fips140_3SemeruEnabled = false;
+    public static boolean fips140_3Enabled = false;
     //issue 17687
     public static String callbackHandlerWss4j = SAMLConstants.EXAMPLE_CALLBACK_WSS4J;
     public static String featureWss4j = SAMLConstants.EXAMPLE_CALLBACK_FEATURE_WSS4J;
@@ -321,7 +321,7 @@ public class SAMLCommonTest extends CommonTest {
                 usingExternalLDAPServer = shibbolethHelpers.updateToUseExternalLDaPIfInMemoryIsBad(aTestServer);
                 shibbolethHelpers.setShibbolethPropertiesForTestMachine(aTestServer);
                 aTestServer.getServer().setServerLevelFips(false);
-                fips140_3SemeruEnabled = aTestServer.getServer().isSemeruFIPS140_3EnabledAndSupported();
+                fips140_3Enabled = aTestServer.getServer().isFIPS140_3EnabledAndSupported();
 
 
 //                CommonLocalLDAPServerSuite one = new CommonLocalLDAPServerSuite();
@@ -344,7 +344,7 @@ public class SAMLCommonTest extends CommonTest {
             } else {
                 //SAML SP Server
                 aTestServer.getServer().setServerLevelFips(true);
-                fips140_3SemeruEnabled = aTestServer.getServer().isSemeruFIPS140_3EnabledAndSupported();
+                fips140_3Enabled = aTestServer.getServer().isFIPS140_3EnabledAndSupported();
             }
 
             transformApps(aTestServer);

--- a/dev/com.ibm.ws.security.saml.sso_fat.common/src/com/ibm/ws/security/saml20/fat/commonTest/SAMLCommonTest.java
+++ b/dev/com.ibm.ws.security.saml.sso_fat.common/src/com/ibm/ws/security/saml20/fat/commonTest/SAMLCommonTest.java
@@ -77,11 +77,11 @@ public class SAMLCommonTest extends CommonTest {
     public static class skipIfFips140_3Enabled extends MySkipRule {
         @Override
         public Boolean callSpecificCheck() {
-            Log.info(thisClass, "skipIfFips140_3Enabled", "Should we skip the test: " + fips140_3Enabled);
-            if (fips140_3Enabled) {
+            Log.info(thisClass, "skipIfFips140_3Enabled", "Should we skip the test: " + fips140_3SemeruEnabled);
+            if (fips140_3SemeruEnabled) {
                 testSkipped();
             }
-            return fips140_3Enabled;
+            return fips140_3SemeruEnabled;
         }
     }
 
@@ -124,7 +124,7 @@ public class SAMLCommonTest extends CommonTest {
     protected static List<CommonLocalLDAPServerSuite> ldapRefList = new ArrayList<CommonLocalLDAPServerSuite>();
     protected static boolean cipherMayExceed128 = false;
     public static boolean usingExternalLDAPServer = false;
-    public static boolean fips140_3Enabled = false;
+    public static boolean fips140_3SemeruEnabled = false;
     //issue 17687
     public static String callbackHandlerWss4j = SAMLConstants.EXAMPLE_CALLBACK_WSS4J;
     public static String featureWss4j = SAMLConstants.EXAMPLE_CALLBACK_FEATURE_WSS4J;
@@ -321,7 +321,7 @@ public class SAMLCommonTest extends CommonTest {
                 usingExternalLDAPServer = shibbolethHelpers.updateToUseExternalLDaPIfInMemoryIsBad(aTestServer);
                 shibbolethHelpers.setShibbolethPropertiesForTestMachine(aTestServer);
                 aTestServer.getServer().setServerLevelFips(false);
-                fips140_3Enabled = aTestServer.getServer().isFIPS140_3EnabledAndSupported();
+                fips140_3SemeruEnabled = aTestServer.getServer().isSemeruFIPS140_3EnabledAndSupported();
 
 
 //                CommonLocalLDAPServerSuite one = new CommonLocalLDAPServerSuite();
@@ -344,7 +344,7 @@ public class SAMLCommonTest extends CommonTest {
             } else {
                 //SAML SP Server
                 aTestServer.getServer().setServerLevelFips(true);
-                fips140_3Enabled = aTestServer.getServer().isFIPS140_3EnabledAndSupported();
+                fips140_3SemeruEnabled = aTestServer.getServer().isSemeruFIPS140_3EnabledAndSupported();
             }
 
             transformApps(aTestServer);


### PR DESCRIPTION
When FIPS140-3 is enabled IBM Java 8 will cause a different error to occur compared with Semeru as rsa-sha1 is still accessible as an algorithm in IBM Java8, but is not in this case FIPS compliant.

Fixes [#307254](https://wasrtc.hursley.ibm.com:9443/jazz/web/projects/WS-CD#action=com.ibm.team.workitem.viewWorkItem&id=307254)

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".