### PR TITLE
Fix linkConfiguration logic to not get an exception

### DIFF
--- a/dev/com.ibm.ws.security.authorization.jacc/src/com/ibm/ws/security/authorization/jacc/common/PolicyConfigurationManagerImpl.java
+++ b/dev/com.ibm.ws.security.authorization.jacc/src/com/ibm/ws/security/authorization/jacc/common/PolicyConfigurationManagerImpl.java
@@ -13,7 +13,8 @@
 package com.ibm.ws.security.authorization.jacc.common;
 
 import java.util.ArrayList;
-import java.util.LinkedHashSet;
+import java.util.Collections;
+import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -36,7 +37,7 @@ import com.ibm.ws.security.authorization.jacc.ejb.EJBSecurityPropagator;
 @Component(service = { ApplicationStateListener.class, PolicyConfigurationManager.class })
 public class PolicyConfigurationManagerImpl implements ApplicationStateListener, PolicyConfigurationManager {
     private static final TraceComponent tc = Tr.register(PolicyConfigurationManagerImpl.class);
-    private final Map<String, List<PolicyConfiguration>> pcConfigsMap = new ConcurrentHashMap<String, List<PolicyConfiguration>>();
+    private final Map<String, Set<PolicyConfiguration>> pcConfigsMap = new ConcurrentHashMap<>();
     private final Map<String, List<String>> pcModulesMap = new ConcurrentHashMap<String, List<String>>();
     private final Map<String, List<String>> pcEjbMap = new ConcurrentHashMap<String, List<String>>();
     private final List<String> pcRunningList = new CopyOnWriteArrayList<String>();
@@ -65,11 +66,22 @@ public class PolicyConfigurationManagerImpl implements ApplicationStateListener,
 
     @Override
     public void linkConfiguration(String appName, PolicyConfiguration pc) throws PolicyContextException {
-        List<PolicyConfiguration> pcs = pcConfigsMap.get(appName);
+        Set<PolicyConfiguration> pcs = pcConfigsMap.get(appName);
         if (pcs != null) {
-            pc.linkConfiguration(pcs.get(0));
+            for (PolicyConfiguration lpc : pcs) {
+                if (lpc != pc) {
+                    try {
+                        pc.linkConfiguration(lpc);
+                    } catch (Exception e) {
+                        // linkConfiguration can throw IllegalArgumentException if we pass the wrong
+                        // PolicyConfiguration that has the same context id as the one being linked.
+                        // The if (lpc != pc) check should sufficient since we shouldn't have two PolicyConfiguration
+                        // objects for the same contextID, but catch the exception and FFDC it just in case.
+                    }
+                }
+            }
         } else {
-            pcs = new ArrayList<PolicyConfiguration>();
+            pcs = Collections.newSetFromMap(new IdentityHashMap<>());
             pcConfigsMap.put(appName, pcs);
         }
         pcs.add(pc);
@@ -153,7 +165,7 @@ public class PolicyConfigurationManagerImpl implements ApplicationStateListener,
     }
 
     private void commitModules(String appName) {
-        List<PolicyConfiguration> pcs = pcConfigsMap.get(appName);
+        Set<PolicyConfiguration> pcs = pcConfigsMap.get(appName);
         if (pcs != null) {
             for (PolicyConfiguration pc : pcs) {
                 if (tc.isDebugEnabled())


### PR DESCRIPTION
- Update the linkConfiguration logic now that the Authorization 3.0 code checks the condition for linking to oneself and throws an exception as required by the specification.  If custom authz modules were doing the same, they would get this failure.  The TCK was hitting it the error.
- Also updated to handle the exception and just FFDC it and move on.


- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [ ] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
