### PR TITLE
Restrictions on exists methods

### DIFF
--- a/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
+++ b/dev/io.openliberty.data.internal.persistence/src/io/openliberty/data/internal/persistence/QueryInfo.java
@@ -1395,9 +1395,8 @@ public class QueryInfo {
         if (trace && tc.isEntryEnabled())
             Tr.entry(this, tc, "exists");
 
-        TypedQuery<?> query = em.createQuery(jpql, Object.class);
+        jakarta.persistence.Query query = createQuery(em, Object.class, args);
         query.setMaxResults(1);
-        setParameters(query, args, NO_CONSTRAINTS_DEFERRED, null); // TODO 1.1 constraints
 
         List<?> results = query.getResultList();
         boolean found = !results.isEmpty();

--- a/dev/io.openliberty.data.internal_fat_1_1/test-applications/Data_1_1_App/src/test/jakarta/data/v1_1/web/Data_1_1_Servlet.java
+++ b/dev/io.openliberty.data.internal_fat_1_1/test-applications/Data_1_1_App/src/test/jakarta/data/v1_1/web/Data_1_1_Servlet.java
@@ -1345,6 +1345,48 @@ public class Data_1_1_Servlet extends FATServlet {
     }
 
     /**
+     * Use a repository method that imposes restrictions on a Query By Method Name
+     * exists method that has no constraints indicated by the method name.
+     */
+    @Test
+    public void testRestrictedExists() {
+
+        assertEquals(true,
+                     fractions.exists(_Fraction.numerator
+                                     .times(_Fraction.denominator)
+                                     .equalTo(133))); // 7/19 is present in data
+
+        assertEquals(false,
+                     fractions.exists(_Fraction.numerator
+                                     .times(_Fraction.denominator)
+                                     .equalTo(134))); // 2/67 and 1/134 not present
+    }
+
+    /**
+     * Use a repository method that imposes restrictions on a Query By Method Name
+     * exists method that has additional constraints from its method name.
+     */
+    @Test
+    public void testRestrictedExistsBy() {
+
+        Restriction<Fraction> filter = //
+                        Restrict.all(_Fraction.reduced.isTrue(),
+                                     _Fraction.numerator.between(2, 4));
+
+        assertEquals(Boolean.FALSE, // none of (2/6, 3/6, 4/6) are reduced
+                     fractions.existsByDenominatorGreaterThanAndDenominatorLessThan //
+                     (5,
+                      7,
+                      filter));
+
+        assertEquals(Boolean.TRUE, // at least one of (2/8, 3/8, 4/8) is reduced
+                     fractions.existsByDenominatorGreaterThanAndDenominatorLessThan //
+                     (7,
+                      9,
+                      filter));
+    }
+
+    /**
      * Use a repository method that performs a Query consisting of a SELECT
      * clause that uses the NEW keyword to specify the constructor for a
      * Java record.

--- a/dev/io.openliberty.data.internal_fat_1_1/test-applications/Data_1_1_App/src/test/jakarta/data/v1_1/web/Fractions.java
+++ b/dev/io.openliberty.data.internal_fat_1_1/test-applications/Data_1_1_App/src/test/jakarta/data/v1_1/web/Fractions.java
@@ -70,6 +70,13 @@ public interface Fractions {
                  @By("denominator") AtMost<Integer> maxDenominator,
                  Restriction<Fraction> filter);
 
+    boolean exists(Restriction<Fraction> filter);
+
+    Boolean existsByDenominatorGreaterThanAndDenominatorLessThan//
+    (int exclusiveMin,
+     int exclusiveMax,
+     Restriction<Fraction> filter);
+
     @Find
     @OrderBy(_Fraction.NUMERATOR)
     @OrderBy(_Fraction.DENOMINATOR)


### PR DESCRIPTION
Ability to apply Restriction to `exists` and `existsBy` following the Query by Method Name pattern.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
