### PR TITLE
updated the feature utility artifact downloader utils to provide messages showing the HTTP error code and extended stack traces on feature not found in --verbose flag

### DIFF
--- a/dev/com.ibm.ws.install/src/com/ibm/ws/install/InstallException.java
+++ b/dev/com.ibm.ws.install/src/com/ibm/ws/install/InstallException.java
@@ -57,6 +57,16 @@ public class InstallException extends Exception {
     }
 
     /**
+     * Creates an Install Exception with a message and a cause.
+     *
+     * @param message Exception message
+     * @param cause   Exception cause
+     */
+    public InstallException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    /**
      * Creates an Install Exception with a return code.
      *
      * @param message Exception message

--- a/dev/com.ibm.ws.install/src/com/ibm/ws/install/internal/ArtifactDownloader.java
+++ b/dev/com.ibm.ws.install/src/com/ibm/ws/install/internal/ArtifactDownloader.java
@@ -103,7 +103,7 @@ public class ArtifactDownloader implements AutoCloseable {
         try {
             missingFeaturesURLs = ArtifactDownloaderUtils.getMissingFiles(URLtoMavenCoordMap.keySet(), envMap, repository);
         } catch (InterruptedException | ExecutionException e) {
-            throw new InstallException(e.getMessage());
+            throw new InstallException(e.getMessage(), e);
         }
 
         if (!missingFeaturesURLs.isEmpty()) {
@@ -154,7 +154,7 @@ public class ArtifactDownloader implements AutoCloseable {
                 fine("Remaining artifacts: " + futures.size());
                 Thread.sleep(ArtifactDownloaderUtils.THREAD_SLEEP);
             } catch (InterruptedException | ExecutionException e) {
-                throw new InstallException(e.getMessage());
+                throw new InstallException(e.getMessage(), e);
             }
         }
         progressBar.manuallyUpdate();
@@ -232,7 +232,7 @@ public class ArtifactDownloader implements AutoCloseable {
             download(mavenCoords, filetype, urlLocation, dLocation, checksumFormats, repository);
 
         } catch (IOException e) {
-            throw new InstallException(e.getMessage());
+            throw new InstallException(e.getMessage(), e);
         }
 
     }

--- a/dev/com.ibm.ws.install/src/com/ibm/ws/install/internal/ArtifactDownloaderUtils.java
+++ b/dev/com.ibm.ws.install/src/com/ibm/ws/install/internal/ArtifactDownloaderUtils.java
@@ -82,7 +82,9 @@ public class ArtifactDownloaderUtils {
         for (String url : featureURLs) {
             Future<?> future = executor.submit(() -> {
                 try {
-                    if (exists(url, envMap, repository) != HttpURLConnection.HTTP_OK) {
+                    int code = exists(url, envMap, repository);
+                    if (code != HttpURLConnection.HTTP_OK) {
+                        logger.fine("Unable to download feature from " + url + ". HTTP response code: " + code);
                         result.add(url);
                     }
                 } catch (IOException e) {


### PR DESCRIPTION
Fixes #25990

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".