### PR TITLE
Remove oss index gradle tasks

### DIFF
--- a/dev/build.gradle
+++ b/dev/build.gradle
@@ -1,14 +1,11 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
  * 
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 
 /**
@@ -50,9 +47,6 @@ apply from: 'wlp-gradle/java.gradle'
  * See: https://github.com/bndtools/bnd/blob/master/biz.aQute.bnd.gradle/README.md
  *
  * Apply from all scripts in `wlp-gradle/subprojects`.
- *
- * Apply OSS Audit plugin to all non-test projects that output bundles.
- * See: https://github.com/OSSIndex/ossindex-gradle-plugin/blob/master/README.md
  */
 apply from: 'wlp-gradle/biz.aQute.bnd.gradle'
 

--- a/dev/wlp-gradle/biz.aQute.bnd.gradle
+++ b/dev/wlp-gradle/biz.aQute.bnd.gradle
@@ -1,14 +1,11 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
  * 
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 
 /**
@@ -43,25 +40,9 @@ subprojects {
     // Configure 'assemble' to depend on above tasks.	
     apply from: rootProject.file('wlp-gradle/subprojects/assemble.gradle')
 
-    // Configure 'buildfat', 'runfat', 'buildandrun', and 'cleanFat' tasks.	
+    // Configure 'buildfat', 'runfat', 'buildandrun', and 'cleanFat' tasks.
     if (bnd.is('fat.project')) {
       apply from: rootProject.file('wlp-gradle/subprojects/fat.gradle')
-
-    // Apply OSS Audit plugin to all non-test projects that output bundles.
-    // See: https://github.com/OSSIndex/ossindex-gradle-plugin/blob/master/README.md
-    } else if (!bnd.is('test.project') && !bndProject.isNoBundles()) {
-      apply plugin: 'net.ossindex.audit'
-
-      audit {
-        group = "verification"
-        failOnError = true
-        rateLimitAsError = false
-        if (gradle.userProps.getProperty("ossindexUser") != null && 
-            gradle.userProps.getProperty("ossindexToken") != null) { 
-              user  = gradle.userProps.getProperty("ossindexUser") 
-              token = gradle.userProps.getProperty("ossindexToken") 
-        }
-      }
     }
 
   } else {
@@ -76,9 +57,4 @@ subprojects {
   // will publish jar updates to the local `build.image/wlp` image and `cnf/release` repository
   release.dependsOn assemble
   release.dependsOn publish
-}
-
-// Ensure the root project has the 'audit' task so it shows up in the output of `./gradlew tasks`
-task audit {
-  group = "verification"
 }

--- a/dev/wlp-gradle/bndSettings.gradle
+++ b/dev/wlp-gradle/bndSettings.gradle
@@ -1,14 +1,11 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2025 IBM Corporation and others.
+ * Copyright (c) 2019, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
  * 
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 
 /**
@@ -53,7 +50,6 @@ buildscript {
     dependencies {
         classpath bnd_plugin
         classpath 'biz.aQute.bnd:biz.aQute.bnd:7.0.0'
-        classpath 'gradle.plugin.net.ossindex:ossindex-gradle-plugin:0.4.11'
         classpath 'com.gradle:build-scan-plugin:2.1'
             
     }


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

################################################################################################

The commit cleanly removes the ossindex audit gradle task and all related references:
- Removed ossindex plugin dependency from [`bndSettings.gradle`](dev/wlp-gradle/bndSettings.gradle:53)
- Removed audit task configuration from [`biz.aQute.bnd.gradle`](dev/wlp-gradle/biz.aQute.bnd.gradle:43-46)
- Removed audit task stub from root project
- Updated copyright years to 2026
- Removed contributor comments (standard cleanup)

