### PR TITLE
Jakarta Authorization 3.0 update for unauthenticated users

### DIFF
--- a/dev/com.ibm.ws.security.authorization.jacc.web/src/com/ibm/ws/security/authorization/jacc/web/impl/WebJaccServiceImpl.java
+++ b/dev/com.ibm.ws.security.authorization.jacc.web/src/com/ibm/ws/security/authorization/jacc/web/impl/WebJaccServiceImpl.java
@@ -821,4 +821,14 @@ public class WebJaccServiceImpl implements WebJaccService {
         PolicyProxy policyProxy = jaccService.getPolicyProxy();
         return policyProxy == null ? false : policyProxy.isPolicyConfigured();
     }
+
+    @Override
+    public boolean isUnauthenticatedAuthorizationCheckAllowed() {
+        JaccService jaccService = jaccServiceRef.getService();
+        if (jaccService == null) {
+            return false;
+        }
+        PolicyProxy policyProxy = jaccService.getPolicyProxy();
+        return policyProxy == null ? false : policyProxy.isUnauthenticatedAuthorizationCheckAllowed();
+    }
 }

--- a/dev/com.ibm.ws.security.authorization.jacc/src/com/ibm/ws/security/authorization/jacc/common/PolicyProxy.java
+++ b/dev/com.ibm.ws.security.authorization.jacc/src/com/ibm/ws/security/authorization/jacc/common/PolicyProxy.java
@@ -52,4 +52,17 @@ public interface PolicyProxy {
         // return true for pre EE 11 versions since the PolicyProxy isn't created unless there is a Policy
         return true;
     }
+
+    /**
+     * Determines whether to do an authorization check for an Unauthenticated user. Before Jakarta Authorization
+     * 3.0, Liberty followed the servlet's spec behavior, but with Authorization 3.0, we are now allowing for a unchecked
+     * Permission to allow unauthenticated users to have permission to access servlets and EJBs even if there are
+     * roles constraints defined on the servlet or EJB.
+     *
+     * @return
+     */
+    default public boolean isUnauthenticatedAuthorizationCheckAllowed() {
+        // return false for pre EE 11 versions since that was the previous behavior before Authorization 3.0 behavior change
+        return false;
+    }
 }

--- a/dev/com.ibm.ws.webcontainer.security.jacc.1.5_fat/fat/src/com/ibm/ws/webcontainer/security/jacc15/fat/SpecialAuthConstraintServlet31.java
+++ b/dev/com.ibm.ws.webcontainer.security.jacc.1.5_fat/fat/src/com/ibm/ws/webcontainer/security/jacc15/fat/SpecialAuthConstraintServlet31.java
@@ -1,14 +1,11 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2024 IBM Corporation and others.
+ * Copyright (c) 2014, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 
 package com.ibm.ws.webcontainer.security.jacc15.fat;
@@ -18,7 +15,6 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import org.junit.AfterClass;
-import org.junit.Assume;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
@@ -36,7 +32,6 @@ import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.impl.LibertyServerFactory;
-import componenttest.topology.utils.LDAPUtils;
 
 /*
  * Testcase for Servlet 3.1 special authorization constraint "**" (all authenticated users).
@@ -74,10 +69,6 @@ public class SpecialAuthConstraintServlet31 extends CommonServletTestScenarios {
 
     @BeforeClass
     public static void setUp() throws Exception {
-        /*
-         * These tests have not been configured to run with the local LDAP server.
-         */
-        Assume.assumeTrue(!LDAPUtils.USE_LOCAL_LDAP_SERVER);
 
         myServer.setServerConfigurationFile(CONFIG_WITH_ALL_AUTH);
 

--- a/dev/com.ibm.ws.webcontainer.security/src/com/ibm/ws/webcontainer/security/WebAppAuthorizationHelper.java
+++ b/dev/com.ibm.ws.webcontainer.security/src/com/ibm/ws/webcontainer/security/WebAppAuthorizationHelper.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2021 IBM Corporation and others.
+ * Copyright (c) 2015, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -28,4 +28,18 @@ public interface WebAppAuthorizationHelper {
     boolean isSSLRequired(WebRequest webRequest, String uriName);
 
     WebReply checkPrecludedAccess(WebRequest webRequest, String uriName);
+
+    /**
+     * Built-in authorization and pre-Authorization 3.0 versions do not allow for unauthenticated
+     * users to call the Authorization Policy to override the unauthenticated user behavior when there are roles defined.
+     * Without JACC / Authorization, the servlet specification rules are followed, and until Authorization 3.0,
+     * the servlet rules were followed for JACC / Authorization behavior as well. This is done in order to not
+     * break zero migration for previous versions of the feature.
+     *
+     * @return
+     */
+    default boolean isUnauthenticatedAuthorizationCheckAllowed() {
+        return false;
+    }
+
 }

--- a/dev/com.ibm.ws.webcontainer.security/src/com/ibm/ws/webcontainer/security/WebAppSecurityCollaboratorImpl.java
+++ b/dev/com.ibm.ws.webcontainer.security/src/com/ibm/ws/webcontainer/security/WebAppSecurityCollaboratorImpl.java
@@ -1009,25 +1009,46 @@ public class WebAppSecurityCollaboratorImpl implements IWebAppSecurityCollaborat
                                        String uriName,
                                        WebRequest webRequest,
                                        AuthenticationResult authResult) {
+        boolean isAuthorized = false;
         WebReply reply = null;
-        if (authResult != null && authResult.getStatus() != AuthResult.SUCCESS) {
+        if (authResult != null) {
             String realm = authResult.realm;
             if (realm == null) {
                 realm = collabUtils.getUserRegistryRealm(securityServiceRef);
             }
-            reply = createReplyForAuthnFailure(authResult, realm);
-            authResult.setTargetRealm(authResult.realm != null ? authResult.realm : collabUtils.getUserRegistryRealm(securityServiceRef));
-            Audit.audit(Audit.EventID.SECURITY_AUTHN_01, webRequest, authResult, Integer.valueOf(reply.getStatusCode()));
-            return reply;
-        }
-        boolean isAuthorized = false;
 
-        if (authResult != null) {
-            authResult.setTargetRealm(authResult.realm != null ? authResult.realm : collabUtils.getUserRegistryRealm(securityServiceRef));
-            subjectManager.setCallerSubject(authResult.getSubject());
-            Audit.audit(Audit.EventID.SECURITY_AUTHN_01, webRequest, authResult, Integer.valueOf(HttpServletResponse.SC_OK));
-            isAuthorized = wasch.authorize(authResult, webRequest, uriName);
+            // If the authentication result is successful or it is an unauthenticated user with
+            // Jakarta Authorization 3.0 being active, we do an authorization check to see if the
+            // a WebResource unchecked permission is granted for the web resource.
+            if (authResult.getStatus() != AuthResult.SUCCESS) {
+                reply = createReplyForAuthnFailure(authResult, realm);
+                authResult.setTargetRealm(realm);
+                Audit.audit(Audit.EventID.SECURITY_AUTHN_01, webRequest, authResult, Integer.valueOf(reply.getStatusCode()));
+
+                // isUnauthenticatedAuthorizationCheckAllowed() returns true if using Jakarta Authorization 3.0
+                // and there is a policy defined.
+                if (wasch.isUnauthenticatedAuthorizationCheckAllowed()) {
+                    subjectManager.setCallerSubject(authResult.getSubject());
+                    isAuthorized = wasch.authorize(authResult, webRequest, uriName);
+                }
+
+                // If using Jakarta Authorization 3.0 and an unchecked permission check returns authorized, we do
+                // not send back the 401 because the unchecked permission check overrides the not authenticated
+                // behavior to now say that the caller is permitted.  This is done only for Jakarta Authorization 3.0
+                // in order to not break zero migration when using older JACC / Jakarta Authorization versions.
+                //
+                // isAuthorized == false if we didn't do the check or if the authorize() method returned false
+                if (!isAuthorized) {
+                    return reply;
+                }
+            } else {
+                authResult.setTargetRealm(realm);
+                subjectManager.setCallerSubject(authResult.getSubject());
+                Audit.audit(Audit.EventID.SECURITY_AUTHN_01, webRequest, authResult, Integer.valueOf(HttpServletResponse.SC_OK));
+                isAuthorized = wasch.authorize(authResult, webRequest, uriName);
+            }
         }
+
         // For audit set reply now but leave Subject on thread
         reply = isAuthorized ? new PermitReply() : DENY_AUTHZ_FAILED;
 

--- a/dev/com.ibm.ws.webcontainer.security/src/com/ibm/ws/webcontainer/security/WebJaccService.java
+++ b/dev/com.ibm.ws.webcontainer.security/src/com/ibm/ws/webcontainer/security/WebJaccService.java
@@ -103,9 +103,19 @@ public interface WebJaccService {
     public void resetPolicyContextHandlerInfo();
 
     /**
-     * Determines if a Policy is configured.  In EE 11, we create the WebJaccService always even if there
+     * Determines if a Policy is configured. In EE 11, we create the WebJaccService always even if there
      * isn't a PolicyFactory defined because it can be added dynamically by applications in their web.xml
      * or using the PolicyFactory.setPolicyFactory() method.
      */
     public boolean isPolicyConfigured();
+
+    /**
+     * Pre-Authorization 3.0 versions of the JACC/ Authorization liberty features did not allow for
+     * unauthenticated users to call the Authorization Policy to override the unauthenticated user
+     * behavior when there are roles defined. Until Authorization 3.0, the servlet rules were followed
+     * for JACC / Authorization behavior that if roles were defined a 401 was returned to the caller.
+     *
+     * @return
+     */
+    public boolean isUnauthenticatedAuthorizationCheckAllowed();
 }

--- a/dev/com.ibm.ws.webcontainer.security/src/com/ibm/ws/webcontainer/security/jacc/WebAppJaccAuthorizationHelper.java
+++ b/dev/com.ibm.ws.webcontainer.security/src/com/ibm/ws/webcontainer/security/jacc/WebAppJaccAuthorizationHelper.java
@@ -12,6 +12,9 @@
  *******************************************************************************/
 package com.ibm.ws.webcontainer.security.jacc;
 
+import java.util.Collections;
+import java.util.Set;
+
 import javax.security.auth.Subject;
 import javax.servlet.http.HttpServletRequest;
 
@@ -63,6 +66,12 @@ public class WebAppJaccAuthorizationHelper implements WebAppAuthorizationHelper 
         return webJaccService.isSubjectInRole(getApplicationName(), getModuleName(), servletName, role, req, subject);
     }
 
+    @Override
+    public boolean isUnauthenticatedAuthorizationCheckAllowed() {
+        WebJaccService webJaccService = jaccServiceRef.getService();
+        return webJaccService.isUnauthenticatedAuthorizationCheckAllowed();
+    }
+
     /**
      * Call the JACC authorization service to determine if the subject is authorized
      *
@@ -71,7 +80,6 @@ public class WebAppJaccAuthorizationHelper implements WebAppAuthorizationHelper 
      * @param previousCaller the previous caller, used to restore the previous state if authorization fails
      * @return true if the subject is authorized, otherwise false
      */
-
     @Override
     public boolean authorize(AuthenticationResult authResult, WebRequest webRequest, String uriName) {
         WebJaccService webJaccService = jaccServiceRef.getService();
@@ -101,7 +109,9 @@ public class WebAppJaccAuthorizationHelper implements WebAppAuthorizationHelper 
                 Tr.audit(tc, "SEC_JACC_AUTHZ_FAILED", authUserName.concat(":").concat(authRealm), appName, uriName);
             } else {
                 // We have a subject if we got this far, use it to determine the name
-                authUserName = authResult.getSubject().getPrincipals(WSPrincipal.class).iterator().next().getName();
+                Subject subject = authResult.getSubject();
+                Set<WSPrincipal> principals = subject == null ? Collections.emptySet() : subject.getPrincipals(WSPrincipal.class);
+                authUserName = principals.isEmpty() ? "UNAUTHENTICATED" : principals.iterator().next().getName();
                 //WebReply reply = isAuthorized ? new PermitReply() : DENY_AUTHZ_FAILED;
                 Tr.audit(tc, "SEC_JACC_AUTHZ_FAILED", authUserName, appName, uriName);
             }

--- a/dev/io.openliberty.security.authorization.internal.jacc.3.0/src/io/openliberty/security/authorization/jacc/internal/proxy/JakartaPolicyFactoryProxyImpl.java
+++ b/dev/io.openliberty.security.authorization.internal.jacc.3.0/src/io/openliberty/security/authorization/jacc/internal/proxy/JakartaPolicyFactoryProxyImpl.java
@@ -80,4 +80,11 @@ class JakartaPolicyFactoryProxyImpl implements PolicyProxy {
     public boolean isPolicyConfigured() {
         return PolicyFactory.getPolicyFactory() != null;
     }
+
+    @Override
+    public boolean isUnauthenticatedAuthorizationCheckAllowed() {
+        // If there is no policy defined, we fall back to built-in authorization behavior which
+        // follows the servlet specification rules.
+        return PolicyFactory.getPolicyFactory() != null;
+    }
 }

--- a/dev/io.openliberty.security.authorization.jacc.testprovider/src/com/ibm/ws/security/authorization/jacc/provider/PolicyImpl.java
+++ b/dev/io.openliberty.security.authorization.jacc.testprovider/src/com/ibm/ws/security/authorization/jacc/provider/PolicyImpl.java
@@ -59,7 +59,7 @@ public class PolicyImpl implements Policy {
             }
         }
         PrincipalMapper principalMapper = PolicyContext.get(PolicyContext.PRINCIPAL_MAPPER);
-        if (!principalMapper.isAnyAuthenticatedUserRoleMapped()) {
+        if (!principalMapper.isAnyAuthenticatedUserRoleMapped() && !subject.getPrincipals().isEmpty()) {
             PermissionCollection rolePermissions = perRolePermissions.get("**");
             if (rolePermissions != null && rolePermissions.implies(p)) {
                 return true;


### PR DESCRIPTION
- With Jakarta Authorization 3.0 now an authorization check for an unauthenticated is called.  If there are roles defined on the servlet, the unchecked policy will override the servlet rule to return a 401 for an unauthenticated user.
- This is only done for Authorization 3.0, even though the spec hasn't changed to add this, but the TCK now tests it.  The reason not to change all implementations is to not break zero migration.
- Change SpecialAuthConstraintServlet31 to be able to be run locally since it doesn't actually use ldap it didn't need to be disabled to run locally
- Update 3.0 authorization test policy implementation to check to see if the subject has principals when doing any authenticated user check.  Now that we do auth check with unauthenticated users, it was passing when it shouldn't have


- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [ ] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
