### PR TITLE
Convert TokenService components to annotations to help with slow systems

### DIFF
--- a/dev/com.ibm.ws.security.token.ltpa/bnd.bnd
+++ b/dev/com.ibm.ws.security.token.ltpa/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017, 2024 IBM Corporation and others.
+# Copyright (c) 2017, 2026 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -40,6 +40,9 @@ Include-Resource: \
 
 IBM-Default-Config: OSGI-INF/wlp/defaultInstances.xml
 
+-dsannotations: \
+  com.ibm.ws.security.token.ltpa.internal.LTPATokenService
+
 Service-Component: \
   com.ibm.ws.security.token.ltpa.LTPAConfiguration; \
     implementation:=com.ibm.ws.security.token.ltpa.internal.LTPAConfigurationImpl; \
@@ -52,14 +55,6 @@ Service-Component: \
     executorService=java.util.concurrent.ExecutorService; \
     ltpaKeysChangeNotifier=com.ibm.ws.security.token.ltpa.internal.LTPAKeysChangeNotifier; \
     dynamic:='ltpaKeysChangeNotifier'; \
-    properties:='service.vendor=IBM,tokenType=Ltpa2', \
-  com.ibm.ws.security.token.ltpa.LTPATokenService; \
-    implementation:=com.ibm.ws.security.token.ltpa.internal.LTPATokenService; \
-    provide:='com.ibm.ws.security.token.TokenService'; \
-    activate:=activate; \
-    deactivate:=deactivate; \
-    configuration-policy:=ignore; \
-    ltpaConfig=com.ibm.ws.security.token.ltpa.LTPAConfiguration; \
     properties:='service.vendor=IBM,tokenType=Ltpa2', \
   com.ibm.ws.security.token.ltpa.internal.LTPAKeysChangeNotifier; \
     implementation:=com.ibm.ws.security.token.ltpa.internal.LTPAKeysChangeNotifier; \
@@ -101,6 +96,7 @@ instrument.classesExcludes: com/ibm/ws/security/token/ltpa/internal/resources/*.
 	com.ibm.ws.org.osgi.annotation.versioning;version=latest,\
   com.ibm.ws.security.fat.common;version=latest,\
     com.ibm.ws.security.registry;version=latest,\
+	com.ibm.wsspi.org.osgi.service.component.annotations,\
 	com.ibm.ws.config;version=latest
 
 -testpath: \

--- a/dev/com.ibm.ws.security.token.ltpa/src/com/ibm/ws/security/token/ltpa/internal/LTPATokenService.java
+++ b/dev/com.ibm.ws.security.token.ltpa/src/com/ibm/ws/security/token/ltpa/internal/LTPATokenService.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 IBM Corporation and others.
+ * Copyright (c) 2011, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -15,6 +15,11 @@ package com.ibm.ws.security.token.ltpa.internal;
 import java.util.Map;
 
 import org.osgi.service.component.ComponentContext;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ConfigurationPolicy;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Reference;
 
 import com.ibm.websphere.security.auth.InvalidTokenException;
 import com.ibm.websphere.security.auth.TokenCreationFailedException;
@@ -27,22 +32,20 @@ import com.ibm.wsspi.security.ltpa.TokenFactory;
 /**
  *
  */
+@Component(name = "com.ibm.ws.security.token.ltpa.LTPATokenService", service = TokenService.class, configurationPolicy = ConfigurationPolicy.IGNORE,
+           property = { "service.vendor=IBM", "tokenType=Ltpa2" })
 public class LTPATokenService implements TokenService {
-    private volatile LTPAConfiguration ltpaConfig;
 
-    protected void setLtpaConfig(LTPAConfiguration ltpaConfig) {
+    private final LTPAConfiguration ltpaConfig;
+
+    @Activate
+    public LTPATokenService(@Reference LTPAConfiguration ltpaConfig) {
         this.ltpaConfig = ltpaConfig;
     }
 
-    protected void unsetLtpaConfig(LTPAConfiguration ltpaConfig) {
-        if (this.ltpaConfig == ltpaConfig) {
-            ltpaConfig = null;
-        }
+    @Deactivate
+    protected void deactivate(ComponentContext context) {
     }
-
-    protected void activate(ComponentContext context) {}
-
-    protected void deactivate(ComponentContext context) {}
 
     /**
      * {@inheritDoc}

--- a/dev/com.ibm.ws.security.token.ltpa/test/com/ibm/ws/security/token/ltpa/internal/LTPATokenServiceTest.java
+++ b/dev/com.ibm.ws.security.token.ltpa/test/com/ibm/ws/security/token/ltpa/internal/LTPATokenServiceTest.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2011 IBM Corporation and others.
+ * Copyright (c) 2011, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -27,10 +27,10 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.osgi.service.component.ComponentContext;
 
-import test.common.SharedOutputManager;
-
 import com.ibm.ws.security.token.ltpa.LTPAConfiguration;
 import com.ibm.wsspi.security.ltpa.TokenFactory;
+
+import test.common.SharedOutputManager;
 
 /**
  *
@@ -53,15 +53,12 @@ public class LTPATokenServiceTest {
 
     @Before
     public void setUp() {
-        ltpaTokenService = new LTPATokenService();
-        ltpaTokenService.setLtpaConfig(ltpaConfig);
-        ltpaTokenService.activate(context);
+        ltpaTokenService = new LTPATokenService(ltpaConfig);
     }
 
     @After
     public void tearDown() throws Exception {
         ltpaTokenService.deactivate(context);
-        ltpaTokenService.unsetLtpaConfig(ltpaConfig);
         outputMgr.resetStreams();
     }
 

--- a/dev/com.ibm.ws.security.token/bnd.bnd
+++ b/dev/com.ibm.ws.security.token/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017, 2022 IBM Corporation and others.
+# Copyright (c) 2017, 2026 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -39,19 +39,10 @@ Include-Resource: \
     OSGI-INF/metatype=resources/OSGI-INF/metatype, \
     OSGI-INF/l10n=resources/OSGI-INF/l10n
 
+-dsannotations: \
+  com.ibm.ws.security.token.internal.TokenManagerImpl
+
 Service-Component: \
-  com.ibm.ws.security.token; \
-    implementation:=com.ibm.ws.security.token.internal.TokenManagerImpl; \
-    provide:=com.ibm.ws.security.token.TokenManager; \
-    activate:=activate; \
-    deactivate:=deactivate; \
-    modified:='modified'; \
-    configuration-policy:=optional; \
-    tokenService=com.ibm.ws.security.token.TokenService; \
-    dynamic:='tokenService'; \
-    optional:='tokenService'; \
-    multiple:='tokenService'; \
-    properties:='service.vendor=IBM', \
   com.ibm.wsspi.security.token.WSSecurityPropagationHelper;\
     implementation:=com.ibm.wsspi.security.token.WSSecurityPropagationHelper;\
     configuration-policy:=ignore;\
@@ -75,6 +66,7 @@ instrument.classesExcludes: com/ibm/ws/security/token/internal/resources/*.class
 	com.ibm.websphere.org.osgi.core,\
 	com.ibm.websphere.org.osgi.service.component,\
 	com.ibm.ws.security.jaas.common;version=latest, \
+	com.ibm.wsspi.org.osgi.service.component.annotations,\
 	com.ibm.ws.org.osgi.annotation.versioning;version=latest
 
 -testpath: \

--- a/dev/com.ibm.ws.security.token/src/com/ibm/ws/security/token/internal/TokenManagerImpl.java
+++ b/dev/com.ibm.ws.security.token/src/com/ibm/ws/security/token/internal/TokenManagerImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 IBM Corporation and others.
+ * Copyright (c) 2011, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -17,6 +17,15 @@ import java.util.Map;
 
 import org.osgi.framework.ServiceReference;
 import org.osgi.service.component.ComponentContext;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ConfigurationPolicy;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Modified;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceCardinality;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 import com.ibm.ejs.ras.TraceNLS;
 import com.ibm.websphere.ras.Tr;
@@ -34,6 +43,7 @@ import com.ibm.wsspi.security.token.SingleSignonToken;
 /**
  * The TokenManager class creates tokens as specified by the token type and recreates a token from the token bytes.
  */
+@Component(name = "com.ibm.ws.security.token", service = TokenManager.class, configurationPolicy = ConfigurationPolicy.OPTIONAL, property = "service.vendor=IBM")
 public class TokenManagerImpl implements TokenManager {
     private static final TraceComponent tc = Tr.register(TokenManagerImpl.class, TraceConstants.TRACE_GROUP, TraceConstants.MESSAGE_BUNDLE);
 
@@ -43,6 +53,7 @@ public class TokenManagerImpl implements TokenManager {
     private final ConcurrentServiceReferenceMap<String, TokenService> services = new ConcurrentServiceReferenceMap<String, TokenService>(KEY_TOKEN_SERVICE);
     private volatile String ssoTokenType;
 
+    @Reference(name = KEY_TOKEN_SERVICE, cardinality = ReferenceCardinality.MULTIPLE, policy = ReferencePolicy.DYNAMIC, policyOption = ReferencePolicyOption.GREEDY)
     protected void setTokenService(ServiceReference<TokenService> tokenServiceReference) {
         String tokenType = (String) tokenServiceReference.getProperty(KEY_TOKEN_TYPE);
         services.putReference(tokenType, tokenServiceReference);
@@ -53,15 +64,18 @@ public class TokenManagerImpl implements TokenManager {
         services.removeReference(tokenType, tokenServiceReference);
     }
 
+    @Activate
     protected void activate(ComponentContext componentContext, Map<String, Object> props) {
         services.activate(componentContext);
         ssoTokenType = (String) props.get(CFG_KEY_SSO_TOKEN_TYPE);
     }
 
+    @Modified
     protected void modified(Map<String, Object> props) {
         ssoTokenType = (String) props.get(CFG_KEY_SSO_TOKEN_TYPE);
     }
 
+    @Deactivate
     protected void deactivate(ComponentContext componentContext) {
         services.deactivate(componentContext);
     }


### PR DESCRIPTION
- Presently the TokenManager was not using greedy option so it defaults to reluctant which can be slow and then things are not set and can cause messages to come out on slower systems about the token service not being set.
- Using annotations instead of bnd.bnd has other advantages as well for faster resolution besides just the greedy improvement.
- As part of using the annotations, I also converted to use the @Activate on the constructor and using @Reference there to be able to make the reference final.


- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [ ] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
