### PR TITLE
stateful resource accessor

### DIFF
--- a/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/PageImpl.java
+++ b/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/PageImpl.java
@@ -211,6 +211,8 @@ public class PageImpl<T> implements Page<T> {
                       queryInfo.jpqlCount,
                       queryInfo.jpql);
 
+        // TODO share EntityManager from constructor if stateful and still
+        // in the same transaction
         EntityManager em = queryInfo.entityInfo.builder.createEntityManager();
         try {
             if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())

--- a/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/RepositoryImpl.java
+++ b/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/RepositoryImpl.java
@@ -15,6 +15,7 @@ package io.openliberty.data.internal;
 import static io.openliberty.data.internal.QueryType.RESOURCE_ACCESS;
 import static io.openliberty.data.internal.cdi.DataExtension.exc;
 
+import java.io.PrintWriter;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
 import java.sql.Connection;
@@ -491,6 +492,28 @@ public class RepositoryImpl<R> implements InvocationHandler {
         @SuppressWarnings("unchecked")
         T t = (T) resource;
         return t;
+    }
+
+    /**
+     * Write information about this instance to the introspection file for
+     * Jakarta Data.
+     *
+     * @param writer writes to the introspection file.
+     * @param indent indentation for lines.
+     */
+    @Trivial
+    public void introspect(PrintWriter writer, String indent) {
+
+        writer.println(indent + "RepositoryImpl@" + Integer.toHexString(hashCode()));
+        writer.println(indent + "  builder: " + builder);
+        writer.println(indent + "  isDisposed? " + isDisposed);
+        writer.println(indent + "  primary entity future: " + primaryEntityInfoFuture);
+        writer.println(indent + "  provider: " + provider);
+        writer.println(indent + "  repository: " + repositoryInterface.getName());
+        writer.println(indent + "  validator: " + validator);
+        writer.println(indent + "  stateless entity manager per transaction:");
+        entityManagerPerTx.forEach((tx, em) -> writer //
+                        .println(indent + "    " + tx + " -> " + em));
     }
 
     /**

--- a/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/RepositoryImpl.java
+++ b/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/RepositoryImpl.java
@@ -21,6 +21,7 @@ import java.sql.Connection;
 import java.sql.SQLException;
 import java.sql.SQLIntegrityConstraintViolationException;
 import java.sql.SQLSyntaxErrorException;
+import java.util.AbstractMap.SimpleEntry;
 import java.util.ArrayList;
 import java.util.Deque;
 import java.util.HashMap;
@@ -377,6 +378,42 @@ public class RepositoryImpl<R> implements InvocationHandler {
     }
 
     /**
+     * Obtains a shared EntityManager instance if running in a transaction
+     * and the repository is stateful. Otherwise create a new instance.
+     *
+     * @param stateful indicates a stateful repository.
+     * @return EntityManager and indicator of whether the EntityManager will be
+     *         automatically closed by the current transaction.
+     * @throws Exception if an error occurs.
+     */
+    private SimpleEntry<EntityManager, Boolean> getEntityManager(boolean stateful) //
+                    throws Exception {
+        boolean autoClosedByTx;
+        EntityManager em;
+
+        if (stateful) {
+            Transaction tx = provider.tranMgr.getTransaction();
+            if (tx == null) {
+                autoClosedByTx = false;
+                em = builder.createEntityManager();
+            } else {
+                autoClosedByTx = true;
+                em = entityManagerPerTx.get(tx);
+                if (em == null) {
+                    em = builder.createEntityManager();
+                    tx.registerSynchronization(new EntityManagerCleanup(tx));
+                    entityManagerPerTx.put(tx, em);
+                }
+            }
+        } else {
+            autoClosedByTx = false;
+            em = builder.createEntityManager();
+        }
+
+        return new SimpleEntry<>(em, autoClosedByTx);
+    }
+
+    /**
      * Used during introspection to report errors that occurred when processing
      * repository methods.
      *
@@ -391,37 +428,44 @@ public class RepositoryImpl<R> implements InvocationHandler {
     /**
      * Request an instance of a resource of the specified type.
      *
-     * @param method the repository method.
+     * @param info query information.
      * @return instance of the resource. Never null.
+     * @throws Exception                     if unable to obtain an EntityManager.
      * @throws UnsupportedOperationException if the type of resource is not available.
      */
-    private <T> T getResource(Method method) {
-        Deque<AutoCloseable> resources = defaultMethodResources.get();
+    private <T> T getResource(QueryInfo info) throws Exception {
         Object resource = null;
-        Class<?> type = method.getReturnType();
-        if (EntityManager.class.equals(type))
-            resource = builder.createEntityManager();
-        else if (DataSource.class.equals(type))
-            resource = builder.getDataSource(method, repositoryInterface);
-        else if (Connection.class.equals(type))
+        boolean resourceAutoClosedByTx = false;
+        boolean stateful = info.producer.stateful();
+        Class<?> type = info.method.getReturnType();
+
+        if (EntityManager.class.equals(type)) {
+            SimpleEntry<EntityManager, Boolean> emAutoCloseable = //
+                            getEntityManager(stateful);
+            resource = emAutoCloseable.getKey();
+            resourceAutoClosedByTx = emAutoCloseable.getValue();
+        } else if (DataSource.class.equals(type)) {
+            resource = builder.getDataSource(info.method, repositoryInterface);
+        } else if (Connection.class.equals(type)) {
             try {
-                resource = builder.getDataSource(method, repositoryInterface) //
+                resource = builder.getDataSource(info.method, repositoryInterface) //
                                 .getConnection();
             } catch (SQLException x) {
                 throw new DataConnectionException(x);
             }
+        }
 
         if (resource == null)
             throw exc(UnsupportedOperationException.class,
                       "CWWKD1044.invalid.resource.type",
-                      method.getName(),
+                      info.method.getName(),
                       repositoryInterface.getName(),
                       type.getName(),
-                      List.of(Connection.class.getName(),
-                              DataSource.class.getName(),
-                              EntityManager.class.getName()));
+                      Util.names(provider.compat.resourceAccessorTypes(stateful)));
 
-        if (resource instanceof AutoCloseable) {
+        if (!resourceAutoClosedByTx &&
+            resource instanceof AutoCloseable) {
+            Deque<AutoCloseable> resources = defaultMethodResources.get();
             if (resources == null) {
                 if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
                     StackTraceElement[] stack = Thread.currentThread().getStackTrace();
@@ -534,8 +578,8 @@ public class RepositoryImpl<R> implements InvocationHandler {
                 }
             }
 
-            boolean closeEntityManager = true;
             Object returnValue;
+            boolean emAutoClosedByTx = false;
             boolean failed = true;
             QueryType queryType = null;
             boolean startedTransaction = false;
@@ -567,21 +611,11 @@ public class RepositoryImpl<R> implements InvocationHandler {
                     Tr.debug(this, tc, Util.txStatusToString(txStatus));
                 }
 
-                if (stateful) {
-                    Transaction tx = provider.tranMgr.getTransaction();
-                    if (tx == null) {
-                        em = builder.createEntityManager();
-                    } else {
-                        closeEntityManager = false;
-                        em = entityManagerPerTx.get(tx);
-                        if (em == null) {
-                            em = builder.createEntityManager();
-                            tx.registerSynchronization(new EntityManagerCleanup(tx));
-                            entityManagerPerTx.put(tx, em);
-                        }
-                    }
-                } else if (queryType != RESOURCE_ACCESS) {
-                    em = builder.createEntityManager();
+                if (queryType != RESOURCE_ACCESS) {
+                    SimpleEntry<EntityManager, Boolean> emAutoCloseable = //
+                                    getEntityManager(stateful);
+                    em = emAutoCloseable.getKey();
+                    emAutoClosedByTx = emAutoCloseable.getValue();
                 }
 
                 returnValue = switch (queryType) {
@@ -595,7 +629,7 @@ public class RepositoryImpl<R> implements InvocationHandler {
                     case LC_UPDATE -> queryInfo.update(args[0], em);
                     case LC_UPDATE_MERGE -> queryInfo.findAndUpdate(args[0], em);
                     case DETACH -> queryInfo.detach(args[0], em);
-                    case RESOURCE_ACCESS -> getResource(method); // TODO share em if statefuL?
+                    case RESOURCE_ACCESS -> getResource(queryInfo);
                     default -> throw new UnsupportedOperationException(queryType.operationName);
                 };
 
@@ -649,7 +683,7 @@ public class RepositoryImpl<R> implements InvocationHandler {
                             provider.localTranCurrent.resume(suspendedLTC);
                         }
                     } finally {
-                        if (closeEntityManager && em != null)
+                        if (!emAutoClosedByTx && em != null)
                             em.close();
                     }
                 }

--- a/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/cdi/RepositoryProducer.java
+++ b/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/cdi/RepositoryProducer.java
@@ -284,6 +284,12 @@ public class RepositoryProducer<R> implements Producer<R>, ProducerFactory<R>, B
                        (primaryEntityClass == null ? null : primaryEntityClass.getName()));
         writer.println(indent + "  intercepted: " + intercepted);
 
+        if (repositoryImpl != null) {
+            writer.println();
+            writer.println(indent + "  Most recently created bean:");
+            repositoryImpl.introspect(writer, indent + "  ");
+        }
+
         writer.println();
         writer.println(Util.toString(repositoryInterface, indent + "  "));
 

--- a/dev/io.openliberty.data.internal_fat_1_1/test-applications/Data_1_1_App/src/test/jakarta/data/v1_1/web/Data_1_1_Servlet.java
+++ b/dev/io.openliberty.data.internal_fat_1_1/test-applications/Data_1_1_App/src/test/jakarta/data/v1_1/web/Data_1_1_Servlet.java
@@ -428,10 +428,10 @@ public class Data_1_1_Servlet extends FATServlet {
     }
 
     /**
-     * Use a stateless repository to find an entity. Modify the entity. Update the
-     * entity. Use a detach operation to make the entity unmanaged. Make additional
-     * updates to the entity. Verify that only the updates made before the detach
-     * operation are written to the database.
+     * Use a stateful repository to find an entity. Use a detach operation to
+     * make the entity unmanaged. Make updates to the entity. After committing,
+     * verify that updates made after the detach operation are not written to
+     * the database.
      */
     @Test
     public void testDetach() throws Exception {
@@ -441,7 +441,7 @@ public class Data_1_1_Servlet extends FATServlet {
         // Ensure deletion in the finally block.
         fractions.supply(List.of(Fraction.of(5, 23)));
         try {
-            System.out.println("Fetch 5/23 to modify, detach, modify, and commit");
+            System.out.println("Fetch 5/23 to detach, modify, and commit");
 
             tx.begin();
             Fraction f = statefulFractions.fetch(5, 23).orElseThrow();
@@ -1576,6 +1576,56 @@ public class Data_1_1_Servlet extends FATServlet {
                                      .sorted()
                                      .limit(15)
                                      .collect(Collectors.toList()));
+    }
+
+    /**
+     * Use a stateful repository to find an entity. Make updates to the entity.
+     * Obtain the EntityManager via a resource accessor method and use it to
+     * flush changes to the database. Then use a repository detach operation to
+     * make the entity unmanaged and make additional changes to the entity.
+     * After committing, verify that only the updates from before the flush
+     * are written to the database.
+     */
+    @Test
+    public void testStatefulResourceAccessor() throws Exception {
+
+        // TODO use stateful method to persist entities
+        // Populate with 6/23.
+        // Ensure deletion in the finally block.
+        fractions.supply(List.of(Fraction.of(6, 23)));
+        try {
+            System.out.println("Fetch 6/23 to modify, flush, detach, modify," +
+                               " and commit");
+
+            tx.begin();
+            Fraction f = statefulFractions.fetch(6, 23).orElseThrow();
+            f.reduced = false;
+            statefulFractions.flush(); // via resource accessor
+            statefulFractions.detach(f);
+            f.decimal = Decimal.of(3, 23);
+            tx.commit();
+
+            f = statefulFractions.fetch(6, 23).orElseThrow();
+
+            // modifications from before flush should be persisted
+
+            assertEquals(false,
+                         f.reduced);
+
+            // modifications from after detach should not be persisted
+
+            assertEquals(BigDecimal.valueOf(2608, 4), // first 4 decimals of 6/23
+                         f.decimal.truncated());
+        } finally {
+            if (tx.getStatus() != Status.STATUS_NO_TRANSACTION)
+                tx.rollback();
+
+            // TODO use stateful method to remove entities
+            // Ensure no fractions with denominator of 23 or more are left around
+            fractions.discard(AtLeast.min(23),
+                              AtMost.max(Integer.MAX_VALUE),
+                              Restrict.unrestricted());
+        }
     }
 
 }

--- a/dev/io.openliberty.data.internal_fat_1_1/test-applications/Data_1_1_App/src/test/jakarta/data/v1_1/web/StatefulFractions.java
+++ b/dev/io.openliberty.data.internal_fat_1_1/test-applications/Data_1_1_App/src/test/jakarta/data/v1_1/web/StatefulFractions.java
@@ -20,6 +20,7 @@ import jakarta.data.repository.Find;
 import jakarta.data.repository.Is;
 import jakarta.data.repository.Repository;
 import jakarta.data.repository.stateful.Detach;
+import jakarta.persistence.EntityManager;
 
 /**
  * Stateful repository for the Fraction entity
@@ -34,4 +35,10 @@ public interface StatefulFractions {
     Optional<Fraction> fetch//
     (@By(_Fraction.NUMERATOR) @Is(EqualTo.class) long num,
      @By(_Fraction.DENOMINATOR) @Is long den);
+
+    default void flush() {
+        manager().flush();
+    }
+
+    EntityManager manager();
 }


### PR DESCRIPTION
Stateful repository resource accessor methods that return EntityManager should return the shared EntityManager for the active transaction if a transaction is active.
Also, add introspection for RepositoryImpl, which was lacking it.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
