### PR TITLE
TS020988281:Formatting the double quotes for Doc change for APAR PH58796, for Skill case TS020868904, disableCNCheck description

### DIFF
--- a/dev/com.ibm.ws.jaxrs.2.x.config/resources/OSGI-INF/l10n/metatype.properties
+++ b/dev/com.ibm.ws.jaxrs.2.x.config/resources/OSGI-INF/l10n/metatype.properties
@@ -47,7 +47,7 @@ proxyType.desc=The type of proxy server.  The type must be either HTTP or SOCKS.
 
   
 disableCNCheck=Disable common name check
-disableCNCheck.desc=Disables the Common Name Check. Valid values are true or false. It functions identically to the com.ibm.ws.jaxrs.client.disableCNCheck programmatic property. As of Liberty 24.0.0.9 APAR PH58796, this only disables JAX-RS layer verification. To fully disable hostname verification, configure both: disableCNCheck=“true” on webTarget; and either verifyHostname=“false” or skipHostnameVerificationForHosts=“hostNameList” in the ssl configuration that is referenced by sslConfig. For more information, see the sslConfig parameter and IBM Doc 7163230.
+disableCNCheck.desc=Disables the Common Name Check. Valid values are true or false. It functions identically to the com.ibm.ws.jaxrs.client.disableCNCheck programmatic property. As of Liberty 24.0.0.9 APAR PH58796, this only disables JAX-RS layer verification. To fully disable hostname verification, configure both: disableCNCheck="true" on webTarget, and either verifyHostname="false" or skipHostnameVerificationForHosts="hostNameList" in the ssl configuration that is referenced by sslConfig. For more information, see the sslConfig parameter and IBM Doc 7163230.
 
 
 authnToken=Type of authorization token to use


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

Small change of double quote formatting 