### PR TITLE
Update checking to avoid ordering issue

### DIFF
--- a/dev/com.ibm.ws.jbatch.open.partition_fat/fat/src/batch/fat/junit/PartitionReducerTest.java
+++ b/dev/com.ibm.ws.jbatch.open.partition_fat/fat/src/batch/fat/junit/PartitionReducerTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022 IBM Corporation and others.
+ * Copyright (c) 2022, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -68,8 +68,7 @@ public class PartitionReducerTest extends BatchFATHelper {
         }
     }
 
-    @ExpectedFFDC({ "com.ibm.jbatch.container.exception.BatchContainerRuntimeException" })
-    @AllowedFFDC({ "java.lang.IllegalStateException" })
+    @AllowedFFDC({ "com.ibm.jbatch.container.exception.BatchContainerRuntimeException", "java.lang.IllegalStateException" })
     @Test
     public void testPartitionReducerMethodsForceFailure() throws Exception {
 


### PR DESCRIPTION
Fix test timing bug, depending on ordering of ffdc the test case fail.  Explicit assertion within test still validates the exception occurred.