### PR TITLE
NPE in SessionInvalidatorWithThreadPool during dynamic config update

### DIFF
--- a/dev/com.ibm.ws.session/src/com/ibm/ws/session/SessionContext.java
+++ b/dev/com.ibm.ws.session/src/com/ibm/ws/session/SessionContext.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.EnumSet;
 import java.util.Hashtable;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.logging.Level;
 
 import javax.servlet.ServletContext;
@@ -44,6 +45,7 @@ import com.ibm.ws.session.store.memory.SessionSimpleHashMap;
 import com.ibm.ws.session.utils.IDGeneratorImpl;
 import com.ibm.ws.session.utils.LoggingUtil;
 import com.ibm.ws.util.WSThreadLocal;
+import com.ibm.ws.webcontainer.httpsession.SessionMgrComponentImpl;
 import com.ibm.wsspi.session.IGenericSessionManager;
 import com.ibm.wsspi.session.IProtocolAdapter;
 import com.ibm.wsspi.session.ISession;
@@ -266,7 +268,10 @@ public class SessionContext {
         _invalidator = createInvalidator();
         final int reaperInterval = getReaperInterval(sessionTimeout);
         final IStore fStore = _store;
-        CheckpointPhase.onRestore(3, () -> _invalidator.start(fStore, reaperInterval));
+        // Capture the ScheduledExecutorService reference before registering the lambda
+        // to avoid NPE during dynamic config updates when the service may be temporarily unavailable
+        final ScheduledExecutorService scheduler = SessionMgrComponentImpl.INSTANCE.get().getScheduledExecutorService();
+        CheckpointPhase.onRestore(3, () -> _invalidator.start(scheduler, fStore, reaperInterval));
 
         // storer - handles manual write, eos, and time based differences
         _storer = createStorer(_smc, _store);

--- a/dev/com.ibm.ws.session/src/com/ibm/ws/session/SessionInvalidatorWithThreadPool.java
+++ b/dev/com.ibm.ws.session/src/com/ibm/ws/session/SessionInvalidatorWithThreadPool.java
@@ -32,7 +32,19 @@ public class SessionInvalidatorWithThreadPool implements ITimer{
     public void start(IStore store, int interval) {
         /*Get reference to ScheduledExecutorService from SessionMgrComponentImpl*/
         ScheduledExecutorService scheduler = SessionMgrComponentImpl.INSTANCE.get().getScheduledExecutorService();
+        start(scheduler, store, interval);
+    }
 
+    /**
+     * Start the invalidator with a pre-captured ScheduledExecutorService.
+     * This method is used when the service reference needs to be captured before
+     * checkpoint/restore operations to avoid NPE during dynamic config updates.
+     *
+     * @param scheduler the ScheduledExecutorService to use
+     * @param store the session store
+     * @param interval the invalidation interval in seconds
+     */
+    public void start(ScheduledExecutorService scheduler, IStore store, int interval) {
         InvalidationTask invalTask = new InvalidationTask(store);
 
         /*schedule periodic invalidation task and store in ScheduledFuture object*/


### PR DESCRIPTION
Fixes RTC 309157

During dynamic config updates, SessionCacheConfigUpdateTest intermittently 
fails (~10%) with a NPE in SessionInvalidatorWithThreadPool.start() at line 34:

  Cannot invoke "SessionMgrComponentImpl.getScheduledExecutorService()" 
  because the return value of "AtomicReference.get()" is null

The original CheckpointPhase.onRestore lambda deferred the 
SessionMgrComponentImpl.INSTANCE.get() lookup until restore time. During a 
config update cycle, DS unsets this reference before re-injecting it, creating 
a window where .get() returns null.

## Fix
Capture _smc.getScheduledExecutorService() eagerly before registering the 
lambda. _smc is guaranteed non-null at this point — it is set in the 
SessionContext constructor (line 156) before createCoreSessionManager() is 
called (lines 160-164).

Added overloaded start(scheduler, store, interval) to 
SessionInvalidatorWithThreadPool to accept the pre-captured reference, keeping 
existing callers of start(store, interval) unaffected.
