### PR TITLE
Stateful persist and share entity manager across repositories

### DIFF
--- a/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/EntityManagerBuilder.java
+++ b/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/EntityManagerBuilder.java
@@ -25,6 +25,7 @@ import java.sql.SQLException;
 import java.sql.SQLNonTransientConnectionException;
 import java.sql.SQLRecoverableException;
 import java.sql.SQLTransientConnectionException;
+import java.util.AbstractMap.SimpleEntry;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -60,6 +61,8 @@ import jakarta.persistence.metamodel.Metamodel;
 import jakarta.persistence.metamodel.PluralAttribute;
 import jakarta.persistence.metamodel.SingularAttribute;
 import jakarta.persistence.metamodel.Type;
+import jakarta.transaction.Synchronization;
+import jakarta.transaction.Transaction;
 
 /**
  * Creates EntityManager instances from an EntityManagerFactory (from a persistence unit reference)
@@ -85,7 +88,15 @@ public abstract class EntityManagerBuilder {
      * Mapping of entity class (as seen by the user, not a generated record entity class)
      * to entity information.
      */
-    protected final ConcurrentHashMap<Class<?>, CompletableFuture<EntityInfo>> entityInfoMap = new ConcurrentHashMap<>();
+    protected final ConcurrentHashMap<Class<?>, CompletableFuture<EntityInfo>> entityInfoMap = //
+                    new ConcurrentHashMap<>();
+
+    /**
+     * Map of Transaction to EntityManager that allows stateful repositories to
+     * reuse the same EnityManager within a transaction.
+     */
+    private final Map<Transaction, EntityManager> entityManagerPerTx = //
+                    new ConcurrentHashMap<>();
 
     /**
      * OSGi service component that provides the CDI extension for Data.
@@ -397,10 +408,12 @@ public abstract class EntityManagerBuilder {
 
     /**
      * Creates a new EntityManager instance.
+     * Use the getEntityManager method instead to ensure the same EntityManager
+     * and its persistence context are reused within a transaction.
      *
      * @return a new EntityManager instance.
      */
-    public abstract EntityManager createEntityManager();
+    protected abstract EntityManager createEntityManager();
 
     /**
      * Returns an alphabetized comma-delimited list of the class names as text
@@ -439,6 +452,42 @@ public abstract class EntityManagerBuilder {
      */
     public abstract DataSource getDataSource(Method repoMethod,
                                              Class<?> repoInterface);
+
+    /**
+     * Obtains a shared EntityManager instance if running in a transaction
+     * and the repository is stateful. Otherwise create a new instance.
+     *
+     * @param stateful indicates a stateful repository.
+     * @return EntityManager and indicator of whether the EntityManager will be
+     *         automatically closed by the current transaction.
+     * @throws Exception if an error occurs.
+     */
+    SimpleEntry<EntityManager, Boolean> getEntityManager(boolean stateful) //
+                    throws Exception {
+        boolean autoClosedByTx;
+        EntityManager em;
+
+        if (stateful) {
+            Transaction tx = provider.tranMgr.getTransaction();
+            if (tx == null) {
+                autoClosedByTx = false;
+                em = createEntityManager();
+            } else {
+                autoClosedByTx = true;
+                em = entityManagerPerTx.get(tx);
+                if (em == null) {
+                    em = createEntityManager();
+                    tx.registerSynchronization(new EntityManagerCleanup(tx));
+                    entityManagerPerTx.put(tx, em);
+                }
+            }
+        } else {
+            autoClosedByTx = false;
+            em = createEntityManager();
+        }
+
+        return new SimpleEntry<>(em, autoClosedByTx);
+    }
 
     @FFDCIgnore(NoSuchFieldException.class)
     private static final SortedMap<String, Member> getIdClassAccessors(Class<?> idType,
@@ -578,6 +627,12 @@ public abstract class EntityManagerBuilder {
             for (Class<?> c : convertibleTypes)
                 writer.println(indent + "    " + c.getName());
         }
+
+        if (!entityManagerPerTx.isEmpty()) {
+            writer.println(indent + "  stateless entity manager per transaction:");
+            entityManagerPerTx.forEach((tx, em) -> writer //
+                            .println(indent + "    " + tx + " -> " + em));
+        }
     }
 
     /**
@@ -593,4 +648,26 @@ public abstract class EntityManagerBuilder {
                cause instanceof SQLTransientConnectionException;
     }
 
+    /**
+     * Cleans up the state of the entityManagerPerTx map and closes the
+     * respective EntityManager instance after the transaction completes.
+     */
+    private class EntityManagerCleanup implements Synchronization {
+        private final Transaction tx;
+
+        private EntityManagerCleanup(Transaction tx) {
+            this.tx = tx;
+        }
+
+        @Override
+        public void afterCompletion(int status) {
+            EntityManager em = entityManagerPerTx.remove(tx);
+            if (em != null)
+                em.close();
+        }
+
+        @Override
+        public void beforeCompletion() {
+        }
+    }
 }

--- a/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/PageImpl.java
+++ b/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/PageImpl.java
@@ -15,6 +15,7 @@ package io.openliberty.data.internal;
 import static io.openliberty.data.internal.cdi.DataExtension.exc;
 
 import java.util.AbstractList;
+import java.util.AbstractMap.SimpleEntry;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -211,20 +212,24 @@ public class PageImpl<T> implements Page<T> {
                       queryInfo.jpqlCount,
                       queryInfo.jpql);
 
-        // TODO share EntityManager from constructor if stateful and still
-        // in the same transaction
-        EntityManager em = queryInfo.entityInfo.builder.createEntityManager();
+        EntityManagerBuilder builder = queryInfo.entityInfo.builder;
+        boolean stateful = queryInfo.producer.stateful();
+        SimpleEntry<EntityManager, Boolean> emAutoCloseable = null;
         try {
+            emAutoCloseable = builder.getEntityManager(stateful);
+            EntityManager em = emAutoCloseable.getKey();
             if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
                 Tr.debug(this, tc, "query for count: " + queryInfo.jpqlCount);
+
             TypedQuery<Long> query = em.createQuery(queryInfo.jpqlCount, Long.class);
             queryInfo.setParameters(query, args, deferredConstraints, addedJPQLParams);
 
             return query.getSingleResult();
         } catch (Exception x) {
-            throw RepositoryImpl.failure(x, queryInfo.entityInfo.builder);
+            throw RepositoryImpl.failure(x, builder);
         } finally {
-            em.close();
+            if (emAutoCloseable != null && emAutoCloseable.getValue())
+                emAutoCloseable.getKey().close();
         }
     }
 

--- a/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/QueryInfo.java
+++ b/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/QueryInfo.java
@@ -1333,15 +1333,19 @@ public abstract class QueryInfo {
         if (trace && tc.isEntryEnabled())
             Tr.entry(this, tc, "detach", loggable(arg));
 
+        int count = 0;
         if (arg instanceof Iterable) {
-            for (Object e : ((Iterable<?>) arg))
-                em.detach(e);
+            for (Object entity : ((Iterable<?>) arg)) {
+                em.detach(entityNotNull(entity));
+                count++;
+            }
         } else if (entityParamType.isArray()) {
             int length = Array.getLength(arg);
-            for (int i = 0; i < length; i++)
-                em.detach(Array.get(arg, i));
+            for (; count < length; count++)
+                em.detach(entityNotNull(Array.get(arg, count)));
         } else {
-            em.detach(arg);
+            em.detach(entityNotNull(arg));
+            count++;
         }
 
         if (trace && tc.isEntryEnabled())
@@ -1366,6 +1370,21 @@ public abstract class QueryInfo {
     private static boolean endsWith(String searchFor, String text, int minStart, int endBefore) {
         int searchLen = searchFor.length();
         return endBefore - minStart >= searchLen && text.regionMatches(endBefore - searchLen, searchFor, 0, searchLen);
+    }
+
+    /**
+     * Convenience method that raises an error if the given entity is null
+     * and otherwise returns the entity.
+     *
+     * @param entity entity instance that might be null.
+     * @return the non-null entity.
+     * @throws NullPointerException if the given entity is null.
+     */
+    @Trivial
+    private Object entityNotNull(Object entity) {
+        if (entity == null)
+            throw Fail.entityNull(this);
+        return entity;
     }
 
     /**
@@ -4739,6 +4758,46 @@ public abstract class QueryInfo {
         }
 
         return insertConstructorBeginAt;
+    }
+
+    /**
+     * Adds entities to the persistence context to be inserted in to the database.
+     *
+     * @param arg the entity or array/Iterable/Stream of entity
+     * @param em  the entity manager
+     * @throws Exception if an error occurs.
+     */
+    @Trivial
+    Void persist(Object arg, EntityManager em) throws Exception {
+        arg = arg instanceof Stream //
+                        ? ((Stream<?>) arg).sequential().toList() //
+                        : arg;
+
+        final boolean trace = TraceComponent.isAnyTracingEnabled();
+        if (trace && tc.isEntryEnabled())
+            Tr.entry(this, tc, "persist", loggable(arg));
+
+        int count = 0;
+        if (entityParamType.isArray()) {
+            int length = Array.getLength(arg);
+            for (; count < length; count++)
+                em.persist(entityNotNull(Array.get(arg, count)));
+        } else if (arg instanceof Iterable) {
+            for (Object entity : ((Iterable<?>) arg)) {
+                em.persist(entityNotNull(entity));
+                count++;
+            }
+        } else {
+            em.persist(entityNotNull(arg));
+            count = 1;
+        }
+
+        if (count == 0)
+            throw Fail.emptyLifeCycleParam(this);
+
+        if (trace && tc.isEntryEnabled())
+            Tr.exit(this, tc, "persist", count);
+        return null;
     }
 
     /**

--- a/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/QueryType.java
+++ b/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/QueryType.java
@@ -110,7 +110,7 @@ public enum QueryType {
     // stateful repository life cycle method @Persist
     PERSIST("Persist", //
             Is.LIFE_CYCLE_METHOD, //
-            !Require.AUTO_START_TX, //
+            Require.AUTO_START_TX, //
             !Require.DETACH_ENTITIES, //
             !Require.RETURN_HIDDEN, //
             Require.STATEFUL),
@@ -168,7 +168,6 @@ public enum QueryType {
     /**
      * Indicate if we must automatically start a transaction before invoking
      * the repository operation if a transaction is not already present.
-     * For stateful entities, this will always be false.
      */
     public final boolean autoStartTransaction;
 

--- a/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/RepositoryImpl.java
+++ b/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/RepositoryImpl.java
@@ -32,7 +32,6 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import javax.sql.DataSource;
@@ -59,8 +58,6 @@ import jakarta.persistence.OptimisticLockException;
 import jakarta.persistence.PersistenceException;
 import jakarta.persistence.Table;
 import jakarta.transaction.Status;
-import jakarta.transaction.Synchronization;
-import jakarta.transaction.Transaction;
 
 /**
  * Provides implementation of the methods of a repository interface.
@@ -83,12 +80,6 @@ public class RepositoryImpl<R> implements InvocationHandler {
      */
     private final EntityManagerBuilder builder;
 
-    /**
-     * Map of Transaction to EntityManager that allows stateful repositories to
-     * reuse the same EnityManager within a transaction.
-     */
-    private final Map<Transaction, EntityManager> entityManagerPerTx = //
-                    new ConcurrentHashMap<>();
     /**
      * Indicates if the bean for the repository has been disposed.
      */
@@ -379,42 +370,6 @@ public class RepositoryImpl<R> implements InvocationHandler {
     }
 
     /**
-     * Obtains a shared EntityManager instance if running in a transaction
-     * and the repository is stateful. Otherwise create a new instance.
-     *
-     * @param stateful indicates a stateful repository.
-     * @return EntityManager and indicator of whether the EntityManager will be
-     *         automatically closed by the current transaction.
-     * @throws Exception if an error occurs.
-     */
-    private SimpleEntry<EntityManager, Boolean> getEntityManager(boolean stateful) //
-                    throws Exception {
-        boolean autoClosedByTx;
-        EntityManager em;
-
-        if (stateful) {
-            Transaction tx = provider.tranMgr.getTransaction();
-            if (tx == null) {
-                autoClosedByTx = false;
-                em = builder.createEntityManager();
-            } else {
-                autoClosedByTx = true;
-                em = entityManagerPerTx.get(tx);
-                if (em == null) {
-                    em = builder.createEntityManager();
-                    tx.registerSynchronization(new EntityManagerCleanup(tx));
-                    entityManagerPerTx.put(tx, em);
-                }
-            }
-        } else {
-            autoClosedByTx = false;
-            em = builder.createEntityManager();
-        }
-
-        return new SimpleEntry<>(em, autoClosedByTx);
-    }
-
-    /**
      * Used during introspection to report errors that occurred when processing
      * repository methods.
      *
@@ -442,7 +397,7 @@ public class RepositoryImpl<R> implements InvocationHandler {
 
         if (EntityManager.class.equals(type)) {
             SimpleEntry<EntityManager, Boolean> emAutoCloseable = //
-                            getEntityManager(stateful);
+                            builder.getEntityManager(stateful);
             resource = emAutoCloseable.getKey();
             resourceAutoClosedByTx = emAutoCloseable.getValue();
         } else if (DataSource.class.equals(type)) {
@@ -511,9 +466,6 @@ public class RepositoryImpl<R> implements InvocationHandler {
         writer.println(indent + "  provider: " + provider);
         writer.println(indent + "  repository: " + repositoryInterface.getName());
         writer.println(indent + "  validator: " + validator);
-        writer.println(indent + "  stateless entity manager per transaction:");
-        entityManagerPerTx.forEach((tx, em) -> writer //
-                        .println(indent + "    " + tx + " -> " + em));
     }
 
     /**
@@ -636,7 +588,7 @@ public class RepositoryImpl<R> implements InvocationHandler {
 
                 if (queryType != RESOURCE_ACCESS) {
                     SimpleEntry<EntityManager, Boolean> emAutoCloseable = //
-                                    getEntityManager(stateful);
+                                    builder.getEntityManager(stateful);
                     em = emAutoCloseable.getKey();
                     emAutoClosedByTx = emAutoCloseable.getValue();
                 }
@@ -732,26 +684,4 @@ public class RepositoryImpl<R> implements InvocationHandler {
         }
     }
 
-    /**
-     * Cleans up the state of the entityManagerPerTx map and closes the
-     * respective EntityManager instance after the transaction completes.
-     */
-    private class EntityManagerCleanup implements Synchronization {
-        private final Transaction tx;
-
-        private EntityManagerCleanup(Transaction tx) {
-            this.tx = tx;
-        }
-
-        @Override
-        public void afterCompletion(int status) {
-            EntityManager em = entityManagerPerTx.remove(tx);
-            if (em != null)
-                em.close();
-        }
-
-        @Override
-        public void beforeCompletion() {
-        }
-    }
 }

--- a/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/RepositoryImpl.java
+++ b/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/RepositoryImpl.java
@@ -604,6 +604,7 @@ public class RepositoryImpl<R> implements InvocationHandler {
                     case LC_UPDATE -> queryInfo.update(args[0], em);
                     case LC_UPDATE_MERGE -> queryInfo.findAndUpdate(args[0], em);
                     case DETACH -> queryInfo.detach(args[0], em);
+                    case PERSIST -> queryInfo.persist(args[0], em);
                     case RESOURCE_ACCESS -> getResource(queryInfo);
                     default -> throw new UnsupportedOperationException(queryType.operationName);
                 };

--- a/dev/io.openliberty.data.internal_fat_1_1/test-applications/Data_1_1_App/src/test/jakarta/data/v1_1/web/Data_1_1_Servlet.java
+++ b/dev/io.openliberty.data.internal_fat_1_1/test-applications/Data_1_1_App/src/test/jakarta/data/v1_1/web/Data_1_1_Servlet.java
@@ -69,6 +69,9 @@ public class Data_1_1_Servlet extends FATServlet {
     Fractions fractions;
 
     @Inject
+    StatefulFractionRepository statefulFractionRepo;
+
+    @Inject
     StatefulFractions statefulFractions;
 
     @Resource
@@ -436,11 +439,13 @@ public class Data_1_1_Servlet extends FATServlet {
     @Test
     public void testDetach() throws Exception {
 
-        // TODO use stateful method to persist entities
-        // Populate with 5/23.
-        // Ensure deletion in the finally block.
-        fractions.supply(List.of(Fraction.of(5, 23)));
         try {
+            // Populate with 5/23.
+            // Ensure deletion in the finally block.
+            tx.begin();
+            statefulFractionRepo.write(Fraction.of(5, 23));
+            tx.commit();
+
             System.out.println("Fetch 5/23 to detach, modify, and commit");
 
             tx.begin();
@@ -1175,11 +1180,10 @@ public class Data_1_1_Servlet extends FATServlet {
     @Test
     public void testPersistenceContext() throws Exception {
 
-        // TODO use stateful method to persist entities
         // Populate with 2/23 and 3/23.
         // Ensure deletion in the finally block.
-        fractions.supply(List.of(Fraction.of(2, 23),
-                                 Fraction.of(3, 23)));
+        statefulFractionRepo.persistAll(List.of(Fraction.of(2, 23),
+                                                Fraction.of(3, 23)));
         try {
             System.out.println("Fetch 2/23 to modify and commit");
 
@@ -1589,10 +1593,9 @@ public class Data_1_1_Servlet extends FATServlet {
     @Test
     public void testStatefulResourceAccessor() throws Exception {
 
-        // TODO use stateful method to persist entities
         // Populate with 6/23.
         // Ensure deletion in the finally block.
-        fractions.supply(List.of(Fraction.of(6, 23)));
+        statefulFractionRepo.write(Fraction.of(6, 23));
         try {
             System.out.println("Fetch 6/23 to modify, flush, detach, modify," +
                                " and commit");

--- a/dev/io.openliberty.data.internal_fat_1_1/test-applications/Data_1_1_App/src/test/jakarta/data/v1_1/web/StatefulFractionRepository.java
+++ b/dev/io.openliberty.data.internal_fat_1_1/test-applications/Data_1_1_App/src/test/jakarta/data/v1_1/web/StatefulFractionRepository.java
@@ -1,0 +1,37 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package test.jakarta.data.v1_1.web;
+
+import java.util.List;
+
+import jakarta.data.repository.DataRepository;
+import jakarta.data.repository.Repository;
+import jakarta.data.repository.stateful.Persist;
+import jakarta.transaction.Transactional;
+
+/**
+ * Stateful repository for the Fraction entity.
+ * The repository inherits from the DataRepository interface.
+ */
+@Repository(dataStore = "MyDataStore")
+public interface StatefulFractionRepository //
+                extends DataRepository<Fraction, String> {
+
+    @Persist
+    @Transactional
+    void persistAll(List<Fraction> fractions);
+
+    @Persist
+    void write(Fraction fraction);
+
+}


### PR DESCRIPTION
Implement stateful repository Persist operations.
Also, share the peristence context/EntityManager across repositories, which could be accessing the same entity.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
