### PR TITLE
Repeat `com.ibm.ws.rest.handler.validator_fat` for Jakarta EE11

### DIFF
--- a/dev/com.ibm.ws.rest.handler.validator_fat/bnd.bnd
+++ b/dev/com.ibm.ws.rest.handler.validator_fat/bnd.bnd
@@ -1,14 +1,11 @@
 #*******************************************************************************
-# Copyright (c) 2017, 2025 IBM Corporation and others.
+# Copyright (c) 2017, 2026 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-2.0/
 #
 # SPDX-License-Identifier: EPL-2.0
-#
-# Contributors:
-#     IBM Corporation - initial API and implementation
 #*******************************************************************************
 -include= ~../cnf/resources/bnd/bundle.props
 bVersion=1.0
@@ -55,7 +52,9 @@ tested.features: mpOpenApi-2.0,\
                  appsecurity-5.0,\
                  cdi-2.0,\
                  el-3.0,\
-                 expressionLanguage-5.0
+                 expressionLanguage-5.0,\
+                 appsecurity-6.0,\
+                 expressionlanguage-6.0
 
 -buildpath: \
 	com.ibm.websphere.javaee.annotation.1.2;version=latest,\

--- a/dev/com.ibm.ws.rest.handler.validator_fat/fat/src/com/ibm/ws/rest/handler/validator/fat/ValidateDSCustomLoginModuleTest.java
+++ b/dev/com.ibm.ws.rest.handler.validator_fat/fat/src/com/ibm/ws/rest/handler/validator/fat/ValidateDSCustomLoginModuleTest.java
@@ -1,14 +1,11 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2024 IBM Corporation and others.
+ * Copyright (c) 2017, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package com.ibm.ws.rest.handler.validator.fat;
 
@@ -60,6 +57,7 @@ public class ValidateDSCustomLoginModuleTest extends FATServletClient {
 
     @ClassRule
     public static RepeatTests r1 = EERepeatActions.repeat(FeatureReplacementAction.ALL_SERVERS,
+                                                          EERepeatActions.EE11,
                                                           EERepeatActions.EE10,
                                                           EERepeatActions.EE9,
                                                           EERepeatActions.EE8,

--- a/dev/com.ibm.ws.rest.handler.validator_fat/fat/src/com/ibm/ws/rest/handler/validator/fat/ValidateDataSourceTest.java
+++ b/dev/com.ibm.ws.rest.handler.validator_fat/fat/src/com/ibm/ws/rest/handler/validator/fat/ValidateDataSourceTest.java
@@ -6,9 +6,6 @@
  * http://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package com.ibm.ws.rest.handler.validator.fat;
 

--- a/dev/com.ibm.ws.rest.handler.validator_fat/fat/src/com/ibm/ws/rest/handler/validator/fat/ValidateDataSourceTest.java
+++ b/dev/com.ibm.ws.rest.handler.validator_fat/fat/src/com/ibm/ws/rest/handler/validator/fat/ValidateDataSourceTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2024 IBM Corporation and others.
+ * Copyright (c) 2017, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -49,6 +49,10 @@ public class ValidateDataSourceTest extends FATServletClient {
 
     @ClassRule
     public static RepeatTests r1 = MicroProfileActions.repeat("com.ibm.ws.rest.handler.validator.jdbc.fat",
+                                                              MicroProfileActions.MP71_EE11,
+                                                              MicroProfileActions.MP71_EE10,
+                                                              MicroProfileActions.MP70_EE11,
+                                                              MicroProfileActions.MP70_EE10,
                                                               MicroProfileActions.MP61,
                                                               MicroProfileActions.MP50, // EE9
                                                               MicroProfileActions.MP40, // EE8

--- a/dev/com.ibm.ws.rest.handler.validator_fat/fat/src/com/ibm/ws/rest/handler/validator/fat/ValidateJCATest.java
+++ b/dev/com.ibm.ws.rest.handler.validator_fat/fat/src/com/ibm/ws/rest/handler/validator/fat/ValidateJCATest.java
@@ -6,9 +6,6 @@
  * http://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package com.ibm.ws.rest.handler.validator.fat;
 

--- a/dev/com.ibm.ws.rest.handler.validator_fat/fat/src/com/ibm/ws/rest/handler/validator/fat/ValidateJCATest.java
+++ b/dev/com.ibm.ws.rest.handler.validator_fat/fat/src/com/ibm/ws/rest/handler/validator/fat/ValidateJCATest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2024 IBM Corporation and others.
+ * Copyright (c) 2019, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -51,6 +51,10 @@ public class ValidateJCATest extends FATServletClient {
 
     @ClassRule
     public static RepeatTests r1 = MicroProfileActions.repeat("com.ibm.ws.rest.handler.validator.jca.fat",
+                                                              MicroProfileActions.MP71_EE11,
+                                                              MicroProfileActions.MP71_EE10,
+                                                              MicroProfileActions.MP70_EE11,
+                                                              MicroProfileActions.MP70_EE10,
                                                               MicroProfileActions.MP61,
                                                               MicroProfileActions.MP50, // EE9
                                                               MicroProfileActions.MP40, // EE8

--- a/dev/com.ibm.ws.rest.handler.validator_fat/fat/src/com/ibm/ws/rest/handler/validator/fat/ValidateJMSTest.java
+++ b/dev/com.ibm.ws.rest.handler.validator_fat/fat/src/com/ibm/ws/rest/handler/validator/fat/ValidateJMSTest.java
@@ -6,9 +6,6 @@
  * http://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package com.ibm.ws.rest.handler.validator.fat;
 

--- a/dev/com.ibm.ws.rest.handler.validator_fat/fat/src/com/ibm/ws/rest/handler/validator/fat/ValidateJMSTest.java
+++ b/dev/com.ibm.ws.rest.handler.validator_fat/fat/src/com/ibm/ws/rest/handler/validator/fat/ValidateJMSTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2024 IBM Corporation and others.
+ * Copyright (c) 2019, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -45,6 +45,10 @@ public class ValidateJMSTest extends FATServletClient {
 
     @ClassRule
     public static RepeatTests r1 = MicroProfileActions.repeat("com.ibm.ws.rest.handler.validator.jms.fat",
+                                                              MicroProfileActions.MP71_EE11,
+                                                              MicroProfileActions.MP71_EE10,
+                                                              MicroProfileActions.MP70_EE11,
+                                                              MicroProfileActions.MP70_EE10,
                                                               MicroProfileActions.MP61,
                                                               MicroProfileActions.MP50, // EE9
                                                               MicroProfileActions.MP40, // EE8

--- a/dev/com.ibm.ws.rest.handler.validator_fat/fat/src/com/ibm/ws/rest/handler/validator/fat/ValidateOpenApiSchemaTest.java
+++ b/dev/com.ibm.ws.rest.handler.validator_fat/fat/src/com/ibm/ws/rest/handler/validator/fat/ValidateOpenApiSchemaTest.java
@@ -6,9 +6,6 @@
  * http://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package com.ibm.ws.rest.handler.validator.fat;
 

--- a/dev/com.ibm.ws.rest.handler.validator_fat/publish/servers/com.ibm.ws.rest.handler.validator.jca.fat/server.xml
+++ b/dev/com.ibm.ws.rest.handler.validator_fat/publish/servers/com.ibm.ws.rest.handler.validator.jca.fat/server.xml
@@ -1,14 +1,11 @@
 <!--
-    Copyright (c) 2019, 2022 IBM Corporation and others.
+    Copyright (c) 2019, 2026 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-2.0/
     
     SPDX-License-Identifier: EPL-2.0
-   
-    Contributors:
-        IBM Corporation - initial API and implementation
  -->
 <server>
   <include location="../fatTestPorts.xml" />
@@ -19,6 +16,7 @@
     <feature>restConnector-2.0</feature>
     <feature>jca-1.7</feature>
     <feature>mpOpenApi-1.0</feature>
+    <feature>mpConfig-1.2</feature>
   </featureManager>
 
   <variable name="onError" value="FAIL"/>

--- a/dev/com.ibm.ws.rest.handler.validator_fat/publish/servers/com.ibm.ws.rest.handler.validator.jdbc.fat/server.xml
+++ b/dev/com.ibm.ws.rest.handler.validator_fat/publish/servers/com.ibm.ws.rest.handler.validator.jdbc.fat/server.xml
@@ -1,14 +1,11 @@
 <!--
-    Copyright (c) 2017,2023 IBM Corporation and others.
+    Copyright (c) 2017, 2026 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-2.0/
     
     SPDX-License-Identifier: EPL-2.0
-   
-    Contributors:
-        IBM Corporation - initial API and implementation
  -->
 <server>
   <include location="../fatTestPorts.xml" />
@@ -18,6 +15,12 @@
     <feature>restConnector-2.0</feature>
     <feature>jdbc-4.2</feature>
     <feature>mpOpenApi-1.0</feature>
+    <feature>cdi-1.2</feature>
+    <feature>mpConfig-1.2</feature>
+    <feature>servlet-3.1</feature>
+    <feature>appSecurity-2.0</feature>
+    <feature>jaxrs-2.0</feature>
+    <feature>jaxrsClient-2.0</feature>
   </featureManager>
 
   <variable name="onError" value="FAIL"/>

--- a/dev/com.ibm.ws.rest.handler.validator_fat/publish/servers/com.ibm.ws.rest.handler.validator.jms.fat/server.xml
+++ b/dev/com.ibm.ws.rest.handler.validator_fat/publish/servers/com.ibm.ws.rest.handler.validator.jms.fat/server.xml
@@ -1,14 +1,11 @@
 <!--
-    Copyright (c) 2019 IBM Corporation and others.
+    Copyright (c) 2019, 2026 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-2.0/
     
     SPDX-License-Identifier: EPL-2.0
-   
-    Contributors:
-        IBM Corporation - initial API and implementation
  -->
 <server>
   <include location="../fatTestPorts.xml" />
@@ -21,6 +18,7 @@
     <feature>mpOpenApi-1.0</feature>
     <feature>wasJmsClient-2.0</feature>
     <feature>wasJmsServer-1.0</feature>
+    <feature>mpConfig-1.2</feature>
   </featureManager>
 
   <variable name="onError" value="FAIL"/>

--- a/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyServer.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyServer.java
@@ -3589,11 +3589,6 @@ public class LibertyServer implements LogMonitorClient {
 
                                                      "HungRequestTimingServer", //com.ibm.ws.request.timing.hung_fat
 
-                                                     "com.ibm.ws.rest.handler.validator.jdbc.fat", //com.ibm.ws.rest.handler.validator_fat
-                                                     "com.ibm.ws.rest.handler.validator.jca.fat", //com.ibm.ws.rest.handler.validator_fat
-                                                     "com.ibm.ws.rest.handler.validator.jms.fat", //com.ibm.ws.rest.handler.validator_fat
-                                                     "com.ibm.ws.rest.handler.validator.openapi.fat", //com.ibm.ws.rest.handler.validator_fat
-
                                                      "com.ibm.ws.scaling.member.fat.member1", //com.ibm.ws.scaling.member_fat
                                                      "com.ibm.ws.scaling.member.fat.controller1", //com.ibm.ws.scaling.member_fat
 


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

Updated the server.xml so that we could remove the servers from the EXEMPT_SERVERS. The following errors will no longer occur when executing the FAT locally:

> ValidateDataSourceTest / com.ibm.ws.rest.handler.validator.jdbc.fat
> 
>     Runtime features were not of the expected version for repeat action (Server: com.ibm.ws.rest.handler.validator.jdbc.fat, Action: EE11_FEATURES_MicroProfile_71). Expected: restfulWS-4.0, Actual: restfulWS-3.1. Expected: restfulWSClient-4.0, Actual: restfulWSClient-3.1. Expected: cdi-4.1, Actual: cdi-4.0. Expected: servlet-6.1, Actual: servlet-6.0. This is usually caused by a feature not being explicitly set in the FAT's server.xml such that FeatureReplacementAction does not replace it properly. You should also ensure that the test server has been removed from LibertyServer.EXEMPT_SERVERS. 
>     Runtime features were not of the expected version for repeat action (Server: com.ibm.ws.rest.handler.validator.jdbc.fat, Action: EE11_FEATURES_MicroProfile_70). Expected: restfulWS-4.0, Actual: restfulWS-3.1. Expected: restfulWSClient-4.0, Actual: restfulWSClient-3.1. Expected: cdi-4.1, Actual: cdi-4.0. Expected: servlet-6.1, Actual: servlet-6.0. This is usually caused by a feature not being explicitly set in the FAT's server.xml such that FeatureReplacementAction does not replace it properly. You should also ensure that the test server has been removed from LibertyServer.EXEMPT_SERVERS. 
>     Runtime features were not of the expected version for repeat action (Server: com.ibm.ws.rest.handler.validator.jdbc.fat, Action: EE10_FEATURES_MicroProfile_61). Expected: mpConfig-3.1, Actual: mpConfig-3.0. This is usually caused by a feature not being explicitly set in the FAT's server.xml such that FeatureReplacementAction does not replace it properly. You should also ensure that the test server has been removed from LibertyServer.EXEMPT_SERVERS. 
>     Runtime features were not of the expected version for repeat action (Server: com.ibm.ws.rest.handler.validator.jdbc.fat, Action: EE8_FEATURES_MicroProfile_30). Expected: servlet-4.0, Actual: servlet-3.1. Expected: appSecurity-3.0, Actual: appSecurity-2.0. Expected: mpConfig-1.3, Actual: mpConfig-1.2. Expected: jaxrsClient-2.1, Actual: jaxrsClient-2.0. Expected: jaxrs-2.1, Actual: jaxrs-2.0. This is usually caused by a feature not being explicitly set in the FAT's server.xml such that FeatureReplacementAction does not replace it properly. You should also ensure that the test server has been removed from LibertyServer.EXEMPT_SERVERS. 
>     Runtime features were not of the expected version for repeat action (Server: com.ibm.ws.rest.handler.validator.jdbc.fat, Action: EE8_FEATURES_MicroProfile_20). Expected: servlet-4.0, Actual: servlet-3.1. Expected: appSecurity-3.0, Actual: appSecurity-2.0. Expected: mpConfig-1.3, Actual: mpConfig-1.2. Expected: jaxrsClient-2.1, Actual: jaxrsClient-2.0. Expected: jaxrs-2.1, Actual: jaxrs-2.0. This is usually caused by a feature not being explicitly set in the FAT's server.xml such that FeatureReplacementAction does not replace it properly. You should also ensure that the test server has been removed from LibertyServer.EXEMPT_SERVERS. 
> 
> 

> ValidateJCATest / com.ibm.ws.rest.handler.validator.jca.fat
> 
>     Runtime features were not of the expected version for repeat action (Server: com.ibm.ws.rest.handler.validator.jca.fat, Action: EE10_FEATURES_MicroProfile_61). Expected: mpConfig-3.1, Actual: mpConfig-3.0. This is usually caused by a feature not being explicitly set in the FAT's server.xml such that FeatureReplacementAction does not replace it properly. You should also ensure that the test server has been removed from LibertyServer.EXEMPT_SERVERS. 
>     Runtime features were not of the expected version for repeat action (Server: com.ibm.ws.rest.handler.validator.jca.fat, Action: EE8_FEATURES_MicroProfile_30). Expected: mpConfig-1.3, Actual: mpConfig-1.2. This is usually caused by a feature not being explicitly set in the FAT's server.xml such that FeatureReplacementAction does not replace it properly. You should also ensure that the test server has been removed from LibertyServer.EXEMPT_SERVERS. 
>     Runtime features were not of the expected version for repeat action (Server: com.ibm.ws.rest.handler.validator.jca.fat, Action: EE8_FEATURES_MicroProfile_20). Expected: mpConfig-1.3, Actual: mpConfig-1.2. This is usually caused by a feature not being explicitly set in the FAT's server.xml such that FeatureReplacementAction does not replace it properly. You should also ensure that the test server has been removed from LibertyServer.EXEMPT_SERVERS. 

> ValidateJMSTest / com.ibm.ws.rest.handler.validator.jms.fat
> 
>     Runtime features were not of the expected version for repeat action (Server: com.ibm.ws.rest.handler.validator.jms.fat, Action: EE10_FEATURES_MicroProfile_61). Expected: mpConfig-3.1, Actual: mpConfig-3.0. This is usually caused by a feature not being explicitly set in the FAT's server.xml such that FeatureReplacementAction does not replace it properly. You should also ensure that the test server has been removed from LibertyServer.EXEMPT_SERVERS. 
>     Runtime features were not of the expected version for repeat action (Server: com.ibm.ws.rest.handler.validator.jms.fat, Action: EE8_FEATURES_MicroProfile_30). Expected: mpConfig-1.3, Actual: mpConfig-1.2. This is usually caused by a feature not being explicitly set in the FAT's server.xml such that FeatureReplacementAction does not replace it properly. You should also ensure that the test server has been removed from LibertyServer.EXEMPT_SERVERS. 
>     Runtime features were not of the expected version for repeat action (Server: com.ibm.ws.rest.handler.validator.jms.fat, Action: EE8_FEATURES_MicroProfile_20). Expected: mpConfig-1.3, Actual: mpConfig-1.2. This is usually caused by a feature not being explicitly set in the FAT's server.xml such that FeatureReplacementAction does not replace it properly. You should also ensure that the test server has been removed from LibertyServer.EXEMPT_SERVERS. 

for #34093