### PR TITLE
Fixing config update race condition in JsonB test

### DIFF
--- a/dev/com.ibm.ws.jsonb_fat/fat/src/com/ibm/ws/jsonb/fat/JSONBTest.java
+++ b/dev/com.ibm.ws.jsonb_fat/fat/src/com/ibm/ws/jsonb/fat/JSONBTest.java
@@ -96,6 +96,7 @@ public class JSONBTest extends FATServletClient {
         assertTrue(found, found.contains("410"));
 
         // Clean up the test by removing the jsonb-1.0 feature
+        server.setMarkToEndOfLog();
         config.getFeatureManager().getFeatures().remove("usr:testFeatureUsingJsonb-1.0");
         server.updateServerConfiguration(config);
         server.waitForConfigUpdateInLogUsingMark(Collections.emptySet());


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

Without the `setMarkToEndOfLog()` the second config update was catching the output from the first config update, and not waiting. This results in tests intermittently being run during the update, resulting in failures.