### PR TITLE
Disable OidcClient signatureAlg tests from running in FIPS 140-3

### DIFF
--- a/dev/com.ibm.ws.security.oidc.client_fat.2/fat/src/com/ibm/ws/security/openidconnect/client/fat/IBM/OidcClientSignatureAlgTests.java
+++ b/dev/com.ibm.ws.security.oidc.client_fat.2/fat/src/com/ibm/ws/security/openidconnect/client/fat/IBM/OidcClientSignatureAlgTests.java
@@ -17,7 +17,7 @@ import java.util.HashMap;
 import java.util.List;
 
 import org.junit.BeforeClass;
-import org.junit.Rule;
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -56,6 +56,7 @@ import componenttest.rules.SkipJavaSemeruWithFipsEnabled.SkipJavaSemeruWithFipsE
 
 @Mode(TestMode.FULL)
 @RunWith(FATRunner.class)
+@SkipJavaSemeruWithFipsEnabledRule
 public class OidcClientSignatureAlgTests extends CommonTest {
 
     public static Class<?> thisClass = OidcClientSignatureAlgTests.class;
@@ -70,7 +71,7 @@ public class OidcClientSignatureAlgTests extends CommonTest {
     public static final String MSG_USER_NOT_IN_REG = "CWWKS1106A";
     protected static SignatureEncryptionUserinfoUtils signingUtils = new SignatureEncryptionUserinfoUtils();
 
-    @Rule
+    @ClassRule
     public static final SkipJavaSemeruWithFipsEnabled skipJavaSemeruWithFipsEnabled = new SkipJavaSemeruWithFipsEnabled("com.ibm.ws.security.openidconnect.client-1.0_fat.opWithStub");
 
     @SuppressWarnings("serial")
@@ -514,7 +515,7 @@ public class OidcClientSignatureAlgTests extends CommonTest {
      * @throws Exception
      */
     @Test
-    @SkipJavaSemeruWithFipsEnabledRule
+    // @SkipJavaSemeruWithFipsEnabledRule
     public void OidcClientSignatureAlgTests_SignTokenRS256_RPVerifyRS256_keyMismatch() throws Exception {
 
         genericSigAlgTest("short_" + Constants.SIGALG_RS256, Constants.SIGALG_RS256);
@@ -528,7 +529,7 @@ public class OidcClientSignatureAlgTests extends CommonTest {
      * @throws Exception
      */
     @Test
-    @SkipJavaSemeruWithFipsEnabledRule
+    // @SkipJavaSemeruWithFipsEnabledRule
     public void OidcClientSignatureAlgTests_SignTokenRS384_RPVerifyRS384_keyMismatch() throws Exception {
 
         genericSigAlgTest("short_" + Constants.SIGALG_RS384, Constants.SIGALG_RS384);
@@ -542,7 +543,7 @@ public class OidcClientSignatureAlgTests extends CommonTest {
      * @throws Exception
      */
     @Test
-    @SkipJavaSemeruWithFipsEnabledRule
+    // @SkipJavaSemeruWithFipsEnabledRule
     public void OidcClientSignatureAlgTests_SignTokenRS512_RPVerifyRS512_keyMismatch() throws Exception {
 
         genericSigAlgTest("short_" + Constants.SIGALG_RS512, Constants.SIGALG_RS512);


### PR DESCRIPTION
- [ ] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [ ] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

---

- When running an SOE on Semeru FIPS platforms, the `com.ibm.ws.security.oidc.client_fat.2` bucket is timing out and not completing in the allotted 3 hours.
- When running the bucket locally with FIPS 140-3 enabled, many tests are failing due to a known issue (EC Key) with the Java 17.0.18 driver, likely resulting in things hanging up.
- The tests are passing on all other SOE platforms, and also pass on local testing with FIPS 140-3 enabled with the Java 17.0.17 driver.
- To prevent the bucket from being marked as `impossible` due to the timeout, we are temporarily disabling the tests from running when FIPS 140-3 is enabled

Note: `@SkipForSecurity` could not be used as the annotation is only valid on FATServletClient classes
