### PR TITLE
Fixes assertion logic in EclipseLink Query FAT

### DIFF
--- a/dev/com.ibm.ws.jpa.tests.eclipselink.query_31_fat.common/test-applications/jpa31/src/com/ibm/ws/jpa/jpa31/testlogic/TestMathLogic.java
+++ b/dev/com.ibm.ws.jpa.tests.eclipselink.query_31_fat.common/test-applications/jpa31/src/com/ibm/ws/jpa/jpa31/testlogic/TestMathLogic.java
@@ -80,7 +80,9 @@ public class TestMathLogic extends AbstractTestLogic {
             query.getResultList();
             List<String> sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT CEIL(?) FROM JPA31ENTITY WHERE (INTVAL1 = ?)", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT CEIL(1.1) FROM JPA31ENTITY WHERE (INTVAL1 = 3)", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT CEIL(?) FROM JPA31ENTITY WHERE (INTVAL1 = ?)", sql.remove(0));
@@ -90,7 +92,9 @@ public class TestMathLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT CEIL(?) FROM JPA31ENTITY WHERE (INTVAL1 = ?)", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT CEIL(1.1) FROM JPA31ENTITY WHERE (INTVAL1 = 3)", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT CEIL(?) FROM JPA31ENTITY WHERE (INTVAL1 = ?)", sql.remove(0));
@@ -112,7 +116,9 @@ public class TestMathLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT CEIL(?) FROM JPA31ENTITY WHERE (INTVAL1 = ?)", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT CEIL(1.1) FROM JPA31ENTITY WHERE (INTVAL1 = 3)", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT CEIL(?) FROM JPA31ENTITY WHERE (INTVAL1 = ?)", sql.remove(0));
@@ -128,7 +134,9 @@ public class TestMathLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT CEIL(?) FROM JPA31ENTITY WHERE (INTVAL1 = ?)", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT CEIL(1.1) FROM JPA31ENTITY WHERE (INTVAL1 = 3)", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT CEIL(?) FROM JPA31ENTITY WHERE (INTVAL1 = ?)", sql.remove(0));
@@ -401,7 +409,9 @@ public class TestMathLogic extends AbstractTestLogic {
             query.getResultList();
             List<String> sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT 1 FROM JPA31ENTITY WHERE (INTVAL1 = CEIL(?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT 1 FROM JPA31ENTITY WHERE (INTVAL1 = CEIL(3.3))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT ? FROM JPA31ENTITY WHERE (INTVAL1 = CEIL(?))", sql.remove(0));
@@ -411,7 +421,9 @@ public class TestMathLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT 1 FROM JPA31ENTITY WHERE (INTVAL1 = CEIL(?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT 1 FROM JPA31ENTITY WHERE (INTVAL1 = CEIL(3.3))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT ? FROM JPA31ENTITY WHERE (INTVAL1 = CEIL(?))", sql.remove(0));
@@ -433,7 +445,9 @@ public class TestMathLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT 1 FROM JPA31ENTITY WHERE (INTVAL1 = CEIL(?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT 1 FROM JPA31ENTITY WHERE (INTVAL1 = CEIL(3.3))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT ? FROM JPA31ENTITY WHERE (INTVAL1 = CEIL(?))", sql.remove(0));
@@ -449,7 +463,9 @@ public class TestMathLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT 1 FROM JPA31ENTITY WHERE (INTVAL1 = CEIL(?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT 1 FROM JPA31ENTITY WHERE (INTVAL1 = CEIL(3.3))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT ? FROM JPA31ENTITY WHERE (INTVAL1 = CEIL(?))", sql.remove(0));
@@ -723,7 +739,9 @@ public class TestMathLogic extends AbstractTestLogic {
             query.getResultList();
             List<String> sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT 1 FROM JPA31ENTITY HAVING (? < CEIL(?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT 1 FROM JPA31ENTITY HAVING (0 < CEIL(9.9))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT ? FROM JPA31ENTITY HAVING (? < CEIL(?))", sql.remove(0));
@@ -733,7 +751,9 @@ public class TestMathLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT 1 FROM JPA31ENTITY HAVING (? < CEIL(?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT 1 FROM JPA31ENTITY HAVING (0 < CEIL(9.9))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT ? FROM JPA31ENTITY HAVING (? < CEIL(?))", sql.remove(0));
@@ -745,7 +765,9 @@ public class TestMathLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT 1 FROM JPA31ENTITY HAVING (? < CEIL(?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT 1 FROM JPA31ENTITY HAVING (0 < CEIL(9.9))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT ? FROM JPA31ENTITY HAVING (? < CEIL(?))", sql.remove(0));
@@ -769,7 +791,9 @@ public class TestMathLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT 1 FROM JPA31ENTITY HAVING (? < CEIL(?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT 1 FROM JPA31ENTITY HAVING (0.0 < CEIL(9.9))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT ? FROM JPA31ENTITY HAVING (? < CEIL(?))", sql.remove(0));
@@ -785,7 +809,9 @@ public class TestMathLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT 1 FROM JPA31ENTITY HAVING (? < CEIL(?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT 1 FROM JPA31ENTITY HAVING (0.0 < CEIL(9.9))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT ? FROM JPA31ENTITY HAVING (? < CEIL(?))", sql.remove(0));
@@ -805,7 +831,9 @@ public class TestMathLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT 1 FROM JPA31ENTITY HAVING (? < CEIL(?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT 1 FROM JPA31ENTITY HAVING (0.0 < CEIL(9.9))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT ? FROM JPA31ENTITY HAVING (? < CEIL(?))", sql.remove(0));
@@ -1148,7 +1176,9 @@ public class TestMathLogic extends AbstractTestLogic {
             query.getResultList();
             List<String> sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT FLOOR(?) FROM JPA31ENTITY WHERE (INTVAL1 = ?)", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT FLOOR(1.1) FROM JPA31ENTITY WHERE (INTVAL1 = 3)", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT FLOOR(?) FROM JPA31ENTITY WHERE (INTVAL1 = ?)", sql.remove(0));
@@ -1158,7 +1188,9 @@ public class TestMathLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT FLOOR(?) FROM JPA31ENTITY WHERE (INTVAL1 = ?)", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT FLOOR(1.1) FROM JPA31ENTITY WHERE (INTVAL1 = 3)", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT FLOOR(?) FROM JPA31ENTITY WHERE (INTVAL1 = ?)", sql.remove(0));
@@ -1180,7 +1212,9 @@ public class TestMathLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT FLOOR(?) FROM JPA31ENTITY WHERE (INTVAL1 = ?)", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT FLOOR(1.1) FROM JPA31ENTITY WHERE (INTVAL1 = 3)", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT FLOOR(?) FROM JPA31ENTITY WHERE (INTVAL1 = ?)", sql.remove(0));
@@ -1196,7 +1230,9 @@ public class TestMathLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT FLOOR(?) FROM JPA31ENTITY WHERE (INTVAL1 = ?)", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT FLOOR(1.1) FROM JPA31ENTITY WHERE (INTVAL1 = 3)", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT FLOOR(?) FROM JPA31ENTITY WHERE (INTVAL1 = ?)", sql.remove(0));
@@ -1469,7 +1505,9 @@ public class TestMathLogic extends AbstractTestLogic {
             query.getResultList();
             List<String> sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT 1 FROM JPA31ENTITY WHERE (INTVAL1 = FLOOR(?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT 1 FROM JPA31ENTITY WHERE (INTVAL1 = FLOOR(3.3))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT ? FROM JPA31ENTITY WHERE (INTVAL1 = FLOOR(?))", sql.remove(0));
@@ -1479,7 +1517,9 @@ public class TestMathLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT 1 FROM JPA31ENTITY WHERE (INTVAL1 = FLOOR(?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT 1 FROM JPA31ENTITY WHERE (INTVAL1 = FLOOR(3.3))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT ? FROM JPA31ENTITY WHERE (INTVAL1 = FLOOR(?))", sql.remove(0));
@@ -1501,7 +1541,9 @@ public class TestMathLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT 1 FROM JPA31ENTITY WHERE (INTVAL1 = FLOOR(?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT 1 FROM JPA31ENTITY WHERE (INTVAL1 = FLOOR(3.3))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT ? FROM JPA31ENTITY WHERE (INTVAL1 = FLOOR(?))", sql.remove(0));
@@ -1517,7 +1559,9 @@ public class TestMathLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT 1 FROM JPA31ENTITY WHERE (INTVAL1 = FLOOR(?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT 1 FROM JPA31ENTITY WHERE (INTVAL1 = FLOOR(3.3))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT ? FROM JPA31ENTITY WHERE (INTVAL1 = FLOOR(?))", sql.remove(0));
@@ -1791,7 +1835,9 @@ public class TestMathLogic extends AbstractTestLogic {
             query.getResultList();
             List<String> sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT 1 FROM JPA31ENTITY HAVING (? < FLOOR(?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT 1 FROM JPA31ENTITY HAVING (0 < FLOOR(9.9))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT ? FROM JPA31ENTITY HAVING (? < FLOOR(?))", sql.remove(0));
@@ -1801,7 +1847,9 @@ public class TestMathLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT 1 FROM JPA31ENTITY HAVING (? < FLOOR(?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT 1 FROM JPA31ENTITY HAVING (0 < FLOOR(9.9))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT ? FROM JPA31ENTITY HAVING (? < FLOOR(?))", sql.remove(0));
@@ -1813,7 +1861,9 @@ public class TestMathLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT 1 FROM JPA31ENTITY HAVING (? < FLOOR(?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT 1 FROM JPA31ENTITY HAVING (0 < FLOOR(9.9))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT ? FROM JPA31ENTITY HAVING (? < FLOOR(?))", sql.remove(0));
@@ -1837,7 +1887,9 @@ public class TestMathLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT 1 FROM JPA31ENTITY HAVING (? < FLOOR(?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT 1 FROM JPA31ENTITY HAVING (0.0 < FLOOR(9.9))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT ? FROM JPA31ENTITY HAVING (? < FLOOR(?))", sql.remove(0));
@@ -1853,7 +1905,9 @@ public class TestMathLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT 1 FROM JPA31ENTITY HAVING (? < FLOOR(?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT 1 FROM JPA31ENTITY HAVING (0.0 < FLOOR(9.9))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT ? FROM JPA31ENTITY HAVING (? < FLOOR(?))", sql.remove(0));
@@ -1873,7 +1927,9 @@ public class TestMathLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT 1 FROM JPA31ENTITY HAVING (? < FLOOR(?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT 1 FROM JPA31ENTITY HAVING (0.0 < FLOOR(9.9))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT ? FROM JPA31ENTITY HAVING (? < FLOOR(?))", sql.remove(0));
@@ -2216,7 +2272,9 @@ public class TestMathLogic extends AbstractTestLogic {
             query.getResultList();
             List<String> sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT EXP(?) FROM JPA31ENTITY WHERE (INTVAL1 = ?)", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT EXP(1.1) FROM JPA31ENTITY WHERE (INTVAL1 = 3)", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT EXP(?) FROM JPA31ENTITY WHERE (INTVAL1 = ?)", sql.remove(0));
@@ -2226,7 +2284,9 @@ public class TestMathLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT EXP(?) FROM JPA31ENTITY WHERE (INTVAL1 = ?)", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT EXP(1.1) FROM JPA31ENTITY WHERE (INTVAL1 = 3)", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT EXP(?) FROM JPA31ENTITY WHERE (INTVAL1 = ?)", sql.remove(0));
@@ -2248,7 +2308,9 @@ public class TestMathLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT EXP(?) FROM JPA31ENTITY WHERE (INTVAL1 = ?)", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT EXP(1.1) FROM JPA31ENTITY WHERE (INTVAL1 = 3)", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT EXP(?) FROM JPA31ENTITY WHERE (INTVAL1 = ?)", sql.remove(0));
@@ -2264,7 +2326,9 @@ public class TestMathLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT EXP(?) FROM JPA31ENTITY WHERE (INTVAL1 = ?)", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT EXP(1.1) FROM JPA31ENTITY WHERE (INTVAL1 = 3)", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT EXP(?) FROM JPA31ENTITY WHERE (INTVAL1 = ?)", sql.remove(0));
@@ -2537,7 +2601,9 @@ public class TestMathLogic extends AbstractTestLogic {
             query.getResultList();
             List<String> sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT 1 FROM JPA31ENTITY WHERE (INTVAL1 = EXP(?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT 1 FROM JPA31ENTITY WHERE (INTVAL1 = EXP(3.3))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT ? FROM JPA31ENTITY WHERE (INTVAL1 = EXP(?))", sql.remove(0));
@@ -2547,7 +2613,9 @@ public class TestMathLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT 1 FROM JPA31ENTITY WHERE (INTVAL1 = EXP(?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT 1 FROM JPA31ENTITY WHERE (INTVAL1 = EXP(3.3))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT ? FROM JPA31ENTITY WHERE (INTVAL1 = EXP(?))", sql.remove(0));
@@ -2569,7 +2637,9 @@ public class TestMathLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT 1 FROM JPA31ENTITY WHERE (INTVAL1 = EXP(?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT 1 FROM JPA31ENTITY WHERE (INTVAL1 = EXP(3.3))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT ? FROM JPA31ENTITY WHERE (INTVAL1 = EXP(?))", sql.remove(0));
@@ -2585,7 +2655,9 @@ public class TestMathLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT 1 FROM JPA31ENTITY WHERE (INTVAL1 = EXP(?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT 1 FROM JPA31ENTITY WHERE (INTVAL1 = EXP(3.3))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT ? FROM JPA31ENTITY WHERE (INTVAL1 = EXP(?))", sql.remove(0));
@@ -2859,7 +2931,9 @@ public class TestMathLogic extends AbstractTestLogic {
             query.getResultList();
             List<String> sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT 1 FROM JPA31ENTITY HAVING (? < EXP(?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT 1 FROM JPA31ENTITY HAVING (0 < EXP(9.9))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT ? FROM JPA31ENTITY HAVING (? < EXP(?))", sql.remove(0));
@@ -2869,7 +2943,9 @@ public class TestMathLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT 1 FROM JPA31ENTITY HAVING (? < EXP(?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT 1 FROM JPA31ENTITY HAVING (0 < EXP(9.9))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT ? FROM JPA31ENTITY HAVING (? < EXP(?))", sql.remove(0));
@@ -2881,7 +2957,9 @@ public class TestMathLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT 1 FROM JPA31ENTITY HAVING (? < EXP(?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT 1 FROM JPA31ENTITY HAVING (0 < EXP(9.9))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT ? FROM JPA31ENTITY HAVING (? < EXP(?))", sql.remove(0));
@@ -2905,7 +2983,9 @@ public class TestMathLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT 1 FROM JPA31ENTITY HAVING (? < EXP(?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT 1 FROM JPA31ENTITY HAVING (0.0 < EXP(9.9))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT ? FROM JPA31ENTITY HAVING (? < EXP(?))", sql.remove(0));
@@ -2921,7 +3001,9 @@ public class TestMathLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT 1 FROM JPA31ENTITY HAVING (? < EXP(?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT 1 FROM JPA31ENTITY HAVING (0.0 < EXP(9.9))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT ? FROM JPA31ENTITY HAVING (? < EXP(?))", sql.remove(0));
@@ -2941,7 +3023,9 @@ public class TestMathLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT 1 FROM JPA31ENTITY HAVING (? < EXP(?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT 1 FROM JPA31ENTITY HAVING (0.0 < EXP(9.9))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT ? FROM JPA31ENTITY HAVING (? < EXP(?))", sql.remove(0));
@@ -3284,7 +3368,9 @@ public class TestMathLogic extends AbstractTestLogic {
             query.getResultList();
             List<String> sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT LN(?) FROM JPA31ENTITY WHERE (INTVAL1 = ?)", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT LN(1.1) FROM JPA31ENTITY WHERE (INTVAL1 = 3)", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT LN(?) FROM JPA31ENTITY WHERE (INTVAL1 = ?)", sql.remove(0));
@@ -3294,7 +3380,9 @@ public class TestMathLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT LN(?) FROM JPA31ENTITY WHERE (INTVAL1 = ?)", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT LN(1.1) FROM JPA31ENTITY WHERE (INTVAL1 = 3)", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT LN(?) FROM JPA31ENTITY WHERE (INTVAL1 = ?)", sql.remove(0));
@@ -3316,7 +3404,9 @@ public class TestMathLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT LN(?) FROM JPA31ENTITY WHERE (INTVAL1 = ?)", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT LN(1.1) FROM JPA31ENTITY WHERE (INTVAL1 = 3)", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT LN(?) FROM JPA31ENTITY WHERE (INTVAL1 = ?)", sql.remove(0));
@@ -3332,7 +3422,9 @@ public class TestMathLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT LN(?) FROM JPA31ENTITY WHERE (INTVAL1 = ?)", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT LN(1.1) FROM JPA31ENTITY WHERE (INTVAL1 = 3)", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT LN(?) FROM JPA31ENTITY WHERE (INTVAL1 = ?)", sql.remove(0));
@@ -3605,7 +3697,9 @@ public class TestMathLogic extends AbstractTestLogic {
             query.getResultList();
             List<String> sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT 1 FROM JPA31ENTITY WHERE (INTVAL1 = LN(?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT 1 FROM JPA31ENTITY WHERE (INTVAL1 = LN(3.3))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT ? FROM JPA31ENTITY WHERE (INTVAL1 = LN(?))", sql.remove(0));
@@ -3615,7 +3709,9 @@ public class TestMathLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT 1 FROM JPA31ENTITY WHERE (INTVAL1 = LN(?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT 1 FROM JPA31ENTITY WHERE (INTVAL1 = LN(3.3))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT ? FROM JPA31ENTITY WHERE (INTVAL1 = LN(?))", sql.remove(0));
@@ -3637,7 +3733,9 @@ public class TestMathLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT 1 FROM JPA31ENTITY WHERE (INTVAL1 = LN(?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT 1 FROM JPA31ENTITY WHERE (INTVAL1 = LN(3.3))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT ? FROM JPA31ENTITY WHERE (INTVAL1 = LN(?))", sql.remove(0));
@@ -3653,7 +3751,9 @@ public class TestMathLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT 1 FROM JPA31ENTITY WHERE (INTVAL1 = LN(?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT 1 FROM JPA31ENTITY WHERE (INTVAL1 = LN(3.3))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT ? FROM JPA31ENTITY WHERE (INTVAL1 = LN(?))", sql.remove(0));
@@ -3927,7 +4027,9 @@ public class TestMathLogic extends AbstractTestLogic {
             query.getResultList();
             List<String> sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT 1 FROM JPA31ENTITY HAVING (? < LN(?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT 1 FROM JPA31ENTITY HAVING (0 < LN(9.9))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT ? FROM JPA31ENTITY HAVING (? < LN(?))", sql.remove(0));
@@ -3937,7 +4039,9 @@ public class TestMathLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT 1 FROM JPA31ENTITY HAVING (? < LN(?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT 1 FROM JPA31ENTITY HAVING (0 < LN(9.9))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT ? FROM JPA31ENTITY HAVING (? < LN(?))", sql.remove(0));
@@ -3949,7 +4053,9 @@ public class TestMathLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT 1 FROM JPA31ENTITY HAVING (? < LN(?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT 1 FROM JPA31ENTITY HAVING (0 < LN(9.9))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT ? FROM JPA31ENTITY HAVING (? < LN(?))", sql.remove(0));
@@ -3973,7 +4079,9 @@ public class TestMathLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT 1 FROM JPA31ENTITY HAVING (? < LN(?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT 1 FROM JPA31ENTITY HAVING (0.0 < LN(9.9))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT ? FROM JPA31ENTITY HAVING (? < LN(?))", sql.remove(0));
@@ -3989,7 +4097,9 @@ public class TestMathLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT 1 FROM JPA31ENTITY HAVING (? < LN(?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT 1 FROM JPA31ENTITY HAVING (0.0 < LN(9.9))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT ? FROM JPA31ENTITY HAVING (? < LN(?))", sql.remove(0));
@@ -4009,7 +4119,9 @@ public class TestMathLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT 1 FROM JPA31ENTITY HAVING (? < LN(?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT 1 FROM JPA31ENTITY HAVING (0.0 < LN(9.9))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT ? FROM JPA31ENTITY HAVING (? < LN(?))", sql.remove(0));
@@ -4353,7 +4465,9 @@ public class TestMathLogic extends AbstractTestLogic {
             query.getResultList();
             List<String> sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT POWER(?, ?) FROM JPA31ENTITY WHERE (INTVAL1 = ?)", sql.remove(0));
+            } else if (isDerby) {
                 Assert.assertEquals("SELECT EXP((3)*LN(1.1)) FROM JPA31ENTITY WHERE (INTVAL1 = 9)", sql.remove(0));
             } else if (isDB2Z || isDB2) {
                 Assert.assertEquals("SELECT POWER(1.1, 3) FROM JPA31ENTITY WHERE (INTVAL1 = 9)", sql.remove(0));
@@ -4365,7 +4479,9 @@ public class TestMathLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT POWER(?, ?) FROM JPA31ENTITY WHERE (INTVAL1 = ?)", sql.remove(0));
+            } else if (isDerby) {
                 Assert.assertEquals("SELECT EXP((3)*LN(1.1)) FROM JPA31ENTITY WHERE (INTVAL1 = 9)", sql.remove(0));
             } else if (isDB2Z || isDB2) {
                 Assert.assertEquals("SELECT POWER(1.1, 3) FROM JPA31ENTITY WHERE (INTVAL1 = 9)", sql.remove(0));
@@ -4378,7 +4494,9 @@ public class TestMathLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT POWER(?, ?) FROM JPA31ENTITY WHERE (INTVAL1 = ?)", sql.remove(0));
+            } else if (isDerby) {
                 Assert.assertEquals("SELECT EXP((3)*LN(1.1)) FROM JPA31ENTITY WHERE (INTVAL1 = 9)", sql.remove(0));
             } else if (isDB2Z || isDB2) {
                 Assert.assertEquals("SELECT POWER(1.1, 3) FROM JPA31ENTITY WHERE (INTVAL1 = 9)", sql.remove(0));
@@ -4404,7 +4522,9 @@ public class TestMathLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT POWER(?, ?) FROM JPA31ENTITY WHERE (INTVAL1 = ?)", sql.remove(0));
+            } else if (isDerby) {
                 Assert.assertEquals("SELECT EXP((3)*LN(1.1)) FROM JPA31ENTITY WHERE (INTVAL1 = 9)", sql.remove(0));
             } else if (isDB2Z || isDB2) {
                 Assert.assertEquals("SELECT POWER(1.1, 3) FROM JPA31ENTITY WHERE (INTVAL1 = 9)", sql.remove(0));
@@ -4422,7 +4542,9 @@ public class TestMathLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT POWER(?, ?) FROM JPA31ENTITY WHERE (INTVAL1 = ?)", sql.remove(0));
+            } else if (isDerby) {
                 Assert.assertEquals("SELECT EXP((3)*LN(1.1)) FROM JPA31ENTITY WHERE (INTVAL1 = 9)", sql.remove(0));
             } else if (isDB2Z || isDB2) {
                 Assert.assertEquals("SELECT POWER(1.1, 3) FROM JPA31ENTITY WHERE (INTVAL1 = 9)", sql.remove(0));
@@ -4442,7 +4564,9 @@ public class TestMathLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT POWER(?, ?) FROM JPA31ENTITY WHERE (INTVAL1 = ?)", sql.remove(0));
+            } else if (isDerby) {
                 Assert.assertEquals("SELECT EXP((3)*LN(1.1)) FROM JPA31ENTITY WHERE (INTVAL1 = 9)", sql.remove(0));
             } else if (isDB2Z || isDB2) {
                 Assert.assertEquals("SELECT POWER(1.1, 3) FROM JPA31ENTITY WHERE (INTVAL1 = 9)", sql.remove(0));
@@ -4808,6 +4932,8 @@ public class TestMathLogic extends AbstractTestLogic {
             Assert.assertEquals(1, sql.size());
             if (isDerby) {
                 Assert.assertEquals("SELECT 1 FROM JPA31ENTITY WHERE (INTVAL1 = EXP((9)*LN(3.3)))", sql.remove(0));
+            } else if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT 1 FROM JPA31ENTITY WHERE (INTVAL1 = POWER(?, ?))", sql.remove(0));
             } else if (isDB2Z || isDB2) {
                 Assert.assertEquals("SELECT 1 FROM JPA31ENTITY WHERE (INTVAL1 = POWER(3.3, 9))", sql.remove(0));
             } else {
@@ -4820,6 +4946,8 @@ public class TestMathLogic extends AbstractTestLogic {
             Assert.assertEquals(1, sql.size());
             if (isDerby) {
                 Assert.assertEquals("SELECT 1 FROM JPA31ENTITY WHERE (INTVAL1 = EXP((9)*LN(3.3)))", sql.remove(0));
+            } else if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT 1 FROM JPA31ENTITY WHERE (INTVAL1 = POWER(?, ?))", sql.remove(0));
             } else if (isDB2Z || isDB2) {
                 Assert.assertEquals("SELECT 1 FROM JPA31ENTITY WHERE (INTVAL1 = POWER(3.3, 9))", sql.remove(0));
             } else {
@@ -4833,6 +4961,8 @@ public class TestMathLogic extends AbstractTestLogic {
             Assert.assertEquals(1, sql.size());
             if (isDerby) {
                 Assert.assertEquals("SELECT 1 FROM JPA31ENTITY WHERE (INTVAL1 = EXP((9)*LN(3.3)))", sql.remove(0));
+            } else if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT 1 FROM JPA31ENTITY WHERE (INTVAL1 = POWER(?, ?))", sql.remove(0));
             } else if (isDB2Z || isDB2) {
                 Assert.assertEquals("SELECT 1 FROM JPA31ENTITY WHERE (INTVAL1 = POWER(3.3, 9))", sql.remove(0));
             } else {
@@ -4859,6 +4989,8 @@ public class TestMathLogic extends AbstractTestLogic {
             Assert.assertEquals(1, sql.size());
             if (isDerby) {
                 Assert.assertEquals("SELECT 1 FROM JPA31ENTITY WHERE (INTVAL1 = EXP((9)*LN(3.3)))", sql.remove(0));
+            } else if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT 1 FROM JPA31ENTITY WHERE (INTVAL1 = POWER(?, ?))", sql.remove(0));
             } else if (isDB2Z || isDB2) {
                 Assert.assertEquals("SELECT 1 FROM JPA31ENTITY WHERE (INTVAL1 = POWER(3.3, 9))", sql.remove(0));
             } else {
@@ -4877,6 +5009,8 @@ public class TestMathLogic extends AbstractTestLogic {
             Assert.assertEquals(1, sql.size());
             if (isDerby) {
                 Assert.assertEquals("SELECT 1 FROM JPA31ENTITY WHERE (INTVAL1 = EXP((9)*LN(3.3)))", sql.remove(0));
+            } else if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT 1 FROM JPA31ENTITY WHERE (INTVAL1 = POWER(?, ?))", sql.remove(0));
             } else if (isDB2Z || isDB2) {
                 Assert.assertEquals("SELECT 1 FROM JPA31ENTITY WHERE (INTVAL1 = POWER(3.3, 9))", sql.remove(0));
             } else {
@@ -4897,6 +5031,8 @@ public class TestMathLogic extends AbstractTestLogic {
             Assert.assertEquals(1, sql.size());
             if (isDerby) {
                 Assert.assertEquals("SELECT 1 FROM JPA31ENTITY WHERE (INTVAL1 = EXP((9)*LN(3.3)))", sql.remove(0));
+            } else if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT 1 FROM JPA31ENTITY WHERE (INTVAL1 = POWER(?, ?))", sql.remove(0));
             } else if (isDB2Z || isDB2) {
                 Assert.assertEquals("SELECT 1 FROM JPA31ENTITY WHERE (INTVAL1 = POWER(3.3, 9))", sql.remove(0));
             } else {
@@ -5260,7 +5396,9 @@ public class TestMathLogic extends AbstractTestLogic {
             query.getResultList();
             List<String> sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT 1 FROM JPA31ENTITY HAVING (? < POWER(?, ?))", sql.remove(0));
+            } else if (isDerby) {
                 Assert.assertEquals("SELECT 1 FROM JPA31ENTITY HAVING (0 < EXP((2)*LN(9.9)))", sql.remove(0));
             } else if (isDB2Z || isDB2) {
                 Assert.assertEquals("SELECT 1 FROM JPA31ENTITY HAVING (0 < POWER(9.9, 2))", sql.remove(0));
@@ -5272,7 +5410,9 @@ public class TestMathLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT 1 FROM JPA31ENTITY HAVING (? < POWER(?, ?))", sql.remove(0));
+            } else if (isDerby) {
                 Assert.assertEquals("SELECT 1 FROM JPA31ENTITY HAVING (0 < EXP((2)*LN(9.9)))", sql.remove(0));
             } else if (isDB2Z || isDB2) {
                 Assert.assertEquals("SELECT 1 FROM JPA31ENTITY HAVING (0 < POWER(9.9, 2))", sql.remove(0));
@@ -5286,7 +5426,9 @@ public class TestMathLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT 1 FROM JPA31ENTITY HAVING (? < POWER(?, ?))", sql.remove(0));
+            } else if (isDerby) {
                 Assert.assertEquals("SELECT 1 FROM JPA31ENTITY HAVING (0 < EXP((2)*LN(9.9)))", sql.remove(0));
             } else if (isDB2Z || isDB2) {
                 Assert.assertEquals("SELECT 1 FROM JPA31ENTITY HAVING (0 < POWER(9.9, 2))", sql.remove(0));
@@ -5314,7 +5456,9 @@ public class TestMathLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT 1 FROM JPA31ENTITY HAVING (? < POWER(?, ?))", sql.remove(0));
+            } else if (isDerby) {
                 Assert.assertEquals("SELECT 1 FROM JPA31ENTITY HAVING (0.0 < EXP((2)*LN(9.9)))", sql.remove(0));
             } else if (isDB2Z || isDB2) {
                 Assert.assertEquals("SELECT 1 FROM JPA31ENTITY HAVING (0.0 < POWER(9.9, 2))", sql.remove(0));
@@ -5332,7 +5476,9 @@ public class TestMathLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT 1 FROM JPA31ENTITY HAVING (? < POWER(?, ?))", sql.remove(0));
+            } else if (isDerby) {
                 Assert.assertEquals("SELECT 1 FROM JPA31ENTITY HAVING (0.0 < EXP((2)*LN(9.9)))", sql.remove(0));
             } else if (isDB2Z || isDB2) {
                 Assert.assertEquals("SELECT 1 FROM JPA31ENTITY HAVING (0.0 < POWER(9.9, 2))", sql.remove(0));
@@ -5354,7 +5500,9 @@ public class TestMathLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT 1 FROM JPA31ENTITY HAVING (? < POWER(?, ?))", sql.remove(0));
+            } else if (isDerby) {
                 Assert.assertEquals("SELECT 1 FROM JPA31ENTITY HAVING (0.0 < EXP((2)*LN(9.9)))", sql.remove(0));
             } else if (isDB2Z || isDB2) {
                 Assert.assertEquals("SELECT 1 FROM JPA31ENTITY HAVING (0.0 < POWER(9.9, 2))", sql.remove(0));
@@ -5731,7 +5879,9 @@ public class TestMathLogic extends AbstractTestLogic {
             query.getResultList();
             List<String> sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT ROUND(?, 3) FROM JPA31ENTITY WHERE (INTVAL1 = ?)", sql.remove(0));
+            } else if (isDerby) {
                 Assert.assertEquals("SELECT FLOOR((1.1)*1e3+0.5)/1e3 FROM JPA31ENTITY WHERE (INTVAL1 = 9)", sql.remove(0));
             } else if (isPostgres) {
                 Assert.assertEquals("SELECT FLOOR((?)*10^(?)+0.5)/10^(?) FROM JPA31ENTITY WHERE (INTVAL1 = ?)", sql.remove(0));
@@ -5745,7 +5895,9 @@ public class TestMathLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT ROUND(?, 3) FROM JPA31ENTITY WHERE (INTVAL1 = ?)", sql.remove(0));
+            } else if (isDerby) {
                 Assert.assertEquals("SELECT FLOOR((1.1)*1e3+0.5)/1e3 FROM JPA31ENTITY WHERE (INTVAL1 = 9)", sql.remove(0));
             } else if (isPostgres) {
                 Assert.assertEquals("SELECT FLOOR((?)*10^(?)+0.5)/10^(?) FROM JPA31ENTITY WHERE (INTVAL1 = ?)", sql.remove(0));
@@ -5760,7 +5912,9 @@ public class TestMathLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT ROUND(?, 3) FROM JPA31ENTITY WHERE (INTVAL1 = ?)", sql.remove(0));
+            } else if (isDerby) {
                 Assert.assertEquals("SELECT FLOOR((1.1)*1e3+0.5)/1e3 FROM JPA31ENTITY WHERE (INTVAL1 = 9)", sql.remove(0));
             } else if (isPostgres) {
                 Assert.assertEquals("SELECT FLOOR((?)*10^(?)+0.5)/10^(?) FROM JPA31ENTITY WHERE (INTVAL1 = ?)", sql.remove(0));
@@ -5786,7 +5940,9 @@ public class TestMathLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT ROUND(?, 3) FROM JPA31ENTITY WHERE (INTVAL1 = ?)", sql.remove(0));
+            } else if (isDerby) {
                 Assert.assertEquals("SELECT FLOOR((1.1)*1e3+0.5)/1e3 FROM JPA31ENTITY WHERE (INTVAL1 = 9)", sql.remove(0));
             } else if (isPostgres) {
                 Assert.assertEquals("SELECT FLOOR((?)*10^(?)+0.5)/10^(?) FROM JPA31ENTITY WHERE (INTVAL1 = ?)", sql.remove(0));
@@ -5806,7 +5962,9 @@ public class TestMathLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT ROUND(?, 3) FROM JPA31ENTITY WHERE (INTVAL1 = ?)", sql.remove(0));
+            } else if (isDerby) {
                 Assert.assertEquals("SELECT FLOOR((1.1)*1e3+0.5)/1e3 FROM JPA31ENTITY WHERE (INTVAL1 = 9)", sql.remove(0));
             } else if (isPostgres) {
                 Assert.assertEquals("SELECT FLOOR((?)*10^(?)+0.5)/10^(?) FROM JPA31ENTITY WHERE (INTVAL1 = ?)", sql.remove(0));
@@ -5828,7 +5986,9 @@ public class TestMathLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT ROUND(?, 3) FROM JPA31ENTITY WHERE (INTVAL1 = ?)", sql.remove(0));
+            } else if (isDerby) {
                 Assert.assertEquals("SELECT FLOOR((1.1)*1e3+0.5)/1e3 FROM JPA31ENTITY WHERE (INTVAL1 = 9)", sql.remove(0));
             } else if (isPostgres) {
                 Assert.assertEquals("SELECT FLOOR((?)*10^(?)+0.5)/10^(?) FROM JPA31ENTITY WHERE (INTVAL1 = ?)", sql.remove(0));
@@ -6241,7 +6401,9 @@ public class TestMathLogic extends AbstractTestLogic {
             query.getResultList();
             List<String> sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT 1 FROM JPA31ENTITY WHERE (INTVAL1 = ROUND(?, 9))", sql.remove(0));
+            } else if (isDerby) {
                 Assert.assertEquals("SELECT 1 FROM JPA31ENTITY WHERE (INTVAL1 = FLOOR((3.3)*1e9+0.5)/1e9)", sql.remove(0));
             } else if (isPostgres) {
                 Assert.assertEquals("SELECT ? FROM JPA31ENTITY WHERE (INTVAL1 = FLOOR((?)*10^(?)+0.5)/10^(?))", sql.remove(0));
@@ -6255,7 +6417,9 @@ public class TestMathLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT 1 FROM JPA31ENTITY WHERE (INTVAL1 = ROUND(?, 9))", sql.remove(0));
+            } else if (isDerby) {
                 Assert.assertEquals("SELECT 1 FROM JPA31ENTITY WHERE (INTVAL1 = FLOOR((3.3)*1e9+0.5)/1e9)", sql.remove(0));
             } else if (isPostgres) {
                 Assert.assertEquals("SELECT ? FROM JPA31ENTITY WHERE (INTVAL1 = FLOOR((?)*10^(?)+0.5)/10^(?))", sql.remove(0));
@@ -6270,7 +6434,9 @@ public class TestMathLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT 1 FROM JPA31ENTITY WHERE (INTVAL1 = ROUND(?, 9))", sql.remove(0));
+            } else if (isDerby) {
                 Assert.assertEquals("SELECT 1 FROM JPA31ENTITY WHERE (INTVAL1 = FLOOR((3.3)*1e9+0.5)/1e9)", sql.remove(0));
             } else if (isPostgres) {
                 Assert.assertEquals("SELECT ? FROM JPA31ENTITY WHERE (INTVAL1 = FLOOR((?)*10^(?)+0.5)/10^(?))", sql.remove(0));
@@ -6296,7 +6462,9 @@ public class TestMathLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT 1 FROM JPA31ENTITY WHERE (INTVAL1 = ROUND(?, 9))", sql.remove(0));
+            } else if (isDerby) {
                 Assert.assertEquals("SELECT 1 FROM JPA31ENTITY WHERE (INTVAL1 = FLOOR((3.3)*1e9+0.5)/1e9)", sql.remove(0));
             } else if (isPostgres) {
                 Assert.assertEquals("SELECT ? FROM JPA31ENTITY WHERE (INTVAL1 = FLOOR((?)*10^(?)+0.5)/10^(?))", sql.remove(0));
@@ -6316,7 +6484,9 @@ public class TestMathLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT 1 FROM JPA31ENTITY WHERE (INTVAL1 = ROUND(?, 9))", sql.remove(0));
+            } else if (isDerby) {
                 Assert.assertEquals("SELECT 1 FROM JPA31ENTITY WHERE (INTVAL1 = FLOOR((3.3)*1e9+0.5)/1e9)", sql.remove(0));
             } else if (isPostgres) {
                 Assert.assertEquals("SELECT ? FROM JPA31ENTITY WHERE (INTVAL1 = FLOOR((?)*10^(?)+0.5)/10^(?))", sql.remove(0));
@@ -6338,7 +6508,9 @@ public class TestMathLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT 1 FROM JPA31ENTITY WHERE (INTVAL1 = ROUND(?, 9))", sql.remove(0));
+            } else if (isDerby) {
                 Assert.assertEquals("SELECT 1 FROM JPA31ENTITY WHERE (INTVAL1 = FLOOR((3.3)*1e9+0.5)/1e9)", sql.remove(0));
             } else if (isPostgres) {
                 Assert.assertEquals("SELECT ? FROM JPA31ENTITY WHERE (INTVAL1 = FLOOR((?)*10^(?)+0.5)/10^(?))", sql.remove(0));
@@ -6752,7 +6924,9 @@ public class TestMathLogic extends AbstractTestLogic {
             query.getResultList();
             List<String> sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT 1 FROM JPA31ENTITY HAVING (? < ROUND(?, 2))", sql.remove(0));
+            } else if (isDerby) {
                 Assert.assertEquals("SELECT 1 FROM JPA31ENTITY HAVING (0 < FLOOR((9.9)*1e2+0.5)/1e2)", sql.remove(0));
             } else if (isPostgres) {
                 Assert.assertEquals("SELECT ? FROM JPA31ENTITY HAVING (? < FLOOR((?)*10^(?)+0.5)/10^(?))", sql.remove(0));
@@ -6766,7 +6940,9 @@ public class TestMathLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT 1 FROM JPA31ENTITY HAVING (? < ROUND(?, 2))", sql.remove(0));
+            } else if (isDerby) {
                 Assert.assertEquals("SELECT 1 FROM JPA31ENTITY HAVING (0 < FLOOR((9.9)*1e2+0.5)/1e2)", sql.remove(0));
             } else if (isPostgres) {
                 Assert.assertEquals("SELECT ? FROM JPA31ENTITY HAVING (? < FLOOR((?)*10^(?)+0.5)/10^(?))", sql.remove(0));
@@ -6782,7 +6958,9 @@ public class TestMathLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT 1 FROM JPA31ENTITY HAVING (? < ROUND(?, 2))", sql.remove(0));
+            } else if (isDerby) {
                 Assert.assertEquals("SELECT 1 FROM JPA31ENTITY HAVING (0 < FLOOR((9.9)*1e2+0.5)/1e2)", sql.remove(0));
             } else if (isPostgres) {
                 Assert.assertEquals("SELECT ? FROM JPA31ENTITY HAVING (? < FLOOR((?)*10^(?)+0.5)/10^(?))", sql.remove(0));
@@ -6810,7 +6988,9 @@ public class TestMathLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT 1 FROM JPA31ENTITY HAVING (? < ROUND(?, 2))", sql.remove(0));
+            } else if (isDerby) {
                 Assert.assertEquals("SELECT 1 FROM JPA31ENTITY HAVING (0.0 < FLOOR((9.9)*1e2+0.5)/1e2)", sql.remove(0));
             } else if (isPostgres) {
                 Assert.assertEquals("SELECT ? FROM JPA31ENTITY HAVING (? < FLOOR((?)*10^(?)+0.5)/10^(?))", sql.remove(0));
@@ -6830,7 +7010,9 @@ public class TestMathLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT 1 FROM JPA31ENTITY HAVING (? < ROUND(?, 2))", sql.remove(0));
+            } else if (isDerby) {
                 Assert.assertEquals("SELECT 1 FROM JPA31ENTITY HAVING (0.0 < FLOOR((9.9)*1e2+0.5)/1e2)", sql.remove(0));
             } else if (isPostgres) {
                 Assert.assertEquals("SELECT ? FROM JPA31ENTITY HAVING (? < FLOOR((?)*10^(?)+0.5)/10^(?))", sql.remove(0));
@@ -6854,7 +7036,9 @@ public class TestMathLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT 1 FROM JPA31ENTITY HAVING (? < ROUND(?, 2))", sql.remove(0));
+            } else if (isDerby) {
                 Assert.assertEquals("SELECT 1 FROM JPA31ENTITY HAVING (0.0 < FLOOR((9.9)*1e2+0.5)/1e2)", sql.remove(0));
             } else if (isPostgres) {
                 Assert.assertEquals("SELECT ? FROM JPA31ENTITY HAVING (? < FLOOR((?)*10^(?)+0.5)/10^(?))", sql.remove(0));
@@ -7277,7 +7461,9 @@ public class TestMathLogic extends AbstractTestLogic {
             query.getResultList();
             List<String> sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT SIGN(?) FROM JPA31ENTITY WHERE (INTVAL1 = ?)", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT SIGN(1.1) FROM JPA31ENTITY WHERE (INTVAL1 = 3)", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT SIGN(?) FROM JPA31ENTITY WHERE (INTVAL1 = ?)", sql.remove(0));
@@ -7287,7 +7473,9 @@ public class TestMathLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT SIGN(?) FROM JPA31ENTITY WHERE (INTVAL1 = ?)", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT SIGN(1.1) FROM JPA31ENTITY WHERE (INTVAL1 = 3)", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT SIGN(?) FROM JPA31ENTITY WHERE (INTVAL1 = ?)", sql.remove(0));
@@ -7309,7 +7497,9 @@ public class TestMathLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT SIGN(?) FROM JPA31ENTITY WHERE (INTVAL1 = ?)", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT SIGN(1.1) FROM JPA31ENTITY WHERE (INTVAL1 = 3)", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT SIGN(?) FROM JPA31ENTITY WHERE (INTVAL1 = ?)", sql.remove(0));
@@ -7325,7 +7515,9 @@ public class TestMathLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT SIGN(?) FROM JPA31ENTITY WHERE (INTVAL1 = ?)", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT SIGN(1.1) FROM JPA31ENTITY WHERE (INTVAL1 = 3)", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT SIGN(?) FROM JPA31ENTITY WHERE (INTVAL1 = ?)", sql.remove(0));
@@ -7598,7 +7790,9 @@ public class TestMathLogic extends AbstractTestLogic {
             query.getResultList();
             List<String> sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT 1 FROM JPA31ENTITY WHERE (INTVAL1 = SIGN(?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT 1 FROM JPA31ENTITY WHERE (INTVAL1 = SIGN(3.3))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT ? FROM JPA31ENTITY WHERE (INTVAL1 = SIGN(?))", sql.remove(0));
@@ -7608,7 +7802,9 @@ public class TestMathLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT 1 FROM JPA31ENTITY WHERE (INTVAL1 = SIGN(?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT 1 FROM JPA31ENTITY WHERE (INTVAL1 = SIGN(3.3))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT ? FROM JPA31ENTITY WHERE (INTVAL1 = SIGN(?))", sql.remove(0));
@@ -7630,7 +7826,9 @@ public class TestMathLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT 1 FROM JPA31ENTITY WHERE (INTVAL1 = SIGN(?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT 1 FROM JPA31ENTITY WHERE (INTVAL1 = SIGN(3.3))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT ? FROM JPA31ENTITY WHERE (INTVAL1 = SIGN(?))", sql.remove(0));
@@ -7646,7 +7844,9 @@ public class TestMathLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT 1 FROM JPA31ENTITY WHERE (INTVAL1 = SIGN(?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT 1 FROM JPA31ENTITY WHERE (INTVAL1 = SIGN(3.3))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT ? FROM JPA31ENTITY WHERE (INTVAL1 = SIGN(?))", sql.remove(0));
@@ -7920,7 +8120,9 @@ public class TestMathLogic extends AbstractTestLogic {
             query.getResultList();
             List<String> sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT 1 FROM JPA31ENTITY HAVING (? < SIGN(?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT 1 FROM JPA31ENTITY HAVING (0 < SIGN(9.9))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT ? FROM JPA31ENTITY HAVING (? < SIGN(?))", sql.remove(0));
@@ -7930,7 +8132,9 @@ public class TestMathLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT 1 FROM JPA31ENTITY HAVING (? < SIGN(?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT 1 FROM JPA31ENTITY HAVING (0 < SIGN(9.9))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT ? FROM JPA31ENTITY HAVING (? < SIGN(?))", sql.remove(0));
@@ -7942,7 +8146,9 @@ public class TestMathLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT 1 FROM JPA31ENTITY HAVING (? < SIGN(?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT 1 FROM JPA31ENTITY HAVING (0 < SIGN(9.9))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT ? FROM JPA31ENTITY HAVING (? < SIGN(?))", sql.remove(0));
@@ -7966,7 +8172,9 @@ public class TestMathLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT 1 FROM JPA31ENTITY HAVING (? < SIGN(?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT 1 FROM JPA31ENTITY HAVING (0 < SIGN(9.9))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT ? FROM JPA31ENTITY HAVING (? < SIGN(?))", sql.remove(0));
@@ -7982,7 +8190,9 @@ public class TestMathLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT 1 FROM JPA31ENTITY HAVING (? < SIGN(?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT 1 FROM JPA31ENTITY HAVING (0 < SIGN(9.9))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT ? FROM JPA31ENTITY HAVING (? < SIGN(?))", sql.remove(0));
@@ -8002,7 +8212,9 @@ public class TestMathLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT 1 FROM JPA31ENTITY HAVING (? < SIGN(?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT 1 FROM JPA31ENTITY HAVING (0 < SIGN(9.9))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT ? FROM JPA31ENTITY HAVING (? < SIGN(?))", sql.remove(0));

--- a/dev/com.ibm.ws.jpa.tests.eclipselink.query_fat.common/test-applications/olgh17837/src/com/ibm/ws/jpa/olgh17837/testlogic/TestAggregateLogic.java
+++ b/dev/com.ibm.ws.jpa.tests.eclipselink.query_fat.common/test-applications/olgh17837/src/com/ibm/ws/jpa/olgh17837/testlogic/TestAggregateLogic.java
@@ -78,18 +78,23 @@ public class TestAggregateLogic extends AbstractTestLogic {
             query.setParameter(1, 1);
             query.getResultList();
             List<String> sql = SQLCallListener.getAndClearCallList();
-            Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            Assert.assertEquals(1, sql.size());   
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT AVG(?) FROM OLGH17837ENTITY", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT AVG(1) FROM OLGH17837ENTITY", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT AVG(?) FROM OLGH17837ENTITY", sql.remove(0));
             }
+            
 
             query = em.createQuery("SELECT AVG(1) FROM OLGH17837Entity s");
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT AVG(?) FROM OLGH17837ENTITY", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT AVG(1) FROM OLGH17837ENTITY", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT AVG(?) FROM OLGH17837ENTITY", sql.remove(0));
@@ -108,7 +113,9 @@ public class TestAggregateLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT AVG(?) FROM OLGH17837ENTITY", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT AVG(1) FROM OLGH17837ENTITY", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT AVG(?) FROM OLGH17837ENTITY", sql.remove(0));
@@ -123,7 +130,9 @@ public class TestAggregateLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT AVG(?) FROM OLGH17837ENTITY", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT AVG(1) FROM OLGH17837ENTITY", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT AVG(?) FROM OLGH17837ENTITY", sql.remove(0));
@@ -402,7 +411,9 @@ public class TestAggregateLogic extends AbstractTestLogic {
             query.getResultList();
             List<String> sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT AVG(?) FROM OLGH17837ENTITY HAVING (? < AVG(?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT AVG(1) FROM OLGH17837ENTITY HAVING (0 < AVG(1))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT AVG(?) FROM OLGH17837ENTITY HAVING (? < AVG(?))", sql.remove(0));
@@ -412,7 +423,9 @@ public class TestAggregateLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT AVG(?) FROM OLGH17837ENTITY HAVING (? < AVG(?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT AVG(1) FROM OLGH17837ENTITY HAVING (0 < AVG(1))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT AVG(?) FROM OLGH17837ENTITY HAVING (? < AVG(?))", sql.remove(0));
@@ -424,7 +437,9 @@ public class TestAggregateLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT AVG(?) FROM OLGH17837ENTITY HAVING (? < AVG(?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT AVG(1) FROM OLGH17837ENTITY HAVING (0 < AVG(1))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT AVG(?) FROM OLGH17837ENTITY HAVING (? < AVG(?))", sql.remove(0));
@@ -448,7 +463,9 @@ public class TestAggregateLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT AVG(?) FROM OLGH17837ENTITY HAVING (? < AVG(?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT AVG(1) FROM OLGH17837ENTITY HAVING (0.0 < AVG(1))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT AVG(?) FROM OLGH17837ENTITY HAVING (? < AVG(?))", sql.remove(0));
@@ -464,7 +481,9 @@ public class TestAggregateLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT AVG(?) FROM OLGH17837ENTITY HAVING (? < AVG(?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT AVG(1) FROM OLGH17837ENTITY HAVING (0.0 < AVG(1))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT AVG(?) FROM OLGH17837ENTITY HAVING (? < AVG(?))", sql.remove(0));
@@ -484,7 +503,9 @@ public class TestAggregateLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT AVG(?) FROM OLGH17837ENTITY HAVING (? < AVG(?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT AVG(1) FROM OLGH17837ENTITY HAVING (0.0 < AVG(1))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT AVG(?) FROM OLGH17837ENTITY HAVING (? < AVG(?))", sql.remove(0));
@@ -1184,7 +1205,9 @@ public class TestAggregateLogic extends AbstractTestLogic {
             query.getResultList();
             List<String> sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT AVG(?) FROM OLGH17837ENTITY HAVING (? < AVG(DISTINCT(1)))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT AVG(1) FROM OLGH17837ENTITY HAVING (0 < AVG(DISTINCT(1)))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT AVG(?) FROM OLGH17837ENTITY HAVING (? < AVG(DISTINCT(?)))", sql.remove(0));
@@ -1194,7 +1217,9 @@ public class TestAggregateLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT AVG(?) FROM OLGH17837ENTITY HAVING (? < AVG(DISTINCT(1)))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT AVG(1) FROM OLGH17837ENTITY HAVING (0 < AVG(DISTINCT(1)))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT AVG(?) FROM OLGH17837ENTITY HAVING (? < AVG(DISTINCT(?)))", sql.remove(0));
@@ -1206,7 +1231,9 @@ public class TestAggregateLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT AVG(?) FROM OLGH17837ENTITY HAVING (? < AVG(DISTINCT(1)))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT AVG(1) FROM OLGH17837ENTITY HAVING (0 < AVG(DISTINCT(1)))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT AVG(?) FROM OLGH17837ENTITY HAVING (? < AVG(DISTINCT(?)))", sql.remove(0));
@@ -1959,7 +1986,9 @@ public class TestAggregateLogic extends AbstractTestLogic {
             query.getResultList();
             List<String> sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT COUNT(1) FROM OLGH17837ENTITY HAVING (? < COUNT(1))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT COUNT(1) FROM OLGH17837ENTITY HAVING (0 < COUNT(1))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT COUNT(?) FROM OLGH17837ENTITY HAVING (? < COUNT(?))", sql.remove(0));
@@ -1969,7 +1998,9 @@ public class TestAggregateLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT COUNT(1) FROM OLGH17837ENTITY HAVING (? < COUNT(1))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT COUNT(1) FROM OLGH17837ENTITY HAVING (0 < COUNT(1))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT COUNT(?) FROM OLGH17837ENTITY HAVING (? < COUNT(?))", sql.remove(0));
@@ -1981,7 +2012,9 @@ public class TestAggregateLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT COUNT(1) FROM OLGH17837ENTITY HAVING (? < COUNT(1))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT COUNT(1) FROM OLGH17837ENTITY HAVING (0 < COUNT(1))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT COUNT(?) FROM OLGH17837ENTITY HAVING (? < COUNT(?))", sql.remove(0));
@@ -2005,7 +2038,9 @@ public class TestAggregateLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT COUNT(1) FROM OLGH17837ENTITY HAVING (? < COUNT(1))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT COUNT(1) FROM OLGH17837ENTITY HAVING (0 < COUNT(1))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT COUNT(?) FROM OLGH17837ENTITY HAVING (? < COUNT(?))", sql.remove(0));
@@ -2021,7 +2056,9 @@ public class TestAggregateLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT COUNT(1) FROM OLGH17837ENTITY HAVING (? < COUNT(1))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT COUNT(1) FROM OLGH17837ENTITY HAVING (0 < COUNT(1))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT COUNT(?) FROM OLGH17837ENTITY HAVING (? < COUNT(?))", sql.remove(0));
@@ -2041,7 +2078,9 @@ public class TestAggregateLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT COUNT(1) FROM OLGH17837ENTITY HAVING (? < COUNT(1))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT COUNT(1) FROM OLGH17837ENTITY HAVING (0 < COUNT(1))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT COUNT(?) FROM OLGH17837ENTITY HAVING (? < COUNT(?))", sql.remove(0));
@@ -2706,8 +2745,10 @@ public class TestAggregateLogic extends AbstractTestLogic {
             query.setParameter(3, 1);
             query.getResultList();
             List<String> sql = SQLCallListener.getAndClearCallList();
-            Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            Assert.assertEquals(1, sql.size()); 
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT COUNT(1) FROM OLGH17837ENTITY HAVING (? < COUNT(DISTINCT(1)))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT COUNT(1) FROM OLGH17837ENTITY HAVING (0 < COUNT(DISTINCT(1)))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT COUNT(?) FROM OLGH17837ENTITY HAVING (? < COUNT(DISTINCT(?)))", sql.remove(0));
@@ -2717,7 +2758,9 @@ public class TestAggregateLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT COUNT(1) FROM OLGH17837ENTITY HAVING (? < COUNT(DISTINCT(1)))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT COUNT(1) FROM OLGH17837ENTITY HAVING (0 < COUNT(DISTINCT(1)))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT COUNT(?) FROM OLGH17837ENTITY HAVING (? < COUNT(DISTINCT(?)))", sql.remove(0));
@@ -2729,7 +2772,9 @@ public class TestAggregateLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT COUNT(1) FROM OLGH17837ENTITY HAVING (? < COUNT(DISTINCT(1)))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT COUNT(1) FROM OLGH17837ENTITY HAVING (0 < COUNT(DISTINCT(1)))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT COUNT(?) FROM OLGH17837ENTITY HAVING (? < COUNT(DISTINCT(?)))", sql.remove(0));
@@ -2753,7 +2798,9 @@ public class TestAggregateLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT COUNT(1) FROM OLGH17837ENTITY HAVING (? < COUNT(DISTINCT(1)))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT COUNT(1) FROM OLGH17837ENTITY HAVING (0 < COUNT(DISTINCT(1)))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT COUNT(?) FROM OLGH17837ENTITY HAVING (? < COUNT(DISTINCT(?)))", sql.remove(0));
@@ -2769,7 +2816,9 @@ public class TestAggregateLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT COUNT(1) FROM OLGH17837ENTITY HAVING (? < COUNT(DISTINCT(1)))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT COUNT(1) FROM OLGH17837ENTITY HAVING (0 < COUNT(DISTINCT(1)))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT COUNT(?) FROM OLGH17837ENTITY HAVING (? < COUNT(DISTINCT(?)))", sql.remove(0));
@@ -2789,7 +2838,9 @@ public class TestAggregateLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT COUNT(1) FROM OLGH17837ENTITY HAVING (? < COUNT(DISTINCT(1)))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT COUNT(1) FROM OLGH17837ENTITY HAVING (0 < COUNT(DISTINCT(1)))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT COUNT(?) FROM OLGH17837ENTITY HAVING (? < COUNT(DISTINCT(?)))", sql.remove(0));
@@ -3147,8 +3198,9 @@ public class TestAggregateLogic extends AbstractTestLogic {
             query.setParameter(2, "WORLD");
             query.getResultList();
             List<String> sql = SQLCallListener.getAndClearCallList();
-            Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT DISTINCT 'HELLO' FROM OLGH17837ENTITY WHERE (STRVAL1 = ?)", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT DISTINCT 'HELLO' FROM OLGH17837ENTITY WHERE (STRVAL1 = 'WORLD')", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT DISTINCT ? FROM OLGH17837ENTITY WHERE (STRVAL1 = ?)", sql.remove(0));
@@ -3158,7 +3210,9 @@ public class TestAggregateLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT DISTINCT 'HELLO' FROM OLGH17837ENTITY WHERE (STRVAL1 = ?)", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT DISTINCT 'HELLO' FROM OLGH17837ENTITY WHERE (STRVAL1 = 'WORLD')", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT DISTINCT ? FROM OLGH17837ENTITY WHERE (STRVAL1 = ?)", sql.remove(0));
@@ -3180,7 +3234,9 @@ public class TestAggregateLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT DISTINCT 'HELLO' FROM OLGH17837ENTITY WHERE (STRVAL1 = ?)", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT DISTINCT 'HELLO' FROM OLGH17837ENTITY WHERE (STRVAL1 = 'WORLD')", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT DISTINCT ? FROM OLGH17837ENTITY WHERE (STRVAL1 = ?)", sql.remove(0));
@@ -3196,7 +3252,9 @@ public class TestAggregateLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT DISTINCT 'HELLO' FROM OLGH17837ENTITY WHERE (STRVAL1 = ?)", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT DISTINCT 'HELLO' FROM OLGH17837ENTITY WHERE (STRVAL1 = 'WORLD')", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT DISTINCT ? FROM OLGH17837ENTITY WHERE (STRVAL1 = ?)", sql.remove(0));
@@ -3486,7 +3544,9 @@ public class TestAggregateLogic extends AbstractTestLogic {
             query.getResultList();
             List<String> sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT MAX(1) FROM OLGH17837ENTITY HAVING (? < MAX(1))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT MAX(1) FROM OLGH17837ENTITY HAVING (0 < MAX(1))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT MAX(?) FROM OLGH17837ENTITY HAVING (? < MAX(?))", sql.remove(0));
@@ -3496,7 +3556,9 @@ public class TestAggregateLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT MAX(1) FROM OLGH17837ENTITY HAVING (? < MAX(1))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT MAX(1) FROM OLGH17837ENTITY HAVING (0 < MAX(1))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT MAX(?) FROM OLGH17837ENTITY HAVING (? < MAX(?))", sql.remove(0));
@@ -3508,7 +3570,9 @@ public class TestAggregateLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT MAX(1) FROM OLGH17837ENTITY HAVING (? < MAX(1))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT MAX(1) FROM OLGH17837ENTITY HAVING (0 < MAX(1))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT MAX(?) FROM OLGH17837ENTITY HAVING (? < MAX(?))", sql.remove(0));
@@ -3532,7 +3596,9 @@ public class TestAggregateLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT MAX(1) FROM OLGH17837ENTITY HAVING (? < MAX(1))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT MAX(1) FROM OLGH17837ENTITY HAVING (0 < MAX(1))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT MAX(?) FROM OLGH17837ENTITY HAVING (? < MAX(?))", sql.remove(0));
@@ -3548,7 +3614,9 @@ public class TestAggregateLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT MAX(1) FROM OLGH17837ENTITY HAVING (? < MAX(1))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT MAX(1) FROM OLGH17837ENTITY HAVING (0 < MAX(1))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT MAX(?) FROM OLGH17837ENTITY HAVING (? < MAX(?))", sql.remove(0));
@@ -3568,7 +3636,9 @@ public class TestAggregateLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT MAX(1) FROM OLGH17837ENTITY HAVING (? < MAX(1))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT MAX(1) FROM OLGH17837ENTITY HAVING (0 < MAX(1))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT MAX(?) FROM OLGH17837ENTITY HAVING (? < MAX(?))", sql.remove(0));
@@ -4239,7 +4309,9 @@ public class TestAggregateLogic extends AbstractTestLogic {
             query.getResultList();
             List<String> sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT MIN(1) FROM OLGH17837ENTITY HAVING (? < MIN(1))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT MIN(1) FROM OLGH17837ENTITY HAVING (0 < MIN(1))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT MIN(?) FROM OLGH17837ENTITY HAVING (? < MIN(?))", sql.remove(0));
@@ -4249,7 +4321,9 @@ public class TestAggregateLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT MIN(1) FROM OLGH17837ENTITY HAVING (? < MIN(1))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT MIN(1) FROM OLGH17837ENTITY HAVING (0 < MIN(1))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT MIN(?) FROM OLGH17837ENTITY HAVING (? < MIN(?))", sql.remove(0));
@@ -4261,7 +4335,9 @@ public class TestAggregateLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT MIN(1) FROM OLGH17837ENTITY HAVING (? < MIN(1))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT MIN(1) FROM OLGH17837ENTITY HAVING (0 < MIN(1))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT MIN(?) FROM OLGH17837ENTITY HAVING (? < MIN(?))", sql.remove(0));
@@ -4285,7 +4361,9 @@ public class TestAggregateLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT MIN(1) FROM OLGH17837ENTITY HAVING (? < MIN(1))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT MIN(1) FROM OLGH17837ENTITY HAVING (0 < MIN(1))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT MIN(?) FROM OLGH17837ENTITY HAVING (? < MIN(?))", sql.remove(0));
@@ -4301,7 +4379,9 @@ public class TestAggregateLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT MIN(1) FROM OLGH17837ENTITY HAVING (? < MIN(1))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT MIN(1) FROM OLGH17837ENTITY HAVING (0 < MIN(1))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT MIN(?) FROM OLGH17837ENTITY HAVING (? < MIN(?))", sql.remove(0));
@@ -4321,7 +4401,9 @@ public class TestAggregateLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT MIN(1) FROM OLGH17837ENTITY HAVING (? < MIN(1))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT MIN(1) FROM OLGH17837ENTITY HAVING (0 < MIN(1))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT MIN(?) FROM OLGH17837ENTITY HAVING (? < MIN(?))", sql.remove(0));
@@ -4978,7 +5060,9 @@ public class TestAggregateLogic extends AbstractTestLogic {
             query.getResultList();
             List<String> sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT SUM(?) FROM OLGH17837ENTITY", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT SUM(1) FROM OLGH17837ENTITY", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT SUM(?) FROM OLGH17837ENTITY", sql.remove(0));
@@ -4988,7 +5072,9 @@ public class TestAggregateLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT SUM(?) FROM OLGH17837ENTITY", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT SUM(1) FROM OLGH17837ENTITY", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT SUM(?) FROM OLGH17837ENTITY", sql.remove(0));
@@ -5007,7 +5093,9 @@ public class TestAggregateLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT SUM(?) FROM OLGH17837ENTITY", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT SUM(1) FROM OLGH17837ENTITY", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT SUM(?) FROM OLGH17837ENTITY", sql.remove(0));
@@ -5022,7 +5110,9 @@ public class TestAggregateLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT SUM(?) FROM OLGH17837ENTITY", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT SUM(1) FROM OLGH17837ENTITY", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT SUM(?) FROM OLGH17837ENTITY", sql.remove(0));
@@ -5301,7 +5391,9 @@ public class TestAggregateLogic extends AbstractTestLogic {
             query.getResultList();
             List<String> sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT SUM(?) FROM OLGH17837ENTITY HAVING (? < SUM(?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT SUM(1) FROM OLGH17837ENTITY HAVING (0 < SUM(1))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT SUM(?) FROM OLGH17837ENTITY HAVING (? < SUM(?))", sql.remove(0));
@@ -5311,7 +5403,9 @@ public class TestAggregateLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT SUM(?) FROM OLGH17837ENTITY HAVING (? < SUM(?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT SUM(1) FROM OLGH17837ENTITY HAVING (0 < SUM(1))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT SUM(?) FROM OLGH17837ENTITY HAVING (? < SUM(?))", sql.remove(0));
@@ -5323,7 +5417,9 @@ public class TestAggregateLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT SUM(?) FROM OLGH17837ENTITY HAVING (? < SUM(?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT SUM(1) FROM OLGH17837ENTITY HAVING (0 < SUM(1))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT SUM(?) FROM OLGH17837ENTITY HAVING (? < SUM(?))", sql.remove(0));
@@ -5347,7 +5443,9 @@ public class TestAggregateLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT SUM(?) FROM OLGH17837ENTITY HAVING (? < SUM(?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT SUM(1) FROM OLGH17837ENTITY HAVING (0 < SUM(1))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT SUM(?) FROM OLGH17837ENTITY HAVING (? < SUM(?))", sql.remove(0));
@@ -5363,7 +5461,9 @@ public class TestAggregateLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT SUM(?) FROM OLGH17837ENTITY HAVING (? < SUM(?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT SUM(1) FROM OLGH17837ENTITY HAVING (0 < SUM(1))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT SUM(?) FROM OLGH17837ENTITY HAVING (? < SUM(?))", sql.remove(0));
@@ -5383,7 +5483,9 @@ public class TestAggregateLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT SUM(?) FROM OLGH17837ENTITY HAVING (? < SUM(?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT SUM(1) FROM OLGH17837ENTITY HAVING (0 < SUM(1))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT SUM(?) FROM OLGH17837ENTITY HAVING (? < SUM(?))", sql.remove(0));

--- a/dev/com.ibm.ws.jpa.tests.eclipselink.query_fat.common/test-applications/olgh17837/src/com/ibm/ws/jpa/olgh17837/testlogic/TestArithmeticLogic.java
+++ b/dev/com.ibm.ws.jpa.tests.eclipselink.query_fat.common/test-applications/olgh17837/src/com/ibm/ws/jpa/olgh17837/testlogic/TestArithmeticLogic.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022,2024 IBM Corporation and others.
+ * Copyright (c) 2022,2024,2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -78,7 +78,9 @@ public class TestArithmeticLogic extends AbstractTestLogic {
             query.getResultList();
             List<String> sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2 )){
+                Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE (ABS(?) = INTVAL1)", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE (ABS(-36) = INTVAL1)", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE (ABS(?) = INTVAL1)", sql.remove(0));
@@ -88,7 +90,9 @@ public class TestArithmeticLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2 )){
+                Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE (ABS(?) = INTVAL1)", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE (ABS(-36) = INTVAL1)", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE (ABS(?) = INTVAL1)", sql.remove(0));
@@ -108,7 +112,9 @@ public class TestArithmeticLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2 )){
+                Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE (ABS(?) = INTVAL1)", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE (ABS(-36) = INTVAL1)", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE (ABS(?) = INTVAL1)", sql.remove(0));
@@ -124,7 +130,9 @@ public class TestArithmeticLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2 )){
+                Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE (ABS(?) = INTVAL1)", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE (ABS(-36) = INTVAL1)", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE (ABS(?) = INTVAL1)", sql.remove(0));
@@ -403,7 +411,9 @@ public class TestArithmeticLogic extends AbstractTestLogic {
             query.getResultList();
             List<String> sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT INTVAL1, (? + ?) FROM OLGH17837ENTITY WHERE (INTVAL1 = (? + ?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT INTVAL1, (4 + 2) FROM OLGH17837ENTITY WHERE (INTVAL1 = (4 + 2))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT INTVAL1, (? + ?) FROM OLGH17837ENTITY WHERE (INTVAL1 = (? + ?))", sql.remove(0));
@@ -413,7 +423,9 @@ public class TestArithmeticLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT INTVAL1, (? + ?) FROM OLGH17837ENTITY WHERE (INTVAL1 = (? + ?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT INTVAL1, (4 + 2) FROM OLGH17837ENTITY WHERE (INTVAL1 = (4 + 2))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT INTVAL1, (? + ?) FROM OLGH17837ENTITY WHERE (INTVAL1 = (? + ?))", sql.remove(0));
@@ -424,7 +436,9 @@ public class TestArithmeticLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT INTVAL1, (? + ?) FROM OLGH17837ENTITY WHERE (INTVAL1 = (? + ?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT INTVAL1, (4 + 2) FROM OLGH17837ENTITY WHERE (INTVAL1 = (2 + 4))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT INTVAL1, (? + ?) FROM OLGH17837ENTITY WHERE (INTVAL1 = (? + ?))", sql.remove(0));
@@ -446,7 +460,9 @@ public class TestArithmeticLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT INTVAL1, (? + ?) FROM OLGH17837ENTITY WHERE (INTVAL1 = (? + ?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT INTVAL1, (4 + 2) FROM OLGH17837ENTITY WHERE (INTVAL1 = (4 + 2))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT INTVAL1, (? + ?) FROM OLGH17837ENTITY WHERE (INTVAL1 = (? + ?))", sql.remove(0));
@@ -463,7 +479,9 @@ public class TestArithmeticLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT INTVAL1, (? + ?) FROM OLGH17837ENTITY WHERE (INTVAL1 = (? + ?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT INTVAL1, (4 + 2) FROM OLGH17837ENTITY WHERE (INTVAL1 = (4 + 2))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT INTVAL1, (? + ?) FROM OLGH17837ENTITY WHERE (INTVAL1 = (? + ?))", sql.remove(0));
@@ -482,7 +500,9 @@ public class TestArithmeticLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT INTVAL1, (? + ?) FROM OLGH17837ENTITY WHERE (INTVAL1 = (? + ?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT INTVAL1, (2 + 4) FROM OLGH17837ENTITY WHERE (INTVAL1 = (4 + 2))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT INTVAL1, (? + ?) FROM OLGH17837ENTITY WHERE (INTVAL1 = (? + ?))", sql.remove(0));
@@ -839,7 +859,9 @@ public class TestArithmeticLogic extends AbstractTestLogic {
             query.getResultList();
             List<String> sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE (INTVAL1 = MOD(?, ?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE (INTVAL1 = MOD(36, 10))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE (INTVAL1 = MOD(?, ?))", sql.remove(0));
@@ -849,7 +871,9 @@ public class TestArithmeticLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE (INTVAL1 = MOD(?, ?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE (INTVAL1 = MOD(36, 10))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE (INTVAL1 = MOD(?, ?))", sql.remove(0));
@@ -871,7 +895,9 @@ public class TestArithmeticLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE (INTVAL1 = MOD(?, ?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE (INTVAL1 = MOD(36, 10))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE (INTVAL1 = MOD(?, ?))", sql.remove(0));
@@ -887,7 +913,9 @@ public class TestArithmeticLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE (INTVAL1 = MOD(?, ?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE (INTVAL1 = MOD(36, 10))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE (INTVAL1 = MOD(?, ?))", sql.remove(0));
@@ -1187,7 +1215,9 @@ public class TestArithmeticLogic extends AbstractTestLogic {
             query.getResultList();
             List<String> sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE (INTVAL1 = SQRT(?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE (INTVAL1 = SQRT(36))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE (INTVAL1 = SQRT(?))", sql.remove(0));
@@ -1197,7 +1227,9 @@ public class TestArithmeticLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE (INTVAL1 = SQRT(?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE (INTVAL1 = SQRT(36))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE (INTVAL1 = SQRT(?))", sql.remove(0));
@@ -1217,7 +1249,9 @@ public class TestArithmeticLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE (INTVAL1 = SQRT(?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE (INTVAL1 = SQRT(36))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE (INTVAL1 = SQRT(?))", sql.remove(0));
@@ -1234,7 +1268,9 @@ public class TestArithmeticLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE (INTVAL1 = SQRT(?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE (INTVAL1 = SQRT(36))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE (INTVAL1 = SQRT(?))", sql.remove(0));
@@ -1515,7 +1551,9 @@ public class TestArithmeticLogic extends AbstractTestLogic {
             query.getResultList();
             List<String> sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT STRVAL1, 2 FROM OLGH17837ENTITY WHERE (INTVAL1 <> (? - ?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT STRVAL1, 2 FROM OLGH17837ENTITY WHERE (INTVAL1 <> (4 - 2))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT STRVAL1, ? FROM OLGH17837ENTITY WHERE (INTVAL1 <> (? - ?))", sql.remove(0));
@@ -1525,7 +1563,9 @@ public class TestArithmeticLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT STRVAL1, 2 FROM OLGH17837ENTITY WHERE (INTVAL1 <> (? - ?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT STRVAL1, 2 FROM OLGH17837ENTITY WHERE (INTVAL1 <> (4 - 2))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT STRVAL1, ? FROM OLGH17837ENTITY WHERE (INTVAL1 <> (? - ?))", sql.remove(0));
@@ -1536,7 +1576,9 @@ public class TestArithmeticLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT STRVAL1, 2 FROM OLGH17837ENTITY WHERE (INTVAL1 <> (? - ?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT STRVAL1, 2 FROM OLGH17837ENTITY WHERE (INTVAL1 <> (4 - 2))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT STRVAL1, ? FROM OLGH17837ENTITY WHERE (INTVAL1 <> (? - ?))", sql.remove(0));
@@ -1558,7 +1600,9 @@ public class TestArithmeticLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT STRVAL1, 2 FROM OLGH17837ENTITY WHERE (INTVAL1 <> (? - ?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT STRVAL1, 2 FROM OLGH17837ENTITY WHERE (INTVAL1 <> (4 - 2))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT STRVAL1, ? FROM OLGH17837ENTITY WHERE (INTVAL1 <> (? - ?))", sql.remove(0));
@@ -1574,7 +1618,9 @@ public class TestArithmeticLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT STRVAL1, 2 FROM OLGH17837ENTITY WHERE (INTVAL1 <> (? - ?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT STRVAL1, 2 FROM OLGH17837ENTITY WHERE (INTVAL1 <> (4 - 2))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT STRVAL1, ? FROM OLGH17837ENTITY WHERE (INTVAL1 <> (? - ?))", sql.remove(0));
@@ -1592,7 +1638,9 @@ public class TestArithmeticLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT STRVAL1, 2 FROM OLGH17837ENTITY WHERE (INTVAL1 <> (? - ?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT STRVAL1, 2 FROM OLGH17837ENTITY WHERE (INTVAL1 <> (4 - 2))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT STRVAL1, ? FROM OLGH17837ENTITY WHERE (INTVAL1 <> (? - ?))", sql.remove(0));

--- a/dev/com.ibm.ws.jpa.tests.eclipselink.query_fat.common/test-applications/olgh17837/src/com/ibm/ws/jpa/olgh17837/testlogic/TestComparisonLogic.java
+++ b/dev/com.ibm.ws.jpa.tests.eclipselink.query_fat.common/test-applications/olgh17837/src/com/ibm/ws/jpa/olgh17837/testlogic/TestComparisonLogic.java
@@ -368,7 +368,10 @@ public class TestComparisonLogic extends AbstractTestLogic {
             query.getResultList();
             List<String> sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT INTVAL1, (? + ?) FROM OLGH17837ENTITY WHERE (? = (INTVAL1 + ABS(?)))", sql.remove(0));  
+            }
+            else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT INTVAL1, (4 + -2) FROM OLGH17837ENTITY WHERE (4 = (INTVAL1 + ABS(-2)))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT INTVAL1, (? + ?) FROM OLGH17837ENTITY WHERE (? = (INTVAL1 + ABS(?)))", sql.remove(0));
@@ -378,7 +381,10 @@ public class TestComparisonLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT INTVAL1, (? + ?) FROM OLGH17837ENTITY WHERE (? = (INTVAL1 + ABS(?)))", sql.remove(0));  
+            }
+            else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT INTVAL1, (4 + -2) FROM OLGH17837ENTITY WHERE (4 = (INTVAL1 + ABS(-2)))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT INTVAL1, (? + ?) FROM OLGH17837ENTITY WHERE (? = (INTVAL1 + ABS(?)))", sql.remove(0));
@@ -389,7 +395,10 @@ public class TestComparisonLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT INTVAL1, (? + ?) FROM OLGH17837ENTITY WHERE (? = (INTVAL1 + ABS(?)))", sql.remove(0));  
+            }
+            else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT INTVAL1, (4 + -2) FROM OLGH17837ENTITY WHERE (4 = (INTVAL1 + ABS(-2)))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT INTVAL1, (? + ?) FROM OLGH17837ENTITY WHERE (? = (INTVAL1 + ABS(?)))", sql.remove(0));
@@ -411,7 +420,10 @@ public class TestComparisonLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT INTVAL1, (? + ?) FROM OLGH17837ENTITY WHERE (? = (INTVAL1 + ABS(?)))", sql.remove(0));  
+            }
+            else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT INTVAL1, (4 + -2) FROM OLGH17837ENTITY WHERE (4 = (INTVAL1 + ABS(-2)))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT INTVAL1, (? + ?) FROM OLGH17837ENTITY WHERE (? = (INTVAL1 + ABS(?)))", sql.remove(0));
@@ -427,7 +439,10 @@ public class TestComparisonLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT INTVAL1, (? + ?) FROM OLGH17837ENTITY WHERE (? = (INTVAL1 + ABS(?)))", sql.remove(0));  
+            }
+            else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT INTVAL1, (4 + -2) FROM OLGH17837ENTITY WHERE (4 = (INTVAL1 + ABS(-2)))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT INTVAL1, (? + ?) FROM OLGH17837ENTITY WHERE (? = (INTVAL1 + ABS(?)))", sql.remove(0));
@@ -445,7 +460,10 @@ public class TestComparisonLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT INTVAL1, (? + ?) FROM OLGH17837ENTITY WHERE (? = (INTVAL1 + ABS(?)))", sql.remove(0));  
+            }
+            else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT INTVAL1, (4 + -2) FROM OLGH17837ENTITY WHERE (4 = (INTVAL1 + ABS(-2)))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT INTVAL1, (? + ?) FROM OLGH17837ENTITY WHERE (? = (INTVAL1 + ABS(?)))", sql.remove(0));
@@ -1124,7 +1142,10 @@ public class TestComparisonLogic extends AbstractTestLogic {
             query.getResultList();
             List<String> sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE ((? + ?) < INTVAL1)", sql.remove(0));
+            }
+            else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE ((5 + 10) < INTVAL1)", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE ((? + ?) < INTVAL1)", sql.remove(0));
@@ -1134,18 +1155,23 @@ public class TestComparisonLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE ((? + ?) < INTVAL1)", sql.remove(0));
+            }
+            else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE ((5 + 10) < INTVAL1)", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE ((? + ?) < INTVAL1)", sql.remove(0));
             }
-
             query = em.createQuery("SELECT s.strVal1 FROM OLGH17837Entity s WHERE (5 + ?2) < (s.intVal1)");
             query.setParameter(2, 10);
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE ((? + ?) < INTVAL1)", sql.remove(0));
+            }
+            else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE ((5 + 10) < INTVAL1)", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE ((? + ?) < INTVAL1)", sql.remove(0));
@@ -1167,7 +1193,10 @@ public class TestComparisonLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+             if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE ((? + ?) < INTVAL1)", sql.remove(0));
+            }
+            else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE ((5 + 10) < INTVAL1)", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE ((? + ?) < INTVAL1)", sql.remove(0));
@@ -1183,7 +1212,10 @@ public class TestComparisonLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+             if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE ((? + ?) < INTVAL1)", sql.remove(0));
+            }
+            else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE ((5 + 10) < INTVAL1)", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE ((? + ?) < INTVAL1)", sql.remove(0));
@@ -1201,7 +1233,10 @@ public class TestComparisonLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE ((? + ?) < INTVAL1)", sql.remove(0));
+            }
+            else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE ((5 + 10) < INTVAL1)", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE ((? + ?) < INTVAL1)", sql.remove(0));
@@ -1850,7 +1885,10 @@ public class TestComparisonLogic extends AbstractTestLogic {
             query.getResultList();
             List<String> sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE ? LIKE ?", sql.remove(0));   
+            }
+            else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE 'WORLD' LIKE '%ORL%'", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE ? LIKE ?", sql.remove(0));
@@ -1860,7 +1898,10 @@ public class TestComparisonLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE ? LIKE ?", sql.remove(0));   
+            }
+            else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE 'WORLD' LIKE '%ORL%'", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE ? LIKE ?", sql.remove(0));
@@ -1871,7 +1912,10 @@ public class TestComparisonLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE ? LIKE ?", sql.remove(0));   
+            }
+            else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE 'WORLD' LIKE '%ORL%'", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE ? LIKE ?", sql.remove(0));
@@ -1894,7 +1938,10 @@ public class TestComparisonLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE ? LIKE ?", sql.remove(0));   
+            }
+            else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE 'WORLD' LIKE '%ORL%'", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE ? LIKE ?", sql.remove(0));
@@ -1911,7 +1958,10 @@ public class TestComparisonLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE ? LIKE ?", sql.remove(0));   
+            }
+            else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE 'WORLD' LIKE '%ORL%'", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE ? LIKE ?", sql.remove(0));
@@ -1930,7 +1980,10 @@ public class TestComparisonLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE ? LIKE ?", sql.remove(0));   
+            }
+            else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE 'WORLD' LIKE '%ORL%'", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE ? LIKE ?", sql.remove(0));
@@ -2529,7 +2582,10 @@ public class TestComparisonLogic extends AbstractTestLogic {
             query.getResultList();
             List<String> sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE STRVAL1 LIKE ? ESCAPE ?", sql.remove(0));  
+            }
+            else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE STRVAL1 LIKE 'HELLO' ESCAPE 'R'", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE STRVAL1 LIKE ? ESCAPE ?", sql.remove(0));
@@ -2539,7 +2595,10 @@ public class TestComparisonLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE STRVAL1 LIKE ? ESCAPE ?", sql.remove(0));  
+            }
+            else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE STRVAL1 LIKE 'HELLO' ESCAPE 'R'", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE STRVAL1 LIKE ? ESCAPE ?", sql.remove(0));
@@ -2562,7 +2621,10 @@ public class TestComparisonLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE STRVAL1 LIKE ? ESCAPE ?", sql.remove(0));  
+            }
+            else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE STRVAL1 LIKE 'HELLO' ESCAPE 'R'", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE STRVAL1 LIKE ? ESCAPE ?", sql.remove(0));
@@ -2578,7 +2640,10 @@ public class TestComparisonLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE STRVAL1 LIKE ? ESCAPE ?", sql.remove(0));  
+            }
+            else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE STRVAL1 LIKE 'HELLO' ESCAPE 'R'", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE STRVAL1 LIKE ? ESCAPE ?", sql.remove(0));
@@ -2858,7 +2923,9 @@ public class TestComparisonLogic extends AbstractTestLogic {
             query.getResultList();
             List<String> sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE ? LIKE ? ESCAPE ?", sql.remove(0));
+            }else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE 'HELLO' LIKE 'WORLD' ESCAPE 'A'", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE ? LIKE ? ESCAPE ?", sql.remove(0));
@@ -2868,7 +2935,9 @@ public class TestComparisonLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE ? LIKE ? ESCAPE ?", sql.remove(0));
+            }else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE 'HELLO' LIKE 'WORLD' ESCAPE 'A'", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE ? LIKE ? ESCAPE ?", sql.remove(0));
@@ -2880,7 +2949,9 @@ public class TestComparisonLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE ? LIKE ? ESCAPE ?", sql.remove(0));
+            }else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE 'HELLO' LIKE 'WORLD' ESCAPE 'A'", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE ? LIKE ? ESCAPE ?", sql.remove(0));
@@ -2905,7 +2976,9 @@ public class TestComparisonLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE ? LIKE ? ESCAPE ?", sql.remove(0));
+            }else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE 'HELLO' LIKE 'WORLD' ESCAPE 'A'", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE ? LIKE ? ESCAPE ?", sql.remove(0));
@@ -2921,7 +2994,9 @@ public class TestComparisonLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE ? LIKE ? ESCAPE ?", sql.remove(0));
+            }else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE 'HELLO' LIKE 'WORLD' ESCAPE 'A'", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE ? LIKE ? ESCAPE ?", sql.remove(0));
@@ -2942,7 +3017,9 @@ public class TestComparisonLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE ? LIKE ? ESCAPE ?", sql.remove(0));
+            }else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE 'HELLO' LIKE 'WORLD' ESCAPE 'A'", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE ? LIKE ? ESCAPE ?", sql.remove(0));
@@ -9469,7 +9546,10 @@ public class TestComparisonLogic extends AbstractTestLogic {
             query.getResultList();
             List<String> sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+               Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE (? BETWEEN ? AND ?)", sql.remove(0)); 
+            }
+            else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE (4 BETWEEN 2 AND 9)", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE (? BETWEEN ? AND ?)", sql.remove(0));
@@ -9479,7 +9559,10 @@ public class TestComparisonLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+             if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+               Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE (? BETWEEN ? AND ?)", sql.remove(0)); 
+            }
+            else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE (4 BETWEEN 2 AND 9)", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE (? BETWEEN ? AND ?)", sql.remove(0));
@@ -9491,7 +9574,10 @@ public class TestComparisonLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+              if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+               Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE (? BETWEEN ? AND ?)", sql.remove(0)); 
+            }
+            else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE (4 BETWEEN 2 AND 9)", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE (? BETWEEN ? AND ?)", sql.remove(0));
@@ -9516,7 +9602,10 @@ public class TestComparisonLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+               Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE (? BETWEEN ? AND ?)", sql.remove(0)); 
+            }
+            else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE (4 BETWEEN 2 AND 9)", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE (? BETWEEN ? AND ?)", sql.remove(0));
@@ -9532,7 +9621,10 @@ public class TestComparisonLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+               Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE (? BETWEEN ? AND ?)", sql.remove(0)); 
+            }
+            else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE (4 BETWEEN 2 AND 9)", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE (? BETWEEN ? AND ?)", sql.remove(0));
@@ -9553,7 +9645,10 @@ public class TestComparisonLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+               Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE (? BETWEEN ? AND ?)", sql.remove(0)); 
+            }
+            else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE (4 BETWEEN 2 AND 9)", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE (? BETWEEN ? AND ?)", sql.remove(0));
@@ -10727,7 +10822,9 @@ public class TestComparisonLogic extends AbstractTestLogic {
             query.getResultList();
             List<String> sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)){
+            Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE NOT ((? BETWEEN ? AND ?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE NOT ((4 BETWEEN 2 AND 9))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE NOT ((? BETWEEN ? AND ?))", sql.remove(0));
@@ -10737,7 +10834,9 @@ public class TestComparisonLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)){
+            Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE NOT ((? BETWEEN ? AND ?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE NOT ((4 BETWEEN 2 AND 9))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE NOT ((? BETWEEN ? AND ?))", sql.remove(0));
@@ -10749,7 +10848,9 @@ public class TestComparisonLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)){
+            Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE NOT ((? BETWEEN ? AND ?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE NOT ((4 BETWEEN 2 AND 9))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE NOT ((? BETWEEN ? AND ?))", sql.remove(0));
@@ -10774,7 +10875,9 @@ public class TestComparisonLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)){
+            Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE NOT ((? BETWEEN ? AND ?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE NOT ((4 BETWEEN 2 AND 9))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE NOT ((? BETWEEN ? AND ?))", sql.remove(0));
@@ -10791,7 +10894,9 @@ public class TestComparisonLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)){
+            Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE NOT ((? BETWEEN ? AND ?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE NOT ((4 BETWEEN 2 AND 9))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE NOT ((? BETWEEN ? AND ?))", sql.remove(0));
@@ -10812,7 +10917,9 @@ public class TestComparisonLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)){
+            Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE NOT ((? BETWEEN ? AND ?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE NOT ((4 BETWEEN 2 AND 9))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE NOT ((? BETWEEN ? AND ?))", sql.remove(0));
@@ -11189,7 +11296,10 @@ public class TestComparisonLogic extends AbstractTestLogic {
             query.getResultList();
             List<String> sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE (? IS NULL)", sql.remove(0)); 
+            }
+            else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE ('HELLO' IS NULL)", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE (? IS NULL)", sql.remove(0));
@@ -11199,7 +11309,10 @@ public class TestComparisonLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE (? IS NULL)", sql.remove(0)); 
+            }
+            else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE ('HELLO' IS NULL)", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE (? IS NULL)", sql.remove(0));
@@ -11220,7 +11333,10 @@ public class TestComparisonLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE (? IS NULL)", sql.remove(0)); 
+            }
+            else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE ('HELLO' IS NULL)", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE (? IS NULL)", sql.remove(0));
@@ -11237,7 +11353,10 @@ public class TestComparisonLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE (? IS NULL)", sql.remove(0)); 
+            }
+            else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE ('HELLO' IS NULL)", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE (? IS NULL)", sql.remove(0));
@@ -11518,7 +11637,10 @@ public class TestComparisonLogic extends AbstractTestLogic {
             query.getResultList();
             List<String> sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE (? IS NOT NULL)", sql.remove(0));   
+            }
+            else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE ('HELLO' IS NOT NULL)", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE (? IS NOT NULL)", sql.remove(0));
@@ -11528,7 +11650,10 @@ public class TestComparisonLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE (? IS NOT NULL)", sql.remove(0));   
+            }
+            else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE ('HELLO' IS NOT NULL)", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE (? IS NOT NULL)", sql.remove(0));
@@ -11549,7 +11674,10 @@ public class TestComparisonLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE (? IS NOT NULL)", sql.remove(0));   
+            }
+            else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE ('HELLO' IS NOT NULL)", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE (? IS NOT NULL)", sql.remove(0));
@@ -11566,7 +11694,10 @@ public class TestComparisonLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE (? IS NOT NULL)", sql.remove(0));   
+            }
+            else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE ('HELLO' IS NOT NULL)", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE (? IS NOT NULL)", sql.remove(0));
@@ -11847,7 +11978,9 @@ public class TestComparisonLogic extends AbstractTestLogic {
             query.getResultList();
             List<String> sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+               Assert.assertEquals("SELECT t0.INTVAL1 FROM OLGH17837ENTITY t0 WHERE EXISTS (SELECT 1 FROM OLGH17837ENTITY t1 WHERE (t1.STRVAL1 = ?))", sql.remove(0));
+            }else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT t0.INTVAL1 FROM OLGH17837ENTITY t0 WHERE EXISTS (SELECT 1 FROM OLGH17837ENTITY t1 WHERE (t1.STRVAL1 = 'HELLO'))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT t0.INTVAL1 FROM OLGH17837ENTITY t0 WHERE EXISTS (SELECT ? FROM OLGH17837ENTITY t1 WHERE (t1.STRVAL1 = ?))", sql.remove(0));
@@ -11857,11 +11990,13 @@ public class TestComparisonLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM OLGH17837ENTITY t0 WHERE EXISTS (SELECT 1 FROM OLGH17837ENTITY t1 WHERE (t1.STRVAL1 = 'HELLO'))", sql.remove(0));
-            } else {
-                Assert.assertEquals("SELECT t0.INTVAL1 FROM OLGH17837ENTITY t0 WHERE EXISTS (SELECT ? FROM OLGH17837ENTITY t1 WHERE (t1.STRVAL1 = ?))", sql.remove(0));
-            }
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT t0.INTVAL1 FROM OLGH17837ENTITY t0 WHERE EXISTS (SELECT 1 FROM OLGH17837ENTITY t1 WHERE (t1.STRVAL1 = ?))", sql.remove(0));
+             }else if (isDB2Z || isDB2 || isDerby) {
+                 Assert.assertEquals("SELECT t0.INTVAL1 FROM OLGH17837ENTITY t0 WHERE EXISTS (SELECT 1 FROM OLGH17837ENTITY t1 WHERE (t1.STRVAL1 = 'HELLO'))", sql.remove(0));
+             } else {
+                 Assert.assertEquals("SELECT t0.INTVAL1 FROM OLGH17837ENTITY t0 WHERE EXISTS (SELECT ? FROM OLGH17837ENTITY t1 WHERE (t1.STRVAL1 = ?))", sql.remove(0));
+             }
 
             // -----------------------
 
@@ -12196,7 +12331,10 @@ public class TestComparisonLogic extends AbstractTestLogic {
             query.getResultList();
             List<String> sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT CASE  WHEN EXISTS (SELECT 1 FROM OLGH17837ENTITY t1 WHERE (t1.STRVAL1 = ?)) THEN 1 ELSE 0 END FROM OLGH17837ENTITY t0",
+                                    sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT CASE  WHEN EXISTS (SELECT 1 FROM OLGH17837ENTITY t1 WHERE (t1.STRVAL1 = 'HELLO')) THEN 1 ELSE 0 END FROM OLGH17837ENTITY t0",
                                     sql.remove(0));
             } else {
@@ -12204,17 +12342,22 @@ public class TestComparisonLogic extends AbstractTestLogic {
                                     sql.remove(0));
             }
 
+
             query = em.createQuery("SELECT CASE WHEN EXISTS (SELECT u.intVal2 FROM OLGH17837Entity u WHERE u.strVal1 = 'HELLO') THEN TRUE ELSE FALSE END FROM OLGH17837Entity s");
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT CASE  WHEN EXISTS (SELECT 1 FROM OLGH17837ENTITY t1 WHERE (t1.STRVAL1 = ?)) THEN 1 ELSE 0 END FROM OLGH17837ENTITY t0",
+                                    sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT CASE  WHEN EXISTS (SELECT 1 FROM OLGH17837ENTITY t1 WHERE (t1.STRVAL1 = 'HELLO')) THEN 1 ELSE 0 END FROM OLGH17837ENTITY t0",
                                     sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT CASE  WHEN EXISTS (SELECT ? FROM OLGH17837ENTITY t1 WHERE (t1.STRVAL1 = ?)) THEN ? ELSE ? END FROM OLGH17837ENTITY t0",
                                     sql.remove(0));
             }
+
 
             // -----------------------
 
@@ -12244,13 +12387,17 @@ public class TestComparisonLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT CASE WHEN EXISTS (SELECT t1.INTVAL2 FROM OLGH17837ENTITY t1 WHERE (t1.STRVAL1 = ?)) THEN 1 ELSE 0 END  FROM OLGH17837ENTITY t0",
+                                    sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT CASE WHEN EXISTS (SELECT t1.INTVAL2 FROM OLGH17837ENTITY t1 WHERE (t1.STRVAL1 = 'HELLO')) THEN 1 ELSE 0 END  FROM OLGH17837ENTITY t0",
                                     sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT CASE WHEN EXISTS (SELECT t1.INTVAL2 FROM OLGH17837ENTITY t1 WHERE (t1.STRVAL1 = ?)) THEN ? ELSE ? END  FROM OLGH17837ENTITY t0",
                                     sql.remove(0));
             }
+    
 
             CriteriaBuilder cb2 = em.getCriteriaBuilder();
             CriteriaQuery<Object> cquery2 = cb2.createQuery(Object.class);
@@ -12271,7 +12418,10 @@ public class TestComparisonLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+              if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT CASE WHEN EXISTS (SELECT t1.INTVAL2 FROM OLGH17837ENTITY t1 WHERE (t1.STRVAL1 = ?)) THEN 1 ELSE 0 END  FROM OLGH17837ENTITY t0",
+                                    sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT CASE WHEN EXISTS (SELECT t1.INTVAL2 FROM OLGH17837ENTITY t1 WHERE (t1.STRVAL1 = 'HELLO')) THEN 1 ELSE 0 END  FROM OLGH17837ENTITY t0",
                                     sql.remove(0));
             } else {
@@ -12332,7 +12482,10 @@ public class TestComparisonLogic extends AbstractTestLogic {
             query.getResultList();
             List<String> sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT CASE  WHEN EXISTS (SELECT 1 FROM OLGH17837ENTITY t1 WHERE (t1.STRVAL1 = ?)) THEN 1 ELSE 0 END FROM OLGH17837ENTITY t0",
+                                    sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT CASE  WHEN EXISTS (SELECT 1 FROM OLGH17837ENTITY t1 WHERE (t1.STRVAL1 = ?)) THEN 1 ELSE 0 END FROM OLGH17837ENTITY t0",
                                     sql.remove(0));
             } else {
@@ -12622,7 +12775,10 @@ public class TestComparisonLogic extends AbstractTestLogic {
             query.getResultList();
             List<String> sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT t0.INTVAL1 FROM OLGH17837ENTITY t0 WHERE NOT EXISTS (SELECT 1 FROM OLGH17837ENTITY t1 WHERE (t1.STRVAL1 = ?))", sql.remove(0));   
+            }
+            else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT t0.INTVAL1 FROM OLGH17837ENTITY t0 WHERE NOT EXISTS (SELECT 1 FROM OLGH17837ENTITY t1 WHERE (t1.STRVAL1 = 'HELLO'))",
                                     sql.remove(0));
             } else {
@@ -12633,7 +12789,10 @@ public class TestComparisonLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT t0.INTVAL1 FROM OLGH17837ENTITY t0 WHERE NOT EXISTS (SELECT 1 FROM OLGH17837ENTITY t1 WHERE (t1.STRVAL1 = ?))", sql.remove(0));   
+            }
+            else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT t0.INTVAL1 FROM OLGH17837ENTITY t0 WHERE NOT EXISTS (SELECT 1 FROM OLGH17837ENTITY t1 WHERE (t1.STRVAL1 = 'HELLO'))",
                                     sql.remove(0));
             } else {
@@ -13015,7 +13174,11 @@ public class TestComparisonLogic extends AbstractTestLogic {
             query.getResultList();
             List<String> sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT CASE  WHEN NOT EXISTS (SELECT 1 FROM OLGH17837ENTITY t1 WHERE (t1.STRVAL1 = ?)) THEN 1 ELSE 0 END FROM OLGH17837ENTITY t0",
+                                    sql.remove(0));   
+            }
+            else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT CASE  WHEN NOT EXISTS (SELECT 1 FROM OLGH17837ENTITY t1 WHERE (t1.STRVAL1 = 'HELLO')) THEN 1 ELSE 0 END FROM OLGH17837ENTITY t0",
                                     sql.remove(0));
             } else {
@@ -13027,7 +13190,11 @@ public class TestComparisonLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT CASE  WHEN NOT EXISTS (SELECT 1 FROM OLGH17837ENTITY t1 WHERE (t1.STRVAL1 = ?)) THEN 1 ELSE 0 END FROM OLGH17837ENTITY t0",
+                                    sql.remove(0));   
+            }
+            else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT CASE  WHEN NOT EXISTS (SELECT 1 FROM OLGH17837ENTITY t1 WHERE (t1.STRVAL1 = 'HELLO')) THEN 1 ELSE 0 END FROM OLGH17837ENTITY t0",
                                     sql.remove(0));
             } else {
@@ -13064,7 +13231,10 @@ public class TestComparisonLogic extends AbstractTestLogic {
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
             if (isUsingJPA22Feature() || isUsingJPA30Feature() || isUsingJPA31Feature() || isUsingJPA32Feature()) {
-                if (isDB2Z || isDB2 || isDerby) {
+                if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                    Assert.assertEquals("SELECT CASE WHEN NOT (EXISTS (SELECT t1.INTVAL2 FROM OLGH17837ENTITY t1 WHERE (t1.STRVAL1 = ?))) THEN 1 ELSE 0 END  FROM OLGH17837ENTITY t0",
+                                        sql.remove(0));
+                } else if (isDB2Z || isDB2 || isDerby) {
                     Assert.assertEquals("SELECT CASE WHEN NOT (EXISTS (SELECT t1.INTVAL2 FROM OLGH17837ENTITY t1 WHERE (t1.STRVAL1 = 'HELLO'))) THEN 1 ELSE 0 END  FROM OLGH17837ENTITY t0",
                                         sql.remove(0));
                 } else {
@@ -13101,7 +13271,10 @@ public class TestComparisonLogic extends AbstractTestLogic {
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
             if (isUsingJPA22Feature() || isUsingJPA30Feature() || isUsingJPA31Feature() || isUsingJPA32Feature()) {
-                if (isDB2Z || isDB2 || isDerby) {
+                if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                    Assert.assertEquals("SELECT CASE WHEN NOT (EXISTS (SELECT t1.INTVAL2 FROM OLGH17837ENTITY t1 WHERE (t1.STRVAL1 = ?))) THEN 1 ELSE 0 END  FROM OLGH17837ENTITY t0",
+                                        sql.remove(0));
+                } else if (isDB2Z || isDB2 || isDerby) {
                     Assert.assertEquals("SELECT CASE WHEN NOT (EXISTS (SELECT t1.INTVAL2 FROM OLGH17837ENTITY t1 WHERE (t1.STRVAL1 = 'HELLO'))) THEN 1 ELSE 0 END  FROM OLGH17837ENTITY t0",
                                         sql.remove(0));
                 } else {
@@ -13503,7 +13676,10 @@ public class TestComparisonLogic extends AbstractTestLogic {
             query.getResultList();
             List<String> sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE (INTVAL1 = CASE INTVAL2 WHEN ? THEN 6 WHEN ? THEN 16 ELSE 26 END)", sql.remove(0));    
+            }
+            else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE (INTVAL1 = CASE INTVAL2 WHEN 5 THEN 6 WHEN 15 THEN 16 ELSE 26 END)", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE (INTVAL1 = CASE INTVAL2 WHEN ? THEN ? WHEN ? THEN ? ELSE ? END)", sql.remove(0));
@@ -13513,7 +13689,10 @@ public class TestComparisonLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE (INTVAL1 = CASE INTVAL2 WHEN ? THEN 6 WHEN ? THEN 16 ELSE 26 END)", sql.remove(0));    
+            }
+            else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE (INTVAL1 = CASE INTVAL2 WHEN 5 THEN 6 WHEN 15 THEN 16 ELSE 26 END)", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE (INTVAL1 = CASE INTVAL2 WHEN ? THEN ? WHEN ? THEN ? ELSE ? END)", sql.remove(0));
@@ -13525,7 +13704,10 @@ public class TestComparisonLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE (INTVAL1 = CASE INTVAL2 WHEN ? THEN 6 WHEN ? THEN 16 ELSE 26 END)", sql.remove(0));    
+            }
+            else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE (INTVAL1 = CASE INTVAL2 WHEN 5 THEN 6 WHEN 15 THEN 16 ELSE 26 END)", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE (INTVAL1 = CASE INTVAL2 WHEN ? THEN ? WHEN ? THEN ? ELSE ? END)", sql.remove(0));
@@ -13550,7 +13732,10 @@ public class TestComparisonLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE (INTVAL1 = CASE INTVAL2 WHEN ? THEN 6 WHEN ? THEN 16 ELSE 26 END)", sql.remove(0));    
+            }
+            else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE (INTVAL1 = CASE INTVAL2 WHEN 5 THEN 6 WHEN 15 THEN 16 ELSE 26 END)", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE (INTVAL1 = CASE INTVAL2 WHEN ? THEN ? WHEN ? THEN ? ELSE ? END)", sql.remove(0));
@@ -13851,7 +14036,10 @@ public class TestComparisonLogic extends AbstractTestLogic {
             query.getResultList();
             List<String> sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE (INTVAL1 = CASE  WHEN (INTVAL2 = ?) THEN 6 WHEN (INTVAL2 = ?) THEN 16 ELSE 26 END)", sql.remove(0));
+            }
+            else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE (INTVAL1 = CASE  WHEN (INTVAL2 = 5) THEN 6 WHEN (INTVAL2 = 15) THEN 16 ELSE 26 END)",
                                     sql.remove(0));
             } else {
@@ -13862,7 +14050,10 @@ public class TestComparisonLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE (INTVAL1 = CASE  WHEN (INTVAL2 = ?) THEN 6 WHEN (INTVAL2 = ?) THEN 16 ELSE 26 END)", sql.remove(0));
+            }
+            else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE (INTVAL1 = CASE  WHEN (INTVAL2 = 5) THEN 6 WHEN (INTVAL2 = 15) THEN 16 ELSE 26 END)",
                                     sql.remove(0));
             } else {
@@ -13875,7 +14066,10 @@ public class TestComparisonLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE (INTVAL1 = CASE  WHEN (INTVAL2 = ?) THEN 6 WHEN (INTVAL2 = ?) THEN 16 ELSE 26 END)", sql.remove(0));
+            }
+            else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE (INTVAL1 = CASE  WHEN (INTVAL2 = 5) THEN 6 WHEN (INTVAL2 = 15) THEN 16 ELSE 26 END)",
                                     sql.remove(0));
             } else {
@@ -13912,7 +14106,10 @@ public class TestComparisonLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE (INTVAL1 = CASE WHEN (INTVAL2 = ?) THEN 6 WHEN (INTVAL2 = ?) THEN 16 ELSE 26 END )", sql.remove(0));
+            }
+            else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE (INTVAL1 = CASE WHEN (INTVAL2 = 5) THEN 6 WHEN (INTVAL2 = 15) THEN 16 ELSE 26 END )",
                                     sql.remove(0));
             } else {
@@ -13936,7 +14133,10 @@ public class TestComparisonLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE (INTVAL1 = CASE WHEN (INTVAL2 = ?) THEN 6 WHEN (INTVAL2 = ?) THEN 16 ELSE 26 END )", sql.remove(0));
+            }
+            else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE (INTVAL1 = CASE WHEN (INTVAL2 = 5) THEN 6 WHEN (INTVAL2 = 15) THEN 16 ELSE 26 END )",
                                     sql.remove(0));
             } else {
@@ -13965,7 +14165,10 @@ public class TestComparisonLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE (INTVAL1 = CASE WHEN (INTVAL2 = ?) THEN 6 WHEN (INTVAL2 = ?) THEN 16 ELSE 26 END )", sql.remove(0));
+            }
+            else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE (INTVAL1 = CASE WHEN (INTVAL2 = 5) THEN 6 WHEN (INTVAL2 = 15) THEN 16 ELSE 26 END )",
                                     sql.remove(0));
             } else {
@@ -14111,8 +14314,7 @@ public class TestComparisonLogic extends AbstractTestLogic {
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
             if (isDB2Z || isDB2 || isDerby) {
-                Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE (INTVAL1 = CASE WHEN (INTVAL2 = ?) THEN 6 WHEN (INTVAL2 = ?) THEN 16 ELSE 26 END )",
-                                    sql.remove(0));
+                Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE (INTVAL1 = CASE WHEN (INTVAL2 = ?) THEN 6 WHEN (INTVAL2 = ?) THEN 16 ELSE 26 END )", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE (INTVAL1 = CASE WHEN (INTVAL2 = ?) THEN ? WHEN (INTVAL2 = ?) THEN ? ELSE ? END )", sql.remove(0));
             }
@@ -14424,7 +14626,10 @@ public class TestComparisonLogic extends AbstractTestLogic {
             query.getResultList();
             List<String> sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+             Assert.assertEquals("SELECT CASE INTVAL2 WHEN ? THEN 6 WHEN ? THEN 16 ELSE 26 END FROM OLGH17837ENTITY WHERE (INTVAL1 = ?)", sql.remove(0));
+            }
+            else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT CASE INTVAL2 WHEN 5 THEN 6 WHEN 15 THEN 16 ELSE 26 END FROM OLGH17837ENTITY WHERE (INTVAL1 = 99)", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT CASE INTVAL2 WHEN ? THEN ? WHEN ? THEN ? ELSE ? END FROM OLGH17837ENTITY WHERE (INTVAL1 = ?)", sql.remove(0));
@@ -14434,10 +14639,12 @@ public class TestComparisonLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
-                Assert.assertEquals("SELECT CASE INTVAL2 WHEN 5 THEN 6 WHEN 15 THEN 16 ELSE 26 END FROM OLGH17837ENTITY WHERE (INTVAL1 = 99)", sql.remove(0));
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT CASE INTVAL2 WHEN ? THEN 6 WHEN ? THEN 16 ELSE 26 END FROM OLGH17837ENTITY WHERE (INTVAL1 = ?)", sql.remove(0));
+            }else if (isDB2Z || isDB2 || isDerby) {
+                   Assert.assertEquals("SELECT CASE INTVAL2 WHEN 5 THEN 6 WHEN 15 THEN 16 ELSE 26 END FROM OLGH17837ENTITY WHERE (INTVAL1 = 99)", sql.remove(0));
             } else {
-                Assert.assertEquals("SELECT CASE INTVAL2 WHEN ? THEN ? WHEN ? THEN ? ELSE ? END FROM OLGH17837ENTITY WHERE (INTVAL1 = ?)", sql.remove(0));
+                   Assert.assertEquals("SELECT CASE INTVAL2 WHEN ? THEN ? WHEN ? THEN ? ELSE ? END FROM OLGH17837ENTITY WHERE (INTVAL1 = ?)", sql.remove(0));
             }
 
             query = em.createQuery("SELECT CASE s.intVal2 WHEN ?1 THEN ?2 WHEN 15 THEN 16 ELSE 26 END FROM OLGH17837Entity s WHERE s.intVal1 = ?3");
@@ -14447,10 +14654,12 @@ public class TestComparisonLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
-                Assert.assertEquals("SELECT CASE INTVAL2 WHEN 5 THEN 6 WHEN 15 THEN 16 ELSE 26 END FROM OLGH17837ENTITY WHERE (INTVAL1 = 99)", sql.remove(0));
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT CASE INTVAL2 WHEN ? THEN 6 WHEN ? THEN 16 ELSE 26 END FROM OLGH17837ENTITY WHERE (INTVAL1 = ?)", sql.remove(0));
+            }else if (isDB2Z || isDB2 || isDerby) {
+                   Assert.assertEquals("SELECT CASE INTVAL2 WHEN 5 THEN 6 WHEN 15 THEN 16 ELSE 26 END FROM OLGH17837ENTITY WHERE (INTVAL1 = 99)", sql.remove(0));
             } else {
-                Assert.assertEquals("SELECT CASE INTVAL2 WHEN ? THEN ? WHEN ? THEN ? ELSE ? END FROM OLGH17837ENTITY WHERE (INTVAL1 = ?)", sql.remove(0));
+                   Assert.assertEquals("SELECT CASE INTVAL2 WHEN ? THEN ? WHEN ? THEN ? ELSE ? END FROM OLGH17837ENTITY WHERE (INTVAL1 = ?)", sql.remove(0));
             }
 
             // -----------------------
@@ -14471,10 +14680,12 @@ public class TestComparisonLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
-                Assert.assertEquals("SELECT CASE INTVAL2 WHEN 5 THEN 6 WHEN 15 THEN 16 ELSE 26 END FROM OLGH17837ENTITY WHERE (INTVAL1 = 99)", sql.remove(0));
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT CASE INTVAL2 WHEN ? THEN 6 WHEN ? THEN 16 ELSE 26 END FROM OLGH17837ENTITY WHERE (INTVAL1 = ?)", sql.remove(0));
+            }else if (isDB2Z || isDB2 || isDerby) {
+                   Assert.assertEquals("SELECT CASE INTVAL2 WHEN 5 THEN 6 WHEN 15 THEN 16 ELSE 26 END FROM OLGH17837ENTITY WHERE (INTVAL1 = 99)", sql.remove(0));
             } else {
-                Assert.assertEquals("SELECT CASE INTVAL2 WHEN ? THEN ? WHEN ? THEN ? ELSE ? END FROM OLGH17837ENTITY WHERE (INTVAL1 = ?)", sql.remove(0));
+                   Assert.assertEquals("SELECT CASE INTVAL2 WHEN ? THEN ? WHEN ? THEN ? ELSE ? END FROM OLGH17837ENTITY WHERE (INTVAL1 = ?)", sql.remove(0));
             }
         } catch (java.lang.AssertionError ae) {
             throw ae;
@@ -14775,7 +14986,10 @@ public class TestComparisonLogic extends AbstractTestLogic {
             query.getResultList();
             List<String> sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT CASE  WHEN (INTVAL2 = ?) THEN 6 WHEN (INTVAL2 = ?) THEN 16 ELSE 26 END FROM OLGH17837ENTITY WHERE (INTVAL1 = ?)", sql.remove(0));   
+            }
+            else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT CASE  WHEN (INTVAL2 = 5) THEN 6 WHEN (INTVAL2 = 15) THEN 16 ELSE 26 END FROM OLGH17837ENTITY WHERE (INTVAL1 = 99)", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT CASE  WHEN (INTVAL2 = ?) THEN ? WHEN (INTVAL2 = ?) THEN ? ELSE ? END FROM OLGH17837ENTITY WHERE (INTVAL1 = ?)", sql.remove(0));
@@ -14785,7 +14999,9 @@ public class TestComparisonLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT CASE  WHEN (INTVAL2 = ?) THEN 6 WHEN (INTVAL2 = ?) THEN 16 ELSE 26 END FROM OLGH17837ENTITY WHERE (INTVAL1 = ?)", sql.remove(0));   
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT CASE  WHEN (INTVAL2 = 5) THEN 6 WHEN (INTVAL2 = 15) THEN 16 ELSE 26 END FROM OLGH17837ENTITY WHERE (INTVAL1 = 99)", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT CASE  WHEN (INTVAL2 = ?) THEN ? WHEN (INTVAL2 = ?) THEN ? ELSE ? END FROM OLGH17837ENTITY WHERE (INTVAL1 = ?)", sql.remove(0));
@@ -14798,7 +15014,9 @@ public class TestComparisonLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT CASE  WHEN (INTVAL2 = ?) THEN 6 WHEN (INTVAL2 = ?) THEN 16 ELSE 26 END FROM OLGH17837ENTITY WHERE (INTVAL1 = ?)", sql.remove(0));   
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT CASE  WHEN (INTVAL2 = 5) THEN 6 WHEN (INTVAL2 = 15) THEN 16 ELSE 26 END FROM OLGH17837ENTITY WHERE (INTVAL1 = 99)", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT CASE  WHEN (INTVAL2 = ?) THEN ? WHEN (INTVAL2 = ?) THEN ? ELSE ? END FROM OLGH17837ENTITY WHERE (INTVAL1 = ?)", sql.remove(0));
@@ -14835,7 +15053,9 @@ public class TestComparisonLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT CASE WHEN (INTVAL2 = ?) THEN 6 WHEN (INTVAL2 = ?) THEN 16 ELSE 26 END  FROM OLGH17837ENTITY WHERE (INTVAL1 = ?)", sql.remove(0));   
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT CASE WHEN (INTVAL2 = 5) THEN 6 WHEN (INTVAL2 = 15) THEN 16 ELSE 26 END  FROM OLGH17837ENTITY WHERE (INTVAL1 = 99)", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT CASE WHEN (INTVAL2 = ?) THEN ? WHEN (INTVAL2 = ?) THEN ? ELSE ? END  FROM OLGH17837ENTITY WHERE (INTVAL1 = ?)", sql.remove(0));
@@ -14857,7 +15077,9 @@ public class TestComparisonLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT CASE WHEN (INTVAL2 = ?) THEN 6 WHEN (INTVAL2 = ?) THEN 16 ELSE 26 END  FROM OLGH17837ENTITY WHERE (INTVAL1 = ?)", sql.remove(0));   
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT CASE WHEN (INTVAL2 = 5) THEN 6 WHEN (INTVAL2 = 15) THEN 16 ELSE 26 END  FROM OLGH17837ENTITY WHERE (INTVAL1 = 99)", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT CASE WHEN (INTVAL2 = ?) THEN ? WHEN (INTVAL2 = ?) THEN ? ELSE ? END  FROM OLGH17837ENTITY WHERE (INTVAL1 = ?)", sql.remove(0));
@@ -14886,7 +15108,9 @@ public class TestComparisonLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT CASE WHEN (INTVAL2 = ?) THEN 6 WHEN (INTVAL2 = ?) THEN 16 ELSE 26 END  FROM OLGH17837ENTITY WHERE (INTVAL1 = ?)", sql.remove(0));   
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT CASE WHEN (INTVAL2 = 5) THEN 6 WHEN (INTVAL2 = 15) THEN 16 ELSE 26 END  FROM OLGH17837ENTITY WHERE (INTVAL1 = 99)", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT CASE WHEN (INTVAL2 = ?) THEN ? WHEN (INTVAL2 = ?) THEN ? ELSE ? END  FROM OLGH17837ENTITY WHERE (INTVAL1 = ?)", sql.remove(0));
@@ -15322,7 +15546,9 @@ public class TestComparisonLogic extends AbstractTestLogic {
             query.getResultList();
             List<String> sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT 1 FROM OLGH17837ENTITY WHERE (? = NULLIF(STRVAL1, ?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT 1 FROM OLGH17837ENTITY WHERE ('HELLO' = NULLIF(STRVAL1, 'WORLD'))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT ? FROM OLGH17837ENTITY WHERE (? = NULLIF(STRVAL1, ?))", sql.remove(0));
@@ -15332,7 +15558,9 @@ public class TestComparisonLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT 1 FROM OLGH17837ENTITY WHERE (? = NULLIF(STRVAL1, ?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT 1 FROM OLGH17837ENTITY WHERE ('HELLO' = NULLIF(STRVAL1, 'WORLD'))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT ? FROM OLGH17837ENTITY WHERE (? = NULLIF(STRVAL1, ?))", sql.remove(0));
@@ -15354,7 +15582,9 @@ public class TestComparisonLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT 1 FROM OLGH17837ENTITY WHERE (? = NULLIF(STRVAL1, ?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT 1 FROM OLGH17837ENTITY WHERE ('HELLO' = NULLIF(STRVAL1, 'WORLD'))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT ? FROM OLGH17837ENTITY WHERE (? = NULLIF(STRVAL1, ?))", sql.remove(0));
@@ -15370,7 +15600,9 @@ public class TestComparisonLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT 1 FROM OLGH17837ENTITY WHERE (? = NULLIF(STRVAL1, ?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT 1 FROM OLGH17837ENTITY WHERE ('HELLO' = NULLIF(STRVAL1, 'WORLD'))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT ? FROM OLGH17837ENTITY WHERE (? = NULLIF(STRVAL1, ?))", sql.remove(0));
@@ -15656,7 +15888,10 @@ public class TestComparisonLogic extends AbstractTestLogic {
             query.getResultList();
             List<String> sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT 1 FROM OLGH17837ENTITY WHERE (? = NULLIF(?, STRVAL1))", sql.remove(0));  
+            }
+            else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT 1 FROM OLGH17837ENTITY WHERE ('HELLO' = NULLIF('WORLD', STRVAL1))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT ? FROM OLGH17837ENTITY WHERE (? = NULLIF(?, STRVAL1))", sql.remove(0));
@@ -15666,7 +15901,10 @@ public class TestComparisonLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT 1 FROM OLGH17837ENTITY WHERE (? = NULLIF(?, STRVAL1))", sql.remove(0));  
+            }
+            else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT 1 FROM OLGH17837ENTITY WHERE ('HELLO' = NULLIF('WORLD', STRVAL1))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT ? FROM OLGH17837ENTITY WHERE (? = NULLIF(?, STRVAL1))", sql.remove(0));
@@ -15688,7 +15926,10 @@ public class TestComparisonLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT 1 FROM OLGH17837ENTITY WHERE (? = NULLIF(?, STRVAL1))", sql.remove(0));  
+            }
+            else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT 1 FROM OLGH17837ENTITY WHERE ('HELLO' = NULLIF('WORLD', STRVAL1))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT ? FROM OLGH17837ENTITY WHERE (? = NULLIF(?, STRVAL1))", sql.remove(0));
@@ -15704,7 +15945,10 @@ public class TestComparisonLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT 1 FROM OLGH17837ENTITY WHERE (? = NULLIF(?, STRVAL1))", sql.remove(0));  
+            }
+            else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT 1 FROM OLGH17837ENTITY WHERE ('HELLO' = NULLIF('WORLD', STRVAL1))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT ? FROM OLGH17837ENTITY WHERE (? = NULLIF(?, STRVAL1))", sql.remove(0));
@@ -15990,7 +16234,9 @@ public class TestComparisonLogic extends AbstractTestLogic {
             query.getResultList();
             List<String> sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT NULLIF(?, 'WORLD') FROM OLGH17837ENTITY", sql.remove(0)); 
+            }else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT NULLIF('HELLO', 'WORLD') FROM OLGH17837ENTITY", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT NULLIF(?, ?) FROM OLGH17837ENTITY", sql.remove(0));
@@ -16000,7 +16246,9 @@ public class TestComparisonLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT NULLIF(?, 'WORLD') FROM OLGH17837ENTITY", sql.remove(0)); 
+            }else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT NULLIF('HELLO', 'WORLD') FROM OLGH17837ENTITY", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT NULLIF(?, ?) FROM OLGH17837ENTITY", sql.remove(0));
@@ -16011,7 +16259,9 @@ public class TestComparisonLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT NULLIF(?, 'WORLD') FROM OLGH17837ENTITY", sql.remove(0)); 
+            }else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT NULLIF('HELLO', 'WORLD') FROM OLGH17837ENTITY", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT NULLIF(?, ?) FROM OLGH17837ENTITY", sql.remove(0));
@@ -16032,7 +16282,9 @@ public class TestComparisonLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT NULLIF(?, 'WORLD') FROM OLGH17837ENTITY", sql.remove(0)); 
+            }else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT NULLIF('HELLO', 'WORLD') FROM OLGH17837ENTITY", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT NULLIF(?, ?) FROM OLGH17837ENTITY", sql.remove(0));
@@ -16047,7 +16299,9 @@ public class TestComparisonLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT NULLIF(?, 'WORLD') FROM OLGH17837ENTITY", sql.remove(0)); 
+            }else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT NULLIF('HELLO', 'WORLD') FROM OLGH17837ENTITY", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT NULLIF(?, ?) FROM OLGH17837ENTITY", sql.remove(0));
@@ -16064,7 +16318,9 @@ public class TestComparisonLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT NULLIF(?, 'WORLD') FROM OLGH17837ENTITY", sql.remove(0)); 
+            }else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT NULLIF('HELLO', 'WORLD') FROM OLGH17837ENTITY", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT NULLIF(?, ?) FROM OLGH17837ENTITY", sql.remove(0));
@@ -17235,7 +17491,10 @@ public class TestComparisonLogic extends AbstractTestLogic {
             } finally {
                 sql = SQLCallListener.getAndClearCallList();
                 Assert.assertEquals(1, sql.size());
-                if (isDB2Z || isDB2 || isDerby) {
+                if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                    Assert.assertNull(exception);
+                    Assert.assertEquals("SELECT STRVAL2 FROM OLGH17837ENTITY WHERE (COALESCE(?, ?, ?, ?, 12) = INTVAL2)", sql.remove(0));
+                } else if (isDB2Z || isDB2 || isDerby) {
                     Assert.assertNotNull("Expected query '" + sql.remove(0) + "' to fail", exception);
                 } else {
                     Assert.assertNull(exception);
@@ -17253,7 +17512,10 @@ public class TestComparisonLogic extends AbstractTestLogic {
                 sql = SQLCallListener.getAndClearCallList();
                 Assert.assertEquals(1, sql.size());
                 if (isUsingJPA31Feature() || isUsingJPA32Feature()) {
-                    if (isDB2Z || isDB2 || isDerby) {
+                    if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                        Assert.assertNull(exception);
+                        Assert.assertEquals("SELECT STRVAL2 FROM OLGH17837ENTITY WHERE (COALESCE(?, ?, ?, ?, 12) = INTVAL2)", sql.remove(0));
+                    } else if (isDB2Z || isDB2 || isDerby) {
                         // DB2 z throws `DB2 SQL Error: SQLCODE=-206, SQLSTATE=42703` because a "NULL" value is being passed
                         // Derby throws `ERROR 42X01: Syntax error: Encountered "NULL" at line 1, column 50.`
                         Assert.assertNotNull("Expected query '" + sql.remove(0) + "' to fail", exception);
@@ -17310,7 +17572,10 @@ public class TestComparisonLogic extends AbstractTestLogic {
             } finally {
                 sql = SQLCallListener.getAndClearCallList();
                 Assert.assertEquals(1, sql.size());
-                if (isDB2Z || isDB2 || isDerby) {
+                if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                    Assert.assertNull(exception);
+                    Assert.assertEquals("SELECT STRVAL2 FROM OLGH17837ENTITY WHERE (COALESCE(?, ?, ?, ?, 12) = INTVAL2)", sql.remove(0));
+                } else if (isDerby || isDB2 || isDB2Z) {
                     Assert.assertNotNull("Expected query '" + sql.remove(0) + "' to fail", exception);
                 } else {
                     Assert.assertNull(exception);
@@ -17341,9 +17606,10 @@ public class TestComparisonLogic extends AbstractTestLogic {
                 sql = SQLCallListener.getAndClearCallList();
                 Assert.assertEquals(1, sql.size());
                 if (isUsingJPA31Feature() || isUsingJPA32Feature()) {
-                    if (isDB2Z || isDB2 || isDerby) {
-                        // DB2 z throws `DB2 SQL Error: SQLCODE=-206, SQLSTATE=42703` because a "NULL" value is being passed
-                        // Derby throws `ERROR 42X01: Syntax error: Encountered "NULL" at line 1, column 50.`
+                    if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                        Assert.assertNull(exception);
+                        Assert.assertEquals("SELECT STRVAL2 FROM OLGH17837ENTITY WHERE (COALESCE(?, ?, ?, ?, 12) = INTVAL2)", sql.remove(0));
+                    } else if (isDerby || isDB2Z || isDB2) {
                         Assert.assertNotNull("Expected query '" + sql.remove(0) + "' to fail", exception);
                     } else {
                         Assert.assertNull(exception);

--- a/dev/com.ibm.ws.jpa.tests.eclipselink.query_fat.common/test-applications/olgh17837/src/com/ibm/ws/jpa/olgh17837/testlogic/TestFunctionLogic.java
+++ b/dev/com.ibm.ws.jpa.tests.eclipselink.query_fat.common/test-applications/olgh17837/src/com/ibm/ws/jpa/olgh17837/testlogic/TestFunctionLogic.java
@@ -1207,7 +1207,9 @@ public class TestFunctionLogic extends AbstractTestLogic {
             query.getResultList();
             List<String> sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE (STRVAL1 = VARCHAR(VARCHAR(? || ?) || ?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE (STRVAL1 = VARCHAR(VARCHAR('HELLO' || ' ') || 'WORLD'))", sql.remove(0));
             } else if (isPostgres) {
                 Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE (STRVAL1 = ? || ? || ?)", sql.remove(0));
@@ -1219,7 +1221,9 @@ public class TestFunctionLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE (STRVAL1 = VARCHAR(VARCHAR(? || ?) || ?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE (STRVAL1 = VARCHAR(VARCHAR('HELLO' || ' ') || 'WORLD'))", sql.remove(0));
             } else if (isPostgres) {
                 Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE (STRVAL1 = ? || ? || ?)", sql.remove(0));
@@ -1232,7 +1236,9 @@ public class TestFunctionLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE (STRVAL1 = VARCHAR(VARCHAR(? || ?) || STRVAL2))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE (STRVAL1 = VARCHAR(VARCHAR('HELLO' || ' ') || STRVAL2))", sql.remove(0));
             } else if (isPostgres) {
                 Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE (STRVAL1 = ? || ? || STRVAL2)", sql.remove(0));
@@ -1258,7 +1264,9 @@ public class TestFunctionLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE (STRVAL1 = VARCHAR(VARCHAR(? || ?) || ?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE (STRVAL1 = VARCHAR(VARCHAR('HELLO' || ' ') || 'WORLD'))", sql.remove(0));
             } else if (isPostgres) {
                 Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE (STRVAL1 = ? || ? || ?)", sql.remove(0));
@@ -1276,7 +1284,9 @@ public class TestFunctionLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE (STRVAL1 = VARCHAR(VARCHAR(? || ?) || ?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE (STRVAL1 = VARCHAR(VARCHAR('HELLO' || ' ') || 'WORLD'))", sql.remove(0));
             } else if (isPostgres) {
                 Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE (STRVAL1 = ? || ? || ?)", sql.remove(0));
@@ -2239,7 +2249,9 @@ public class TestFunctionLogic extends AbstractTestLogic {
             query.getResultList();
             List<String> sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE (STRVAL1 = LTRIM(?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE (STRVAL1 = LTRIM('  HELLO WORD '))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE (STRVAL1 = LTRIM(?))", sql.remove(0));
@@ -2249,7 +2261,9 @@ public class TestFunctionLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE (STRVAL1 = LTRIM(?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE (STRVAL1 = LTRIM('  HELLO WORD '))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE (STRVAL1 = LTRIM(?))", sql.remove(0));
@@ -2269,7 +2283,9 @@ public class TestFunctionLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE (STRVAL1 = LTRIM(?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE (STRVAL1 = LTRIM('  HELLO WORD '))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE (STRVAL1 = LTRIM(?))", sql.remove(0));
@@ -2285,7 +2301,9 @@ public class TestFunctionLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE (STRVAL1 = LTRIM(?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE (STRVAL1 = LTRIM('  HELLO WORD '))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE (STRVAL1 = LTRIM(?))", sql.remove(0));
@@ -2568,7 +2586,9 @@ public class TestFunctionLogic extends AbstractTestLogic {
             query.getResultList();
             List<String> sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE (STRVAL1 = TRIM(LEADING 'A' FROM ?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE (STRVAL1 = TRIM(LEADING 'A' FROM 'AAAHELLO WORDAA'))", sql.remove(0));
             } else if (isOracle || isPostgres) {
                 Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE (STRVAL1 = LTRIM(?, ?))", sql.remove(0));
@@ -2580,7 +2600,9 @@ public class TestFunctionLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE (STRVAL1 = TRIM(LEADING 'A' FROM ?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE (STRVAL1 = TRIM(LEADING 'A' FROM 'AAAHELLO WORDAA'))", sql.remove(0));
             } else if (isOracle || isPostgres) {
                 Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE (STRVAL1 = LTRIM(?, ?))", sql.remove(0));
@@ -2593,7 +2615,9 @@ public class TestFunctionLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE (STRVAL1 = TRIM(LEADING 'A' FROM ?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE (STRVAL1 = TRIM(LEADING 'A' FROM 'AAAHELLO WORDAA'))", sql.remove(0));
             } else if (isOracle || isPostgres) {
                 Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE (STRVAL1 = LTRIM(?, ?))", sql.remove(0));
@@ -2617,7 +2641,9 @@ public class TestFunctionLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE (STRVAL1 = TRIM(LEADING 'A' FROM ?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE (STRVAL1 = TRIM(LEADING 'A' FROM 'AAAHELLO WORDAA'))", sql.remove(0));
             } else if (isOracle || isPostgres) {
                 Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE (STRVAL1 = LTRIM(?, ?))", sql.remove(0));
@@ -2635,7 +2661,9 @@ public class TestFunctionLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE (STRVAL1 = TRIM(LEADING 'A' FROM ?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE (STRVAL1 = TRIM(LEADING 'A' FROM 'AAAHELLO WORDAA'))", sql.remove(0));
             } else if (isOracle || isPostgres) {
                 Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE (STRVAL1 = LTRIM(?, ?))", sql.remove(0));
@@ -2655,7 +2683,9 @@ public class TestFunctionLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE (STRVAL1 = TRIM(LEADING 'A' FROM ?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE (STRVAL1 = TRIM(LEADING 'A' FROM 'AAAHELLO WORDAA'))", sql.remove(0));
             } else if (isOracle || isPostgres) {
                 Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE (STRVAL1 = LTRIM(?, ?))", sql.remove(0));
@@ -3083,7 +3113,9 @@ public class TestFunctionLogic extends AbstractTestLogic {
             query.getResultList();
             List<String> sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE (? = LENGTH('HELLO WORLD'))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE (11 = LENGTH('HELLO WORLD'))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE (? = LENGTH(?))", sql.remove(0));
@@ -3093,7 +3125,9 @@ public class TestFunctionLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE (? = LENGTH('HELLO WORLD'))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE (11 = LENGTH('HELLO WORLD'))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE (? = LENGTH(?))", sql.remove(0));
@@ -3115,7 +3149,9 @@ public class TestFunctionLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE (? = LENGTH('HELLO WORLD'))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE (11 = LENGTH('HELLO WORLD'))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE (? = LENGTH(?))", sql.remove(0));
@@ -3131,7 +3167,9 @@ public class TestFunctionLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE (? = LENGTH('HELLO WORLD'))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE (11 = LENGTH('HELLO WORLD'))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE (? = LENGTH(?))", sql.remove(0));
@@ -3734,7 +3772,9 @@ public class TestFunctionLogic extends AbstractTestLogic {
             query.getResultList();
             List<String> sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE (INTVAL1 = LOCATE(?, ?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE (INTVAL1 = LOCATE('HI', 'ABCDEFGHIJKLMNOP'))", sql.remove(0));
             } else if (isOracle) {
                 Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE (INTVAL1 = INSTR(?, ?))", sql.remove(0));
@@ -3748,7 +3788,9 @@ public class TestFunctionLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE (INTVAL1 = LOCATE(?, ?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE (INTVAL1 = LOCATE('HI', 'ABCDEFGHIJKLMNOP'))", sql.remove(0));
             } else if (isOracle) {
                 Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE (INTVAL1 = INSTR(?, ?))", sql.remove(0));
@@ -3763,7 +3805,9 @@ public class TestFunctionLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE (INTVAL1 = LOCATE(?, ?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE (INTVAL1 = LOCATE('HI', 'ABCDEFGHIJKLMNOP'))", sql.remove(0));
             } else if (isOracle) {
                 Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE (INTVAL1 = INSTR(?, ?))", sql.remove(0));
@@ -3789,7 +3833,9 @@ public class TestFunctionLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE (INTVAL1 = LOCATE(?, ?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE (INTVAL1 = LOCATE('HI', 'ABCDEFGHIJKLMNOP'))", sql.remove(0));
             } else if (isOracle) {
                 Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE (INTVAL1 = INSTR(?, ?))", sql.remove(0));
@@ -3809,7 +3855,9 @@ public class TestFunctionLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE (INTVAL1 = LOCATE(?, ?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE (INTVAL1 = LOCATE('HI', 'ABCDEFGHIJKLMNOP'))", sql.remove(0));
             } else if (isOracle) {
                 Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE (INTVAL1 = INSTR(?, ?))", sql.remove(0));
@@ -3831,7 +3879,9 @@ public class TestFunctionLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE (INTVAL1 = LOCATE(?, ?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE (INTVAL1 = LOCATE('HI', 'ABCDEFGHIJKLMNOP'))", sql.remove(0));
             } else if (isOracle) {
                 Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE (INTVAL1 = INSTR(?, ?))", sql.remove(0));
@@ -4292,7 +4342,9 @@ public class TestFunctionLogic extends AbstractTestLogic {
             query.getResultList();
             List<String> sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE (INTVAL1 = LOCATE(?, ?, ?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE (INTVAL1 = LOCATE('X', 'OXOOOOOXXOOOOOOXX', 3))", sql.remove(0));
             } else if (isOracle) {
                 Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE (INTVAL1 = INSTR(?, ?, ?))", sql.remove(0));
@@ -4306,7 +4358,9 @@ public class TestFunctionLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE (INTVAL1 = LOCATE(?, ?, ?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE (INTVAL1 = LOCATE('X', 'OXOOOOOXXOOOOOOXX', 3))", sql.remove(0));
             } else if (isOracle) {
                 Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE (INTVAL1 = INSTR(?, ?, ?))", sql.remove(0));
@@ -4321,7 +4375,9 @@ public class TestFunctionLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE (INTVAL1 = LOCATE(?, ?, ?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE (INTVAL1 = LOCATE('X', 'OXOOOOOXXOOOOOOXX', 3))", sql.remove(0));
             } else if (isOracle) {
                 Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE (INTVAL1 = INSTR(?, ?, ?))", sql.remove(0));
@@ -4349,7 +4405,9 @@ public class TestFunctionLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE (INTVAL1 = LOCATE(?, ?, ?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE (INTVAL1 = LOCATE('X', 'OXOOOOOXXOOOOOOXX', 3))", sql.remove(0));
             } else if (isOracle) {
                 Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE (INTVAL1 = INSTR(?, ?, ?))", sql.remove(0));
@@ -4369,7 +4427,9 @@ public class TestFunctionLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE (INTVAL1 = LOCATE(?, ?, ?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE (INTVAL1 = LOCATE('X', 'OXOOOOOXXOOOOOOXX', 3))", sql.remove(0));
             } else if (isOracle) {
                 Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE (INTVAL1 = INSTR(?, ?, ?))", sql.remove(0));
@@ -4393,7 +4453,9 @@ public class TestFunctionLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE (INTVAL1 = LOCATE(?, ?, ?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE (INTVAL1 = LOCATE('X', 'OXOOOOOXXOOOOOOXX', 3))", sql.remove(0));
             } else if (isOracle) {
                 Assert.assertEquals("SELECT INTVAL1 FROM OLGH17837ENTITY WHERE (INTVAL1 = INSTR(?, ?, ?))", sql.remove(0));
@@ -4839,7 +4901,9 @@ public class TestFunctionLogic extends AbstractTestLogic {
             query.getResultList();
             List<String> sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE (STRVAL1 = LCASE(?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE (STRVAL1 = LCASE('HELLO WORLD'))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE (STRVAL1 = LOWER(?))", sql.remove(0));
@@ -4849,7 +4913,9 @@ public class TestFunctionLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE (STRVAL1 = LCASE(?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE (STRVAL1 = LCASE('HELLO WORLD'))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE (STRVAL1 = LOWER(?))", sql.remove(0));
@@ -4869,7 +4935,9 @@ public class TestFunctionLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE (STRVAL1 = LCASE(?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE (STRVAL1 = LCASE('HELLO WORLD'))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE (STRVAL1 = LOWER(?))", sql.remove(0));
@@ -4885,7 +4953,9 @@ public class TestFunctionLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE (STRVAL1 = LCASE(?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE (STRVAL1 = LCASE('HELLO WORLD'))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE (STRVAL1 = LOWER(?))", sql.remove(0));
@@ -5167,7 +5237,9 @@ public class TestFunctionLogic extends AbstractTestLogic {
             query.getResultList();
             List<String> sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE (STRVAL1 = RTRIM(?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE (STRVAL1 = RTRIM('  HELLO WORD '))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE (STRVAL1 = RTRIM(?))", sql.remove(0));
@@ -5177,7 +5249,9 @@ public class TestFunctionLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE (STRVAL1 = RTRIM(?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE (STRVAL1 = RTRIM('  HELLO WORD '))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE (STRVAL1 = RTRIM(?))", sql.remove(0));
@@ -5197,7 +5271,9 @@ public class TestFunctionLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE (STRVAL1 = RTRIM(?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE (STRVAL1 = RTRIM('  HELLO WORD '))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE (STRVAL1 = RTRIM(?))", sql.remove(0));
@@ -5213,7 +5289,9 @@ public class TestFunctionLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE (STRVAL1 = RTRIM(?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE (STRVAL1 = RTRIM('  HELLO WORD '))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE (STRVAL1 = RTRIM(?))", sql.remove(0));
@@ -5497,7 +5575,9 @@ public class TestFunctionLogic extends AbstractTestLogic {
             query.getResultList();
             List<String> sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE (STRVAL1 = TRIM(TRAILING 'A' FROM ?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE (STRVAL1 = TRIM(TRAILING 'A' FROM 'AAAHELLO WORDAA'))", sql.remove(0));
             } else if (isOracle || isPostgres) {
                 Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE (STRVAL1 = RTRIM(?, ?))", sql.remove(0));
@@ -5509,7 +5589,9 @@ public class TestFunctionLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE (STRVAL1 = TRIM(TRAILING 'A' FROM ?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE (STRVAL1 = TRIM(TRAILING 'A' FROM 'AAAHELLO WORDAA'))", sql.remove(0));
             } else if (isOracle || isPostgres) {
                 Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE (STRVAL1 = RTRIM(?, ?))", sql.remove(0));
@@ -5533,7 +5615,9 @@ public class TestFunctionLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE (STRVAL1 = TRIM(TRAILING 'A' FROM ?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE (STRVAL1 = TRIM(TRAILING 'A' FROM 'AAAHELLO WORDAA'))", sql.remove(0));
             } else if (isOracle || isPostgres) {
                 Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE (STRVAL1 = RTRIM(?, ?))", sql.remove(0));
@@ -5551,7 +5635,9 @@ public class TestFunctionLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE (STRVAL1 = TRIM(TRAILING 'A' FROM ?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE (STRVAL1 = TRIM(TRAILING 'A' FROM 'AAAHELLO WORDAA'))", sql.remove(0));
             } else if (isOracle || isPostgres) {
                 Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE (STRVAL1 = RTRIM(?, ?))", sql.remove(0));
@@ -5880,7 +5966,10 @@ public class TestFunctionLogic extends AbstractTestLogic {
             query.getResultList();
             List<String> sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT 1 FROM OLGH17837ENTITY t0 WHERE ((SELECT COUNT(t1.ID) FROM COLTABLE1 t2, OLGH17837ENTITY t1 WHERE (t2.ent_id = t0.ID)) = ?)",
+                                    sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT 1 FROM OLGH17837ENTITY t0 WHERE ((SELECT COUNT(t1.ID) FROM COLTABLE1 t2, OLGH17837ENTITY t1 WHERE (t2.ent_id = t0.ID)) = 36)",
                                     sql.remove(0));
             } else {
@@ -5892,7 +5981,10 @@ public class TestFunctionLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT 1 FROM OLGH17837ENTITY t0 WHERE ((SELECT COUNT(t1.ID) FROM COLTABLE1 t2, OLGH17837ENTITY t1 WHERE (t2.ent_id = t0.ID)) = ?)",
+                                    sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT 1 FROM OLGH17837ENTITY t0 WHERE ((SELECT COUNT(t1.ID) FROM COLTABLE1 t2, OLGH17837ENTITY t1 WHERE (t2.ent_id = t0.ID)) = 36)",
                                     sql.remove(0));
             } else {
@@ -5914,7 +6006,10 @@ public class TestFunctionLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT 1 FROM OLGH17837ENTITY t0 WHERE ((SELECT COUNT(t1.ID) FROM COLTABLE1 t2, OLGH17837ENTITY t1 WHERE (t2.ent_id = t0.ID)) = ?)",
+                                    sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT 1 FROM OLGH17837ENTITY t0 WHERE ((SELECT COUNT(t1.ID) FROM COLTABLE1 t2, OLGH17837ENTITY t1 WHERE (t2.ent_id = t0.ID)) = 36)",
                                     sql.remove(0));
             } else {
@@ -5932,7 +6027,10 @@ public class TestFunctionLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT 1 FROM OLGH17837ENTITY t0 WHERE ((SELECT COUNT(t1.ID) FROM COLTABLE1 t2, OLGH17837ENTITY t1 WHERE (t2.ent_id = t0.ID)) = ?)",
+                                    sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT 1 FROM OLGH17837ENTITY t0 WHERE ((SELECT COUNT(t1.ID) FROM COLTABLE1 t2, OLGH17837ENTITY t1 WHERE (t2.ent_id = t0.ID)) = 36)",
                                     sql.remove(0));
             } else {
@@ -6705,7 +6803,9 @@ public class TestFunctionLogic extends AbstractTestLogic {
             query.getResultList();
             List<String> sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE (STRVAL1 = SUBSTR(?, ?, ?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE (STRVAL1 = SUBSTR('HELLO WORLD', 1, 5))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE (STRVAL1 = SUBSTR(?, ?, ?))", sql.remove(0));
@@ -6715,7 +6815,9 @@ public class TestFunctionLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE (STRVAL1 = SUBSTR(?, ?, ?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE (STRVAL1 = SUBSTR('HELLO WORLD', 1, 5))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE (STRVAL1 = SUBSTR(?, ?, ?))", sql.remove(0));
@@ -6726,7 +6828,9 @@ public class TestFunctionLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE (STRVAL1 = SUBSTR(?, ?, ?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE (STRVAL1 = SUBSTR('HELLO WORLD', 1, 5))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE (STRVAL1 = SUBSTR(?, ?, ?))", sql.remove(0));
@@ -6750,7 +6854,9 @@ public class TestFunctionLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE (STRVAL1 = SUBSTR(?, ?, ?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE (STRVAL1 = SUBSTR('HELLO WORLD', 1, 5))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE (STRVAL1 = SUBSTR(?, ?, ?))", sql.remove(0));
@@ -6766,7 +6872,9 @@ public class TestFunctionLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE (STRVAL1 = SUBSTR(?, ?, ?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE (STRVAL1 = SUBSTR('HELLO WORLD', 1, 5))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE (STRVAL1 = SUBSTR(?, ?, ?))", sql.remove(0));
@@ -6784,7 +6892,9 @@ public class TestFunctionLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE (STRVAL1 = SUBSTR(?, ?, ?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE (STRVAL1 = SUBSTR('HELLO WORLD', 1, 5))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE (STRVAL1 = SUBSTR(?, ?, ?))", sql.remove(0));
@@ -7100,7 +7210,9 @@ public class TestFunctionLogic extends AbstractTestLogic {
             query.getResultList();
             List<String> sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)){
+                Assert.assertEquals("SELECT SUBSTR(?, ?, ?), STRVAL2 FROM OLGH17837ENTITY WHERE (STRVAL1 = SUBSTR(SUBSTR(STRVAL2, ?, ?), ?, ?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT SUBSTR('HELLO WORLD', 1, 5), STRVAL2 FROM OLGH17837ENTITY WHERE (STRVAL1 = SUBSTR(SUBSTR(STRVAL2, 1, 5), 1, 2))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT SUBSTR(?, ?, ?), STRVAL2 FROM OLGH17837ENTITY WHERE (STRVAL1 = SUBSTR(SUBSTR(STRVAL2, ?, ?), ?, ?))", sql.remove(0));
@@ -7110,7 +7222,9 @@ public class TestFunctionLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)){
+                Assert.assertEquals("SELECT SUBSTR(?, ?, ?), STRVAL2 FROM OLGH17837ENTITY WHERE (STRVAL1 = SUBSTR(SUBSTR(STRVAL2, ?, ?), ?, ?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT SUBSTR('HELLO WORLD', 1, 5), STRVAL2 FROM OLGH17837ENTITY WHERE (STRVAL1 = SUBSTR(SUBSTR(STRVAL2, 1, 5), 1, 2))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT SUBSTR(?, ?, ?), STRVAL2 FROM OLGH17837ENTITY WHERE (STRVAL1 = SUBSTR(SUBSTR(STRVAL2, ?, ?), ?, ?))", sql.remove(0));
@@ -7122,7 +7236,9 @@ public class TestFunctionLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)){
+                Assert.assertEquals("SELECT SUBSTR(?, ?, ?), STRVAL2 FROM OLGH17837ENTITY WHERE (STRVAL1 = SUBSTR(SUBSTR(STRVAL2, ?, ?), ?, ?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT SUBSTR('HELLO WORLD', 1, 5), STRVAL2 FROM OLGH17837ENTITY WHERE (STRVAL1 = SUBSTR(SUBSTR(STRVAL2, 1, 5), 1, 2))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT SUBSTR(?, ?, ?), STRVAL2 FROM OLGH17837ENTITY WHERE (STRVAL1 = SUBSTR(SUBSTR(STRVAL2, ?, ?), ?, ?))", sql.remove(0));
@@ -7148,7 +7264,9 @@ public class TestFunctionLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)){
+                Assert.assertEquals("SELECT SUBSTR(?, ?, ?), STRVAL2 FROM OLGH17837ENTITY WHERE (STRVAL1 = SUBSTR(SUBSTR(STRVAL2, ?, ?), ?, ?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT SUBSTR('HELLO WORLD', 1, 5), STRVAL2 FROM OLGH17837ENTITY WHERE (STRVAL1 = SUBSTR(SUBSTR(STRVAL2, 1, 5), 1, 2))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT SUBSTR(?, ?, ?), STRVAL2 FROM OLGH17837ENTITY WHERE (STRVAL1 = SUBSTR(SUBSTR(STRVAL2, ?, ?), ?, ?))", sql.remove(0));
@@ -7164,7 +7282,9 @@ public class TestFunctionLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)){
+                Assert.assertEquals("SELECT SUBSTR(?, ?, ?), STRVAL2 FROM OLGH17837ENTITY WHERE (STRVAL1 = SUBSTR(SUBSTR(STRVAL2, ?, ?), ?, ?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT SUBSTR('HELLO WORLD', 1, 5), STRVAL2 FROM OLGH17837ENTITY WHERE (STRVAL1 = SUBSTR(SUBSTR(STRVAL2, 1, 5), 1, 2))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT SUBSTR(?, ?, ?), STRVAL2 FROM OLGH17837ENTITY WHERE (STRVAL1 = SUBSTR(SUBSTR(STRVAL2, ?, ?), ?, ?))", sql.remove(0));
@@ -7186,7 +7306,9 @@ public class TestFunctionLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)){
+                Assert.assertEquals("SELECT SUBSTR(?, ?, ?), STRVAL2 FROM OLGH17837ENTITY WHERE (STRVAL1 = SUBSTR(SUBSTR(STRVAL2, ?, ?), ?, ?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT SUBSTR('HELLO WORLD', 1, 5), STRVAL2 FROM OLGH17837ENTITY WHERE (STRVAL1 = SUBSTR(SUBSTR(STRVAL2, 1, 5), 1, 2))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT SUBSTR(?, ?, ?), STRVAL2 FROM OLGH17837ENTITY WHERE (STRVAL1 = SUBSTR(SUBSTR(STRVAL2, ?, ?), ?, ?))", sql.remove(0));
@@ -7515,7 +7637,9 @@ public class TestFunctionLogic extends AbstractTestLogic {
             query.getResultList();
             List<String> sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE (STRVAL1 = TRIM(?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE (STRVAL1 = TRIM('  HELLO WORD '))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE (STRVAL1 = TRIM(?))", sql.remove(0));
@@ -7525,7 +7649,9 @@ public class TestFunctionLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE (STRVAL1 = TRIM(?))", sql.remove(0));
+            } else  if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE (STRVAL1 = TRIM('  HELLO WORD '))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE (STRVAL1 = TRIM(?))", sql.remove(0));
@@ -7545,7 +7671,9 @@ public class TestFunctionLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE (STRVAL1 = TRIM(?))", sql.remove(0));
+            } else  if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE (STRVAL1 = TRIM('  HELLO WORD '))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE (STRVAL1 = TRIM(?))", sql.remove(0));
@@ -7561,7 +7689,9 @@ public class TestFunctionLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE (STRVAL1 = TRIM(?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE (STRVAL1 = TRIM('  HELLO WORD '))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE (STRVAL1 = TRIM(?))", sql.remove(0));
@@ -7842,7 +7972,9 @@ public class TestFunctionLogic extends AbstractTestLogic {
             query.getResultList();
             List<String> sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE (STRVAL1 = TRIM('A' FROM ?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE (STRVAL1 = TRIM('A' FROM 'AAAHELLO WORDAA'))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE (STRVAL1 = TRIM(? FROM ?))", sql.remove(0));
@@ -7852,7 +7984,9 @@ public class TestFunctionLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+             if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE (STRVAL1 = TRIM('A' FROM ?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE (STRVAL1 = TRIM('A' FROM 'AAAHELLO WORDAA'))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE (STRVAL1 = TRIM(? FROM ?))", sql.remove(0));
@@ -7863,7 +7997,9 @@ public class TestFunctionLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE (STRVAL1 = TRIM('A' FROM ?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE (STRVAL1 = TRIM('A' FROM 'AAAHELLO WORDAA'))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE (STRVAL1 = TRIM(? FROM ?))", sql.remove(0));
@@ -7885,7 +8021,9 @@ public class TestFunctionLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE (STRVAL1 = TRIM('A' FROM ?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE (STRVAL1 = TRIM('A' FROM 'AAAHELLO WORDAA'))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE (STRVAL1 = TRIM(? FROM ?))", sql.remove(0));
@@ -7901,7 +8039,9 @@ public class TestFunctionLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE (STRVAL1 = TRIM('A' FROM ?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE (STRVAL1 = TRIM('A' FROM 'AAAHELLO WORDAA'))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE (STRVAL1 = TRIM(? FROM ?))", sql.remove(0));
@@ -7920,7 +8060,9 @@ public class TestFunctionLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE (STRVAL1 = TRIM('A' FROM ?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE (STRVAL1 = TRIM('A' FROM 'AAAHELLO WORDAA'))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE (STRVAL1 = TRIM(? FROM ?))", sql.remove(0));
@@ -8312,7 +8454,10 @@ public class TestFunctionLogic extends AbstractTestLogic {
             query.getResultList();
             List<String> sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT TRIM(?), STRVAL1 FROM OLGH17837ENTITY WHERE (INTVAL1 = ?)", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT TRIM('  HELLO WORD '), STRVAL1 FROM OLGH17837ENTITY WHERE (INTVAL1 = 23)", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT TRIM(?), STRVAL1 FROM OLGH17837ENTITY WHERE (INTVAL1 = ?)", sql.remove(0));
@@ -8322,7 +8467,9 @@ public class TestFunctionLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT TRIM(?), STRVAL1 FROM OLGH17837ENTITY WHERE (INTVAL1 = ?)", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT TRIM('  HELLO WORD '), STRVAL1 FROM OLGH17837ENTITY WHERE (INTVAL1 = 23)", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT TRIM(?), STRVAL1 FROM OLGH17837ENTITY WHERE (INTVAL1 = ?)", sql.remove(0));
@@ -8344,7 +8491,9 @@ public class TestFunctionLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT TRIM(?), STRVAL1 FROM OLGH17837ENTITY WHERE (INTVAL1 = ?)", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT TRIM('  HELLO WORD '), STRVAL1 FROM OLGH17837ENTITY WHERE (INTVAL1 = 23)", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT TRIM(?), STRVAL1 FROM OLGH17837ENTITY WHERE (INTVAL1 = ?)", sql.remove(0));
@@ -8360,7 +8509,9 @@ public class TestFunctionLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT TRIM(?), STRVAL1 FROM OLGH17837ENTITY WHERE (INTVAL1 = ?)", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT TRIM('  HELLO WORD '), STRVAL1 FROM OLGH17837ENTITY WHERE (INTVAL1 = 23)", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT TRIM(?), STRVAL1 FROM OLGH17837ENTITY WHERE (INTVAL1 = ?)", sql.remove(0));
@@ -8646,7 +8797,9 @@ public class TestFunctionLogic extends AbstractTestLogic {
             query.getResultList();
             List<String> sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)){
+                Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE (STRVAL1 = UCASE(?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE (STRVAL1 = UCASE('HELLO WORLD'))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE (STRVAL1 = UPPER(?))", sql.remove(0));
@@ -8656,7 +8809,9 @@ public class TestFunctionLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)){
+                Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE (STRVAL1 = UCASE(?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE (STRVAL1 = UCASE('HELLO WORLD'))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE (STRVAL1 = UPPER(?))", sql.remove(0));
@@ -8676,7 +8831,9 @@ public class TestFunctionLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)){
+                Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE (STRVAL1 = UCASE(?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE (STRVAL1 = UCASE('HELLO WORLD'))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE (STRVAL1 = UPPER(?))", sql.remove(0));
@@ -8692,7 +8849,9 @@ public class TestFunctionLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)){
+                Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE (STRVAL1 = UCASE(?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE (STRVAL1 = UCASE('HELLO WORLD'))", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT STRVAL1 FROM OLGH17837ENTITY WHERE (STRVAL1 = UPPER(?))", sql.remove(0));

--- a/dev/com.ibm.ws.jpa.tests.eclipselink.query_fat.common/test-applications/olgh17837/src/com/ibm/ws/jpa/olgh17837/testlogic/TestOrderingLogic.java
+++ b/dev/com.ibm.ws.jpa.tests.eclipselink.query_fat.common/test-applications/olgh17837/src/com/ibm/ws/jpa/olgh17837/testlogic/TestOrderingLogic.java
@@ -392,7 +392,9 @@ public class TestOrderingLogic extends AbstractTestLogic {
             query.getResultList();
             List<String> sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT INTVAL1, INTVAL2 FROM OLGH17837ENTITY WHERE (INTVAL1 = ?) ORDER BY 1 ASC", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT INTVAL1, INTVAL2 FROM OLGH17837ENTITY WHERE (INTVAL1 = 36) ORDER BY 1 ASC", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT INTVAL1, INTVAL2 FROM OLGH17837ENTITY WHERE (INTVAL1 = ?) ORDER BY ? ASC", sql.remove(0));
@@ -402,7 +404,9 @@ public class TestOrderingLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT INTVAL1, INTVAL2 FROM OLGH17837ENTITY WHERE (INTVAL1 = ?) ORDER BY 1 ASC", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT INTVAL1, INTVAL2 FROM OLGH17837ENTITY WHERE (INTVAL1 = 36) ORDER BY 1 ASC", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT INTVAL1, INTVAL2 FROM OLGH17837ENTITY WHERE (INTVAL1 = ?) ORDER BY ? ASC", sql.remove(0));
@@ -413,7 +417,9 @@ public class TestOrderingLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT INTVAL1, INTVAL2 FROM OLGH17837ENTITY WHERE (INTVAL1 = ?) ORDER BY 1 ASC", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT INTVAL1, INTVAL2 FROM OLGH17837ENTITY WHERE (INTVAL1 = 36) ORDER BY 1 ASC", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT INTVAL1, INTVAL2 FROM OLGH17837ENTITY WHERE (INTVAL1 = ?) ORDER BY ? ASC", sql.remove(0));
@@ -428,7 +434,7 @@ public class TestOrderingLogic extends AbstractTestLogic {
             ParameterExpression<Integer> intParam2 = cb.parameter(Integer.class);
             cquery.multiselect(root.get(OLGH17837Entity_.intVal1), root.get(OLGH17837Entity_.intVal2));
             cquery.where(cb.equal(root.get(OLGH17837Entity_.intVal1), intParam1));
-            cquery.orderBy(cb.desc(intParam2));
+            cquery.orderBy(cb.asc(intParam2));
 
             query = em.createQuery(cquery);
             query.setParameter(intParam1, 36);
@@ -436,10 +442,12 @@ public class TestOrderingLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
-                Assert.assertEquals("SELECT INTVAL1, INTVAL2 FROM OLGH17837ENTITY WHERE (INTVAL1 = 36) ORDER BY 1 DESC", sql.remove(0));
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT INTVAL1, INTVAL2 FROM OLGH17837ENTITY WHERE (INTVAL1 = ?) ORDER BY 1 ASC", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
+                Assert.assertEquals("SELECT INTVAL1, INTVAL2 FROM OLGH17837ENTITY WHERE (INTVAL1 = 36) ORDER BY 1 ASC", sql.remove(0));
             } else {
-                Assert.assertEquals("SELECT INTVAL1, INTVAL2 FROM OLGH17837ENTITY WHERE (INTVAL1 = ?) ORDER BY ? DESC", sql.remove(0));
+                Assert.assertEquals("SELECT INTVAL1, INTVAL2 FROM OLGH17837ENTITY WHERE (INTVAL1 = ?) ORDER BY ? ASC", sql.remove(0));
             }
 
             CriteriaBuilder cb2 = em.getCriteriaBuilder();
@@ -447,16 +455,18 @@ public class TestOrderingLogic extends AbstractTestLogic {
             Root<OLGH17837Entity> root2 = cquery2.from(OLGH17837Entity.class);
             cquery2.multiselect(root2.get(OLGH17837Entity_.intVal1), root2.get(OLGH17837Entity_.intVal2));
             cquery2.where(cb2.equal(root2.get(OLGH17837Entity_.intVal1), cb2.literal(36)));
-            cquery2.orderBy(cb2.desc(cb2.literal(1)));
+            cquery2.orderBy(cb2.asc(cb2.literal(1)));
 
             query = em.createQuery(cquery2);
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
-                Assert.assertEquals("SELECT INTVAL1, INTVAL2 FROM OLGH17837ENTITY WHERE (INTVAL1 = 36) ORDER BY 1 DESC", sql.remove(0));
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT INTVAL1, INTVAL2 FROM OLGH17837ENTITY WHERE (INTVAL1 = ?) ORDER BY 1 ASC", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
+                Assert.assertEquals("SELECT INTVAL1, INTVAL2 FROM OLGH17837ENTITY WHERE (INTVAL1 = 36) ORDER BY 1 ASC", sql.remove(0));
             } else {
-                Assert.assertEquals("SELECT INTVAL1, INTVAL2 FROM OLGH17837ENTITY WHERE (INTVAL1 = ?) ORDER BY ? DESC", sql.remove(0));
+                Assert.assertEquals("SELECT INTVAL1, INTVAL2 FROM OLGH17837ENTITY WHERE (INTVAL1 = ?) ORDER BY ? ASC", sql.remove(0));
             }
 
             CriteriaBuilder cb3 = em.getCriteriaBuilder();
@@ -465,17 +475,19 @@ public class TestOrderingLogic extends AbstractTestLogic {
             ParameterExpression<Integer> intParam4 = cb3.parameter(Integer.class);
             cquery3.multiselect(root3.get(OLGH17837Entity_.intVal1), root3.get(OLGH17837Entity_.intVal2));
             cquery3.where(cb3.equal(root3.get(OLGH17837Entity_.intVal1), intParam4));
-            cquery3.orderBy(cb3.desc(cb3.literal(1)));
+            cquery3.orderBy(cb3.asc(cb3.literal(1)));
 
             query = em.createQuery(cquery3);
             query.setParameter(intParam4, 36);
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
-                Assert.assertEquals("SELECT INTVAL1, INTVAL2 FROM OLGH17837ENTITY WHERE (INTVAL1 = 36) ORDER BY 1 DESC", sql.remove(0));
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT INTVAL1, INTVAL2 FROM OLGH17837ENTITY WHERE (INTVAL1 = ?) ORDER BY 1 ASC", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
+                Assert.assertEquals("SELECT INTVAL1, INTVAL2 FROM OLGH17837ENTITY WHERE (INTVAL1 = 36) ORDER BY 1 ASC", sql.remove(0));
             } else {
-                Assert.assertEquals("SELECT INTVAL1, INTVAL2 FROM OLGH17837ENTITY WHERE (INTVAL1 = ?) ORDER BY ? DESC", sql.remove(0));
+                Assert.assertEquals("SELECT INTVAL1, INTVAL2 FROM OLGH17837ENTITY WHERE (INTVAL1 = ?) ORDER BY ? ASC", sql.remove(0));
             }
         } catch (java.lang.AssertionError ae) {
             throw ae;
@@ -1137,7 +1149,9 @@ public class TestOrderingLogic extends AbstractTestLogic {
             query.getResultList();
             List<String> sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT INTVAL1, INTVAL2 FROM OLGH17837ENTITY WHERE (INTVAL1 = ?) ORDER BY 1 DESC", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT INTVAL1, INTVAL2 FROM OLGH17837ENTITY WHERE (INTVAL1 = 36) ORDER BY 1 DESC", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT INTVAL1, INTVAL2 FROM OLGH17837ENTITY WHERE (INTVAL1 = ?) ORDER BY ? DESC", sql.remove(0));
@@ -1147,7 +1161,9 @@ public class TestOrderingLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT INTVAL1, INTVAL2 FROM OLGH17837ENTITY WHERE (INTVAL1 = ?) ORDER BY 1 DESC", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT INTVAL1, INTVAL2 FROM OLGH17837ENTITY WHERE (INTVAL1 = 36) ORDER BY 1 DESC", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT INTVAL1, INTVAL2 FROM OLGH17837ENTITY WHERE (INTVAL1 = ?) ORDER BY ? DESC", sql.remove(0));
@@ -1158,7 +1174,9 @@ public class TestOrderingLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT INTVAL1, INTVAL2 FROM OLGH17837ENTITY WHERE (INTVAL1 = ?) ORDER BY 1 DESC", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT INTVAL1, INTVAL2 FROM OLGH17837ENTITY WHERE (INTVAL1 = 36) ORDER BY 1 DESC", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT INTVAL1, INTVAL2 FROM OLGH17837ENTITY WHERE (INTVAL1 = ?) ORDER BY ? DESC", sql.remove(0));
@@ -1181,7 +1199,9 @@ public class TestOrderingLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT INTVAL1, INTVAL2 FROM OLGH17837ENTITY WHERE (INTVAL1 = ?) ORDER BY 1 DESC", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT INTVAL1, INTVAL2 FROM OLGH17837ENTITY WHERE (INTVAL1 = 36) ORDER BY 1 DESC", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT INTVAL1, INTVAL2 FROM OLGH17837ENTITY WHERE (INTVAL1 = ?) ORDER BY ? DESC", sql.remove(0));
@@ -1198,7 +1218,9 @@ public class TestOrderingLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT INTVAL1, INTVAL2 FROM OLGH17837ENTITY WHERE (INTVAL1 = ?) ORDER BY 1 DESC", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT INTVAL1, INTVAL2 FROM OLGH17837ENTITY WHERE (INTVAL1 = 36) ORDER BY 1 DESC", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT INTVAL1, INTVAL2 FROM OLGH17837ENTITY WHERE (INTVAL1 = ?) ORDER BY ? DESC", sql.remove(0));
@@ -1217,7 +1239,9 @@ public class TestOrderingLogic extends AbstractTestLogic {
             query.getResultList();
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("SELECT INTVAL1, INTVAL2 FROM OLGH17837ENTITY WHERE (INTVAL1 = ?) ORDER BY 1 DESC", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("SELECT INTVAL1, INTVAL2 FROM OLGH17837ENTITY WHERE (INTVAL1 = 36) ORDER BY 1 DESC", sql.remove(0));
             } else {
                 Assert.assertEquals("SELECT INTVAL1, INTVAL2 FROM OLGH17837ENTITY WHERE (INTVAL1 = ?) ORDER BY ? DESC", sql.remove(0));

--- a/dev/com.ibm.ws.jpa.tests.eclipselink.query_fat.common/test-applications/olgh17837/src/com/ibm/ws/jpa/olgh17837/testlogic/TestUpdateLogic.java
+++ b/dev/com.ibm.ws.jpa.tests.eclipselink.query_fat.common/test-applications/olgh17837/src/com/ibm/ws/jpa/olgh17837/testlogic/TestUpdateLogic.java
@@ -83,8 +83,10 @@ public class TestUpdateLogic extends AbstractTestLogic {
             query.executeUpdate();
 
             List<String> sql = SQLCallListener.getAndClearCallList();
-            Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            Assert.assertEquals(1, sql.size());            
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("UPDATE OLGH17837ENTITY SET INTVAL1 = ? WHERE (STRVAL2 = LCASE(?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("UPDATE OLGH17837ENTITY SET INTVAL1 = 9 WHERE (STRVAL2 = LCASE('HELLO'))", sql.remove(0));
             } else {
                 Assert.assertEquals("UPDATE OLGH17837ENTITY SET INTVAL1 = ? WHERE (STRVAL2 = LOWER(?))", sql.remove(0));
@@ -101,7 +103,9 @@ public class TestUpdateLogic extends AbstractTestLogic {
 
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("UPDATE OLGH17837ENTITY SET INTVAL1 = ? WHERE (STRVAL2 = LCASE(?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("UPDATE OLGH17837ENTITY SET INTVAL1 = 9 WHERE (STRVAL2 = LCASE('HELLO'))", sql.remove(0));
             } else {
                 Assert.assertEquals("UPDATE OLGH17837ENTITY SET INTVAL1 = ? WHERE (STRVAL2 = LOWER(?))", sql.remove(0));
@@ -119,7 +123,9 @@ public class TestUpdateLogic extends AbstractTestLogic {
 
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("UPDATE OLGH17837ENTITY SET INTVAL1 = ? WHERE (STRVAL2 = LCASE(?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("UPDATE OLGH17837ENTITY SET INTVAL1 = 9 WHERE (STRVAL2 = LCASE('HELLO'))", sql.remove(0));
             } else {
                 Assert.assertEquals("UPDATE OLGH17837ENTITY SET INTVAL1 = ? WHERE (STRVAL2 = LOWER(?))", sql.remove(0));
@@ -149,7 +155,9 @@ public class TestUpdateLogic extends AbstractTestLogic {
 
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("UPDATE OLGH17837ENTITY SET INTVAL1 = ? WHERE (STRVAL2 = LCASE(?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("UPDATE OLGH17837ENTITY SET INTVAL1 = 9 WHERE (STRVAL2 = LCASE('HELLO'))", sql.remove(0));
             } else {
                 Assert.assertEquals("UPDATE OLGH17837ENTITY SET INTVAL1 = ? WHERE (STRVAL2 = LOWER(?))", sql.remove(0));
@@ -172,7 +180,9 @@ public class TestUpdateLogic extends AbstractTestLogic {
 
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("UPDATE OLGH17837ENTITY SET INTVAL1 = ? WHERE (STRVAL2 = LCASE(?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("UPDATE OLGH17837ENTITY SET INTVAL1 = 9 WHERE (STRVAL2 = LCASE('HELLO'))", sql.remove(0));
             } else {
                 Assert.assertEquals("UPDATE OLGH17837ENTITY SET INTVAL1 = ? WHERE (STRVAL2 = LOWER(?))", sql.remove(0));
@@ -198,7 +208,9 @@ public class TestUpdateLogic extends AbstractTestLogic {
 
             sql = SQLCallListener.getAndClearCallList();
             Assert.assertEquals(1, sql.size());
-            if (isDB2Z || isDB2 || isDerby) {
+            if (isUsingJPA32Feature() && (isDB2Z || isDB2)) {
+                Assert.assertEquals("UPDATE OLGH17837ENTITY SET INTVAL1 = ? WHERE (STRVAL2 = LCASE(?))", sql.remove(0));
+            } else if (isDB2Z || isDB2 || isDerby) {
                 Assert.assertEquals("UPDATE OLGH17837ENTITY SET INTVAL1 = 9 WHERE (STRVAL2 = LCASE('HELLO'))", sql.remove(0));
             } else {
                 Assert.assertEquals("UPDATE OLGH17837ENTITY SET INTVAL1 = ? WHERE (STRVAL2 = LOWER(?))", sql.remove(0));


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

Fixes assertion logic in EclipseLink Query FAT
Fix for RTC 309221