### PR TITLE
Increase MPJWT test message timeout

### DIFF
--- a/dev/com.ibm.ws.security.mp.jwt.1.1_fat.commonTest/fat/src/com/ibm/ws/security/mp/jwt11/fat/MPJwtConfigUsingBuilderTests.java
+++ b/dev/com.ibm.ws.security.mp.jwt.1.1_fat.commonTest/fat/src/com/ibm/ws/security/mp/jwt11/fat/MPJwtConfigUsingBuilderTests.java
@@ -1612,6 +1612,11 @@ public class MPJwtConfigUsingBuilderTests extends MPJwt11MPConfigTests {
      */
     @Test
     public void MPJwtConfigUsingBuilderTests_FromHeader_AllowAllRSAlgs_useTrustAlias() throws Exception {
+
+        // Increase timeout for server configuration update messages to prevent failures on slower platforms
+        int timeout = resourceServer.getConfigUpdateTimeout(); 
+        resourceServer.setConfigUpdateTimeout(timeout * 2);
+        
         resourceServer.reconfigureServerUsingExpandedConfiguration(_testName, "rs_server_diff_sigAlg_FROM_HEADER_allow_RSAlgs.xml");
         
         for (String sigAlg : Arrays.asList(Constants.ALL_TEST_RSSIGALGS)) {


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

---
- `MPJwtConfigUsingBuilderTests_FromHeader_AllowAllRSAlgs_useTrustAlias` is intermittently failing on slower infra platforms due to `CWWKF0008I` not being found in the logs
- Increasing the timeout resolves this issue, however further investigation will take place to determine the root cause.