### PR TITLE
refresh and remove methods during transaction

### DIFF
--- a/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/QueryInfo.java
+++ b/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/QueryInfo.java
@@ -4801,6 +4801,43 @@ public abstract class QueryInfo {
     }
 
     /**
+     * Refreshes the state of managed entities from the database.
+     *
+     * @param arg the entity or array/Iterable/Stream of entity
+     * @param em  the entity manager
+     * @throws Exception if an error occurs.
+     */
+    @Trivial
+    Void refresh(Object arg, EntityManager em) throws Exception {
+        arg = arg instanceof Stream //
+                        ? ((Stream<?>) arg).sequential().toList() //
+                        : arg;
+
+        final boolean trace = TraceComponent.isAnyTracingEnabled();
+        if (trace && tc.isEntryEnabled())
+            Tr.entry(this, tc, "refresh", loggable(arg));
+
+        int count = 0;
+        if (arg instanceof Iterable) {
+            for (Object entity : ((Iterable<?>) arg)) {
+                em.refresh(entityNotNull(entity));
+                count++;
+            }
+        } else if (entityParamType.isArray()) {
+            int length = Array.getLength(arg);
+            for (; count < length; count++)
+                em.refresh(entityNotNull(Array.get(arg, count)));
+        } else {
+            em.refresh(entityNotNull(arg));
+            count++;
+        }
+
+        if (trace && tc.isEntryEnabled())
+            Tr.exit(this, tc, "refresh");
+        return null;
+    }
+
+    /**
      * Replaces the given query with one that includes the requested modifications.
      *
      * @param ql       the query.

--- a/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/QueryInfo.java
+++ b/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/QueryInfo.java
@@ -4832,8 +4832,53 @@ public abstract class QueryInfo {
             count++;
         }
 
+        if (count == 0)
+            throw Fail.emptyLifeCycleParam(this);
+
         if (trace && tc.isEntryEnabled())
             Tr.exit(this, tc, "refresh");
+        return null;
+    }
+
+    /**
+     * Requests the removal of entities from the database.
+     * Removal might be delayed by the persistence context.
+     *
+     * @param arg the entity or array/Iterable/Stream of entities.
+     * @param em  the entity manager
+     * @throws Exception if an error occurs.
+     */
+    @Trivial
+    Void remove(Object arg, EntityManager em) throws Exception {
+        arg = arg instanceof Stream //
+                        ? ((Stream<?>) arg).sequential().toList() //
+                        : arg;
+
+        final boolean trace = TraceComponent.isAnyTracingEnabled();
+        if (trace && tc.isEntryEnabled())
+            Tr.entry(this, tc, "remove", loggable(arg));
+
+        int removalsRequested = 0;
+
+        if (arg instanceof Iterable) {
+            for (Object e : ((Iterable<?>) arg)) {
+                removalsRequested++;
+                em.remove(entityNotNull(e));
+            }
+        } else if (entityParamType.isArray()) {
+            removalsRequested = Array.getLength(arg);
+            for (int i = 0; i < removalsRequested; i++)
+                em.remove(entityNotNull(Array.get(arg, i)));
+        } else {
+            removalsRequested = 1;
+            em.remove(entityNotNull(arg));
+        }
+
+        if (removalsRequested == 0)
+            throw Fail.emptyLifeCycleParam(this);
+
+        if (trace && tc.isEntryEnabled())
+            Tr.exit(this, tc, "remove");
         return null;
     }
 

--- a/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/RepositoryImpl.java
+++ b/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/RepositoryImpl.java
@@ -605,6 +605,7 @@ public class RepositoryImpl<R> implements InvocationHandler {
                     case LC_UPDATE_MERGE -> queryInfo.findAndUpdate(args[0], em);
                     case DETACH -> queryInfo.detach(args[0], em);
                     case PERSIST -> queryInfo.persist(args[0], em);
+                    case REFRESH -> queryInfo.refresh(args[0], em);
                     case RESOURCE_ACCESS -> getResource(queryInfo);
                     default -> throw new UnsupportedOperationException(queryType.operationName);
                 };

--- a/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/RepositoryImpl.java
+++ b/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/RepositoryImpl.java
@@ -606,6 +606,7 @@ public class RepositoryImpl<R> implements InvocationHandler {
                     case DETACH -> queryInfo.detach(args[0], em);
                     case PERSIST -> queryInfo.persist(args[0], em);
                     case REFRESH -> queryInfo.refresh(args[0], em);
+                    case REMOVE -> queryInfo.remove(args[0], em);
                     case RESOURCE_ACCESS -> getResource(queryInfo);
                     default -> throw new UnsupportedOperationException(queryType.operationName);
                 };

--- a/dev/io.openliberty.data.internal_fat_1_1/test-applications/Data_1_1_App/src/test/jakarta/data/v1_1/web/Data_1_1_Servlet.java
+++ b/dev/io.openliberty.data.internal_fat_1_1/test-applications/Data_1_1_App/src/test/jakarta/data/v1_1/web/Data_1_1_Servlet.java
@@ -1284,6 +1284,59 @@ public class Data_1_1_Servlet extends FATServlet {
     }
 
     /**
+     * Use a stateful repository to find an entity. Modify the entity. Use a
+     * repository Refresh method to restore the state of the entity from the
+     * database and verify that the previously modified entity attributes
+     * have been restored to their prior values.
+     */
+    @Test
+    public void testRefresh() throws Exception {
+
+        // Populate with 7/23 and 8/23.
+        // Ensure deletion in the finally block.
+        statefulFractionRepo.persistAll(List.of(Fraction.of(7, 23),
+                                                Fraction.of(8, 23)));
+        try {
+            Fraction f;
+
+            // TODO clarify how persistence context works for a stateful repository
+            // apart from a transaction
+            //System.out.println("Fetch 7/23 to modify and refresh outside of tran");
+
+            //f = statefulFractions.fetch(7, 23).orElseThrow();
+            //f.decimal = Decimal.of(7, 21);
+            //f.reduced = false;
+            //statefulFractionRepo.restore(f);
+            //assertEquals(true,
+            //             f.reduced);
+            //assertEquals(BigDecimal.valueOf(3043, 4), // first 4 decimals of 7/23
+            //             f.decimal.truncated());
+
+            System.out.println("Fetch 8/23 to modify and refresh within tran");
+
+            tx.begin();
+            f = statefulFractions.fetch(8, 23).orElseThrow();
+            f.decimal = Decimal.of(8, 16);
+            f.reduced = false;
+            statefulFractionRepo.restore(f);
+            assertEquals(true,
+                         f.reduced);
+            assertEquals(BigDecimal.valueOf(3478, 4), // first 4 decimals of 8/23
+                         f.decimal.truncated());
+            tx.commit();
+        } finally {
+            if (tx.getStatus() != Status.STATUS_NO_TRANSACTION)
+                tx.rollback();
+
+            // TODO use stateful method to remove entities
+            // Ensure no fractions with denominator of 23 or more are left around
+            fractions.discard(AtLeast.min(23),
+                              AtMost.max(Integer.MAX_VALUE),
+                              Restrict.unrestricted());
+        }
+    }
+
+    /**
      * Use a repository method that imposes restrictions on a Query By Method Name
      * count method that has no constraints indicated by the method name.
      */

--- a/dev/io.openliberty.data.internal_fat_1_1/test-applications/Data_1_1_App/src/test/jakarta/data/v1_1/web/Data_1_1_Servlet.java
+++ b/dev/io.openliberty.data.internal_fat_1_1/test-applications/Data_1_1_App/src/test/jakarta/data/v1_1/web/Data_1_1_Servlet.java
@@ -1337,6 +1337,57 @@ public class Data_1_1_Servlet extends FATServlet {
     }
 
     /**
+     * Use a stateful repository to remove entities.
+     */
+    @Test
+    public void testRemove() throws Exception {
+
+        // Populate with 9/23, 10/23, 11/23, and 12/23.
+        // Ensure deletion in the finally block.
+        statefulFractionRepo.persistAll(List.of(Fraction.of(9, 23),
+                                                Fraction.of(10, 23),
+                                                Fraction.of(11, 23),
+                                                Fraction.of(12, 23)));
+        try {
+            System.out.println("Remove 10/23 and 12/23 within the same tran");
+
+            tx.begin();
+            Fraction f10_23 = statefulFractions.fetch(10, 23).orElseThrow();
+            Fraction f12_23 = statefulFractions.fetch(12, 23).orElseThrow();
+            statefulFractionRepo.remove(f10_23, f12_23);
+            tx.commit();
+
+            Fraction f9_23 = statefulFractions.fetch(9, 23).orElseThrow();
+
+            assertEquals(true,
+                         statefulFractions.fetch(10, 23).isEmpty());
+
+            Fraction f11_23 = statefulFractions.fetch(11, 23).orElseThrow();
+
+            assertEquals(true,
+                         statefulFractions.fetch(12, 23).isEmpty());
+
+            // TODO once persistence context can be used outside of a transaction,
+            //System.out.println("Remove 11/23, fetched outside of tran");
+
+            //statefulFractionRepo.remove(f11_23);
+
+            //f9_23 = statefulFractions.fetch(9, 23).orElseThrow();
+
+            //assertEquals(true,
+            //             statefulFractions.fetch(11, 23).isEmpty());
+        } finally {
+            if (tx.getStatus() != Status.STATUS_NO_TRANSACTION)
+                tx.rollback();
+
+            // Ensure no fractions with denominator of 23 or more are left around
+            fractions.discard(AtLeast.min(23),
+                              AtMost.max(Integer.MAX_VALUE),
+                              Restrict.unrestricted());
+        }
+    }
+
+    /**
      * Use a repository method that imposes restrictions on a Query By Method Name
      * count method that has no constraints indicated by the method name.
      */

--- a/dev/io.openliberty.data.internal_fat_1_1/test-applications/Data_1_1_App/src/test/jakarta/data/v1_1/web/StatefulFractionRepository.java
+++ b/dev/io.openliberty.data.internal_fat_1_1/test-applications/Data_1_1_App/src/test/jakarta/data/v1_1/web/StatefulFractionRepository.java
@@ -17,6 +17,7 @@ import java.util.List;
 import jakarta.data.repository.DataRepository;
 import jakarta.data.repository.Repository;
 import jakarta.data.repository.stateful.Persist;
+import jakarta.data.repository.stateful.Refresh;
 import jakarta.transaction.Transactional;
 
 /**
@@ -30,6 +31,9 @@ public interface StatefulFractionRepository //
     @Persist
     @Transactional
     void persistAll(List<Fraction> fractions);
+
+    @Refresh
+    void restore(Fraction fraction);
 
     @Persist
     void write(Fraction fraction);

--- a/dev/io.openliberty.data.internal_fat_1_1/test-applications/Data_1_1_App/src/test/jakarta/data/v1_1/web/StatefulFractionRepository.java
+++ b/dev/io.openliberty.data.internal_fat_1_1/test-applications/Data_1_1_App/src/test/jakarta/data/v1_1/web/StatefulFractionRepository.java
@@ -18,6 +18,7 @@ import jakarta.data.repository.DataRepository;
 import jakarta.data.repository.Repository;
 import jakarta.data.repository.stateful.Persist;
 import jakarta.data.repository.stateful.Refresh;
+import jakarta.data.repository.stateful.Remove;
 import jakarta.transaction.Transactional;
 
 /**
@@ -31,6 +32,9 @@ public interface StatefulFractionRepository //
     @Persist
     @Transactional
     void persistAll(List<Fraction> fractions);
+
+    @Remove
+    void remove(Fraction... fractions);
 
     @Refresh
     void restore(Fraction fraction);


### PR DESCRIPTION
Stateful repository refresh and remove methods, when using within a transaction.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
