### PR TITLE
Address Netty TODOs PR #1

### DIFF
--- a/dev/com.ibm.ws.transport.http/src/io/openliberty/http/constants/HttpGenerics.java
+++ b/dev/com.ibm.ws.transport.http/src/io/openliberty/http/constants/HttpGenerics.java
@@ -10,10 +10,13 @@
 package io.openliberty.http.constants;
 
 /**
- *
+ * Generic constants used within the HTTP Transport code.
  */
 public class HttpGenerics {
 
+    /*
+     * Used for various config (Access Log, Content Length, etc) where no value is set.    
+     */
     public static final int NOT_SET = -1;
 
 }

--- a/dev/com.ibm.ws.transport.http/src/io/openliberty/http/constants/HttpGenerics.java
+++ b/dev/com.ibm.ws.transport.http/src/io/openliberty/http/constants/HttpGenerics.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 IBM Corporation and others.
+ * Copyright (c) 2023, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.transport.http/src/io/openliberty/http/options/HttpOption.java
+++ b/dev/com.ibm.ws.transport.http/src/io/openliberty/http/options/HttpOption.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024, 2025 IBM Corporation and others.
+ * Copyright (c) 2024, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -24,9 +24,9 @@ public enum HttpOption implements EndpointOption {
 
     KEEP_ALIVE_ENABLED("keepAliveEnabled", false, Boolean.class, ConfigType.HTTP),
     MAX_KEEP_ALIVE_REQUESTS("maxKeepAliveRequests", -1, Integer.class, ConfigType.HTTP),
-    PERSIST_TIMEOUT("persistTimeout", "30s", String.class, ConfigType.HTTP),
-    READ_TIMEOUT("readTimeout", 60, Long.class, ConfigType.HTTP),
-    WRITE_TIMEOUT("writeTimeout", 60, Long.class, ConfigType.HTTP),
+    PERSIST_TIMEOUT("persistTimeout", 30L, Long.class, ConfigType.HTTP),
+    READ_TIMEOUT("readTimeout", 60L, Long.class, ConfigType.HTTP),
+    WRITE_TIMEOUT("writeTimeout", 60L, Long.class, ConfigType.HTTP),
     REMOVE_SERVER_HEADER("removeServerHeader", false, Boolean.class, ConfigType.HTTP),  
     NO_CACHE_COOKIES_CONTROL("NoCacheCookiesControl", true, Boolean.class, ConfigType.HTTP),
     AUTO_DECOMPRESSION("AutoDecompression", true, Boolean.class, ConfigType.HTTP),


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

For Issue #32386

Although HttpGenerics only has one variable, I thought it best to leave it be not not have duplicate `-1` values in our classes.  I added a description per the TODO.

~The readTimeout and writeTimeout config are defined as string per the metatype, so I updated them rather than change the persistTimeout to a Long.~
