### PR TITLE
Improve null handling in session cache tests - Follow-up to #34388

### DIFF
--- a/dev/com.ibm.ws.session.cache_fat_infinispan/test-applications/sessionCacheApp/src/session/cache/infinispan/web/SessionCacheTestServlet.java
+++ b/dev/com.ibm.ws.session.cache_fat_infinispan/test-applications/sessionCacheApp/src/session/cache/infinispan/web/SessionCacheTestServlet.java
@@ -916,8 +916,10 @@ public class SessionCacheTestServlet extends FATServlet {
         }        
         if (session != null) {
             StringBuffer value = (StringBuffer) session.getAttribute(key);
-            if (value != null)
-                value.append("Appended");
+            if (value == null) {
+                throw new AssertionError("Session attribute '" + key + "' is null despite successful replication check. This may indicate a cache inconsistency.");
+            }
+            value.append("Appended");
         }
     }
 


### PR DESCRIPTION
Address review feedback from @jjiwooLim in #34388 to fail fast with a clear error message when session attribute is null, rather than silently skipping the append operation.

Changes:
- Replace silent null check with AssertionError that includes the attribute key and explains the likely cause
- Applied to all 4 servlet variants for consistency

Related: #34388
Fixes: RTC 309112
