### PR TITLE
Fix NullPointerException in session cache tests - RTC 309112

### DIFF
--- a/dev/com.ibm.ws.session.cache_fat_infinispan/fat/src/com/ibm/ws/session/cache/fat/infinispan/SessionCacheTwoServerTest.java
+++ b/dev/com.ibm.ws.session.cache_fat_infinispan/fat/src/com/ibm/ws/session/cache/fat/infinispan/SessionCacheTwoServerTest.java
@@ -277,7 +277,7 @@ public class SessionCacheTwoServerTest extends FATServletClient {
         AssertionError lastError = null;
         while (System.currentTimeMillis() < timeout) {
             try {
-                appB.invokeServlet("testStringBufferAppendWithoutSetAttribute&key=testModifyWithoutPut-key", session);
+                appB.sessionGet("testModifyWithoutPut-key&compareAsString=true", new StringBuffer("MyValue"), session);
                 replicated = true;
                 break; // replication succeeded
             } catch (AssertionError e) {
@@ -290,6 +290,7 @@ public class SessionCacheTwoServerTest extends FATServletClient {
         }
         
         try {
+            appB.invokeServlet("testStringBufferAppendWithoutSetAttribute&key=testModifyWithoutPut-key", session);
             // appA should not see the update because it does not get written to the persistent store without a putAttribute per writeContents=ONLY_SET_ATTRIBUTES
             appA.sessionGet("testModifyWithoutPut-key&compareAsString=true", new StringBuffer("MyValue"), session);
 

--- a/dev/com.ibm.ws.session.cache_fat_infinispan/fat/src/com/ibm/ws/session/cache/fat/infinispan/SessionCacheTwoServerTest.java
+++ b/dev/com.ibm.ws.session.cache_fat_infinispan/fat/src/com/ibm/ws/session/cache/fat/infinispan/SessionCacheTwoServerTest.java
@@ -145,17 +145,20 @@ public class SessionCacheTwoServerTest extends FATServletClient {
         
         // Poll for session replication to serverB before stopping serverA (especially important on slower platforms like z/OS)
         long timeout = System.currentTimeMillis() + 10_000; // 10 second max wait
+        boolean replicated = false;
+        AssertionError lastError = null;
         while (System.currentTimeMillis() < timeout) {
             try {
                 appB.sessionGet("testFailover-1", "foo", session);
+                replicated = true;
                 break; // replication succeeded
             } catch (AssertionError e) {
-                if (System.currentTimeMillis() < timeout) {
-                    TimeUnit.MILLISECONDS.sleep(500);
-                } else {
-                    throw new AssertionError("Session did not replicate to appB within 10 seconds before failover", e);
-                }
+                lastError = e;
+                TimeUnit.MILLISECONDS.sleep(500);
             }
+        }
+        if (!replicated) {
+            throw new AssertionError("Session did not replicate to appB within 10 seconds before failover", lastError);
         }
         
         serverA.stopServer();
@@ -270,17 +273,20 @@ public class SessionCacheTwoServerTest extends FATServletClient {
         
         // Poll for session replication to appB (especially important on slower platforms like z/OS)
         long timeout = System.currentTimeMillis() + 10_000; // 10 second max wait
+        boolean replicated = false;
+        AssertionError lastError = null;
         while (System.currentTimeMillis() < timeout) {
             try {
                 appB.invokeServlet("testStringBufferAppendWithoutSetAttribute&key=testModifyWithoutPut-key", session);
+                replicated = true;
                 break; // replication succeeded
             } catch (AssertionError e) {
-                if (System.currentTimeMillis() < timeout) {
-                    TimeUnit.MILLISECONDS.sleep(500);
-                } else {
-                    throw new AssertionError("Session attribute did not replicate to appB within 10 seconds", e);
-                }
+                lastError = e;
+                TimeUnit.MILLISECONDS.sleep(500);
             }
+        }
+        if (!replicated) {
+            throw new AssertionError("Session attribute did not replicate to appB within 10 seconds", lastError);
         }
         
         try {
@@ -374,17 +380,20 @@ public class SessionCacheTwoServerTest extends FATServletClient {
         
         // Poll for session replication to appB (especially important on slower platforms like z/OS)
         long timeout = System.currentTimeMillis() + 10_000; // 10 second max wait
+        boolean replicated = false;
+        AssertionError lastError = null;
         while (System.currentTimeMillis() < timeout) {
             try {
                 appB.sessionGet("testMaxInactiveInterval-key", 55901, session);
+                replicated = true;
                 break; // replication succeeded
             } catch (AssertionError e) {
-                if (System.currentTimeMillis() < timeout) {
-                    TimeUnit.MILLISECONDS.sleep(500);
-                } else {
-                    throw new AssertionError("Session did not replicate to appB within 10 seconds", e);
-                }
+                lastError = e;
+                TimeUnit.MILLISECONDS.sleep(500);
             }
+        }
+        if (!replicated) {
+            throw new AssertionError("Session did not replicate to appB within 10 seconds", lastError);
         }
         appA.invokeServlet("setMaxInactiveInterval", session); //set max inactive interval to 1 second
 

--- a/dev/com.ibm.ws.session.cache_fat_infinispan/fat/src/com/ibm/ws/session/cache/fat/infinispan/SessionCacheTwoServerTest.java
+++ b/dev/com.ibm.ws.session.cache_fat_infinispan/fat/src/com/ibm/ws/session/cache/fat/infinispan/SessionCacheTwoServerTest.java
@@ -142,9 +142,25 @@ public class SessionCacheTwoServerTest extends FATServletClient {
         List<String> session = new ArrayList<>();
         appA.sessionPut("testFailover-1", "foo", session, true);
         appA.sessionGet("testFailover-1", "foo", session);
+        
+        // Poll for session replication to serverB before stopping serverA (especially important on slower platforms like z/OS)
+        long timeout = System.currentTimeMillis() + 10_000; // 10 second max wait
+        while (System.currentTimeMillis() < timeout) {
+            try {
+                appB.sessionGet("testFailover-1", "foo", session);
+                break; // replication succeeded
+            } catch (AssertionError e) {
+                if (System.currentTimeMillis() < timeout) {
+                    TimeUnit.MILLISECONDS.sleep(500);
+                } else {
+                    throw new AssertionError("Session did not replicate to appB within 10 seconds before failover", e);
+                }
+            }
+        }
+        
         serverA.stopServer();
 
-        // Now verify the cache failed over to Server B
+        // Now verify the cache is still available on Server B after failover
         appB.sessionGet("testFailover-1", "foo", session);
         serverB.stopServer();
 
@@ -251,8 +267,23 @@ public class SessionCacheTwoServerTest extends FATServletClient {
     public void testModifyWithoutPut() throws Exception {
         List<String> session = new ArrayList<>();
         appA.sessionPut("testModifyWithoutPut-key", new StringBuffer("MyValue"), session, true);
+        
+        // Poll for session replication to appB (especially important on slower platforms like z/OS)
+        long timeout = System.currentTimeMillis() + 10_000; // 10 second max wait
+        while (System.currentTimeMillis() < timeout) {
+            try {
+                appB.invokeServlet("testStringBufferAppendWithoutSetAttribute&key=testModifyWithoutPut-key", session);
+                break; // replication succeeded
+            } catch (AssertionError e) {
+                if (System.currentTimeMillis() < timeout) {
+                    TimeUnit.MILLISECONDS.sleep(500);
+                } else {
+                    throw new AssertionError("Session attribute did not replicate to appB within 10 seconds", e);
+                }
+            }
+        }
+        
         try {
-            appB.invokeServlet("testStringBufferAppendWithoutSetAttribute&key=testModifyWithoutPut-key", session);
             // appA should not see the update because it does not get written to the persistent store without a putAttribute per writeContents=ONLY_SET_ATTRIBUTES
             appA.sessionGet("testModifyWithoutPut-key&compareAsString=true", new StringBuffer("MyValue"), session);
 
@@ -340,7 +371,21 @@ public class SessionCacheTwoServerTest extends FATServletClient {
     public void testMaxInactiveInterval() throws Exception {
         List<String> session = new ArrayList<>();
         appA.sessionPut("testMaxInactiveInterval-key", 55901, session, true);
-        appB.sessionGet("testMaxInactiveInterval-key", 55901, session);
+        
+        // Poll for session replication to appB (especially important on slower platforms like z/OS)
+        long timeout = System.currentTimeMillis() + 10_000; // 10 second max wait
+        while (System.currentTimeMillis() < timeout) {
+            try {
+                appB.sessionGet("testMaxInactiveInterval-key", 55901, session);
+                break; // replication succeeded
+            } catch (AssertionError e) {
+                if (System.currentTimeMillis() < timeout) {
+                    TimeUnit.MILLISECONDS.sleep(500);
+                } else {
+                    throw new AssertionError("Session did not replicate to appB within 10 seconds", e);
+                }
+            }
+        }
         appA.invokeServlet("setMaxInactiveInterval", session); //set max inactive interval to 1 second
 
         for (int attempt = 0; attempt < 5; attempt++) {

--- a/dev/com.ibm.ws.session.cache_fat_infinispan/test-applications/sessionCacheApp/src/session/cache/infinispan/web/SessionCacheTestServlet.java
+++ b/dev/com.ibm.ws.session.cache_fat_infinispan/test-applications/sessionCacheApp/src/session/cache/infinispan/web/SessionCacheTestServlet.java
@@ -916,7 +916,8 @@ public class SessionCacheTestServlet extends FATServlet {
         }        
         if (session != null) {
             StringBuffer value = (StringBuffer) session.getAttribute(key);
-            value.append("Appended");
+            if (value != null)
+                value.append("Appended");
         }
     }
 

--- a/dev/com.ibm.ws.session.cache_fat_infinispan_container/test-applications/sessionCacheApp/src/session/cache/infinispan/web/SessionCacheTestServlet.java
+++ b/dev/com.ibm.ws.session.cache_fat_infinispan_container/test-applications/sessionCacheApp/src/session/cache/infinispan/web/SessionCacheTestServlet.java
@@ -897,7 +897,8 @@ public class SessionCacheTestServlet extends FATServlet {
         String key = request.getParameter("key");
         HttpSession session = request.getSession(true);
         StringBuffer value = (StringBuffer) session.getAttribute(key);
-        value.append("Appended");
+        if (value != null)
+            value.append("Appended");
     }
 
     public void testTimeoutExtensionA(HttpServletRequest request, HttpServletResponse response) throws Exception {

--- a/dev/io.openliberty.checkpoint_fat_session_cache_infinispan/test-applications/sessionCacheApp/src/session/cache/infinispan/web/SessionCacheTestServlet.java
+++ b/dev/io.openliberty.checkpoint_fat_session_cache_infinispan/test-applications/sessionCacheApp/src/session/cache/infinispan/web/SessionCacheTestServlet.java
@@ -876,7 +876,8 @@ public class SessionCacheTestServlet extends FATServlet {
         String key = request.getParameter("key");
         HttpSession session = request.getSession(true);
         StringBuffer value = (StringBuffer) session.getAttribute(key);
-        value.append("Appended");
+        if (value != null)
+            value.append("Appended");
     }
 
     public void testTimeoutExtensionA(HttpServletRequest request, HttpServletResponse response) throws Exception {

--- a/dev/io.openliberty.checkpoint_fat_session_cache_infinispan_container/test-applications/sessionCacheApp/src/session/cache/infinispan/web/SessionCacheTestServlet.java
+++ b/dev/io.openliberty.checkpoint_fat_session_cache_infinispan_container/test-applications/sessionCacheApp/src/session/cache/infinispan/web/SessionCacheTestServlet.java
@@ -882,7 +882,8 @@ public class SessionCacheTestServlet extends FATServlet {
         String key = request.getParameter("key");
         HttpSession session = request.getSession(true);
         StringBuffer value = (StringBuffer) session.getAttribute(key);
-        value.append("Appended");
+        if (value != null)
+            value.append("Appended");
     }
 
     public void testTimeoutExtensionA(HttpServletRequest request, HttpServletResponse response) throws Exception {


### PR DESCRIPTION
Problem: Three tests in SessionCacheTwoServerTest were failing intermittently on z/OS platforms (OS/390 v2, v3.1) due to two separate issues:

testModifyWithoutPut — NullPointerException in SessionCacheTestServlet.testStringBufferAppendWithoutSetAttribute when session.getAttribute() returned null before the session attribute had replicated from serverA to serverB.
testMaxInactiveInterval and testFailover — null session errors caused by cross-server session reads happening before Infinispan replication completed, particularly on slower z/OS machines.

Fix:
Added null check in testStringBufferAppendWithoutSetAttribute across all 4 servlet variants, matching the existing pattern in the base session.cache_fat servlet.
Replaced direct cross-server session reads with poll/retry loops (10s timeout, 500ms interval) in testModifyWithoutPut, testMaxInactiveInterval, and testFailover to wait for replication before proceeding.