### PR TITLE
Update enterpriseBeans-4.0 to not start ejbHome for EE 11

### DIFF
--- a/dev/build.image/profiles/jakartaee11/features.xml
+++ b/dev/build.image/profiles/jakartaee11/features.xml
@@ -1,6 +1,7 @@
 <feature>jakartaee-11.0</feature>
 <feature>jakartaeeClient-11.0</feature>
 <feature>enterpriseBeans-4.0</feature>
+<feature>enterpriseBeansHome-4.0</feature>
 <feature>xmlBinding-4.0</feature>
 <feature>xmlWS-4.0</feature>
 <feature>xmlWSClient-4.0</feature>

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.enterpriseBeans4.0.internal.ee-11.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.enterpriseBeans4.0.internal.ee-11.0.feature
@@ -1,0 +1,8 @@
+-include= ~${workspace}/cnf/resources/bnd/feature.props
+symbolicName=io.openliberty.enterpriseBeans4.0.internal.ee-11.0
+singleton=true
+visibility = private
+-features=com.ibm.websphere.appserver.eeCompatible-11.0
+kind=ga
+edition=base
+WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.enterpriseBeans4.0.internal.ee-9.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.enterpriseBeans4.0.internal.ee-9.0.feature
@@ -1,0 +1,9 @@
+-include= ~${workspace}/cnf/resources/bnd/feature.props
+symbolicName=io.openliberty.enterpriseBeans4.0.internal.ee-9.0
+singleton=true
+visibility = private
+-features=com.ibm.websphere.appserver.eeCompatible-9.0; ibm.tolerates:="10.0", \
+  io.openliberty.enterpriseBeansHome-4.0
+kind=ga
+edition=base
+WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/enterpriseBeans-4.0/io.openliberty.enterpriseBeans-4.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/enterpriseBeans-4.0/io.openliberty.enterpriseBeans-4.0.feature
@@ -7,12 +7,14 @@ IBM-ShortName: enterpriseBeans-4.0
 WLP-AlsoKnownAs: ejb-4.0
 Subsystem-Name: Jakarta Enterprise Beans 4.0
 Subsystem-Category: JakartaEE9Application
+# io.openliberty.enterpriseBeansHome-4.0 is enabled conditionally by io.openliberty.enterpriseBeans4.0.internal.ee-9.0
+# but not enabled for EE 11 since it is not part of EE 11 spec by default which requires the user to enable it explicitly
 -features=com.ibm.websphere.appserver.jdbc-4.2; ibm.tolerates:="4.3", \
   com.ibm.websphere.appserver.eeCompatible-9.0; ibm.tolerates:="10.0,11.0", \
+  io.openliberty.enterpriseBeans4.0.internal.ee-9.0; ibm.tolerates:="11.0", \
   io.openliberty.enterpriseBeansRemote-4.0, \
   io.openliberty.enterpriseBeansPersistentTimer-4.0, \
   io.openliberty.mdb-4.0, \
-  io.openliberty.enterpriseBeansHome-4.0, \
   io.openliberty.enterpriseBeansLite-4.0, \
   com.ibm.websphere.appserver.transaction-2.0
 kind=ga

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/jakartaee-10.0/io.openliberty.jakartaee-10.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/jakartaee-10.0/io.openliberty.jakartaee-10.0.feature
@@ -19,6 +19,7 @@ Subsystem-Name: Jakarta EE Platform 10.0
   io.openliberty.xmlWS-4.0, \
   io.openliberty.appClientSupport-2.0, \
   io.openliberty.enterpriseBeans-4.0, \
+  io.openliberty.enterpriseBeansHome-4.0, \
   io.openliberty.messaging-3.1, \
   io.openliberty.messagingServer-3.0, \
   com.ibm.websphere.appserver.transaction-2.0

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/jakartaee-9.1/io.openliberty.jakartaee-9.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/jakartaee-9.1/io.openliberty.jakartaee-9.1.feature
@@ -24,6 +24,7 @@ Subsystem-Name: Jakarta EE Platform 9.1
   io.openliberty.xmlWS-3.0, \
   io.openliberty.appClientSupport-2.0, \
   io.openliberty.enterpriseBeans-4.0, \
+  io.openliberty.enterpriseBeansHome-4.0, \
   io.openliberty.messaging-3.0, \
   io.openliberty.messagingServer-3.0, \
   io.openliberty.connectorsInboundSecurity-2.0, \

--- a/dev/com.ibm.ws.ejbcontainer.remote.client_fat/bnd.bnd
+++ b/dev/com.ibm.ws.ejbcontainer.remote.client_fat/bnd.bnd
@@ -33,6 +33,7 @@ tested.features: \
 	cdi-4.1, \
 	connectors-2.1, \
 	enterpriseBeans-4.0, \
+	enterpriseBeansHome-4.0, \
 	enterpriseBeansRemote-4.0, \
 	servlet-4.0, \
 	servlet-5.0, \

--- a/dev/com.ibm.ws.ejbcontainer.remote.client_fat/publish/servers/com.ibm.ws.ejbcontainer.remote.client.fat.serverInjection/server.xml
+++ b/dev/com.ibm.ws.ejbcontainer.remote.client_fat/publish/servers/com.ibm.ws.ejbcontainer.remote.client.fat.serverInjection/server.xml
@@ -20,6 +20,7 @@
         <feature>appSecurity-2.0</feature>
         <feature>timedexit-1.0</feature>
         <feature>servlet-3.1</feature>
+        <feature>ejbHome-3.2</feature>
         <feature>ejbRemote-3.2</feature>
         <feature>componenttest-1.0</feature>
     </featureManager>


### PR DESCRIPTION
- When using the enterpriseBeans-4.0 convenience feature with EE 11, do not start enterpriseBeansHome-4.0.  The user needs to explicitly enable the enterpriseBeansHome-4.0 feature when using EE 11.
- Update to explicitly include the enterpriseBeansHome-4.0 feature since it won't be in the package now due to this change.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [ ] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

