### PR TITLE
identify stateful annotations

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/public/data-1.1/io.openliberty.data-1.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/data-1.1/io.openliberty.data-1.1.feature
@@ -21,12 +21,12 @@ IBM-API-Package: \
   jakarta.data.page; type="spec",\
   jakarta.data.page.impl; type="spec",\
   jakarta.data.repository; type="spec",\
+  jakarta.data.repository.stateful; type="spec",\
   jakarta.data.restrict; type="spec",\
   jakarta.data.spi; type="spec",\
   jakarta.data.spi.expression.function; type="spec",\
   jakarta.data.spi.expression.literal; type="spec",\
-  jakarta.data.spi.expression.path; type="spec",\
-  jakarta.data.stateless; type="spec"
+  jakarta.data.spi.expression.path; type="spec"
 Subsystem-Name: Jakarta Data 1.1
 -features=\
   com.ibm.websphere.appserver.eeCompatible-11.0,\

--- a/dev/io.openliberty.data.internal/bnd.bnd
+++ b/dev/io.openliberty.data.internal/bnd.bnd
@@ -37,12 +37,12 @@ DynamicImport-Package: \
   jakarta.data.metamodel, \
   jakarta.data.page, \
   jakarta.data.repository, \
+  jakarta.data.repository.stateful, \
   jakarta.data.restrict, \
   jakarta.data.spi, \
   jakarta.data.spi.expression.function, \
   jakarta.data.spi.expression.literal, \
   jakarta.data.spi.expression.path, \
-  jakarta.data.stateful, \
   jakarta.validation, \
   jakarta.validation.executable, \
   jakarta.validation.metadata

--- a/dev/io.openliberty.data.internal/bnd.bnd
+++ b/dev/io.openliberty.data.internal/bnd.bnd
@@ -42,7 +42,7 @@ DynamicImport-Package: \
   jakarta.data.spi.expression.function, \
   jakarta.data.spi.expression.literal, \
   jakarta.data.spi.expression.path, \
-  jakarta.data.stateless, \
+  jakarta.data.stateful, \
   jakarta.validation, \
   jakarta.validation.executable, \
   jakarta.validation.metadata

--- a/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/DataVersionCompatibility.java
+++ b/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/DataVersionCompatibility.java
@@ -16,7 +16,9 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.util.Collection;
 import java.util.Set;
+import java.util.TreeMap;
 
 import com.ibm.websphere.ras.annotation.Trivial;
 
@@ -84,6 +86,9 @@ public interface DataVersionCompatibility {
      * @param repositoryInterface   interface annotated with @Repository.
      * @param method                repository method.
      * @param methodType            type of repository method, if known in advance.
+     * @param methodTypeAnno        mutually exclusive repository method annotation
+     *                                  (Find/Delete/...) if known in advance,
+     *                                  in which case methodType must be supplied.
      * @param entityParamType       type of the first parameter if a life cycle method,
      *                                  otherwise null.
      * @param isOptional            indicates if the return type is an Optional.
@@ -101,6 +106,7 @@ public interface DataVersionCompatibility {
                                      Class<?> repositoryInterface,
                                      Method method,
                                      QueryType methodType,
+                                     Annotation methodTypeAnno,
                                      Class<?> entityParamType,
                                      boolean isOptional,
                                      Class<?> returnArrayType,
@@ -163,24 +169,60 @@ public interface DataVersionCompatibility {
                                 QueryType queryType);
 
     /**
+     * Returns the repository method annotations that accept JPQL
+     * (such as Query).
+     *
+     * @return the annotation classes.
+     */
+    Set<Class<? extends Annotation>> jpqlQueryAnnoTypes();
+
+    /**
      * Returns the repository method annotations that represent life cycle
      * operations (such as Delete and Insert) for either a stateful or
      * stateless repository, depending on the parameter.
      *
-     * @param stateful true for a stateful repository; false for stateless.
+     * @param stateful true for a stateful repository; false for stateless;
+     *                     null for both.
      * @return the annotation classes.
      */
-    Set<Class<? extends Annotation>> lifeCycleAnnoTypes(boolean stateful);
+    Collection<Class<? extends Annotation>> lifeCycleAnnoTypes(Boolean stateful);
 
     /**
      * Returns the repository method annotations that represent operations
      * (such as Find and Delete, but not OrderBy) for either a stateful or
-     * stateless repository, depending on the parameter.
+     * stateless repository, depending on the parameter. This method is
+     * intended for error reporting and is not written to be efficient.
      *
-     * @param stateful true for a stateful repository; false for stateless.
+     * @param method   the repository method if experimental annotation types
+     *                     should be included. Otherwise null.
+     * @param stateful true for a stateful repository; false for stateless;
+     *                     null for both.
      * @return the annotation classes.
      */
-    Set<Class<? extends Annotation>> operationAnnoTypes(boolean stateful);
+    @Trivial
+    default Collection<Class<? extends Annotation>> operationAnnoTypes(Method method,
+                                                                       Boolean stateful) {
+        TreeMap<String, Class<? extends Annotation>> sorted = new TreeMap<>();
+
+        sorted.put(Find.class.getName(), Find.class);
+
+        for (Class<? extends Annotation> annoClass : jpqlQueryAnnoTypes())
+            sorted.put(annoClass.getSimpleName(), annoClass);
+
+        for (Class<? extends Annotation> annoClass : lifeCycleAnnoTypes(stateful))
+            sorted.put(annoClass.getSimpleName(), annoClass);
+
+        if (method != null) {
+            Annotation anno;
+            if ((anno = getCountAnnotation(method)) != null)
+                sorted.put(anno.annotationType().getName(), anno.annotationType());
+
+            if ((anno = getExistsAnnotation(method)) != null)
+                sorted.put(anno.annotationType().getName(), anno.annotationType());
+        }
+
+        return sorted.values();
+    }
 
     /**
      * Returns the names of annotations that are valid on the parameters of a

--- a/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/Fail.java
+++ b/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/Fail.java
@@ -1053,7 +1053,7 @@ public class Fail {
                   info.method.getName(),
                   info.repositoryInterface.getName(),
                   paramType.getSimpleName(),
-                  info.type.operationName());
+                  info.type.operationName);
     }
 
     /**

--- a/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/QueryInfo.java
+++ b/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/QueryInfo.java
@@ -3352,13 +3352,29 @@ public abstract class QueryInfo {
                     q = generateUpdateEntity();
                 } else if (methodTypeAnno instanceof Delete) { // @Delete annotation
                     q = generateDeleteEntity();
-                } else { // should be unreachable
-                    throw new UnsupportedOperationException("The " + method.getName() + " method of the " +
-                                                            repository.repositoryInterface.getName() +
-                                                            " repository interface must be annotated with one of " +
-                                                            "(Delete, Insert, Save, Update)" +
-                                                            " because the method's parameter accepts entity instances. The following" +
-                                                            " annotations were found: " + Arrays.toString(method.getAnnotations()));
+                } else {
+                    // TODO 1.1 rewrite the following using the superclass and
+                    // move it out of the entityParamType != null block for better
+                    // error checking
+                    Class<? extends Annotation> c = methodTypeAnno.annotationType();
+                    if (c.getSimpleName().equals("Detach"))
+                        setType(c, QueryType.DETACH);
+                    else if (c.getSimpleName().equals("Merge"))
+                        setType(c, QueryType.MERGE);
+                    else if (c.getSimpleName().equals("Persist"))
+                        setType(c, QueryType.PERSIST);
+                    else if (c.getSimpleName().equals("Refresh"))
+                        setType(c, QueryType.REFRESH);
+                    else if (c.getSimpleName().equals("Remove"))
+                        setType(c, QueryType.REMOVE);
+                    else
+                        // should be unreachable
+                        throw new UnsupportedOperationException("The " + method.getName() + " method of the " +
+                                                                repository.repositoryInterface.getName() +
+                                                                " repository interface must be annotated with one of " +
+                                                                "(Delete, Insert, Save, Update)" +
+                                                                " because the method's parameter accepts entity instances. The following" +
+                                                                " annotations were found: " + Arrays.toString(method.getAnnotations()));
                 }
             } else {
                 if (methodTypeAnno != null) {

--- a/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/QueryInfo.java
+++ b/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/QueryInfo.java
@@ -51,6 +51,7 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -59,6 +60,7 @@ import java.util.Set;
 import java.util.TreeMap;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
+import java.util.function.BiFunction;
 import java.util.stream.BaseStream;
 import java.util.stream.Collectors;
 import java.util.stream.DoubleStream;
@@ -162,7 +164,7 @@ public abstract class QueryInfo {
     /**
      * Type of the first parameter if a life cycle method, otherwise null.
      */
-    final Class<?> entityParamType;
+    private final Class<?> entityParamType;
 
     /**
      * Entity identifier variable name if an identifier variable is used.
@@ -360,6 +362,8 @@ public abstract class QueryInfo {
      * @param repositoryInterface   interface annotated with @Repository.
      * @param method                repository method.
      * @param methodType            type of repository method, if known in advance.
+     * @param methodTypeAnno        mutually exclusive repository method annotation
+     *                                  (Find/Delete/...) if known in advance.
      * @param entityParamType       type of the first parameter if a life cycle method,
      *                                  otherwise null.
      * @param isOptional            indicates if the return type is an Optional.
@@ -377,6 +381,7 @@ public abstract class QueryInfo {
                         Class<?> repositoryInterface,
                         Method method,
                         QueryType methodType,
+                        Annotation methodTypeAnno,
                         Class<?> entityParamType,
                         boolean isOptional,
                         Class<?> returnArrayType,
@@ -397,27 +402,28 @@ public abstract class QueryInfo {
             b.append(first ? "()" : ")");
             Tr.entry(this, tc, "<init>",
                      b.toString(),
-                     entityParamType,
+                     "life cycle entity: " + entityParamType,
                      "result isOptional? " + isOptional,
                      "result multiType:  " + multiType,
                      "result singleType: " + singleType,
                      "          element: " + singleTypeElementType,
                      "return array type: " + returnArrayType,
-                     "type if known:     " + type);
+                     "type if known:     " + methodType,
+                     "anno if known:     " + methodTypeAnno);
         }
 
         this.producer = repositoryProducer;
         this.repositoryInterface = repositoryInterface;
         this.method = method;
         this.type = methodType;
+        this.methodTypeAnno = methodTypeAnno;
         this.entityParamType = entityParamType;
         this.isOptional = isOptional;
         this.returnArrayType = returnArrayType;
         this.multiType = multiType;
         this.singleType = singleType;
         this.singleTypeElementType = singleTypeElementType;
-
-        specialParamsStartAt = method.getParameterCount(); // assume none unless found
+        this.specialParamsStartAt = method.getParameterCount(); // assume none unless found
 
         if (trace && tc.isEntryEnabled())
             Tr.exit(this, tc, "<init>", this);
@@ -860,6 +866,7 @@ public abstract class QueryInfo {
                                                 repositoryInterface, //
                                                 method, //
                                                 type, //
+                                                methodTypeAnno, //
                                                 entityParamType, //
                                                 isOptional, //
                                                 multiType, //
@@ -870,7 +877,6 @@ public abstract class QueryInfo {
         info.entityVar = entityVar;
         info.entityVar_ = entityVar_;
         info.maxResults = maxResults;
-        info.methodTypeAnno = methodTypeAnno;
         info.sorts = sortsOverride == null ? sorts : sortsOverride;
         info.validateParams = validateParams;
 
@@ -3149,6 +3155,63 @@ public abstract class QueryInfo {
     }
 
     /**
+     * Looks for mutually exclusive annotations (Delete, Find, Query, ...)
+     * on the repository method, validating that at most one is present and
+     * returning the annotation that is found. Otherwise null.
+     *
+     * @return annotation if present on the method.
+     */
+    @Trivial
+    private Annotation getMutuallyExclusiveMethodAnno() {
+        Annotation methodAnno = null;
+        List<String> conflicts = new LinkedList<String>();
+        DataVersionCompatibility compat = producer.compat();
+
+        BiFunction<Annotation, Annotation, Annotation> inspect = (anno, previous) -> {
+            if (anno == null) {
+                return previous;
+            } else if (previous == null) {
+                return anno;
+            } else { // conflict
+                if (conflicts.isEmpty())
+                    conflicts.add(previous.annotationType().getSimpleName());
+                conflicts.add(anno.annotationType().getSimpleName());
+                return previous;
+            }
+        };
+
+        for (Class<? extends Annotation> annoClass : compat.lifeCycleAnnoTypes(null))
+            methodAnno = inspect.apply(method.getAnnotation(annoClass), methodAnno);
+
+        methodAnno = inspect.apply(compat.getCountAnnotation(method), methodAnno);
+        methodAnno = inspect.apply(compat.getExistsAnnotation(method), methodAnno);
+
+        OrderBy[] orderBy = method.getAnnotationsByType(OrderBy.class);
+        if (orderBy.length > 0 &&
+            methodTypeAnno != null &&
+            !(methodTypeAnno instanceof Delete))
+            conflicts.add(OrderBy.class.getName());
+
+        for (Class<? extends Annotation> annoClass : compat.jpqlQueryAnnoTypes())
+            methodAnno = inspect.apply(method.getAnnotation(annoClass), methodAnno);
+
+        methodAnno = inspect.apply(method.getAnnotation(Find.class), methodAnno);
+
+        if (!conflicts.isEmpty())
+            // Invalid combination of multiple annotations
+            throw exc(UnsupportedOperationException.class,
+                      "CWWKD1002.method.annos.err",
+                      method.getName(),
+                      repositoryInterface.getName(),
+                      conflicts);
+
+        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
+            Tr.debug(this, tc, "getMutuallyExclusiveMethodAnno: " +
+                               (methodAnno == null ? null : methodAnno.annotationType()));
+        return methodAnno;
+    }
+
+    /**
      * Creates a Sort instance with the corresponding entity attribute name
      * or returns the existing instance if it already matches.
      *
@@ -3234,7 +3297,8 @@ public abstract class QueryInfo {
     }
 
     /**
-     * Gathers the information that is needed to perform the query that the repository method represents.
+     * Gathers the information that is needed to perform the query that the
+     * repository method represents.
      *
      * @param entityInfos map of entity name to entity information.
      * @param repository  repository implementation.
@@ -3242,13 +3306,16 @@ public abstract class QueryInfo {
      */
     @FFDCIgnore(Throwable.class) // report invalid repository methods as errors instead
     @Trivial
-    QueryInfo init(Map<String, CompletableFuture<EntityInfo>> entityInfos, RepositoryImpl<?> repository) {
+    QueryInfo init(Map<String, CompletableFuture<EntityInfo>> entityInfos,
+                   RepositoryImpl<?> repository) {
         final boolean trace = TraceComponent.isAnyTracingEnabled();
         if (trace && tc.isEntryEnabled())
             Tr.entry(this, tc, "init", entityInfos, this);
 
         try {
             DataVersionCompatibility compat = repository.provider.compat;
+
+            methodTypeAnno = getMutuallyExclusiveMethodAnno();
 
             entityInfo = entityInfos.size() == 1 //
                             ? entityInfos.values().iterator().next().join() //
@@ -3260,40 +3327,30 @@ public abstract class QueryInfo {
                 validateResult = v[1];
             }
 
-            boolean countPages = Page.class.equals(multiType) || CursoredPage.class.equals(multiType);
+            boolean countPages = Page.class.equals(multiType) ||
+                                 CursoredPage.class.equals(multiType);
             StringBuilder q = null;
             boolean validateNumberOfMethodArgs = true;
 
-            // spec-defined annotation types
-            Delete delete = method.getAnnotation(Delete.class);
-            Find find = method.getAnnotation(Find.class);
-            Insert insert = method.getAnnotation(Insert.class);
-            Update update = method.getAnnotation(Update.class);
-            Save save = method.getAnnotation(Save.class);
-            Query query = method.getAnnotation(Query.class);
-            OrderBy[] orderBy = method.getAnnotationsByType(OrderBy.class);
+            String queryAnnoValue;
+            if (methodTypeAnno instanceof Query query) // @Query annotation
+                queryAnnoValue = query.value();
+            else // TODO query annotations from Jakarta Persistence
+                queryAnnoValue = null;
 
-            // experimental annotation types
-            Annotation count = compat.getCountAnnotation(method);
-            Annotation exists = compat.getExistsAnnotation(method);
-
-            methodTypeAnno = validateAnnotationCombinations(delete, insert, update, save,
-                                                            find, query, orderBy,
-                                                            count, exists);
-
-            if (query != null) { // @Query annotation
-                initQueryLanguage(query.value(),
+            if (queryAnnoValue != null) {
+                initQueryLanguage(queryAnnoValue,
                                   entityInfos,
                                   repository.primaryEntityInfoFuture,
                                   compat);
-            } else if (save != null) { // @Save annotation
-                setType(Save.class, SAVE);
-            } else if (insert != null) { // @Insert annotation
+            } else if (methodTypeAnno instanceof Insert) { // @Insert annotation
                 setType(Insert.class, INSERT);
+            } else if (methodTypeAnno instanceof Save) { // @Save annotation
+                setType(Save.class, SAVE);
             } else if (entityParamType != null) {
-                if (update != null) { // @Update annotation
+                if (methodTypeAnno instanceof Update) { // @Update annotation
                     q = generateUpdateEntity();
-                } else if (delete != null) { // @Delete annotation
+                } else if (methodTypeAnno instanceof Delete) { // @Delete annotation
                     q = generateDeleteEntity();
                 } else { // should be unreachable
                     throw new UnsupportedOperationException("The " + method.getName() + " method of the " +
@@ -3326,6 +3383,7 @@ public abstract class QueryInfo {
             }
 
             // The @OrderBy annotation from Jakarta Data provides sort criteria statically
+            OrderBy[] orderBy = method.getAnnotationsByType(OrderBy.class);
             if (orderBy.length > 0) {
                 if (type != FIND && type != FIND_AND_DELETE || sorts != null)
                     throw Fail.orderByAnnoIncompat(this);
@@ -3355,7 +3413,7 @@ public abstract class QueryInfo {
             // Default to ascending by ID when the repository method that uses
             // pagination does not provide a way to indicate sort criteria.
             if (type == FIND &&
-                query == null && // do not change the user's Query value
+                queryAnnoValue == null && // do not change the user's Query value
                 sortPositions.length == 0 &&
                 (sorts == null || sorts.isEmpty()) &&
                 (Page.class.equals(multiType) ||
@@ -5227,7 +5285,7 @@ public abstract class QueryInfo {
                       "CWWKD1009.lifecycle.param.err",
                       method.getName(),
                       repositoryInterface.getName(),
-                      paramCount == 1 ? method.getGenericParameterTypes()[0] //
+                      paramCount == 1 ? method.getGenericParameterTypes()[0].getTypeName() //
                                       : paramCount,
                       annoClass.getSimpleName());
         }
@@ -5632,70 +5690,6 @@ public abstract class QueryInfo {
                           method.getGenericReturnType().getTypeName(),
                           "Order, Sort, Sort[]");
         }
-    }
-
-    /**
-     * Ensure that the annotations are valid together on the same repository method.
-     *
-     * @param delete  The Delete annotation if present, otherwise null.
-     * @param insert  The Insert annotation if present, otherwise null.
-     * @param update  The Update annotation if present, otherwise null.
-     * @param save    The Save annotation if present, otherwise null.
-     * @param find    The Find annotation if present, otherwise null.
-     * @param query   The Query annotation if present, otherwise null.
-     * @param orderBy array of OrderBy annotations if present, otherwise an empty array.
-     * @param count   The Count annotation if present, otherwise null.
-     * @param exists  The Exists annotation if present, otherwise null.
-     * @return Count, Delete, Exists, Find, Insert, Query, Save, or Update annotation if present. Otherwise null.
-     * @throws UnsupportedOperationException if the combination of annotations is not valid.
-     */
-    @Trivial
-    private Annotation validateAnnotationCombinations(Delete delete, Insert insert, Update update, Save save,
-                                                      Find find, jakarta.data.repository.Query query, OrderBy[] orderBy,
-                                                      Annotation count, Annotation exists) {
-        int o = orderBy.length == 0 ? 0 : 1;
-
-        // These can be paired with OrderBy:
-        int f = find == null ? 0 : 1;
-        int q = query == null ? 0 : 1;
-
-        // These cannot be paired with OrderBy or with each other:
-        int ius = (insert == null ? 0 : 1) +
-                  (update == null ? 0 : 1) +
-                  (save == null ? 0 : 1);
-
-        int iusce = ius +
-                    (count == null ? 0 : 1) +
-                    (exists == null ? 0 : 1);
-
-        int iusdce = iusce +
-                     (delete == null ? 0 : 1);
-
-        if (iusdce + f > 1 // more than one of (Insert, Update, Save, Delete, Count, Exists, Find)
-            || iusce + o > 1 // more than one of (Insert, Update, Save, Delete, Count, Exists, OrderBy)
-            || iusdce + q > 1) { // one of (Insert, Update, Save, Delete, Count, Exists) with Query
-
-            // Invalid combination of multiple annotations
-
-            List<String> annoClassNames = new ArrayList<String>();
-            for (Annotation anno : Arrays.asList(count, delete, exists, find, insert, query, save, update))
-                if (anno != null)
-                    annoClassNames.add(anno.annotationType().getName());
-            if (orderBy.length > 0)
-                annoClassNames.add(OrderBy.class.getName());
-
-            throw exc(UnsupportedOperationException.class,
-                      "CWWKD1002.method.annos.err",
-                      method.getName(),
-                      repositoryInterface.getName(),
-                      annoClassNames);
-        }
-
-        return ius == 1 //
-                        ? (insert != null ? insert : update != null ? update : save) //
-                        : iusdce == 1 //
-                                        ? (delete != null ? delete : count != null ? count : exists) //
-                                        : (q == 1 ? query : f == 1 ? find : null);
     }
 
     /**

--- a/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/QueryInfo.java
+++ b/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/QueryInfo.java
@@ -3188,8 +3188,8 @@ public abstract class QueryInfo {
 
         OrderBy[] orderBy = method.getAnnotationsByType(OrderBy.class);
         if (orderBy.length > 0 &&
-            methodTypeAnno != null &&
-            !(methodTypeAnno instanceof Delete))
+            methodAnno != null &&
+            !(methodAnno instanceof Delete))
             conflicts.add(OrderBy.class.getName());
 
         for (Class<? extends Annotation> annoClass : compat.jpqlQueryAnnoTypes())

--- a/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/QueryType.java
+++ b/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/QueryType.java
@@ -130,7 +130,7 @@ public enum QueryType {
            !Require.AUTO_START_TX, //
            !Require.DETACH_ENTITIES, //
            !Require.RETURN_HIDDEN, //
-           Require.STATELESS),
+           Require.STATEFUL),
 
     // resource accessor method
     RESOURCE_ACCESS(null, //

--- a/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/QueryType.java
+++ b/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/QueryType.java
@@ -12,6 +12,8 @@
  *******************************************************************************/
 package io.openliberty.data.internal;
 
+import com.ibm.websphere.ras.Tr;
+import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.websphere.ras.annotation.Trivial;
 
 import jakarta.data.repository.Delete;
@@ -29,103 +31,122 @@ public enum QueryType {
     COUNT(null, //
           !Require.AUTO_START_TX, //
           !Require.DETACH_ENTITIES, //
-          !Require.RETURN_HIDDEN),
+          !Require.RETURN_HIDDEN, //
+          null), // stateful or stateless
 
     // stateful repository life cycle method @Detach
     DETACH("Detach", //
            !Require.AUTO_START_TX, //
            Require.DETACH_ENTITIES, //
-           !Require.RETURN_HIDDEN),
+           !Require.RETURN_HIDDEN, //
+           Require.STATEFUL),
 
     // repository query method exists
     EXISTS(null, //
            !Require.AUTO_START_TX, //
            !Require.DETACH_ENTITIES, //
-           !Require.RETURN_HIDDEN),
+           !Require.RETURN_HIDDEN, //
+           null), // stateful or stateless
 
     // repository query method find/@Find/@Query(SELECT/FROM/WHERE)
     FIND(Find.class.getSimpleName(), //
          !Require.AUTO_START_TX, //
-         Require.DETACH_ENTITIES, //
-         Require.RETURN_HIDDEN),
+         null, // detach depends on stateless vs stateful repository
+         Require.RETURN_HIDDEN, //
+         null), // stateful or stateless
 
     // stateless repository query method delete/@Delete with entity result
     FIND_AND_DELETE(Delete.class.getSimpleName(), //
                     Require.AUTO_START_TX, //
                     Require.DETACH_ENTITIES, //
-                    Require.RETURN_HIDDEN),
+                    Require.RETURN_HIDDEN, //
+                    Require.STATELESS),
 
     // stateless repository life cycle method @Insert
     INSERT(Insert.class.getSimpleName(), //
            Require.AUTO_START_TX, //
            Require.DETACH_ENTITIES, //
-           Require.RETURN_HIDDEN),
+           Require.RETURN_HIDDEN, //
+           Require.STATELESS),
 
     // stateless repository life cycle method @Delete
     LC_DELETE(Delete.class.getSimpleName(), //
               Require.AUTO_START_TX, //
               !Require.DETACH_ENTITIES, //
-              !Require.RETURN_HIDDEN),
+              !Require.RETURN_HIDDEN, //
+              Require.STATELESS),
 
     // stateless repository life cycle method @Update
     LC_UPDATE(Update.class.getSimpleName(), //
               Require.AUTO_START_TX, //
               !Require.DETACH_ENTITIES, //
-              !Require.RETURN_HIDDEN),
+              !Require.RETURN_HIDDEN, //
+              Require.STATELESS),
 
     // stateless repository life cycle method @Update with entity result (find & merge)
     LC_UPDATE_MERGE(Update.class.getSimpleName(), //
                     Require.AUTO_START_TX, //
                     Require.DETACH_ENTITIES, //
-                    Require.RETURN_HIDDEN),
+                    Require.RETURN_HIDDEN, //
+                    Require.STATELESS),
 
     // stateful repository life cycle method @Merge
     MERGE("Merge", //
           !Require.AUTO_START_TX, //
           !Require.DETACH_ENTITIES, //
-          Require.RETURN_HIDDEN),
+          Require.RETURN_HIDDEN, //
+          Require.STATEFUL),
 
     // stateful repository life cycle method @Persist
     PERSIST("Persist", //
             !Require.AUTO_START_TX, //
             !Require.DETACH_ENTITIES, //
-            !Require.RETURN_HIDDEN),
+            !Require.RETURN_HIDDEN, //
+            Require.STATEFUL),
 
     // stateless repository query method delete/@Delete/@Query(DELETE)
     QM_DELETE(Delete.class.getSimpleName(), //
               Require.AUTO_START_TX, //
               !Require.DETACH_ENTITIES, //
-              !Require.RETURN_HIDDEN),
+              !Require.RETURN_HIDDEN, //
+              Require.STATELESS),
 
     // stateless repository query method update/@Update/@Query(UPDATE)
     QM_UPDATE(Update.class.getSimpleName(), //
               Require.AUTO_START_TX, //
               !Require.DETACH_ENTITIES, //
-              !Require.RETURN_HIDDEN),
+              !Require.RETURN_HIDDEN, //
+              Require.STATELESS),
 
     // stateful repository life cycle method @Refresh
     REFRESH("Refresh", //
             !Require.AUTO_START_TX, //
             !Require.DETACH_ENTITIES, //
-            !Require.RETURN_HIDDEN),
+            !Require.RETURN_HIDDEN, //
+            Require.STATEFUL),
 
     // stateful repository life cycle method @Remove
     REMOVE("Remove", //
            !Require.AUTO_START_TX, //
            !Require.DETACH_ENTITIES, //
-           !Require.RETURN_HIDDEN),
+           !Require.RETURN_HIDDEN, //
+           Require.STATELESS),
 
     // resource accessor method
     RESOURCE_ACCESS(null, //
                     !Require.AUTO_START_TX, //
                     !Require.DETACH_ENTITIES, //
-                    !Require.RETURN_HIDDEN),
+                    !Require.RETURN_HIDDEN, //
+                    null), // stateful or stateless
 
     // stateless repository life cycle method @Save
     SAVE(Save.class.getSimpleName(), //
          Require.AUTO_START_TX, //
          Require.DETACH_ENTITIES, //
-         Require.RETURN_HIDDEN);
+         Require.RETURN_HIDDEN, //
+         Require.STATELESS);
+
+    private final static TraceComponent tc = Tr.register(QueryType.class);
 
     /**
      * Indicate if we must automatically start a transaction before invoking
@@ -135,10 +156,12 @@ public enum QueryType {
     public final boolean autoStartTransaction;
 
     /**
-     * Indicates that a stateless repository must clear the entity manager to
-     * detach entities after the operation.
+     * Indicates that a repository must clear the entity manager to detach entities
+     * after the operation. Null indicates detach depends on the repository type:
+     * For stateful repositories, never detach entities. For stateless repositories,
+     * always detach entities.
      */
-    public final boolean detachEntities;
+    private final Boolean detachEntities;
 
     /**
      * Indicates if a return value from this type of method must be hidden from
@@ -156,25 +179,58 @@ public enum QueryType {
     public final String operationName;
 
     /**
+     * TRUE indicates the operation is for stateful repositories only.
+     * FALSE indicates the operation is for stateless repositories only.
+     * NULL indicates operation is not limited to stateful or stateless
+     * and applies to either repository type.
+     */
+    private final Boolean stateful;
+
+    /**
      * Internal constructor for enumeration values.
      *
      * @param annoName             Simple name of the equivalent repository method
      *                                 annotation.
      * @param autoStartTransaction automatically start a transaction for the
      *                                 operation.
-     * @param detachEntities       require a stateless repository to detach entities
-     *                                 after the operation.
+     * @param detachEntities       require that the repository does (vs does not)
+     *                                 detach entities after the operation.
+     *                                 Null defers to the type of repository.
      * @param hideReturnValue      suppress logging/tracing of the method's return
      *                                 value by default
+     *                                 ;
      */
     private QueryType(String annoName,
                       boolean autoStartTransaction,
-                      boolean detachEntities,
-                      boolean hideReturnValue) {
+                      Boolean detachEntities,
+                      boolean hideReturnValue,
+                      Boolean stateful) {
         this.autoStartTransaction = autoStartTransaction;
         this.detachEntities = detachEntities;
         this.hideReturnValue = hideReturnValue;
         this.operationName = annoName == null ? name() : annoName;
+        this.stateful = stateful;
+    }
+
+    /**
+     * Indicates if the repository must clear the entity manager to
+     * detach entities after the operation completes.
+     *
+     * @param stateful indicates if the repository is stateful (vs stateless).
+     * @return whether the repository should detach entities.
+     */
+    public boolean detachEntities(boolean stateful) {
+        if (stateful && this.stateful == Boolean.FALSE ||
+            !stateful && this.stateful == Boolean.TRUE) // internal error
+            throw new IllegalStateException(name() + ": " + this.stateful +
+                                            " vs " + stateful);
+
+        boolean detach = detachEntities == null ? !stateful : detachEntities;
+        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
+            Tr.debug(this, tc,
+                     name() + " detachEntities stateful? " + stateful,
+                     detach);
+        return detach;
     }
 
     /**
@@ -187,5 +243,7 @@ public enum QueryType {
         static final boolean AUTO_START_TX = true;
         static final boolean DETACH_ENTITIES = true;
         static final boolean RETURN_HIDDEN = true;
+        static final boolean STATEFUL = true;
+        static final boolean STATELESS = false;
     }
 }

--- a/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/QueryType.java
+++ b/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/QueryType.java
@@ -12,8 +12,6 @@
  *******************************************************************************/
 package io.openliberty.data.internal;
 
-import java.lang.annotation.Annotation;
-
 import com.ibm.websphere.ras.annotation.Trivial;
 
 import jakarta.data.repository.Delete;
@@ -27,83 +25,114 @@ import jakarta.data.repository.Update;
  */
 @Trivial
 public enum QueryType {
-    // query method count
+    // repository query method count
     COUNT(null, //
-          !Require.TX, //
+          !Require.AUTO_START_TX, //
           !Require.DETACH_ENTITIES, //
           !Require.RETURN_HIDDEN),
 
-    // query method exists
+    // stateful repository life cycle method @Detach
+    DETACH("Detach", //
+           !Require.AUTO_START_TX, //
+           Require.DETACH_ENTITIES, //
+           !Require.RETURN_HIDDEN),
+
+    // repository query method exists
     EXISTS(null, //
-           !Require.TX, //
+           !Require.AUTO_START_TX, //
            !Require.DETACH_ENTITIES, //
            !Require.RETURN_HIDDEN),
 
-    // query method find/@Find/@Query(SELECT/FROM/WHERE)
-    FIND(Find.class, //
-         !Require.TX, //
+    // repository query method find/@Find/@Query(SELECT/FROM/WHERE)
+    FIND(Find.class.getSimpleName(), //
+         !Require.AUTO_START_TX, //
          Require.DETACH_ENTITIES, //
          Require.RETURN_HIDDEN),
 
-    // query method delete/@Delete with entity result
-    FIND_AND_DELETE(Delete.class, //
-                    Require.TX, //
+    // stateless repository query method delete/@Delete with entity result
+    FIND_AND_DELETE(Delete.class.getSimpleName(), //
+                    Require.AUTO_START_TX, //
                     Require.DETACH_ENTITIES, //
                     Require.RETURN_HIDDEN),
 
-    // life cycle @Insert
-    INSERT(Insert.class, //
-           Require.TX, //
+    // stateless repository life cycle method @Insert
+    INSERT(Insert.class.getSimpleName(), //
+           Require.AUTO_START_TX, //
            Require.DETACH_ENTITIES, //
            Require.RETURN_HIDDEN),
 
-    // life cycle @Delete
-    LC_DELETE(Delete.class, //
-              Require.TX, //
+    // stateless repository life cycle method @Delete
+    LC_DELETE(Delete.class.getSimpleName(), //
+              Require.AUTO_START_TX, //
               !Require.DETACH_ENTITIES, //
               !Require.RETURN_HIDDEN),
 
-    // life cycle @Update
-    LC_UPDATE(Update.class, //
-              Require.TX, //
+    // stateless repository life cycle method @Update
+    LC_UPDATE(Update.class.getSimpleName(), //
+              Require.AUTO_START_TX, //
               !Require.DETACH_ENTITIES, //
               !Require.RETURN_HIDDEN),
 
-    // life cycle @Update with entity result (find & merge)
-    LC_UPDATE_MERGE(Update.class, //
-                    Require.TX, //
+    // stateless repository life cycle method @Update with entity result (find & merge)
+    LC_UPDATE_MERGE(Update.class.getSimpleName(), //
+                    Require.AUTO_START_TX, //
                     Require.DETACH_ENTITIES, //
                     Require.RETURN_HIDDEN),
 
-    // query method delete/@Delete/@Query(DELETE)
-    QM_DELETE(Delete.class, //
-              Require.TX, //
+    // stateful repository life cycle method @Merge
+    MERGE("Merge", //
+          !Require.AUTO_START_TX, //
+          !Require.DETACH_ENTITIES, //
+          Require.RETURN_HIDDEN),
+
+    // stateful repository life cycle method @Persist
+    PERSIST("Persist", //
+            !Require.AUTO_START_TX, //
+            !Require.DETACH_ENTITIES, //
+            !Require.RETURN_HIDDEN),
+
+    // stateless repository query method delete/@Delete/@Query(DELETE)
+    QM_DELETE(Delete.class.getSimpleName(), //
+              Require.AUTO_START_TX, //
               !Require.DETACH_ENTITIES, //
               !Require.RETURN_HIDDEN),
 
-    // query method update/@Update/@Query(UPDATE)
-    QM_UPDATE(Update.class, //
-              Require.TX, //
+    // stateless repository query method update/@Update/@Query(UPDATE)
+    QM_UPDATE(Update.class.getSimpleName(), //
+              Require.AUTO_START_TX, //
               !Require.DETACH_ENTITIES, //
               !Require.RETURN_HIDDEN),
+
+    // stateful repository life cycle method @Refresh
+    REFRESH("Refresh", //
+            !Require.AUTO_START_TX, //
+            !Require.DETACH_ENTITIES, //
+            !Require.RETURN_HIDDEN),
+
+    // stateful repository life cycle method @Remove
+    REMOVE("Remove", //
+           !Require.AUTO_START_TX, //
+           !Require.DETACH_ENTITIES, //
+           !Require.RETURN_HIDDEN),
 
     // resource accessor method
     RESOURCE_ACCESS(null, //
-                    !Require.TX, //
+                    !Require.AUTO_START_TX, //
                     !Require.DETACH_ENTITIES, //
                     !Require.RETURN_HIDDEN),
 
-    // life cycle @Save
-    SAVE(Save.class, //
-         Require.TX, //
+    // stateless repository life cycle method @Save
+    SAVE(Save.class.getSimpleName(), //
+         Require.AUTO_START_TX, //
          Require.DETACH_ENTITIES, //
          Require.RETURN_HIDDEN);
 
     /**
-     * Annotation class that corresponds to the type of repository operation.
-     * Otherwise null.
+     * Indicate if we must automatically start a transaction before invoking
+     * the repository operation if a transaction is not already present.
+     * For stateful entities, this will always be false.
      */
-    public final Class<? extends Annotation> annoClass;
+    public final boolean autoStartTransaction;
 
     /**
      * Indicates that a stateless repository must clear the entity manager to
@@ -118,38 +147,34 @@ public enum QueryType {
     public final boolean hideReturnValue;
 
     /**
-     * Indicate if the operation must be run within a transaction.
+     * Name of the operation performed by the repository method,
+     * suitable for display in messages to the user.
+     * If an equivalent annotation (such as Find, Save, or Delete) exists,
+     * then the name is the simple name of the annotation. Otherwise, the
+     * name is the {@link #name()} of the enumeration constant.
      */
-    public final boolean requiresTransaction;
+    public final String operationName;
 
     /**
      * Internal constructor for enumeration values.
      *
-     * @param annoClass           Jakarta Data annotation class. Otherwise null.
-     * @param requiresTransaction require a transaction for the operation.
-     * @param detachEntities      require a stateless repository to detach entities
-     *                                after the operation.
-     * @param hideReturnValue     suppress logging/tracing of the method's return
-     *                                value by default
+     * @param annoName             Simple name of the equivalent repository method
+     *                                 annotation.
+     * @param autoStartTransaction automatically start a transaction for the
+     *                                 operation.
+     * @param detachEntities       require a stateless repository to detach entities
+     *                                 after the operation.
+     * @param hideReturnValue      suppress logging/tracing of the method's return
+     *                                 value by default
      */
-    private QueryType(Class<? extends Annotation> annoClass,
-                      boolean requiresTransaction,
+    private QueryType(String annoName,
+                      boolean autoStartTransaction,
                       boolean detachEntities,
                       boolean hideReturnValue) {
-        this.annoClass = annoClass;
+        this.autoStartTransaction = autoStartTransaction;
         this.detachEntities = detachEntities;
         this.hideReturnValue = hideReturnValue;
-        this.requiresTransaction = requiresTransaction;
-    }
-
-    /**
-     * Name suitable for display in messages to the user.
-     *
-     * @return name of the repository operation.
-     */
-    @Trivial
-    public String operationName() {
-        return annoClass == null ? name() : annoClass.getSimpleName();
+        this.operationName = annoName == null ? name() : annoName;
     }
 
     /**
@@ -159,8 +184,8 @@ public enum QueryType {
      * declared later in the file.
      */
     private static final class Require {
+        static final boolean AUTO_START_TX = true;
         static final boolean DETACH_ENTITIES = true;
         static final boolean RETURN_HIDDEN = true;
-        static final boolean TX = true;
     }
 }

--- a/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/RepositoryImpl.java
+++ b/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/RepositoryImpl.java
@@ -479,7 +479,7 @@ public class RepositoryImpl<R> implements InvocationHandler {
                                '.' + method.getName(),
                      provider.loggable(repositoryInterface, method, args));
 
-        EntityInfo entityInfo = null;
+        QueryInfo queryInfo = null;
 
         try {
             if (isDisposed.get())
@@ -530,8 +530,7 @@ public class RepositoryImpl<R> implements InvocationHandler {
             boolean startedTransaction = false;
 
             try {
-                QueryInfo queryInfo = queryInfoFuture.join();
-                entityInfo = queryInfo.entityInfo;
+                queryInfo = queryInfoFuture.join();
 
                 if (trace && tc.isDebugEnabled())
                     Tr.debug(this, tc, queryInfo.toString());
@@ -553,7 +552,7 @@ public class RepositoryImpl<R> implements InvocationHandler {
                 }
 
                 if (queryType != RESOURCE_ACCESS)
-                    em = entityInfo.builder.createEntityManager();
+                    em = queryInfo.entityInfo.builder.createEntityManager();
 
                 returnValue = switch (queryType) {
                     case FIND, FIND_AND_DELETE -> queryInfo.find(em, txStatus, args);
@@ -589,25 +588,26 @@ public class RepositoryImpl<R> implements InvocationHandler {
                             provider.tranMgr.commit();
                         }
                     } else {
+                        boolean detach;
+                        detach = em != null &&
+                                 queryType.detachEntities(queryInfo.producer.stateful());
                         if (Status.STATUS_ACTIVE == provider.tranMgr.getStatus()) {
                             if (failed) {
                                 if (trace && tc.isDebugEnabled())
                                     Tr.debug(this, tc, "set rollback only");
                                 provider.tranMgr.setRollbackOnly();
-                            } else if (em != null && queryType.detachEntities) {
+                            } else if (detach) {
                                 // flush changes first because detach interferes with updates
                                 if (trace && tc.isDebugEnabled())
                                     Tr.debug(this, tc, "flush");
                                 em.flush();
-                                // TODO 1.1 only detach if a stateless repository
-                                if (entityInfo != null) {
+                                if (queryInfo.entityInfo != null) {
                                     if (trace && tc.isDebugEnabled())
                                         Tr.debug(this, tc, "clear");
                                     em.clear();
                                 }
                             }
-                        } else if (em != null && queryType.detachEntities) {
-                            // TODO 1.1 only detach if a stateless repository
+                        } else if (detach) {
                             if (trace && tc.isDebugEnabled())
                                 Tr.debug(this, tc, "clear");
                             em.clear();
@@ -638,7 +638,10 @@ public class RepositoryImpl<R> implements InvocationHandler {
             return returnValue;
         } catch (Throwable x) {
             if (!isDefaultMethod && x instanceof Exception)
-                x = failure((Exception) x, entityInfo == null ? null : entityInfo.builder);
+                x = failure((Exception) x,
+                            queryInfo == null || queryInfo.entityInfo == null //
+                                            ? null //
+                                            : queryInfo.entityInfo.builder);
             if (trace && tc.isEntryEnabled())
                 Tr.exit(this, tc, "invoke " + repositoryInterface.getSimpleName() +
                                   '.' + method.getName(),

--- a/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/RepositoryImpl.java
+++ b/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/RepositoryImpl.java
@@ -540,7 +540,7 @@ public class RepositoryImpl<R> implements InvocationHandler {
                     validator.validateParameters(proxy, method, args);
 
                 int txStatus = provider.tranMgr.getStatus();
-                if ((queryType = queryInfo.type).requiresTransaction &&
+                if ((queryType = queryInfo.type).autoStartTransaction &&
                     txStatus == Status.STATUS_NO_TRANSACTION) {
                     suspendedLTC = provider.localTranCurrent.suspend();
                     provider.tranMgr.begin();
@@ -566,6 +566,7 @@ public class RepositoryImpl<R> implements InvocationHandler {
                     case LC_UPDATE -> queryInfo.update(args[0], em);
                     case LC_UPDATE_MERGE -> queryInfo.findAndUpdate(args[0], em);
                     case RESOURCE_ACCESS -> getResource(method);
+                    default -> throw new UnsupportedOperationException(queryType.operationName);
                 };
 
                 if (queryInfo.validateResult)

--- a/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/Util.java
+++ b/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/Util.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024,2025 IBM Corporation and others.
+ * Copyright (c) 2024,2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -47,6 +47,7 @@ import com.ibm.websphere.ras.annotation.Trivial;
 import io.openliberty.data.internal.cdi.RepositoryProducer;
 import jakarta.data.Order;
 import jakarta.data.Sort;
+import jakarta.data.repository.Find;
 import jakarta.data.repository.Insert;
 import jakarta.data.repository.Save;
 import jakarta.data.repository.Update;
@@ -299,13 +300,12 @@ public class Util {
     @Trivial
     static final boolean hasOperationAnno(Method method,
                                           RepositoryProducer<?> producer) {
-        DataVersionCompatibility compat = producer.compat();
-        Set<Class<? extends Annotation>> statefulAnnos = compat.operationAnnoTypes(true);
-        Set<Class<? extends Annotation>> statelessAnnos = compat.operationAnnoTypes(false);
+        Collection<Class<? extends Annotation>> annoTypes = //
+                        producer.compat().operationAnnoTypes(method, null);
 
         for (Annotation anno : method.getAnnotations())
-            if (statefulAnnos.contains(anno.annotationType()) ||
-                statelessAnnos.contains(anno.annotationType()))
+            if (Find.class == anno.annotationType() ||
+                annoTypes.contains(anno.annotationType()))
                 return true;
 
         return false;
@@ -369,7 +369,7 @@ public class Util {
      */
     @Trivial
     static String lifeCycleAnnoNames(RepositoryProducer<?> producer) {
-        Set<Class<? extends Annotation>> annoClasses = producer.compat() //
+        Collection<Class<? extends Annotation>> annoClasses = producer.compat() //
                         .lifeCycleAnnoTypes(producer.stateful());
 
         return annoClasses.stream() //
@@ -438,8 +438,8 @@ public class Util {
      */
     @Trivial
     static String operationAnnoNames(RepositoryProducer<?> producer) {
-        Set<Class<? extends Annotation>> annoClasses = producer.compat() //
-                        .operationAnnoTypes(producer.stateful());
+        Collection<Class<? extends Annotation>> annoClasses = producer.compat() //
+                        .operationAnnoTypes(null, producer.stateful());
 
         return annoClasses.stream() //
                         .map(Class::getSimpleName) //

--- a/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/cdi/DataExtension.java
+++ b/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/cdi/DataExtension.java
@@ -331,9 +331,9 @@ public class DataExtension implements Extension {
                             break;
                         }
 
-                for (Class<? extends Annotation> statefulAnnoType : provider.compat //
+                for (Class<? extends Annotation> queryAnnoType : provider.compat //
                                 .jpqlQueryAnnoTypes())
-                    if (method.getAnnotation(statefulAnnoType) != null) {
+                    if (method.getAnnotation(queryAnnoType) != null) {
                         hasQueryAnno = true;
                         break;
                     }

--- a/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/cdi/DataExtension.java
+++ b/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/cdi/DataExtension.java
@@ -63,13 +63,9 @@ import jakarta.data.exceptions.MappingException;
 import jakarta.data.exceptions.OptimisticLockingFailureException;
 import jakarta.data.repository.By;
 import jakarta.data.repository.DataRepository;
-import jakarta.data.repository.Delete;
 import jakarta.data.repository.Find;
-import jakarta.data.repository.Insert;
 import jakarta.data.repository.Query;
 import jakarta.data.repository.Repository;
-import jakarta.data.repository.Save;
-import jakarta.data.repository.Update;
 import jakarta.data.spi.EntityDefining;
 import jakarta.enterprise.event.Observes;
 import jakarta.enterprise.inject.spi.AfterBeanDiscovery;
@@ -210,6 +206,7 @@ public class DataExtension implements Extension {
         Map<Class<?>, List<QueryInfo>> queriesPerEntity = new HashMap<>();
         List<QueryInfo> queriesWithQueryAnno = new ArrayList<>();
         ArrayList<QueryInfo> additionalQueriesForPrimaryEntity = new ArrayList<>();
+        Boolean stateful = null;
 
         RepositoryProducer<Object> producer = new RepositoryProducer<>( //
                         repositoryInterface, beanMgr, provider, this, //
@@ -225,11 +222,13 @@ public class DataExtension implements Extension {
                 (EntityManager.class.equals(returnType)
                  || DataSource.class.equals(returnType)
                  || Connection.class.equals(returnType))) {
+                // TODO use compat to obtain above types, and identity stateless from EntityAgent type
                 QueryInfo queryInfo = provider.compat //
                                 .createQueryInfo(producer, //
                                                  repositoryInterface, //
                                                  method, //
                                                  QueryType.RESOURCE_ACCESS, //
+                                                 null, //
                                                  null, //
                                                  false, //
                                                  null, //
@@ -247,7 +246,8 @@ public class DataExtension implements Extension {
             Find find = method.getAnnotation(Find.class);
             Class<?> entityClass = find == null //
                             ? void.class //
-                            : producer.compat().getEntityClass(find);
+                            : provider.compat.getEntityClass(find);
+
             Class<?> returnArrayComponentType = null;
             List<Class<?>> returnTypeAtDepth = new ArrayList<>(5);
             Type type = method.getGenericReturnType();
@@ -304,22 +304,45 @@ public class DataExtension implements Extension {
                 }
             }
 
-            if (entityClass == void.class)
+            boolean hasQueryAnno = false;
+            boolean possiblyLifeCycleMethod = false;
+            if (entityClass == void.class) {
                 entityClass = returnTypeAtDepth.get(returnTypeAtDepth.size() - 1);
+
+                for (Class<? extends Annotation> statelessAnnoType : provider.compat //
+                                .lifeCycleAnnoTypes(false))
+                    if (method.getAnnotation(statelessAnnoType) != null)
+                        if (stateful == Boolean.TRUE) {
+                            // TODO error
+                        } else {
+                            stateful = false;
+                            possiblyLifeCycleMethod = true;
+                            break;
+                        }
+
+                for (Class<? extends Annotation> statefulAnnoType : provider.compat //
+                                .lifeCycleAnnoTypes(true))
+                    if (method.getAnnotation(statefulAnnoType) != null)
+                        if (stateful == Boolean.FALSE) {
+                            // TODO error
+                        } else {
+                            stateful = true;
+                            possiblyLifeCycleMethod = true;
+                            break;
+                        }
+
+                for (Class<? extends Annotation> statefulAnnoType : provider.compat //
+                                .jpqlQueryAnnoTypes())
+                    if (method.getAnnotation(statefulAnnoType) != null) {
+                        hasQueryAnno = true;
+                        break;
+                    }
+            }
 
             Class<?> entityParamType = null;
 
-            boolean hasQueryAnno = method.isAnnotationPresent(Query.class);
-
             // Determine entity class from a lifecycle method parameter:
-            if (method.getParameterCount() == 1
-                && !method.isDefault()
-                && !hasQueryAnno
-                && (method.isAnnotationPresent(Insert.class)
-                    || method.isAnnotationPresent(Update.class)
-                    || method.isAnnotationPresent(Save.class)
-                    || method.isAnnotationPresent(Delete.class))) {
-                // TODO 1.1 detect stateful annos and invoke repositoryProducer.setStateful()
+            if ((possiblyLifeCycleMethod &= method.getParameterCount() == 1)) {
                 Class<?> c = method.getParameterTypes()[0];
                 if (Iterable.class.isAssignableFrom(c) || Stream.class.isAssignableFrom(c)) {
                     type = method.getGenericParameterTypes()[0];
@@ -433,6 +456,7 @@ public class DataExtension implements Extension {
                                                         repositoryInterface, //
                                                         method, //
                                                         null, //
+                                                        null, //
                                                         entityParamType, //
                                                         isOptional, //
                                                         multiType, //
@@ -504,6 +528,10 @@ public class DataExtension implements Extension {
 
             producer.setPrimaryEntityClass(primaryEntityClass);
         }
+
+        if (stateful == Boolean.TRUE)
+            // Repository methods indicate a stateful repository
+            producer.setStateful();
 
         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
             Tr.debug(this, tc,

--- a/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/v1_0/Data_1_0.java
+++ b/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/v1_0/Data_1_0.java
@@ -45,6 +45,13 @@ import jakarta.persistence.EntityManager;
 public class Data_1_0 implements DataVersionCompatibility {
 
     /**
+     * Annotations for repository query operations that accept a JPQL query.
+     */
+    private static final Set<Class<? extends Annotation>> JPQL_QUERY_ANNOS = //
+                    // TODO add new Jakarta Persistence anno
+                    Set.of(Query.class);
+
+    /**
      * Annotations that represent lifecycle operations that are allowed for
      * methods of a stateful repository.
      */
@@ -60,26 +67,6 @@ public class Data_1_0 implements DataVersionCompatibility {
                            Insert.class,
                            Update.class,
                            Save.class);
-
-    /**
-     * Annotations that represent operations that are allowed for methods of a
-     * stateful repository.
-     */
-    private static final Set<Class<? extends Annotation>> OP_ANNOS_STATEFUL = //
-                    Set.of(Find.class,
-                           Query.class);
-
-    /**
-     * Annotations that represent operations that are allowed for methods of a
-     * stateless repository.
-     */
-    private static final Set<Class<? extends Annotation>> OP_ANNOS_STATELESS = //
-                    Set.of(Delete.class,
-                           Find.class,
-                           Insert.class,
-                           Query.class,
-                           Save.class,
-                           Update.class);
 
     /**
      * Classes that are valid as return types of resource accessor methods for a
@@ -116,6 +103,7 @@ public class Data_1_0 implements DataVersionCompatibility {
                                      Class<?> repositoryInterface,
                                      Method method,
                                      QueryType methodType,
+                                     Annotation methodTypeAnno,
                                      Class<?> entityParamType,
                                      boolean isOptional,
                                      Class<?> returnArrayType,
@@ -127,6 +115,7 @@ public class Data_1_0 implements DataVersionCompatibility {
                         repositoryInterface, //
                         method, //
                         methodType, //
+                        methodTypeAnno, //
                         entityParamType, //
                         isOptional, //
                         returnArrayType, //
@@ -178,14 +167,16 @@ public class Data_1_0 implements DataVersionCompatibility {
 
     @Override
     @Trivial
-    public Set<Class<? extends Annotation>> lifeCycleAnnoTypes(boolean stateful) {
-        return stateful ? LIFECYCLE_ANNOS_STATEFUL : LIFECYCLE_ANNOS_STATELESS;
+    public Set<Class<? extends Annotation>> jpqlQueryAnnoTypes() {
+        return JPQL_QUERY_ANNOS;
     }
 
     @Override
     @Trivial
-    public Set<Class<? extends Annotation>> operationAnnoTypes(boolean stateful) {
-        return stateful ? OP_ANNOS_STATEFUL : OP_ANNOS_STATELESS;
+    public Set<Class<? extends Annotation>> lifeCycleAnnoTypes(Boolean stateful) {
+        return Boolean.TRUE.equals(stateful) //
+                        ? LIFECYCLE_ANNOS_STATEFUL //
+                        : LIFECYCLE_ANNOS_STATELESS;
     }
 
     @Override

--- a/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/v1_0/QueryInfo_1_0.java
+++ b/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/v1_0/QueryInfo_1_0.java
@@ -36,9 +36,12 @@ public class QueryInfo_1_0 extends QueryInfo {
      * @param repositoryProducer    producer of the repository bean instance.
      * @param repositoryInterface   interface annotated with @Repository.
      * @param method                repository method.
+     * @param methodType            type of repository method, if known in advance.
+     * @param methodTypeAnno        mutually exclusive repository method annotation
+     *                                  (Find/Delete/...) if known in advance,
+     *                                  in which case methodType must be supplied.
      * @param entityParamType       type of the first parameter if a life cycle method,
      *                                  otherwise null.
-     * @param methodType            type of repository method, if known in advance.
      * @param isOptional            indicates if the return type is an Optional.
      * @param returnArrayType       array element type if the repository method returns
      *                                  an array, otherwise null.
@@ -54,6 +57,7 @@ public class QueryInfo_1_0 extends QueryInfo {
                   Class<?> repositoryInterface,
                   Method method,
                   QueryType methodType,
+                  Annotation methodTypeAnno,
                   Class<?> entityParamType,
                   boolean isOptional,
                   Class<?> returnArrayType,
@@ -64,6 +68,7 @@ public class QueryInfo_1_0 extends QueryInfo {
               repositoryInterface, //
               method, //
               methodType, //
+              methodTypeAnno, //
               entityParamType, //
               isOptional, //
               multiType, //

--- a/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/v1_1/Data_1_1.java
+++ b/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/v1_1/Data_1_1.java
@@ -48,12 +48,12 @@ import jakarta.data.repository.Query;
 import jakarta.data.repository.Save;
 import jakarta.data.repository.Select;
 import jakarta.data.repository.Update;
+import jakarta.data.repository.stateful.Detach;
+import jakarta.data.repository.stateful.Merge;
+import jakarta.data.repository.stateful.Persist;
+import jakarta.data.repository.stateful.Refresh;
+import jakarta.data.repository.stateful.Remove;
 import jakarta.data.restrict.Restriction;
-import jakarta.data.stateful.Detach;
-import jakarta.data.stateful.Merge;
-import jakarta.data.stateful.Persist;
-import jakarta.data.stateful.Refresh;
-import jakarta.data.stateful.Remove;
 import jakarta.persistence.EntityManager;
 
 /**

--- a/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/v1_1/Data_1_1.java
+++ b/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/v1_1/Data_1_1.java
@@ -16,12 +16,12 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Method;
 import java.sql.Connection;
+import java.util.Collection;
+import java.util.List;
 import java.util.Set;
+import java.util.stream.Stream;
 
 import javax.sql.DataSource;
-
-import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.ConfigurationPolicy;
 
 import com.ibm.websphere.ras.annotation.Trivial;
 
@@ -49,22 +49,35 @@ import jakarta.data.repository.Save;
 import jakarta.data.repository.Select;
 import jakarta.data.repository.Update;
 import jakarta.data.restrict.Restriction;
+import jakarta.data.stateful.Detach;
+import jakarta.data.stateful.Merge;
+import jakarta.data.stateful.Persist;
+import jakarta.data.stateful.Refresh;
+import jakarta.data.stateful.Remove;
 import jakarta.persistence.EntityManager;
 
 /**
  * Capability that is specific to the version of Jakarta Data.
  */
-@Component(configurationPid = "io.openliberty.data.internal.version.1.1",
-           configurationPolicy = ConfigurationPolicy.IGNORE,
-           service = DataVersionCompatibility.class)
 public class Data_1_1 implements DataVersionCompatibility {
+
+    /**
+     * Annotations for repository query operations that accept a JPQL query.
+     */
+    private static final Set<Class<? extends Annotation>> JPQL_QUERY_ANNOS = //
+                    // TODO add new Jakarta Persistence anno
+                    Set.of(Query.class);
 
     /**
      * Annotations that represent lifecycle operations that are allowed for
      * methods of a stateful repository.
      */
     private static final Set<Class<? extends Annotation>> LIFECYCLE_ANNOS_STATEFUL = //
-                    Set.of(); // TODO 1.1 Detach, Merge, Persist, Refresh, Remove
+                    Set.of(Detach.class,
+                           Merge.class,
+                           Persist.class,
+                           Refresh.class,
+                           Remove.class);
 
     /**
      * Annotations that represent lifecycle operations that are allowed for
@@ -77,25 +90,12 @@ public class Data_1_1 implements DataVersionCompatibility {
                            Save.class);
 
     /**
-     * Annotations that represent operations that are allowed for methods of a
-     * stateful repository.
+     * Annotations that represent lifecycle operations.
      */
-    private static final Set<Class<? extends Annotation>> OP_ANNOS_STATEFUL = //
-                    Set.of(Find.class,
-                           // TODO 1.1 Merge, Persist, ...
-                           Query.class);
-
-    /**
-     * Annotations that represent operations that are allowed for methods of a
-     * stateless repository.
-     */
-    private static final Set<Class<? extends Annotation>> OP_ANNOS_STATELESS = //
-                    Set.of(Delete.class,
-                           Find.class,
-                           Insert.class,
-                           Query.class,
-                           Save.class,
-                           Update.class);
+    private static final List<Class<? extends Annotation>> LIFECYCLE_ANNOS = //
+                    Stream.concat(LIFECYCLE_ANNOS_STATEFUL.stream(),
+                                  LIFECYCLE_ANNOS_STATELESS.stream()) //
+                                    .toList();
 
     /**
      * Classes that are valid as return types of resource accessor methods for a
@@ -117,8 +117,10 @@ public class Data_1_1 implements DataVersionCompatibility {
      * Types that are valid as repository method special parameters.
      */
     private static final Set<Class<?>> SPECIAL_PARAM_TYPES = //
-                    Set.of(Limit.class, Order.class,
-                           Sort.class, Sort[].class,
+                    Set.of(Limit.class,
+                           Order.class,
+                           Sort.class,
+                           Sort[].class,
                            PageRequest.class,
                            Restriction.class);
 
@@ -134,6 +136,7 @@ public class Data_1_1 implements DataVersionCompatibility {
                                      Class<?> repositoryInterface,
                                      Method method,
                                      QueryType methodType,
+                                     Annotation methodTypeAnno,
                                      Class<?> entityParamType,
                                      boolean isOptional,
                                      Class<?> returnArrayType,
@@ -145,6 +148,7 @@ public class Data_1_1 implements DataVersionCompatibility {
                         repositoryInterface, //
                         method, //
                         methodType, //
+                        methodTypeAnno, //
                         entityParamType, //
                         isOptional, //
                         returnArrayType, //
@@ -204,14 +208,18 @@ public class Data_1_1 implements DataVersionCompatibility {
 
     @Override
     @Trivial
-    public Set<Class<? extends Annotation>> lifeCycleAnnoTypes(boolean stateful) {
-        return stateful ? LIFECYCLE_ANNOS_STATEFUL : LIFECYCLE_ANNOS_STATELESS;
+    public Set<Class<? extends Annotation>> jpqlQueryAnnoTypes() {
+        return JPQL_QUERY_ANNOS;
     }
 
     @Override
     @Trivial
-    public Set<Class<? extends Annotation>> operationAnnoTypes(boolean stateful) {
-        return stateful ? OP_ANNOS_STATEFUL : OP_ANNOS_STATELESS;
+    public Collection<Class<? extends Annotation>> lifeCycleAnnoTypes(Boolean stateful) {
+        return stateful == null //
+                        ? LIFECYCLE_ANNOS //
+                        : stateful //
+                                        ? LIFECYCLE_ANNOS_STATEFUL //
+                                        : LIFECYCLE_ANNOS_STATELESS;
     }
 
     @Override

--- a/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/v1_1/QueryInfo_1_1.java
+++ b/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/v1_1/QueryInfo_1_1.java
@@ -115,9 +115,12 @@ public class QueryInfo_1_1 extends QueryInfo {
      * @param repositoryProducer    producer of the repository bean instance.
      * @param repositoryInterface   interface annotated with @Repository.
      * @param method                repository method.
+     * @param methodType            type of repository method, if known in advance.
+     * @param methodTypeAnno        mutually exclusive repository method annotation
+     *                                  (Find/Delete/...) if known in advance,
+     *                                  in which case methodType must be supplied.
      * @param entityParamType       type of the first parameter if a life cycle method,
      *                                  otherwise null.
-     * @param methodType            type of repository method, if known in advance.
      * @param isOptional            indicates if the return type is an Optional.
      * @param returnArrayType       array element type if the repository method returns
      *                                  an array, otherwise null.
@@ -133,6 +136,7 @@ public class QueryInfo_1_1 extends QueryInfo {
                   Class<?> repositoryInterface,
                   Method method,
                   QueryType methodType,
+                  Annotation methodTypeAnno,
                   Class<?> entityParamType,
                   boolean isOptional,
                   Class<?> returnArrayType,
@@ -143,6 +147,7 @@ public class QueryInfo_1_1 extends QueryInfo {
               repositoryInterface, //
               method, //
               methodType, //
+              methodTypeAnno, //
               entityParamType, //
               isOptional, //
               multiType, //

--- a/dev/io.openliberty.data.internal_fat_1_1/test-applications/Data_1_1_App/src/test/jakarta/data/v1_1/web/Data_1_1_Servlet.java
+++ b/dev/io.openliberty.data.internal_fat_1_1/test-applications/Data_1_1_App/src/test/jakarta/data/v1_1/web/Data_1_1_Servlet.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import jakarta.annotation.Resource;
 import jakarta.data.Limit;
 import jakarta.data.Order;
 import jakarta.data.Sort;
@@ -49,10 +50,13 @@ import jakarta.inject.Inject;
 import jakarta.servlet.ServletConfig;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.annotation.WebServlet;
+import jakarta.transaction.Status;
+import jakarta.transaction.UserTransaction;
 
 import org.junit.Test;
 
 import componenttest.app.FATServlet;
+import test.jakarta.data.v1_1.web.Fraction.Decimal;
 
 @SuppressWarnings("serial")
 @WebServlet("/*")
@@ -63,6 +67,12 @@ public class Data_1_1_Servlet extends FATServlet {
 
     @Inject
     Fractions fractions;
+
+    @Inject
+    StatefulFractions statefulFractions;
+
+    @Resource
+    UserTransaction tx;
 
     /**
      * Initialize read-only data that is prepopulated for tests
@@ -1113,6 +1123,60 @@ public class Data_1_1_Servlet extends FATServlet {
                                                  Sort.asc(_Fraction.NUMERATOR)) //
                                      .map(f -> f.name)
                                      .collect(Collectors.toList()));
+    }
+
+    /**
+     * Use a stateless repository to find an entity. Modify the entity. Verify the
+     * updates can be committed or rolled back.
+     */
+    @Test
+    public void testPersistenceContext() throws Exception {
+
+        // TODO use stateful method to persist entities
+        // Populate with 2/23 and 3/23.
+        // Ensure deletion in the finally block.
+        fractions.supply(List.of(Fraction.of(2, 23),
+                                 Fraction.of(3, 23)));
+        try {
+            System.out.println("Fetch 2/23 to modify and commit");
+
+            tx.begin();
+            Fraction f = statefulFractions.fetch(2, 23).orElseThrow();
+            f.numerator = f.numerator * 2;
+            f.decimal = Decimal.of(f.numerator, 23);
+            tx.commit();
+
+            assertEquals(BigDecimal.valueOf(1739, 4),
+                         statefulFractions.fetch(4, 23).orElseThrow() //
+                                         .decimal.truncated());
+
+            assertEquals(true,
+                         statefulFractions.fetch(2, 23).isEmpty());
+
+            System.out.println("Fetch 3/23 to modify and roll back");
+
+            tx.begin();
+            f = statefulFractions.fetch(3, 23).orElseThrow();
+            f.numerator = f.numerator - 2;
+            f.decimal = Decimal.of(f.numerator, 23);
+            tx.rollback();
+
+            assertEquals(BigDecimal.valueOf(1304, 4),
+                         statefulFractions.fetch(3, 23).orElseThrow() //
+                                         .decimal.truncated());
+
+            assertEquals(true,
+                         statefulFractions.fetch(1, 23).isEmpty());
+        } finally {
+            if (tx.getStatus() != Status.STATUS_NO_TRANSACTION)
+                tx.rollback();
+
+            // TODO use stateful method to remove entities
+            // Ensure no fractions with denominator of 23 or more are left around
+            fractions.discard(AtLeast.min(23),
+                              AtMost.max(Integer.MAX_VALUE),
+                              Restrict.unrestricted());
+        }
     }
 
     /**

--- a/dev/io.openliberty.data.internal_fat_1_1/test-applications/Data_1_1_App/src/test/jakarta/data/v1_1/web/Fraction.java
+++ b/dev/io.openliberty.data.internal_fat_1_1/test-applications/Data_1_1_App/src/test/jakarta/data/v1_1/web/Fraction.java
@@ -163,7 +163,8 @@ public class Fraction {
                                                              "Nineteenth",
                                                              "Twentieth",
                                                              "Twenty-first",
-                                                             "Twenty-second"
+                                                             "Twenty-second",
+                                                             "Twenth-third"
     };
 
     static final String[] NUMERATOR_NAMES = new String[] {
@@ -189,7 +190,8 @@ public class Fraction {
                                                            "Nineteen",
                                                            "Twenty",
                                                            "Twenty-one",
-                                                           "Twenty-two"
+                                                           "Twenty-two",
+                                                           "Twenty-three"
     };
 
     public static Fraction of(int numerator, int denominator) {

--- a/dev/io.openliberty.data.internal_fat_1_1/test-applications/Data_1_1_App/src/test/jakarta/data/v1_1/web/Fraction.java
+++ b/dev/io.openliberty.data.internal_fat_1_1/test-applications/Data_1_1_App/src/test/jakarta/data/v1_1/web/Fraction.java
@@ -164,7 +164,7 @@ public class Fraction {
                                                              "Twentieth",
                                                              "Twenty-first",
                                                              "Twenty-second",
-                                                             "Twenth-third"
+                                                             "Twenty-third"
     };
 
     static final String[] NUMERATOR_NAMES = new String[] {

--- a/dev/io.openliberty.data.internal_fat_1_1/test-applications/Data_1_1_App/src/test/jakarta/data/v1_1/web/StatefulFractions.java
+++ b/dev/io.openliberty.data.internal_fat_1_1/test-applications/Data_1_1_App/src/test/jakarta/data/v1_1/web/StatefulFractions.java
@@ -1,0 +1,37 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package test.jakarta.data.v1_1.web;
+
+import java.util.Optional;
+
+import jakarta.data.constraint.EqualTo;
+import jakarta.data.repository.By;
+import jakarta.data.repository.Find;
+import jakarta.data.repository.Is;
+import jakarta.data.repository.Repository;
+import jakarta.data.repository.stateful.Detach;
+
+/**
+ * Stateful repository for the Fraction entity
+ */
+@Repository(dataStore = "MyDataStore")
+public interface StatefulFractions {
+
+    @Detach
+    void detach(Fraction entity);
+
+    @Find
+    Optional<Fraction> fetch//
+    (@By(_Fraction.NUMERATOR) @Is(EqualTo.class) long num,
+     @By(_Fraction.DENOMINATOR) @Is long den);
+}

--- a/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/DataErrPathsTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/DataErrPathsTestServlet.java
@@ -1584,8 +1584,8 @@ public class DataErrPathsTestServlet extends FATServlet {
         } catch (UnsupportedOperationException x) {
             if (x.getMessage() == null ||
                 !x.getMessage().startsWith("CWWKD1002E:") ||
-                !x.getMessage().contains(Find.class.getName()) ||
-                !x.getMessage().contains(Insert.class.getName()))
+                !x.getMessage().contains(Find.class.getSimpleName()) ||
+                !x.getMessage().contains(Insert.class.getSimpleName()))
                 throw x;
         }
     }
@@ -1606,8 +1606,8 @@ public class DataErrPathsTestServlet extends FATServlet {
         } catch (UnsupportedOperationException x) {
             if (x.getMessage() == null ||
                 !x.getMessage().startsWith("CWWKD1002E:") ||
-                !x.getMessage().contains(Save.class.getName()) ||
-                !x.getMessage().contains(Delete.class.getName()))
+                !x.getMessage().contains(Save.class.getSimpleName()) ||
+                !x.getMessage().contains(Delete.class.getSimpleName()))
                 throw x;
         }
     }
@@ -1628,8 +1628,8 @@ public class DataErrPathsTestServlet extends FATServlet {
         } catch (UnsupportedOperationException x) {
             if (x.getMessage() == null ||
                 !x.getMessage().startsWith("CWWKD1002E:") ||
-                !x.getMessage().contains(Query.class.getName()) ||
-                !x.getMessage().contains(Update.class.getName()))
+                !x.getMessage().contains(Query.class.getSimpleName()) ||
+                !x.getMessage().contains(Update.class.getSimpleName()))
                 throw x;
         }
     }

--- a/dev/io.openliberty.jakarta.data.1.1/bnd.bnd
+++ b/dev/io.openliberty.jakarta.data.1.1/bnd.bnd
@@ -38,12 +38,12 @@ Export-Package: \
   jakarta.data.page;version="1.0.0",\
   jakarta.data.page.impl;version="1.0.0",\
   jakarta.data.repository;version="1.0.0",\
+  jakarta.data.repository.stateful;version='1.0.0',\
   jakarta.data.restrict;version="1.0.0",\
   jakarta.data.spi;version="1.0.0",\
   jakarta.data.spi.expression.function;version="1.0.0",\
   jakarta.data.spi.expression.literal;version="1.0.0",\
-  jakarta.data.spi.expression.path;version="1.0.0",\
-  jakarta.data.stateful;version="1.0.0"
+  jakarta.data.spi.expression.path;version="1.0.0"
 
 Private-Package: \
   jakarta.data.messages;version="1.0.0"

--- a/dev/io.openliberty.jakarta.data.1.1/src/jakarta/data/repository/stateful/Detach.java
+++ b/dev/io.openliberty.jakarta.data.1.1/src/jakarta/data/repository/stateful/Detach.java
@@ -10,7 +10,7 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-package jakarta.data.stateful;
+package jakarta.data.repository.stateful;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
@@ -24,6 +24,6 @@ import java.lang.annotation.Target;
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.METHOD)
-public @interface Persist {
+public @interface Detach {
 
 }

--- a/dev/io.openliberty.jakarta.data.1.1/src/jakarta/data/repository/stateful/Merge.java
+++ b/dev/io.openliberty.jakarta.data.1.1/src/jakarta/data/repository/stateful/Merge.java
@@ -10,7 +10,7 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-package jakarta.data.stateful;
+package jakarta.data.repository.stateful;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
@@ -24,6 +24,6 @@ import java.lang.annotation.Target;
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.METHOD)
-public @interface Refresh {
+public @interface Merge {
 
 }

--- a/dev/io.openliberty.jakarta.data.1.1/src/jakarta/data/repository/stateful/Persist.java
+++ b/dev/io.openliberty.jakarta.data.1.1/src/jakarta/data/repository/stateful/Persist.java
@@ -10,7 +10,7 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-package jakarta.data.stateful;
+package jakarta.data.repository.stateful;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
@@ -24,6 +24,6 @@ import java.lang.annotation.Target;
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.METHOD)
-public @interface Detach {
+public @interface Persist {
 
 }

--- a/dev/io.openliberty.jakarta.data.1.1/src/jakarta/data/repository/stateful/Refresh.java
+++ b/dev/io.openliberty.jakarta.data.1.1/src/jakarta/data/repository/stateful/Refresh.java
@@ -10,7 +10,7 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-package jakarta.data.stateful;
+package jakarta.data.repository.stateful;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
@@ -24,6 +24,6 @@ import java.lang.annotation.Target;
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.METHOD)
-public @interface Merge {
+public @interface Refresh {
 
 }

--- a/dev/io.openliberty.jakarta.data.1.1/src/jakarta/data/repository/stateful/Remove.java
+++ b/dev/io.openliberty.jakarta.data.1.1/src/jakarta/data/repository/stateful/Remove.java
@@ -10,7 +10,7 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-package jakarta.data.stateful;
+package jakarta.data.repository.stateful;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;


### PR DESCRIPTION
Corrects the package name of the Data 1.1 annotations for stateful repositories.
Adds identification of annotations for a stateful repository, but doesn't implement any of them yet.
Uses the information about whether the repository is stateful vs stateless to decide whether repository Find operations leave the persistence context in place or automatically clear/detach it.
Add a test case that verifies persistence context remains in place such that updates made within a transaction to an entity after a Find operation are honored.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
