### PR TITLE
Remove internal guards for allowedSignatureAlgorithms metatype attribute

### DIFF
--- a/dev/com.ibm.ws.security.jwt/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.security.jwt/resources/OSGI-INF/metatype/metatype.xml
@@ -83,7 +83,7 @@
             <Option label="%tokenSignAlgorithm.ES512" value="ES512" />
             <Option label="%tokenSignAlgorithm.FROM_HEADER" value="FROM_HEADER" />
         </AD>
-        <AD id="allowedSignatureAlgorithms" required="false" type="String" name="internal" description="internal use only" cardinality="9" default="RS256, RS384, RS512, HS256, HS384, HS512, ES256, ES384, ES512">
+        <AD id="allowedSignatureAlgorithms" required="false" type="String" name="%allowedSignatureAlgorithms" description="%allowedSignatureAlgorithms.desc" cardinality="9" default="RS256, RS384, RS512, HS256, HS384, HS512, ES256, ES384, ES512">
             <Option label="%tokenSignAlgorithm.RS256" value="RS256" />
             <Option label="%tokenSignAlgorithm.RS384" value="RS384" />
             <Option label="%tokenSignAlgorithm.RS512" value="RS512" />

--- a/dev/com.ibm.ws.security.mp.jwt/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.security.mp.jwt/resources/OSGI-INF/metatype/metatype.xml
@@ -69,7 +69,7 @@
             <Option label="%tokenSignAlgorithm.FROM_HEADER" value="FROM_HEADER" />
         </AD>
 
-        <AD id="allowedSignatureAlgorithms" required="false" type="String" name="internal" description="internal use only" cardinality="9" default="RS256, RS384, RS512, HS256, HS384, HS512, ES256, ES384, ES512">
+        <AD id="allowedSignatureAlgorithms" required="false" type="String" name="%allowedSignatureAlgorithms" description="%allowedSignatureAlgorithms.desc" cardinality="9" default="RS256, RS384, RS512, HS256, HS384, HS512, ES256, ES384, ES512">
             <Option label="%tokenSignAlgorithm.RS256" value="RS256" />
             <Option label="%tokenSignAlgorithm.RS384" value="RS384" />
             <Option label="%tokenSignAlgorithm.RS512" value="RS512" />

--- a/dev/com.ibm.ws.security.openidconnect.client/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.security.openidconnect.client/resources/OSGI-INF/metatype/metatype.xml
@@ -50,7 +50,7 @@
              <Option label="%tokenSignAlgorithm.ES512" value="ES512" />
              <Option label="%tokenSignAlgorithm.FROM_HEADER" value="FROM_HEADER" />
          </AD>
-         <AD id="allowedSignatureAlgorithms" required="false" type="String" name="internal" description="internal use only" cardinality="9" default="RS256, RS384, RS512, HS256, HS384, HS512, ES256, ES384, ES512">
+         <AD id="allowedSignatureAlgorithms" required="false" type="String" name="%allowedSignatureAlgorithms" description="%allowedSignatureAlgorithms.desc" cardinality="9" default="RS256, RS384, RS512, HS256, HS384, HS512, ES256, ES384, ES512">
             <Option label="%tokenSignAlgorithm.RS256" value="RS256" />
             <Option label="%tokenSignAlgorithm.RS384" value="RS384" />
             <Option label="%tokenSignAlgorithm.RS512" value="RS512" />

--- a/dev/com.ibm.ws.security.social/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.security.social/resources/OSGI-INF/metatype/metatype.xml
@@ -413,7 +413,7 @@
             required="false"  type="Integer" default="300000" />
         <AD id="signatureAlgorithm" name="%signatureAlgorithm"  description="%signatureAlgorithm.desc"
             required="false" type="String"  default="RS256" />
-        <AD id="allowedSignatureAlgorithms" required="false" type="String" name="internal" description="internal use only" cardinality="9" default="RS256, RS384, RS512, HS256, HS384, HS512, ES256, ES384, ES512">
+        <AD id="allowedSignatureAlgorithms" required="false" type="String" name="%allowedSignatureAlgorithms" description="%allowedSignatureAlgorithms.desc" cardinality="9" default="RS256, RS384, RS512, HS256, HS384, HS512, ES256, ES384, ES512">
             <Option label="%tokenSignAlgorithm.RS256" value="RS256" />
             <Option label="%tokenSignAlgorithm.RS384" value="RS384" />
             <Option label="%tokenSignAlgorithm.RS512" value="RS512" />


### PR DESCRIPTION
- [ ] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [ ] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

################################################################################################
- For #19498
- Remove `internal` and `internal use only` guards from `allowedSignatureAlgorithms` metatype attribute
