### PR TITLE
Detach methods for stateful repositories

### DIFF
--- a/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/EntityInfo.java
+++ b/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/EntityInfo.java
@@ -62,7 +62,7 @@ public class EntityInfo {
      * Excludes inner relation attributes, such as location.address
      * when there is also a location.address.zipcode
      */
-    final SortedSet<String> attributeNamesForEntityUpdate;
+    public final SortedSet<String> attributeNamesForEntityUpdate;
 
     // properly cased/qualified JPQL attribute name --> type
     final SortedMap<String, Class<?>> attributeTypes;

--- a/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/QueryInfo.java
+++ b/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/QueryInfo.java
@@ -18,13 +18,11 @@ import static io.openliberty.data.internal.QueryType.COUNT;
 import static io.openliberty.data.internal.QueryType.EXISTS;
 import static io.openliberty.data.internal.QueryType.FIND;
 import static io.openliberty.data.internal.QueryType.FIND_AND_DELETE;
-import static io.openliberty.data.internal.QueryType.INSERT;
 import static io.openliberty.data.internal.QueryType.LC_DELETE;
 import static io.openliberty.data.internal.QueryType.LC_UPDATE;
 import static io.openliberty.data.internal.QueryType.LC_UPDATE_MERGE;
 import static io.openliberty.data.internal.QueryType.QM_DELETE;
 import static io.openliberty.data.internal.QueryType.QM_UPDATE;
-import static io.openliberty.data.internal.QueryType.SAVE;
 import static io.openliberty.data.internal.Util.SORT_PARAM_TYPES;
 import static io.openliberty.data.internal.cdi.DataExtension.exc;
 import static jakarta.data.repository.By.ID;
@@ -88,11 +86,9 @@ import jakarta.data.page.PageRequest;
 import jakarta.data.repository.By;
 import jakarta.data.repository.Delete;
 import jakarta.data.repository.Find;
-import jakarta.data.repository.Insert;
 import jakarta.data.repository.OrderBy;
 import jakarta.data.repository.Param;
 import jakarta.data.repository.Query;
-import jakarta.data.repository.Save;
 import jakarta.data.repository.Update;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.LockModeType;
@@ -159,12 +155,12 @@ public abstract class QueryInfo {
     /**
      * Information about the type of entity to which the query pertains.
      */
-    EntityInfo entityInfo;
+    protected EntityInfo entityInfo;
 
     /**
      * Type of the first parameter if a life cycle method, otherwise null.
      */
-    private final Class<?> entityParamType;
+    protected final Class<?> entityParamType;
 
     /**
      * Entity identifier variable name if an identifier variable is used.
@@ -258,7 +254,7 @@ public abstract class QueryInfo {
      * Repository method annotation indicating the type of method.
      * Null if the repository method is not annotated Delete, Find, Insert, Query, ...
      */
-    private Annotation methodTypeAnno;
+    protected Annotation methodTypeAnno;
 
     /**
      * The type of data structure that returns multiple results for this query.
@@ -297,7 +293,7 @@ public abstract class QueryInfo {
      * A query that returns List<ArrayList<String>> has singleType ArrayList<String>.
      * A query that returns Optional<String[]> has singleType String[].
      */
-    final Class<?> singleType;
+    protected final Class<?> singleType;
 
     /**
      * Element type of singleType when singleType is an array or collection.
@@ -2359,38 +2355,33 @@ public abstract class QueryInfo {
         if (o != THIS)
             q.append(' ').append(o);
 
-        if (method.getParameterCount() == 0) {
-            type = QM_DELETE;
-            hasWhere = false;
-        } else {
-            setType(Delete.class, LC_DELETE);
-            hasWhere = true;
+        hasWhere = true;
 
-            q.append(" WHERE (");
+        q.append(" WHERE (");
 
-            String idName = entityInfo.attributeNames.get(ID);
-            if (idName == null && entityInfo.idClassAttributeAccessors != null) {
-                // IdClass cannot be a single query parameter because there is
-                // no way to obtain an IdClass object from an entity instance.
-                boolean first = true;
-                for (String name : entityInfo.idClassAttributeAccessors.keySet()) {
-                    if (first)
-                        first = false;
-                    else
-                        q.append(" AND ");
+        String idName = entityInfo.attributeNames.get(ID);
+        if (idName == null && entityInfo.idClassAttributeAccessors != null) {
+            // IdClass cannot be a single query parameter because there is
+            // no way to obtain an IdClass object from an entity instance.
+            boolean first = true;
+            for (String name : entityInfo.idClassAttributeAccessors.keySet()) {
+                if (first)
+                    first = false;
+                else
+                    q.append(" AND ");
 
-                    name = entityInfo.attributeNames.get(name);
-                    q.append(o_).append(name).append("=?").append(++jpqlParamCount);
-                }
-            } else {
-                q.append(o_).append(idName).append("=?").append(++jpqlParamCount);
+                name = entityInfo.attributeNames.get(name);
+                q.append(o_).append(name).append("=?").append(++jpqlParamCount);
             }
-
-            if (entityInfo.versionAttributeName != null)
-                q.append(" AND ").append(o_).append(entityInfo.versionAttributeName).append("=?").append(++jpqlParamCount);
-
-            q.append(')');
+        } else {
+            q.append(o_).append(idName).append("=?").append(++jpqlParamCount);
         }
+
+        if (entityInfo.versionAttributeName != null)
+            q.append(" AND ").append(o_).append(entityInfo.versionAttributeName) //
+                            .append("=?").append(++jpqlParamCount);
+
+        q.append(')');
 
         return q;
     }
@@ -2765,7 +2756,6 @@ public abstract class QueryInfo {
     private StringBuilder generateSelectClause() {
         StringBuilder q = new StringBuilder(200);
         String o = entityVar;
-        String o_ = entityVar_;
 
         String[] cols, selections = entityInfo.builder.provider.compat.getSelections(method);
         if (selections.length == 0) {
@@ -2924,10 +2914,7 @@ public abstract class QueryInfo {
         String o_ = entityVar_;
         StringBuilder q;
 
-        if (entityInfo.attributeNamesForEntityUpdate != null &&
-            Util.UPDATE_COUNT_TYPES.contains(singleType)) {
-            setType(Update.class, LC_UPDATE);
-
+        if (type == LC_UPDATE) {
             q = new StringBuilder(100) //
                             .append("UPDATE ").append(entityInfo.name);
             if (o != THIS)
@@ -2943,11 +2930,10 @@ public abstract class QueryInfo {
 
                 q.append(o_).append(name).append("=?").append(++jpqlParamCount);
             }
-        } else {
+        } else { // type == LC_UPDATE_MERGE
             // Update that returns an entity. And also used when an entity has a
             // version attribute or relation attribute that requires using em.merge.
             // Perform a find operation first so that em.merge can be used.
-            setType(Update.class, LC_UPDATE_MERGE);
 
             q = new StringBuilder(100) //
                             .append("SELECT ").append(o) //
@@ -3212,6 +3198,16 @@ public abstract class QueryInfo {
     }
 
     /**
+     * Value (representing a JPQL or JCQL query) from the Query annotation or
+     * from the similar Jakarta Persistence annotation that supplies JPQL to a
+     * repository method.
+     *
+     * @return JPQL or JCQL value of a query annotation. Null if the repository
+     *         method does not have a query annotation.
+     */
+    protected abstract String getQueryAnnoValue();
+
+    /**
      * Creates a Sort instance with the corresponding entity attribute name
      * or returns the existing instance if it already matches.
      *
@@ -3229,6 +3225,12 @@ public abstract class QueryInfo {
                             ? sort.ignoreCase() ? Sort.ascIgnoreCase(name) : Sort.asc(name) //
                             : sort.ignoreCase() ? Sort.descIgnoreCase(name) : Sort.desc(name);
     }
+
+    /**
+     * Identifies the repository method type based on life cycle annotations.
+     * For example (Insert, Update, Save, Delete, Detach, Merge, ...).
+     */
+    protected abstract void identifyType();
 
     /**
      * Infer the selection value to use for a COUNT query.
@@ -3332,52 +3334,27 @@ public abstract class QueryInfo {
             StringBuilder q = null;
             boolean validateNumberOfMethodArgs = true;
 
-            String queryAnnoValue;
-            if (methodTypeAnno instanceof Query query) // @Query annotation
-                queryAnnoValue = query.value();
-            else // TODO query annotations from Jakarta Persistence
-                queryAnnoValue = null;
+            String queryAnnoValue = getQueryAnnoValue();
 
-            if (queryAnnoValue != null) {
+            if (type == null && queryAnnoValue == null)
+                identifyType();
+
+            if (queryAnnoValue != null) { // query language methods
                 initQueryLanguage(queryAnnoValue,
                                   entityInfos,
                                   repository.primaryEntityInfoFuture,
                                   compat);
-            } else if (methodTypeAnno instanceof Insert) { // @Insert annotation
-                setType(Insert.class, INSERT);
-            } else if (methodTypeAnno instanceof Save) { // @Save annotation
-                setType(Save.class, SAVE);
-            } else if (entityParamType != null) {
-                if (methodTypeAnno instanceof Update) { // @Update annotation
-                    q = generateUpdateEntity();
-                } else if (methodTypeAnno instanceof Delete) { // @Delete annotation
+            } else if (type != null && type.isLifeCycleMethod) {
+                if (type == LC_DELETE)
                     q = generateDeleteEntity();
-                } else {
-                    // TODO 1.1 rewrite the following using the superclass and
-                    // move it out of the entityParamType != null block for better
-                    // error checking
-                    Class<? extends Annotation> c = methodTypeAnno.annotationType();
-                    if (c.getSimpleName().equals("Detach"))
-                        setType(c, QueryType.DETACH);
-                    else if (c.getSimpleName().equals("Merge"))
-                        setType(c, QueryType.MERGE);
-                    else if (c.getSimpleName().equals("Persist"))
-                        setType(c, QueryType.PERSIST);
-                    else if (c.getSimpleName().equals("Refresh"))
-                        setType(c, QueryType.REFRESH);
-                    else if (c.getSimpleName().equals("Remove"))
-                        setType(c, QueryType.REMOVE);
-                    else
-                        // should be unreachable
-                        throw new UnsupportedOperationException("The " + method.getName() + " method of the " +
-                                                                repository.repositoryInterface.getName() +
-                                                                " repository interface must be annotated with one of " +
-                                                                "(Delete, Insert, Save, Update)" +
-                                                                " because the method's parameter accepts entity instances. The following" +
-                                                                " annotations were found: " + Arrays.toString(method.getAnnotations()));
-                }
+                else if (type == LC_UPDATE || type == LC_UPDATE_MERGE)
+                    q = generateUpdateEntity();
+                // other life cycle methods don't use JPQL
             } else {
-                if (methodTypeAnno != null) {
+                if (methodTypeAnno == null) {
+                    // Query by Method Name
+                    q = initQueryByMethodName(countPages);
+                } else {
                     // Query by Parameters
                     q = initQueryByParameters(countPages,
                                               NO_CONSTRAINTS_DEFERRED,
@@ -3386,9 +3363,6 @@ public abstract class QueryInfo {
                     // Only validate if Constraint parameters correspond one-to-one
                     // with JPQL parameters.
                     validateNumberOfMethodArgs = jpqlParamCount == specialParamsStartAt;
-                } else {
-                    // Query by Method Name
-                    q = initQueryByMethodName(countPages);
                 }
 
                 if (type == FIND_AND_DELETE
@@ -3500,8 +3474,6 @@ public abstract class QueryInfo {
                                    Map<String, CompletableFuture<EntityInfo>> entityInfos,
                                    CompletableFuture<EntityInfo> primaryEntityInfoFuture,
                                    DataVersionCompatibility compat) {
-        final boolean trace = TraceComponent.isAnyTracingEnabled();
-
         // Find out how many parameters the method supplies to the query
         // versus which method parameters are special parameters.
         boolean addsToWHERE = false;
@@ -4751,7 +4723,6 @@ public abstract class QueryInfo {
                         ? null //
                         : entityInfo.recordClass.getSimpleName();
         final int rLen = recordName == null ? 0 : recordName.length();
-        final int eLen = entityInfo.name.length();
         final int qlLen = ql.length();
 
         // for editing the main query
@@ -5184,7 +5155,6 @@ public abstract class QueryInfo {
                        Map<Object, Object> addedJPQLParams) {
         final boolean trace = TraceComponent.isAnyTracingEnabled();
         final int numArgs = args == null ? 0 : args.length;
-        final DataVersionCompatibility compat = producer.compat();
 
         if (trace && tc.isDebugEnabled()) {
             Object addedLoggable = loggable(addedJPQLParams);
@@ -5292,8 +5262,8 @@ public abstract class QueryInfo {
      * @param annoClass     Insert, Update, Save, or Delete annotation class.
      * @param operationType corresponding operation type.
      */
-    private void setType(Class<? extends Annotation> annoClass,
-                         QueryType operationType) {
+    protected void setType(Class<? extends Annotation> annoClass,
+                           QueryType operationType) {
         type = operationType;
         if (entityParamType == null) {
             int paramCount = method.getParameterCount();

--- a/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/QueryInfo.java
+++ b/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/QueryInfo.java
@@ -60,7 +60,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.function.BiFunction;
 import java.util.stream.BaseStream;
-import java.util.stream.Collectors;
 import java.util.stream.DoubleStream;
 import java.util.stream.IntStream;
 import java.util.stream.LongStream;
@@ -1195,7 +1194,7 @@ public abstract class QueryInfo {
     @Trivial
     Object delete(Object arg, EntityManager em) throws Exception {
         arg = arg instanceof Stream //
-                        ? ((Stream<?>) arg).sequential().collect(Collectors.toList()) //
+                        ? ((Stream<?>) arg).sequential().toList() //
                         : arg;
 
         final boolean trace = TraceComponent.isAnyTracingEnabled();
@@ -1315,6 +1314,39 @@ public abstract class QueryInfo {
         if (trace && tc.isEntryEnabled())
             Tr.exit(this, tc, "deleteOne", numDeleted);
         return numDeleted;
+    }
+
+    /**
+     * Detaches entities from the persistence context.
+     *
+     * @param arg the entity or array/Iterable/Stream of entity
+     * @param em  the entity manager
+     * @throws Exception if an error occurs.
+     */
+    @Trivial
+    Void detach(Object arg, EntityManager em) throws Exception {
+        arg = arg instanceof Stream //
+                        ? ((Stream<?>) arg).sequential().toList() //
+                        : arg;
+
+        final boolean trace = TraceComponent.isAnyTracingEnabled();
+        if (trace && tc.isEntryEnabled())
+            Tr.entry(this, tc, "detach", loggable(arg));
+
+        if (arg instanceof Iterable) {
+            for (Object e : ((Iterable<?>) arg))
+                em.detach(e);
+        } else if (entityParamType.isArray()) {
+            int length = Array.getLength(arg);
+            for (int i = 0; i < length; i++)
+                em.detach(Array.get(arg, i));
+        } else {
+            em.detach(arg);
+        }
+
+        if (trace && tc.isEntryEnabled())
+            Tr.exit(this, tc, "detach");
+        return null;
     }
 
     /**
@@ -1794,7 +1826,7 @@ public abstract class QueryInfo {
                 results.add(findAndUpdateOne(Array.get(arg, i), em));
         } else {
             arg = arg instanceof Stream //
-                            ? ((Stream<?>) arg).sequential().collect(Collectors.toList()) //
+                            ? ((Stream<?>) arg).sequential().toList() //
                             : arg;
 
             results = new ArrayList<>();
@@ -3827,7 +3859,7 @@ public abstract class QueryInfo {
     @Trivial
     Object insert(Object arg, EntityManager em) throws Exception {
         arg = arg instanceof Stream //
-                        ? ((Stream<?>) arg).sequential().collect(Collectors.toList()) //
+                        ? ((Stream<?>) arg).sequential().toList() //
                         : arg;
 
         final boolean trace = TraceComponent.isAnyTracingEnabled();
@@ -4929,7 +4961,7 @@ public abstract class QueryInfo {
     @Trivial // avoid logging customer data
     Object save(Object arg, EntityManager em) throws Exception {
         arg = arg instanceof Stream //
-                        ? ((Stream<?>) arg).sequential().collect(Collectors.toList()) //
+                        ? ((Stream<?>) arg).sequential().toList() //
                         : arg;
 
         final boolean trace = TraceComponent.isAnyTracingEnabled();
@@ -5522,7 +5554,7 @@ public abstract class QueryInfo {
     @Trivial
     Object update(Object arg, EntityManager em) throws Exception {
         arg = arg instanceof Stream //
-                        ? ((Stream<?>) arg).sequential().collect(Collectors.toList()) //
+                        ? ((Stream<?>) arg).sequential().toList() //
                         : arg;
 
         final boolean trace = TraceComponent.isAnyTracingEnabled();

--- a/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/QueryType.java
+++ b/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/QueryType.java
@@ -29,6 +29,7 @@ import jakarta.data.repository.Update;
 public enum QueryType {
     // repository query method count
     COUNT(null, //
+          !Is.LIFE_CYCLE_METHOD, //
           !Require.AUTO_START_TX, //
           !Require.DETACH_ENTITIES, //
           !Require.RETURN_HIDDEN, //
@@ -36,6 +37,7 @@ public enum QueryType {
 
     // stateful repository life cycle method @Detach
     DETACH("Detach", //
+           Is.LIFE_CYCLE_METHOD, //
            !Require.AUTO_START_TX, //
            Require.DETACH_ENTITIES, //
            !Require.RETURN_HIDDEN, //
@@ -43,6 +45,7 @@ public enum QueryType {
 
     // repository query method exists
     EXISTS(null, //
+           !Is.LIFE_CYCLE_METHOD, //
            !Require.AUTO_START_TX, //
            !Require.DETACH_ENTITIES, //
            !Require.RETURN_HIDDEN, //
@@ -50,6 +53,7 @@ public enum QueryType {
 
     // repository query method find/@Find/@Query(SELECT/FROM/WHERE)
     FIND(Find.class.getSimpleName(), //
+         !Is.LIFE_CYCLE_METHOD, //
          !Require.AUTO_START_TX, //
          null, // detach depends on stateless vs stateful repository
          Require.RETURN_HIDDEN, //
@@ -57,6 +61,7 @@ public enum QueryType {
 
     // stateless repository query method delete/@Delete with entity result
     FIND_AND_DELETE(Delete.class.getSimpleName(), //
+                    !Is.LIFE_CYCLE_METHOD, //
                     Require.AUTO_START_TX, //
                     Require.DETACH_ENTITIES, //
                     Require.RETURN_HIDDEN, //
@@ -64,6 +69,7 @@ public enum QueryType {
 
     // stateless repository life cycle method @Insert
     INSERT(Insert.class.getSimpleName(), //
+           Is.LIFE_CYCLE_METHOD, //
            Require.AUTO_START_TX, //
            Require.DETACH_ENTITIES, //
            Require.RETURN_HIDDEN, //
@@ -71,6 +77,7 @@ public enum QueryType {
 
     // stateless repository life cycle method @Delete
     LC_DELETE(Delete.class.getSimpleName(), //
+              Is.LIFE_CYCLE_METHOD, //
               Require.AUTO_START_TX, //
               !Require.DETACH_ENTITIES, //
               !Require.RETURN_HIDDEN, //
@@ -78,6 +85,7 @@ public enum QueryType {
 
     // stateless repository life cycle method @Update
     LC_UPDATE(Update.class.getSimpleName(), //
+              Is.LIFE_CYCLE_METHOD, //
               Require.AUTO_START_TX, //
               !Require.DETACH_ENTITIES, //
               !Require.RETURN_HIDDEN, //
@@ -85,6 +93,7 @@ public enum QueryType {
 
     // stateless repository life cycle method @Update with entity result (find & merge)
     LC_UPDATE_MERGE(Update.class.getSimpleName(), //
+                    Is.LIFE_CYCLE_METHOD, //
                     Require.AUTO_START_TX, //
                     Require.DETACH_ENTITIES, //
                     Require.RETURN_HIDDEN, //
@@ -92,6 +101,7 @@ public enum QueryType {
 
     // stateful repository life cycle method @Merge
     MERGE("Merge", //
+          Is.LIFE_CYCLE_METHOD, //
           !Require.AUTO_START_TX, //
           !Require.DETACH_ENTITIES, //
           Require.RETURN_HIDDEN, //
@@ -99,6 +109,7 @@ public enum QueryType {
 
     // stateful repository life cycle method @Persist
     PERSIST("Persist", //
+            Is.LIFE_CYCLE_METHOD, //
             !Require.AUTO_START_TX, //
             !Require.DETACH_ENTITIES, //
             !Require.RETURN_HIDDEN, //
@@ -106,6 +117,7 @@ public enum QueryType {
 
     // stateless repository query method delete/@Delete/@Query(DELETE)
     QM_DELETE(Delete.class.getSimpleName(), //
+              !Is.LIFE_CYCLE_METHOD, //
               Require.AUTO_START_TX, //
               !Require.DETACH_ENTITIES, //
               !Require.RETURN_HIDDEN, //
@@ -113,6 +125,7 @@ public enum QueryType {
 
     // stateless repository query method update/@Update/@Query(UPDATE)
     QM_UPDATE(Update.class.getSimpleName(), //
+              !Is.LIFE_CYCLE_METHOD, //
               Require.AUTO_START_TX, //
               !Require.DETACH_ENTITIES, //
               !Require.RETURN_HIDDEN, //
@@ -120,6 +133,7 @@ public enum QueryType {
 
     // stateful repository life cycle method @Refresh
     REFRESH("Refresh", //
+            Is.LIFE_CYCLE_METHOD, //
             !Require.AUTO_START_TX, //
             !Require.DETACH_ENTITIES, //
             !Require.RETURN_HIDDEN, //
@@ -127,6 +141,7 @@ public enum QueryType {
 
     // stateful repository life cycle method @Remove
     REMOVE("Remove", //
+           Is.LIFE_CYCLE_METHOD, //
            !Require.AUTO_START_TX, //
            !Require.DETACH_ENTITIES, //
            !Require.RETURN_HIDDEN, //
@@ -134,6 +149,7 @@ public enum QueryType {
 
     // resource accessor method
     RESOURCE_ACCESS(null, //
+                    !Is.LIFE_CYCLE_METHOD, //
                     !Require.AUTO_START_TX, //
                     !Require.DETACH_ENTITIES, //
                     !Require.RETURN_HIDDEN, //
@@ -141,6 +157,7 @@ public enum QueryType {
 
     // stateless repository life cycle method @Save
     SAVE(Save.class.getSimpleName(), //
+         Is.LIFE_CYCLE_METHOD, //
          Require.AUTO_START_TX, //
          Require.DETACH_ENTITIES, //
          Require.RETURN_HIDDEN, //
@@ -170,6 +187,11 @@ public enum QueryType {
     public final boolean hideReturnValue;
 
     /**
+     * Indicates if the repository method is a life cycle method.
+     */
+    public final boolean isLifeCycleMethod;
+
+    /**
      * Name of the operation performed by the repository method,
      * suitable for display in messages to the user.
      * If an equivalent annotation (such as Find, Save, or Delete) exists,
@@ -191,6 +213,8 @@ public enum QueryType {
      *
      * @param annoName             Simple name of the equivalent repository method
      *                                 annotation.
+     * @param isLifeCycleMethod    indivates if the repository method is a life
+     *                                 cycle method, such as Insert, Save, Detach.
      * @param autoStartTransaction automatically start a transaction for the
      *                                 operation.
      * @param detachEntities       require that the repository does (vs does not)
@@ -198,9 +222,13 @@ public enum QueryType {
      *                                 Null defers to the type of repository.
      * @param hideReturnValue      suppress logging/tracing of the method's return
      *                                 value by default
-     *                                 ;
+     * @param stateful             indicates if the repository method requires a
+     *                                 stateful repository (TRUE), if it requires a
+     *                                 stateless repository (FALSE), or if can be
+     *                                 placed on either type of repository (NULL).
      */
     private QueryType(String annoName,
+                      boolean isLifeCycleMethod,
                       boolean autoStartTransaction,
                       Boolean detachEntities,
                       boolean hideReturnValue,
@@ -208,6 +236,7 @@ public enum QueryType {
         this.autoStartTransaction = autoStartTransaction;
         this.detachEntities = detachEntities;
         this.hideReturnValue = hideReturnValue;
+        this.isLifeCycleMethod = isLifeCycleMethod;
         this.operationName = annoName == null ? name() : annoName;
         this.stateful = stateful;
     }
@@ -231,6 +260,16 @@ public enum QueryType {
                      name() + " detachEntities stateful? " + stateful,
                      detach);
         return detach;
+    }
+
+    /**
+     * Constants used internally by the enumeration.
+     * The constants cannot be declared directly on the enumeration because the
+     * enumerated values need access to them and cannot access fields that are
+     * declared later in the file.
+     */
+    private static final class Is {
+        static final boolean LIFE_CYCLE_METHOD = true;
     }
 
     /**

--- a/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/RepositoryImpl.java
+++ b/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/RepositoryImpl.java
@@ -74,6 +74,11 @@ public class RepositoryImpl<R> implements InvocationHandler {
                     new ThreadLocal<>();
 
     /**
+     * Creates EntityManager instances.
+     */
+    private final EntityManagerBuilder builder;
+
+    /**
      * Indicates if the bean for the repository has been disposed.
      */
     private final AtomicBoolean isDisposed = new AtomicBoolean();
@@ -125,6 +130,7 @@ public class RepositoryImpl<R> implements InvocationHandler {
                           Class<R> repositoryInterface,
                           Class<?> primaryEntityClass,
                           Map<Class<?>, List<QueryInfo>> queriesPerEntityClass) {
+        this.builder = builder;
 
         // EntityManagerBuilder implementations guarantee that the future
         // in the following map will be completed even if an error occurs
@@ -280,6 +286,7 @@ public class RepositoryImpl<R> implements InvocationHandler {
      * jakarta.persistence.PersistenceException (and subclasses).
      *
      * @param original exception to possibly replace.
+     * @parma emb      entity manager builder.
      * @return exception to replace with, if any. Otherwise, the original.
      */
     @Trivial
@@ -384,14 +391,12 @@ public class RepositoryImpl<R> implements InvocationHandler {
         Object resource = null;
         Class<?> type = method.getReturnType();
         if (EntityManager.class.equals(type))
-            resource = primaryEntityInfoFuture.join().builder.createEntityManager();
+            resource = builder.createEntityManager();
         else if (DataSource.class.equals(type))
-            resource = primaryEntityInfoFuture.join().builder //
-                            .getDataSource(method, repositoryInterface);
+            resource = builder.getDataSource(method, repositoryInterface);
         else if (Connection.class.equals(type))
             try {
-                resource = primaryEntityInfoFuture.join().builder //
-                                .getDataSource(method, repositoryInterface) //
+                resource = builder.getDataSource(method, repositoryInterface) //
                                 .getConnection();
             } catch (SQLException x) {
                 throw new DataConnectionException(x);
@@ -452,7 +457,6 @@ public class RepositoryImpl<R> implements InvocationHandler {
     public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
         CompletableFuture<QueryInfo> queryInfoFuture = queries.get(method);
         boolean isDefaultMethod = false;
-        EntityManager em = null;
 
         if (queryInfoFuture == null)
             if (method.isDefault()) {
@@ -479,8 +483,7 @@ public class RepositoryImpl<R> implements InvocationHandler {
                                '.' + method.getName(),
                      provider.loggable(repositoryInterface, method, args));
 
-        QueryInfo queryInfo = null;
-
+        EntityManager em = null;
         try {
             if (isDisposed.get())
                 throw exc(IllegalStateException.class,
@@ -528,12 +531,15 @@ public class RepositoryImpl<R> implements InvocationHandler {
             boolean failed = true;
             QueryType queryType = null;
             boolean startedTransaction = false;
+            boolean stateful = false;
 
             try {
-                queryInfo = queryInfoFuture.join();
+                QueryInfo queryInfo = queryInfoFuture.join();
 
                 if (trace && tc.isDebugEnabled())
                     Tr.debug(this, tc, queryInfo.toString());
+
+                stateful = queryInfo.producer.stateful();
 
                 if (queryInfo.validateParams)
                     validator.validateParameters(proxy, method, args);
@@ -552,7 +558,7 @@ public class RepositoryImpl<R> implements InvocationHandler {
                 }
 
                 if (queryType != RESOURCE_ACCESS)
-                    em = queryInfo.entityInfo.builder.createEntityManager();
+                    em = builder.createEntityManager();
 
                 returnValue = switch (queryType) {
                     case FIND, FIND_AND_DELETE -> queryInfo.find(em, txStatus, args);
@@ -588,9 +594,8 @@ public class RepositoryImpl<R> implements InvocationHandler {
                             provider.tranMgr.commit();
                         }
                     } else {
-                        boolean detach;
-                        detach = em != null &&
-                                 queryType.detachEntities(queryInfo.producer.stateful());
+                        boolean detach = em != null &&
+                                         queryType.detachEntities(stateful);
                         if (Status.STATUS_ACTIVE == provider.tranMgr.getStatus()) {
                             if (failed) {
                                 if (trace && tc.isDebugEnabled())
@@ -601,11 +606,9 @@ public class RepositoryImpl<R> implements InvocationHandler {
                                 if (trace && tc.isDebugEnabled())
                                     Tr.debug(this, tc, "flush");
                                 em.flush();
-                                if (queryInfo.entityInfo != null) {
-                                    if (trace && tc.isDebugEnabled())
-                                        Tr.debug(this, tc, "clear");
-                                    em.clear();
-                                }
+                                if (trace && tc.isDebugEnabled())
+                                    Tr.debug(this, tc, "clear");
+                                em.clear();
                             }
                         } else if (detach) {
                             if (trace && tc.isDebugEnabled())
@@ -638,10 +641,7 @@ public class RepositoryImpl<R> implements InvocationHandler {
             return returnValue;
         } catch (Throwable x) {
             if (!isDefaultMethod && x instanceof Exception)
-                x = failure((Exception) x,
-                            queryInfo == null || queryInfo.entityInfo == null //
-                                            ? null //
-                                            : queryInfo.entityInfo.builder);
+                x = failure((Exception) x, builder);
             if (trace && tc.isEntryEnabled())
                 Tr.exit(this, tc, "invoke " + repositoryInterface.getSimpleName() +
                                   '.' + method.getName(),

--- a/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/RepositoryImpl.java
+++ b/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/RepositoryImpl.java
@@ -30,6 +30,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import javax.sql.DataSource;
@@ -56,6 +57,8 @@ import jakarta.persistence.OptimisticLockException;
 import jakarta.persistence.PersistenceException;
 import jakarta.persistence.Table;
 import jakarta.transaction.Status;
+import jakarta.transaction.Synchronization;
+import jakarta.transaction.Transaction;
 
 /**
  * Provides implementation of the methods of a repository interface.
@@ -78,6 +81,12 @@ public class RepositoryImpl<R> implements InvocationHandler {
      */
     private final EntityManagerBuilder builder;
 
+    /**
+     * Map of Transaction to EntityManager that allows stateful repositories to
+     * reuse the same EnityManager within a transaction.
+     */
+    private final Map<Transaction, EntityManager> entityManagerPerTx = //
+                    new ConcurrentHashMap<>();
     /**
      * Indicates if the bean for the repository has been disposed.
      */
@@ -286,7 +295,7 @@ public class RepositoryImpl<R> implements InvocationHandler {
      * jakarta.persistence.PersistenceException (and subclasses).
      *
      * @param original exception to possibly replace.
-     * @parma emb      entity manager builder.
+     * @param emb      entity manager builder.
      * @return exception to replace with, if any. Otherwise, the original.
      */
     @Trivial
@@ -525,13 +534,13 @@ public class RepositoryImpl<R> implements InvocationHandler {
                 }
             }
 
-            LocalTransactionCoordinator suspendedLTC = null;
-
+            boolean closeEntityManager = true;
             Object returnValue;
             boolean failed = true;
             QueryType queryType = null;
             boolean startedTransaction = false;
             boolean stateful = false;
+            LocalTransactionCoordinator suspendedLTC = null;
 
             try {
                 QueryInfo queryInfo = queryInfoFuture.join();
@@ -551,14 +560,29 @@ public class RepositoryImpl<R> implements InvocationHandler {
                     provider.tranMgr.begin();
                     startedTransaction = true;
                     if (trace && tc.isDebugEnabled())
-                        Tr.debug(this, tc, "started global tran",
+                        Tr.debug(this, tc,
+                                 "started global tran",
                                  "suspended LTC: " + suspendedLTC);
                 } else if (trace && tc.isDebugEnabled()) {
                     Tr.debug(this, tc, Util.txStatusToString(txStatus));
                 }
 
-                if (queryType != RESOURCE_ACCESS)
+                if (stateful) {
+                    Transaction tx = provider.tranMgr.getTransaction();
+                    if (tx == null) {
+                        em = builder.createEntityManager();
+                    } else {
+                        closeEntityManager = false;
+                        em = entityManagerPerTx.get(tx);
+                        if (em == null) {
+                            em = builder.createEntityManager();
+                            tx.registerSynchronization(new EntityManagerCleanup(tx));
+                            entityManagerPerTx.put(tx, em);
+                        }
+                    }
+                } else if (queryType != RESOURCE_ACCESS) {
                     em = builder.createEntityManager();
+                }
 
                 returnValue = switch (queryType) {
                     case FIND, FIND_AND_DELETE -> queryInfo.find(em, txStatus, args);
@@ -570,7 +594,8 @@ public class RepositoryImpl<R> implements InvocationHandler {
                     case LC_DELETE -> queryInfo.delete(args[0], em);
                     case LC_UPDATE -> queryInfo.update(args[0], em);
                     case LC_UPDATE_MERGE -> queryInfo.findAndUpdate(args[0], em);
-                    case RESOURCE_ACCESS -> getResource(method);
+                    case DETACH -> queryInfo.detach(args[0], em);
+                    case RESOURCE_ACCESS -> getResource(method); // TODO share em if statefuL?
                     default -> throw new UnsupportedOperationException(queryType.operationName);
                 };
 
@@ -624,7 +649,7 @@ public class RepositoryImpl<R> implements InvocationHandler {
                             provider.localTranCurrent.resume(suspendedLTC);
                         }
                     } finally {
-                        if (em != null)
+                        if (closeEntityManager && em != null)
                             em.close();
                     }
                 }
@@ -647,6 +672,29 @@ public class RepositoryImpl<R> implements InvocationHandler {
                                   '.' + method.getName(),
                         x);
             throw x;
+        }
+    }
+
+    /**
+     * Cleans up the state of the entityManagerPerTx map and closes the
+     * respective EntityManager instance after the transaction completes.
+     */
+    private class EntityManagerCleanup implements Synchronization {
+        private final Transaction tx;
+
+        private EntityManagerCleanup(Transaction tx) {
+            this.tx = tx;
+        }
+
+        @Override
+        public void afterCompletion(int status) {
+            EntityManager em = entityManagerPerTx.remove(tx);
+            if (em != null)
+                em.close();
+        }
+
+        @Override
+        public void beforeCompletion() {
         }
     }
 }

--- a/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/Util.java
+++ b/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/Util.java
@@ -205,7 +205,7 @@ public class Util {
     /**
      * Valid types for when a repository method computes an update count
      */
-    static final Set<Class<?>> UPDATE_COUNT_TYPES = //
+    public static final Set<Class<?>> UPDATE_COUNT_TYPES = //
                     Set.of(boolean.class, Boolean.class,
                            int.class, Integer.class,
                            long.class, Long.class,

--- a/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/cdi/DataExtension.java
+++ b/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/cdi/DataExtension.java
@@ -222,7 +222,7 @@ public class DataExtension implements Extension {
                 (EntityManager.class.equals(returnType)
                  || DataSource.class.equals(returnType)
                  || Connection.class.equals(returnType))) {
-                // TODO use compat to obtain above types, and identity stateless from EntityAgent type
+                // TODO use compat to obtain above types, and identify stateless from EntityAgent type
                 QueryInfo queryInfo = provider.compat //
                                 .createQueryInfo(producer, //
                                                  repositoryInterface, //
@@ -529,9 +529,17 @@ public class DataExtension implements Extension {
             producer.setPrimaryEntityClass(primaryEntityClass);
         }
 
-        if (stateful == Boolean.TRUE)
+        if (stateful == Boolean.TRUE) {
             // Repository methods indicate a stateful repository
             producer.setStateful();
+
+            for (Class<?> c : queriesPerEntity.keySet())
+                if (c.isRecord()) // TODO NLS
+                    throw new UnsupportedOperationException("The " + c.getName() +
+                                                            " Java record type cannot" +
+                                                            " be an entity class for a" +
+                                                            " stateful repository.");
+        }
 
         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
             Tr.debug(this, tc,

--- a/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/v1_0/QueryInfo_1_0.java
+++ b/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/v1_0/QueryInfo_1_0.java
@@ -12,6 +12,12 @@
  *******************************************************************************/
 package io.openliberty.data.internal.v1_0;
 
+import static io.openliberty.data.internal.QueryType.INSERT;
+import static io.openliberty.data.internal.QueryType.LC_DELETE;
+import static io.openliberty.data.internal.QueryType.LC_UPDATE;
+import static io.openliberty.data.internal.QueryType.LC_UPDATE_MERGE;
+import static io.openliberty.data.internal.QueryType.SAVE;
+
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.util.Collections;
@@ -23,7 +29,13 @@ import com.ibm.websphere.ras.annotation.Trivial;
 import io.openliberty.data.internal.AttributeConstraint;
 import io.openliberty.data.internal.QueryInfo;
 import io.openliberty.data.internal.QueryType;
+import io.openliberty.data.internal.Util;
 import io.openliberty.data.internal.cdi.RepositoryProducer;
+import jakarta.data.repository.Delete;
+import jakarta.data.repository.Insert;
+import jakarta.data.repository.Query;
+import jakarta.data.repository.Save;
+import jakarta.data.repository.Update;
 
 /**
  * QueryInfo implementation for Jakarta Data 1.0.
@@ -117,6 +129,30 @@ public class QueryInfo_1_0 extends QueryInfo {
     protected Map<Integer, Object> getDeferredConstraints(boolean alwaysDefer,
                                                           Object[] methodParams) {
         return Collections.emptyMap();
+    }
+
+    @Override
+    @Trivial
+    protected String getQueryAnnoValue() {
+        return methodTypeAnno instanceof Query query ? query.value() : null;
+    }
+
+    @Override
+    @Trivial
+    protected void identifyType() {
+        if (entityParamType != null && methodTypeAnno instanceof Delete)
+            setType(Delete.class, LC_DELETE);
+
+        else if (entityParamType != null && methodTypeAnno instanceof Update)
+            setType(Update.class,
+                    entityInfo.attributeNamesForEntityUpdate != null &&
+                                  Util.UPDATE_COUNT_TYPES.contains(singleType) //
+                                                  ? LC_UPDATE //
+                                                  : LC_UPDATE_MERGE);
+        else if (methodTypeAnno instanceof Insert)
+            setType(Insert.class, INSERT);
+        else if (methodTypeAnno instanceof Save)
+            setType(Save.class, SAVE);
     }
 
     @Override

--- a/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/v1_1/QueryInfo_1_1.java
+++ b/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/v1_1/QueryInfo_1_1.java
@@ -12,6 +12,17 @@
  *******************************************************************************/
 package io.openliberty.data.internal.v1_1;
 
+import static io.openliberty.data.internal.QueryType.DETACH;
+import static io.openliberty.data.internal.QueryType.INSERT;
+import static io.openliberty.data.internal.QueryType.LC_DELETE;
+import static io.openliberty.data.internal.QueryType.LC_UPDATE;
+import static io.openliberty.data.internal.QueryType.LC_UPDATE_MERGE;
+import static io.openliberty.data.internal.QueryType.MERGE;
+import static io.openliberty.data.internal.QueryType.PERSIST;
+import static io.openliberty.data.internal.QueryType.REFRESH;
+import static io.openliberty.data.internal.QueryType.REMOVE;
+import static io.openliberty.data.internal.QueryType.SAVE;
+
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
@@ -29,6 +40,7 @@ import com.ibm.websphere.ras.annotation.Trivial;
 import io.openliberty.data.internal.AttributeConstraint;
 import io.openliberty.data.internal.QueryInfo;
 import io.openliberty.data.internal.QueryType;
+import io.openliberty.data.internal.Util;
 import io.openliberty.data.internal.cdi.RepositoryProducer;
 import io.openliberty.data.repository.IgnoreCase;
 import io.openliberty.data.repository.function.AbsoluteValue;
@@ -62,7 +74,17 @@ import jakarta.data.expression.NavigableExpression;
 import jakarta.data.expression.TemporalExpression;
 import jakarta.data.metamodel.Attribute;
 import jakarta.data.metamodel.NavigableAttribute;
+import jakarta.data.repository.Delete;
+import jakarta.data.repository.Insert;
 import jakarta.data.repository.Is;
+import jakarta.data.repository.Query;
+import jakarta.data.repository.Save;
+import jakarta.data.repository.Update;
+import jakarta.data.repository.stateful.Detach;
+import jakarta.data.repository.stateful.Merge;
+import jakarta.data.repository.stateful.Persist;
+import jakarta.data.repository.stateful.Refresh;
+import jakarta.data.repository.stateful.Remove;
 import jakarta.data.restrict.BasicRestriction;
 import jakarta.data.restrict.CompositeRestriction;
 import jakarta.data.spi.expression.function.CurrentDate;
@@ -713,6 +735,16 @@ public class QueryInfo_1_1 extends QueryInfo {
         return deferred;
     }
 
+    @Override
+    @Trivial
+    protected String getQueryAnnoValue() {
+        if (methodTypeAnno instanceof Query query)
+            return query.value();
+        // else TODO query annotation(s) from Jakarta Persistence
+        else
+            return null;
+    }
+
     /**
      * Determine if the constraint applies to one or more values that are
      * expressions other than literal expressions.
@@ -757,6 +789,33 @@ public class QueryInfo_1_1 extends QueryInfo {
             throw new UnsupportedOperationException("Constraint: " +
                                                     constraint.getClass().getName());
         return !allLiteral;
+    }
+
+    @Override
+    @Trivial
+    protected void identifyType() {
+        if (entityParamType != null && methodTypeAnno instanceof Delete)
+            setType(Delete.class, LC_DELETE);
+        else if (entityParamType != null && methodTypeAnno instanceof Update)
+            setType(Update.class,
+                    entityInfo.attributeNamesForEntityUpdate != null &&
+                                  Util.UPDATE_COUNT_TYPES.contains(singleType) //
+                                                  ? LC_UPDATE //
+                                                  : LC_UPDATE_MERGE);
+        else if (methodTypeAnno instanceof Insert)
+            setType(Insert.class, INSERT);
+        else if (methodTypeAnno instanceof Save)
+            setType(Save.class, SAVE);
+        else if (methodTypeAnno instanceof Detach)
+            setType(Detach.class, DETACH);
+        else if (methodTypeAnno instanceof Merge)
+            setType(Merge.class, MERGE);
+        else if (methodTypeAnno instanceof Persist)
+            setType(Persist.class, PERSIST);
+        else if (methodTypeAnno instanceof Refresh)
+            setType(Refresh.class, REFRESH);
+        else if (methodTypeAnno instanceof Remove)
+            setType(Remove.class, REMOVE);
     }
 
     @Override

--- a/dev/io.openliberty.data.internal_fat_1_1/test-applications/Data_1_1_App/src/test/jakarta/data/v1_1/web/Data_1_1_Servlet.java
+++ b/dev/io.openliberty.data.internal_fat_1_1/test-applications/Data_1_1_App/src/test/jakarta/data/v1_1/web/Data_1_1_Servlet.java
@@ -427,6 +427,49 @@ public class Data_1_1_Servlet extends FATServlet {
                                      .collect(Collectors.toList()));
     }
 
+    /**
+     * Use a stateless repository to find an entity. Modify the entity. Update the
+     * entity. Use a detach operation to make the entity unmanaged. Make additional
+     * updates to the entity. Verify that only the updates made before the detach
+     * operation are written to the database.
+     */
+    @Test
+    public void testDetach() throws Exception {
+
+        // TODO use stateful method to persist entities
+        // Populate with 5/23.
+        // Ensure deletion in the finally block.
+        fractions.supply(List.of(Fraction.of(5, 23)));
+        try {
+            System.out.println("Fetch 5/23 to modify, detach, modify, and commit");
+
+            tx.begin();
+            Fraction f = statefulFractions.fetch(5, 23).orElseThrow();
+            statefulFractions.detach(f);
+            f.reduced = false;
+            f.decimal = Decimal.of(4, 23);
+            tx.commit();
+
+            f = statefulFractions.fetch(5, 23).orElseThrow();
+
+            // modifications from after detach should not be persisted
+            assertEquals(true,
+                         f.reduced);
+
+            assertEquals(BigDecimal.valueOf(2173, 4), // first 4 decimals of 5/23
+                         f.decimal.truncated());
+        } finally {
+            if (tx.getStatus() != Status.STATUS_NO_TRANSACTION)
+                tx.rollback();
+
+            // TODO use stateful method to remove entities
+            // Ensure no fractions with denominator of 23 or more are left around
+            fractions.discard(AtLeast.min(23),
+                              AtMost.max(Integer.MAX_VALUE),
+                              Restrict.unrestricted());
+        }
+    }
+
     @Test
     public void testInheritanceFromAbstractEntity() {
         ads.removeBySponsorIn(List.of("Open Liberty",


### PR DESCRIPTION
Implement the detach operation for stateful repositories.
A test case is included for a detach method accepting a single entity instance.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
