### PR TITLE
update wssecurity*_fat, wssecurity*saml*_fat test config to support RSA-OAEP

### DIFF
--- a/dev/com.ibm.ws.org.apache.cxf.rt.ws.security.3.4.1/bnd.bnd
+++ b/dev/com.ibm.ws.org.apache.cxf.rt.ws.security.3.4.1/bnd.bnd
@@ -120,4 +120,5 @@ instrument.classesIncludes: \
   com.ibm.websphere.javaee.wsdl4j.1.2;version=latest, \
   org.codehaus.woodstox:stax2-api;version='4.2', \
   org.codehaus.woodstox:woodstox-core-asl;version='4.2.0', \
-  com.ibm.websphere.javaee.jcache.1.1.core;version=latest
+  com.ibm.websphere.javaee.jcache.1.1.core;version=latest, \
+  com.ibm.ws.kernel.service;version=latest

--- a/dev/com.ibm.ws.org.apache.cxf.rt.ws.security.3.4.1/src/org/apache/cxf/ws/security/wss4j/AlgorithmSuiteTranslater.java
+++ b/dev/com.ibm.ws.org.apache.cxf.rt.ws.security.3.4.1/src/org/apache/cxf/ws/security/wss4j/AlgorithmSuiteTranslater.java
@@ -42,6 +42,8 @@ import org.apache.wss4j.policy.model.AlgorithmSuite.AlgorithmSuiteType;
 import org.apache.wss4j.policy.model.SamlToken;
 import org.apache.wss4j.policy.model.SupportingTokens;
 
+import com.ibm.ws.common.crypto.CryptoUtils;
+
 /**
  * Translate any AlgorithmSuite policy that may be operative into a WSS4J AlgorithmSuite object
  * to enforce what algorithms are allowed in a request.
@@ -141,9 +143,34 @@ public final class AlgorithmSuiteTranslater {
                 }
 
                 algorithmSuite.addEncryptionMethod(customAlgSuite.getEncryption());
+
+                // Liberty Change Start: Add aes256-gcm for FIPS 140-3 compatibility
+                // When FIPS 140-3 is enabled, ensure aes256-gcm is in the allowed encryption algorithms
+                if (CryptoUtils.isFips140_3Enabled()) {
+                    algorithmSuite.addEncryptionMethod("http://www.w3.org/2009/xmlenc11#aes256-gcm");
+                }
+                // Liberty Change End
+
                 algorithmSuite.addKeyWrapAlgorithm(customAlgSuite.getSymmetricKeyWrap());
                 algorithmSuite.addKeyWrapAlgorithm(customAlgSuite.getAsymmetricKeyWrap());
+
+                // Liberty Change Start: Add RSA-OAEP for FIPS 140-3 compatibility
+                // When FIPS 140-3 is enabled, ensure RSA-OAEP is in the allowed key wrap algorithms
+                // Standard algorithm suites use RSA 1.5 by default, which is not FIPS compliant
+                if (CryptoUtils.isFips140_3Enabled()) {
+                    algorithmSuite.addKeyWrapAlgorithm(SPConstants.KW_RSA_OAEP);
+                    algorithmSuite.addKeyWrapAlgorithm("http://www.w3.org/2009/xmlenc11#rsa-oaep");
+                }
+                // Liberty Change End
+
                 algorithmSuite.addDigestAlgorithm(customAlgSuite.getDigest());
+
+                // Liberty Change Start: Add sha256 for FIPS 140-3 compatibility
+                // When FIPS 140-3 is enabled, allow SHA-256 for backward compatibility
+                if (CryptoUtils.isFips140_3Enabled()) {
+                    algorithmSuite.addDigestAlgorithm("http://www.w3.org/2001/04/xmlenc#sha256");
+                }
+                // Liberty Change End
 
                 algorithmSuite.addSignatureMethod(customAlgSuite.getAsymmetricSignature());
                 algorithmSuite.addSignatureMethod(customAlgSuite.getSymmetricSignature());

--- a/dev/com.ibm.ws.org.apache.cxf.rt.ws.security.3.4.1/src/org/apache/cxf/ws/security/wss4j/policyvalidators/AlgorithmSuitePolicyValidator.java
+++ b/dev/com.ibm.ws.org.apache.cxf.rt.ws.security.3.4.1/src/org/apache/cxf/ws/security/wss4j/policyvalidators/AlgorithmSuitePolicyValidator.java
@@ -48,6 +48,8 @@ import org.apache.wss4j.policy.model.AlgorithmSuite;
 import org.apache.wss4j.policy.model.AlgorithmSuite.AlgorithmSuiteType;
 import org.apache.xml.security.transforms.Transforms;
 
+import com.ibm.ws.common.crypto.CryptoUtils;
+
 /**
  * Validate results corresponding to the processing of a Signature, EncryptedKey or
  * EncryptedData structure against an AlgorithmSuite policy.
@@ -59,7 +61,9 @@ import org.apache.xml.security.transforms.Transforms;
 public class AlgorithmSuitePolicyValidator extends AbstractSecurityPolicyValidator {
     
 
-    private static final Logger LOG = LogUtils.getL7dLogger(AlgorithmSuitePolicyValidator.class); // Liberty Code Change
+    //private static final Logger LOG = LogUtils.getL7dLogger(AlgorithmSuitePolicyValidator.class); // Liberty Code Change
+    private static final org.slf4j.Logger LOG =
+        org.slf4j.LoggerFactory.getLogger(AlgorithmSuitePolicyValidator.class);
 
     /**
      * Return true if this SecurityPolicyValidator implementation is capable of validating a
@@ -167,11 +171,16 @@ public class AlgorithmSuitePolicyValidator extends AbstractSecurityPolicyValidat
         AssertionInfo ai
     ) {
         AlgorithmSuiteType algorithmSuiteType = algorithmPolicy.getAlgorithmSuiteType();
+        
         for (WSDataRef dataRef : dataRefs) {
+            if (CryptoUtils.isFips140_3Enabled()) {
+                dataRef.setDigestAlgorithm("http://www.w3.org/2001/04/xmlenc#sha256");
+            }
             String digestMethod = dataRef.getDigestAlgorithm();
+             LOG.debug("Mei: line 174, dataRef.getDigestAlgorithm() digestMethod is " +digestMethod);
             if (!algorithmSuiteType.getDigest().equals(digestMethod)) {
                 ai.setNotAsserted(
-                    "The digest method does not match the requirement"
+                    "Mei: line 177, The digest method does not match the requirement"
                 );
                 return false;
             }
@@ -256,21 +265,29 @@ public class AlgorithmSuitePolicyValidator extends AbstractSecurityPolicyValidat
 
         AlgorithmSuiteType algorithmSuiteType = algorithmPolicy.getAlgorithmSuiteType();
         byte[] secret = (byte[])result.get(WSSecurityEngineResult.TAG_SECRET);
+        LOG.debug("Mei: line 261, WSSecurityEngineResult secret is " +secret);
+        LOG.debug("Mei: line 262, secret.length is " +secret.length);
         if (signature) {
             Principal principal = (Principal)result.get(WSSecurityEngineResult.TAG_PRINCIPAL);
+            LOG.debug("Mei: line 265, WSSecurityEngineResult principal  is " +principal);
             if (principal instanceof WSDerivedKeyTokenPrincipal) {
+                LOG.debug("Mei: line 267, principal is instance of WSDerivedKeyTokenPrincipal ");
                 int requiredLength = algorithmSuiteType.getSignatureDerivedKeyLength();
+                LOG.debug("Mei: line 269, requiredLength is " +requiredLength); //192
                 if (secret == null || secret.length != (requiredLength / 8)) {
+                   LOG.debug("Mei line 271, secret null or secret.lenght!= requiredLength ");
                     ai.setNotAsserted(
-                        "The signature derived key length does not match the requirement"
+                        "Mei: line 273, The signature derived key length does not match the requirement"
                     );
                     return false;
                 }
             } else if (secret != null
                 && (secret.length < (algorithmSuiteType.getMinimumSymmetricKeyLength() / 8)
                     || secret.length > (algorithmSuiteType.getMaximumSymmetricKeyLength() / 8))) {
+                LOG.debug("Mei: line 287, algorithmSuiteType.getMinimumSymmetricKeyLength is " +algorithmSuiteType.getMinimumSymmetricKeyLength());
+                LOG.debug("Mei: line 288, algorithmSuiteType.getMaximumSymmetricKeyLength is " +algorithmSuiteType.getMaximumSymmetricKeyLength());
                 ai.setNotAsserted(
-                    "The symmetric key length does not match the requirement"
+                    "Mei: line 288, The symmetric key length does not match the requirement"
                 );
                 return false;
             }
@@ -278,7 +295,7 @@ public class AlgorithmSuitePolicyValidator extends AbstractSecurityPolicyValidat
             && (secret.length < (algorithmSuiteType.getMinimumSymmetricKeyLength() / 8)
                 || secret.length > (algorithmSuiteType.getMaximumSymmetricKeyLength() / 8))) {
             ai.setNotAsserted(
-                "The symmetric key length does not match the requirement"
+                "Mei: line 298, The symmetric key length does not match the requirement"
             );
             return false;
         }

--- a/dev/com.ibm.ws.org.apache.santuario.xmlsec.2.2.0/bnd.bnd
+++ b/dev/com.ibm.ws.org.apache.santuario.xmlsec.2.2.0/bnd.bnd
@@ -34,5 +34,6 @@ instrument.classesExcludes: org/apache/xml/security/stax/ext/*.class
 	com.ibm.websphere.javaee.jaxb.2.2;version=latest,\
 	com.ibm.ws.kernel.service;version=latest,\
     io.openliberty.org.apache.commons.codec;version=latest,\
-    com.ibm.websphere.appserver.spi.logging
+    com.ibm.websphere.appserver.spi.logging, \
+    com.ibm.ws.kernel.service;version=latest
 globalize: false

--- a/dev/com.ibm.ws.org.apache.santuario.xmlsec.2.2.0/src/org/apache/xml/security/encryption/XMLCipher.java
+++ b/dev/com.ibm.ws.org.apache.santuario.xmlsec.2.2.0/src/org/apache/xml/security/encryption/XMLCipher.java
@@ -1,0 +1,3759 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.xml.security.encryption;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UnsupportedEncodingException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
+import java.security.*;
+import java.security.spec.AlgorithmParameterSpec;
+import java.security.spec.MGF1ParameterSpec;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+
+import com.ibm.ws.common.crypto.CryptoUtils;
+
+import javax.crypto.BadPaddingException;
+import javax.crypto.Cipher;
+import javax.crypto.IllegalBlockSizeException;
+import javax.crypto.NoSuchPaddingException;
+import javax.crypto.spec.OAEPParameterSpec;
+import javax.crypto.spec.PSource;
+import javax.xml.transform.TransformerConfigurationException;
+
+import org.apache.xml.security.algorithms.JCEMapper;
+import org.apache.xml.security.algorithms.MessageDigestAlgorithm;
+import org.apache.xml.security.c14n.Canonicalizer;
+import org.apache.xml.security.c14n.InvalidCanonicalizerException;
+import org.apache.xml.security.encryption.keys.KeyInfoEnc;
+import org.apache.xml.security.encryption.params.KeyAgreementParameters;
+import org.apache.xml.security.exceptions.XMLSecurityException;
+import org.apache.xml.security.keys.KeyInfo;
+import org.apache.xml.security.encryption.keys.content.AgreementMethodImpl;
+import org.apache.xml.security.keys.keyresolver.KeyResolverException;
+import org.apache.xml.security.keys.keyresolver.KeyResolverSpi;
+import org.apache.xml.security.keys.keyresolver.implementations.EncryptedKeyResolver;
+import org.apache.xml.security.signature.XMLSignatureException;
+import org.apache.xml.security.stax.ext.XMLSecurityConstants;
+import org.apache.xml.security.transforms.InvalidTransformException;
+import org.apache.xml.security.transforms.TransformationException;
+import org.apache.xml.security.utils.*;
+import org.w3c.dom.Attr;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+/**
+ * <code>XMLCipher</code> encrypts and decrypts the contents of
+ * <code>Document</code>s, <code>Element</code>s and <code>Element</code>
+ * contents. It was designed to resemble <code>javax.crypto.Cipher</code> in
+ * order to facilitate understanding of its functioning.
+ *
+ */
+public final class XMLCipher { // Liberty Change: Backport 4.x
+
+    private static final org.slf4j.Logger LOG =
+        org.slf4j.LoggerFactory.getLogger(XMLCipher.class);
+
+    /** Triple DES EDE (192 bit key) in CBC mode */
+    public static final String TRIPLEDES =
+        EncryptionConstants.ALGO_ID_BLOCKCIPHER_TRIPLEDES;
+
+    /** AES 128 Cipher */
+    public static final String AES_128 =
+        EncryptionConstants.ALGO_ID_BLOCKCIPHER_AES128;
+
+    /** AES 256 Cipher */
+    public static final String AES_256 =
+        EncryptionConstants.ALGO_ID_BLOCKCIPHER_AES256;
+
+    /** AES 192 Cipher */
+    public static final String AES_192 =
+        EncryptionConstants.ALGO_ID_BLOCKCIPHER_AES192;
+
+    /** AES 128 GCM Cipher */
+    public static final String AES_128_GCM =
+        EncryptionConstants.ALGO_ID_BLOCKCIPHER_AES128_GCM;
+
+    /** AES 192 GCM Cipher */
+    public static final String AES_192_GCM =
+        EncryptionConstants.ALGO_ID_BLOCKCIPHER_AES192_GCM;
+
+    /** AES 256 GCM Cipher */
+    public static final String AES_256_GCM =
+        EncryptionConstants.ALGO_ID_BLOCKCIPHER_AES256_GCM;
+
+    /** SEED 128 Cipher */
+    public static final String SEED_128 =
+        EncryptionConstants.ALGO_ID_BLOCKCIPHER_SEED128;
+
+    /** CAMELLIA 128 Cipher */
+    public static final String CAMELLIA_128 =
+        EncryptionConstants.ALGO_ID_BLOCKCIPHER_CAMELLIA128;
+
+    /** CAMELLIA 192 Cipher */
+    public static final String CAMELLIA_192 =
+        EncryptionConstants.ALGO_ID_BLOCKCIPHER_CAMELLIA192;
+
+    /** CAMELLIA 256 Cipher */
+    public static final String CAMELLIA_256 =
+        EncryptionConstants.ALGO_ID_BLOCKCIPHER_CAMELLIA256;
+
+    /** RSA 1.5 Cipher */
+    public static final String RSA_v1dot5 =
+        EncryptionConstants.ALGO_ID_KEYTRANSPORT_RSA15;
+
+    /** RSA OAEP Cipher */
+    public static final String RSA_OAEP =
+        EncryptionConstants.ALGO_ID_KEYTRANSPORT_RSAOAEP;
+
+    /** RSA OAEP Cipher */
+    public static final String RSA_OAEP_11 =
+        EncryptionConstants.ALGO_ID_KEYTRANSPORT_RSAOAEP_11;
+
+    /** DIFFIE_HELLMAN Cipher */
+    public static final String DIFFIE_HELLMAN =
+        EncryptionConstants.ALGO_ID_KEYAGREEMENT_DH;
+
+    /**
+     * DIFFIE_HELLMAN ES Cipher for Elliptic curve and X keys
+     */
+    public static final String DIFFIE_HELLMAN_EC =
+            EncryptionConstants.ALGO_ID_KEYAGREEMENT_ECDH_ES; // Liberty Change: Backport 4.x
+
+    /** Triple DES EDE (192 bit key) in CBC mode KEYWRAP*/
+    public static final String TRIPLEDES_KeyWrap =
+        EncryptionConstants.ALGO_ID_KEYWRAP_TRIPLEDES;
+
+    /** AES 128 Cipher KeyWrap */
+    public static final String AES_128_KeyWrap =
+        EncryptionConstants.ALGO_ID_KEYWRAP_AES128;
+
+    /** AES 256 Cipher KeyWrap */
+    public static final String AES_256_KeyWrap =
+        EncryptionConstants.ALGO_ID_KEYWRAP_AES256;
+
+    /** AES 192 Cipher KeyWrap */
+    public static final String AES_192_KeyWrap =
+        EncryptionConstants.ALGO_ID_KEYWRAP_AES192;
+
+    /** CAMELLIA 128 Cipher KeyWrap */
+    public static final String CAMELLIA_128_KeyWrap =
+        EncryptionConstants.ALGO_ID_KEYWRAP_CAMELLIA128;
+
+    /** CAMELLIA 192 Cipher KeyWrap */
+    public static final String CAMELLIA_192_KeyWrap =
+        EncryptionConstants.ALGO_ID_KEYWRAP_CAMELLIA192;
+
+    /** CAMELLIA 256 Cipher KeyWrap */
+    public static final String CAMELLIA_256_KeyWrap =
+        EncryptionConstants.ALGO_ID_KEYWRAP_CAMELLIA256;
+
+    /** SEED 128 Cipher KeyWrap */
+    public static final String SEED_128_KeyWrap =
+        EncryptionConstants.ALGO_ID_KEYWRAP_SEED128;
+
+    /** SHA1 Cipher */
+    public static final String SHA1 =
+        Constants.ALGO_ID_DIGEST_SHA1;
+
+    /** SHA256 Cipher */
+    public static final String SHA256 =
+        MessageDigestAlgorithm.ALGO_ID_DIGEST_SHA256;
+
+    /** SHA512 Cipher */
+    public static final String SHA512 =
+        MessageDigestAlgorithm.ALGO_ID_DIGEST_SHA512;
+
+    /** RIPEMD Cipher */
+    public static final String RIPEMD_160 =
+        MessageDigestAlgorithm.ALGO_ID_DIGEST_RIPEMD160;
+
+    /** XML Signature NS */
+    public static final String XML_DSIG =
+        Constants.SignatureSpecNS;
+
+    /** N14C_XML */
+    public static final String N14C_XML =
+        Canonicalizer.ALGO_ID_C14N_OMIT_COMMENTS;
+
+    /** N14C_XML with comments*/
+    public static final String N14C_XML_WITH_COMMENTS =
+        Canonicalizer.ALGO_ID_C14N_WITH_COMMENTS;
+
+    /** N14C_XML exclusive */
+    public static final String EXCL_XML_N14C =
+        Canonicalizer.ALGO_ID_C14N_EXCL_OMIT_COMMENTS;
+
+    /** N14C_XML exclusive with comments*/
+    public static final String EXCL_XML_N14C_WITH_COMMENTS =
+        Canonicalizer.ALGO_ID_C14N_EXCL_WITH_COMMENTS;
+
+    /** N14C_PHYSICAL preserve the physical representation*/
+    public static final String PHYSICAL_XML_N14C =
+        Canonicalizer.ALGO_ID_C14N_PHYSICAL;
+
+    /** Base64 encoding */
+    public static final String BASE64_ENCODING =
+        org.apache.xml.security.transforms.Transforms.TRANSFORM_BASE64_DECODE;
+
+    /** ENCRYPT Mode */
+    public static final int ENCRYPT_MODE = Cipher.ENCRYPT_MODE;
+
+    /** DECRYPT Mode */
+    public static final int DECRYPT_MODE = Cipher.DECRYPT_MODE;
+
+    /** UNWRAP Mode */
+    public static final int UNWRAP_MODE = Cipher.UNWRAP_MODE;
+
+    /** WRAP Mode */
+    public static final int WRAP_MODE = Cipher.WRAP_MODE;
+
+    private static final String ENC_ALGORITHMS = TRIPLEDES + "\n" +
+        AES_128 + "\n" + AES_256 + "\n" + AES_192 + "\n" + RSA_v1dot5 + "\n" +
+        RSA_OAEP + "\n" + RSA_OAEP_11 + "\n" + TRIPLEDES_KeyWrap + "\n" +
+        AES_128_KeyWrap + "\n" + AES_256_KeyWrap + "\n" + AES_192_KeyWrap + "\n" +
+        AES_128_GCM + "\n" + AES_192_GCM + "\n" + AES_256_GCM + "\n" + SEED_128 + "\n" +
+        CAMELLIA_128 + "\n" + CAMELLIA_192 + "\n" + CAMELLIA_256 + "\n" +
+        CAMELLIA_128_KeyWrap + "\n" + CAMELLIA_192_KeyWrap + "\n" + CAMELLIA_256_KeyWrap + "\n" +
+        SEED_128_KeyWrap + "\n";
+
+    private static final Set<String> SUPPORTED_ALGORITHMS;
+
+    private static final boolean HAVE_FUNCTIONAL_IDENTITY_TRANSFORMER = haveFunctionalIdentityTransformer();
+
+    /** Cipher created during initialisation that is used for encryption */
+    private Cipher contextCipher;
+
+    /** Mode that the XMLCipher object is operating in */
+    private int cipherMode = Integer.MIN_VALUE;
+
+    /** URI of algorithm that is being used for cryptographic operation */
+    private final String algorithm;
+    
+    /** Cryptographic provider requested by caller */
+    private final String requestedJCEProvider;
+
+    /** Used for creation of DOM nodes in WRAP and ENCRYPT modes */
+    private Document contextDocument;
+
+    /** Instance of factory used to create XML Encryption objects */
+    private final Factory factory;
+
+    /** Serializer class for going to/from UTF-8 */
+    private final Serializer serializer;
+
+    /** Local copy of user's key */
+    private Key key;
+
+    /** Local copy of the kek (used to decrypt EncryptedKeys during a
+     *  DECRYPT_MODE operation */
+    private Key kek;
+
+    // The EncryptedKey being built (part of a WRAP operation) or read
+    // (part of an UNWRAP operation)
+    private EncryptedKey ek;
+
+    // The EncryptedData being built (part of a WRAP operation) or read
+    // (part of an UNWRAP operation)
+    private EncryptedData ed;
+
+    private boolean secureValidation = true;
+
+    private String digestAlg;
+
+    /** List of internal KeyResolvers for DECRYPT and UNWRAP modes. */
+    private List<KeyResolverSpi> internalKeyResolvers;
+
+    static {
+        Set<String> encryptionAlgorithms = new HashSet<>();
+        encryptionAlgorithms.add(TRIPLEDES);
+        encryptionAlgorithms.add(AES_128);
+        encryptionAlgorithms.add(AES_256);
+        encryptionAlgorithms.add(AES_192);
+        encryptionAlgorithms.add(AES_128_GCM);
+        encryptionAlgorithms.add(AES_192_GCM);
+        encryptionAlgorithms.add(AES_256_GCM);
+        encryptionAlgorithms.add(SEED_128);
+        encryptionAlgorithms.add(CAMELLIA_128);
+        encryptionAlgorithms.add(CAMELLIA_192);
+        encryptionAlgorithms.add(CAMELLIA_256);
+        encryptionAlgorithms.add(RSA_v1dot5);
+        encryptionAlgorithms.add(RSA_OAEP);
+        encryptionAlgorithms.add(RSA_OAEP_11);
+        encryptionAlgorithms.add(TRIPLEDES_KeyWrap);
+        encryptionAlgorithms.add(AES_128_KeyWrap);
+        encryptionAlgorithms.add(AES_256_KeyWrap);
+        encryptionAlgorithms.add(AES_192_KeyWrap);
+        encryptionAlgorithms.add(CAMELLIA_128_KeyWrap);
+        encryptionAlgorithms.add(CAMELLIA_192_KeyWrap);
+        encryptionAlgorithms.add(CAMELLIA_256_KeyWrap);
+        encryptionAlgorithms.add(SEED_128_KeyWrap);
+        SUPPORTED_ALGORITHMS = Collections.unmodifiableSet(encryptionAlgorithms);
+    }
+
+    /**
+     * Creates a new <code>XMLCipher</code>.
+     *
+     * @param transformation    the name of the transformation, e.g.,
+     *                          <code>XMLCipher.TRIPLEDES</code>. If null the XMLCipher can only
+     *                          be used for decrypt or unwrap operations where the encryption method
+     *                          is defined in the <code>EncryptionMethod</code> element.
+     * @param provider          the JCE provider that supplies the transformation,
+     *                          if null use the default provider.
+     * @param digestMethod      An optional digestMethod to use.
+     * @param serializer        A Serializer instance to use
+     */
+    private XMLCipher(
+        String transformation,
+        String provider,
+        String digestMethod,
+        Serializer serializer
+    ) throws XMLEncryptionException {
+        LOG.debug("Constructing XMLCipher...");
+
+        factory = new Factory();
+
+        // Liberty Change Start: set FIPS default
+        if (XMLCipher.AES_128.equals(transformation)
+                || XMLCipher.AES_256.equals(transformation)) {
+                transformation = CryptoUtils.isFips140_3Enabled() 
+                                 ? "http://www.w3.org/2009/xmlenc11#aes256-gcm"
+                                 : "http://www.w3.org/2001/04/xmlenc#aes256-cbc";   
+        }
+        // Liberty Change End
+        
+        algorithm = transformation;
+        requestedJCEProvider = provider;
+
+        // Liberty Change Start: set FIPS default
+        if (digestMethod == null || XMLCipher.SHA1.equals(digestMethod)) {
+            digestMethod = CryptoUtils.isFips140_3Enabled() 
+                           ? "http://www.w3.org/2001/04/xmlenc#sha256"
+                           : "http://www.w3.org/2000/09/xmldsig#sha1";  
+        }
+        // Liberty Change End
+
+        digestAlg = digestMethod;
+        LOG.debug("Mei: line 367, digestMethod is " + digestMethod);
+        this.serializer = serializer;
+
+        if (transformation != null) {
+            contextCipher = constructCipher(transformation, digestMethod);
+        }
+    }
+
+    private static Serializer createSerializer(boolean secureValidation) throws XMLEncryptionException {
+        return createSerializer(null, secureValidation);
+    }
+
+    private static Serializer createSerializer(String canonAlg, boolean secureValidation) throws XMLEncryptionException {
+        String c14nAlg = canonAlg != null ? canonAlg : Canonicalizer.ALGO_ID_C14N_PHYSICAL;
+
+        try {
+            if (HAVE_FUNCTIONAL_IDENTITY_TRANSFORMER) {
+                return new TransformSerializer(c14nAlg, secureValidation);
+            }
+            return new DocumentSerializer(c14nAlg, secureValidation);
+        } catch (InvalidCanonicalizerException | TransformerConfigurationException e) {
+            throw new XMLEncryptionException(e);
+        }
+    }
+
+    /**
+     * Checks to ensure that the supplied algorithm is valid.
+     *
+     * @param algorithm the algorithm to check.
+     * @return true if the algorithm is valid, otherwise false.
+     * @since 1.0.
+     */
+    private static boolean isValidEncryptionAlgorithm(String algorithm) {
+        return SUPPORTED_ALGORITHMS.contains(algorithm);
+    }
+
+    /**
+     * Validate the transformation argument of getInstance or getProviderInstance
+     *
+     * @param transformation the name of the transformation, e.g.,
+     *   <code>XMLCipher.TRIPLEDES</code> which is shorthand for
+     *   &quot;http://www.w3.org/2001/04/xmlenc#tripledes-cbc&quot;
+     */
+    private static void validateTransformation(String transformation) {
+
+        // Liberty Change Start: set FIPS default
+        if (XMLCipher.AES_128.equals(transformation)
+                || XMLCipher.AES_256.equals(transformation)) {
+                transformation = CryptoUtils.isFips140_3Enabled() 
+                                 ? "http://www.w3.org/2009/xmlenc11#aes256-gcm"
+                                 : "http://www.w3.org/2001/04/xmlenc#aes256-cbc";   
+        }
+        // Liberty Change End
+
+        if (null == transformation) {
+            throw new NullPointerException("Transformation unexpectedly null...");
+        }
+        if (!isValidEncryptionAlgorithm(transformation)) {
+            LOG.warn("Algorithm non-standard, expected one of " + ENC_ALGORITHMS);
+        }
+    }
+
+    /**
+     * Returns an <code>XMLCipher</code> that implements the specified
+     * transformation and operates on the specified context document.
+     * <p>
+     * If the default provider package supplies an implementation of the
+     * requested transformation, an instance of Cipher containing that
+     * implementation is returned. If the transformation is not available in
+     * the default provider package, other provider packages are searched.
+     * <p>
+     * <b>NOTE<sub>1</sub>:</b> The transformation name does not follow the same
+     * pattern as that outlined in the Java Cryptography Extension Reference
+     * Guide but rather that specified by the XML Encryption Syntax and
+     * Processing document. The rational behind this is to make it easier for a
+     * novice at writing Java Encryption software to use the library.
+     * <p>
+     * <b>NOTE<sub>2</sub>:</b> <code>getInstance()</code> does not follow the
+     * same pattern regarding exceptional conditions as that used in
+     * <code>javax.crypto.Cipher</code>. Instead, it only throws an
+     * <code>XMLEncryptionException</code> which wraps an underlying exception.
+     * The stack trace from the exception should be self explanatory.
+     *
+     * @param transformation the name of the transformation, e.g.,
+     *   <code>XMLCipher.TRIPLEDES</code> which is shorthand for
+     *   &quot;http://www.w3.org/2001/04/xmlenc#tripledes-cbc&quot;
+     * @throws XMLEncryptionException
+     * @return the XMLCipher
+     * @see javax.crypto.Cipher#getInstance(java.lang.String)
+     */
+    public static XMLCipher getInstance(String transformation) throws XMLEncryptionException {    
+        
+        // Liberty Change Start: set FIPS default
+        if (XMLCipher.AES_128.equals(transformation)
+                || XMLCipher.AES_256.equals(transformation)) {
+                transformation = CryptoUtils.isFips140_3Enabled() 
+                                 ? "http://www.w3.org/2009/xmlenc11#aes256-gcm"
+                                 : "http://www.w3.org/2001/04/xmlenc#aes256-cbc";   
+        }
+        // Liberty Change End
+
+        LOG.debug("Getting XMLCipher with transformation");
+        validateTransformation(transformation);
+        return new XMLCipher(transformation, null, null, createSerializer(true));
+    }
+
+    /**
+     * Returns an <code>XMLCipher</code> that implements the specified
+     * transformation, operates on the specified context document and serializes
+     * the document with the specified serializer before it
+     * encrypts the document.
+     * <p>
+     *
+     * @param serializer        A custom Serializer instance
+     * @param transformation    the name of the transformation
+     * @return the XMLCipher
+     * @throws XMLEncryptionException
+     */
+    public static XMLCipher getInstance(Serializer serializer, String transformation) throws XMLEncryptionException {
+
+        // Liberty Change Start: set FIPS default
+        if (XMLCipher.AES_128.equals(transformation)
+                || XMLCipher.AES_256.equals(transformation)) {
+                transformation = CryptoUtils.isFips140_3Enabled() 
+                                 ? "http://www.w3.org/2009/xmlenc11#aes256-gcm"
+                                 : "http://www.w3.org/2001/04/xmlenc#aes256-cbc";   
+        }
+        // Liberty Change End
+
+        LOG.debug("Getting XMLCipher with transformation");
+        validateTransformation(transformation);
+        return new XMLCipher(transformation, null, null, serializer);
+    }
+
+    /**
+     * Returns an <code>XMLCipher</code> that implements the specified
+     * transformation, operates on the specified context document and serializes
+     * the document with the specified canonicalization algorithm before it
+     * encrypts the document.
+     * <p>
+     *
+     * @param transformation	the name of the transformation
+     * @param canon		the name of the c14n algorithm, if <code>null</code> use
+     *                          standard serializer
+     * @return the XMLCipher
+     * @throws XMLEncryptionException
+     */
+    public static XMLCipher getInstance(String transformation, String canon)
+        throws XMLEncryptionException {
+        LOG.debug("Getting XMLCipher with transformation and c14n algorithm");
+        validateTransformation(transformation);
+        return new XMLCipher(transformation, null, null, createSerializer(canon, true));
+    }
+
+    /**
+     * Returns an <code>XMLCipher</code> that implements the specified
+     * transformation, operates on the specified context document and serializes
+     * the document with the specified canonicalization algorithm before it
+     * encrypts the document.
+     * <p>
+     *
+     * @param transformation    the name of the transformation
+     * @param canon             the name of the c14n algorithm, if <code>null</code> use
+     *                          standard serializer
+     * @param digestMethod      An optional digestMethod to use
+     * @return the XMLCipher
+     * @throws XMLEncryptionException
+     */
+    public static XMLCipher getInstance(String transformation, String canon, String digestMethod)
+        throws XMLEncryptionException {
+        LOG.debug("Getting XMLCipher with transformation and c14n algorithm");
+        validateTransformation(transformation);
+        return new XMLCipher(transformation, null, digestMethod, createSerializer(canon, true));
+    }
+
+    /**
+     * Returns an <code>XMLCipher</code> that implements the specified
+     * transformation and operates on the specified context document.
+     *
+     * @param transformation    the name of the transformation
+     * @param provider          the JCE provider that supplies the transformation
+     * @return the XMLCipher
+     * @throws XMLEncryptionException
+     */
+    public static XMLCipher getProviderInstance(String transformation, String provider)
+        throws XMLEncryptionException {
+        LOG.debug("Getting XMLCipher with transformation and provider");
+        if (null == provider) {
+            throw new NullPointerException("Provider unexpectedly null..");
+        }
+        validateTransformation(transformation);
+        return new XMLCipher(transformation, provider, null, createSerializer(true));
+    }
+
+    /**
+     * Returns an <code>XMLCipher</code> that implements the specified
+     * transformation, operates on the specified context document and serializes
+     * the document with the specified canonicalization algorithm before it
+     * encrypts the document.
+     * <p>
+     *
+     * @param transformation	the name of the transformation
+     * @param provider          the JCE provider that supplies the transformation
+     * @param canon		the name of the c14n algorithm, if <code>null</code> use standard
+     *                          serializer
+     * @return the XMLCipher
+     * @throws XMLEncryptionException
+     */
+    public static XMLCipher getProviderInstance(
+        String transformation, String provider, String canon
+    ) throws XMLEncryptionException {
+        LOG.debug("Getting XMLCipher with transformation, provider and c14n algorithm");
+        if (null == provider) {
+            throw new NullPointerException("Provider unexpectedly null..");
+        }
+        validateTransformation(transformation);
+        return new XMLCipher(transformation, provider, null, createSerializer(canon, true));
+    }
+
+    /**
+     * Returns an <code>XMLCipher</code> that implements the specified
+     * transformation, operates on the specified context document and serializes
+     * the document with the specified canonicalization algorithm before it
+     * encrypts the document.
+     * <p>
+     *
+     * @param transformation    the name of the transformation
+     * @param provider          the JCE provider that supplies the transformation
+     * @param canon             the name of the c14n algorithm, if <code>null</code> use standard
+     *                          serializer
+     * @param digestMethod      An optional digestMethod to use
+     * @return the XMLCipher
+     * @throws XMLEncryptionException
+     */
+    public static XMLCipher getProviderInstance(
+        String transformation, String provider, String canon, String digestMethod
+    ) throws XMLEncryptionException {
+        LOG.debug("Getting XMLCipher with transformation, provider and c14n algorithm");
+        if (null == provider) {
+            throw new NullPointerException("Provider unexpectedly null..");
+        }
+        validateTransformation(transformation);
+        return new XMLCipher(transformation, provider, digestMethod, createSerializer(canon, true));
+    }
+
+    /**
+     * Returns an <code>XMLCipher</code> that implements the specified
+     * transformation, operates on the specified context document and serializes
+     * the document with the specified Serializer before it encrypts the document.
+     * <p>
+     *
+     * @param serializer        A custom serializer instance to use
+     * @param transformation    the name of the transformation
+     * @param provider          the JCE provider that supplies the transformation
+     * @param digestMethod      An optional digestMethod to use
+     * @return the XMLCipher
+     * @throws XMLEncryptionException
+     */
+    public static XMLCipher getProviderInstance(
+        Serializer serializer, String transformation, String provider, String digestMethod
+    ) throws XMLEncryptionException {
+        LOG.debug("Getting XMLCipher with transformation, provider and c14n algorithm");
+        if (null == provider) {
+            throw new NullPointerException("Provider unexpectedly null..");
+        }
+        validateTransformation(transformation);
+        return new XMLCipher(transformation, provider, digestMethod, serializer);
+    }
+
+    /**
+     * Returns an <code>XMLCipher</code> that implements no specific
+     * transformation, and can therefore only be used for decrypt or
+     * unwrap operations where the encryption method is defined in the
+     * <code>EncryptionMethod</code> element.
+     *
+     * @return The XMLCipher
+     * @throws XMLEncryptionException
+     */
+    public static XMLCipher getInstance() throws XMLEncryptionException {
+        LOG.debug("Getting XMLCipher with no arguments");
+        return new XMLCipher(null, null, null, createSerializer(true));
+    }
+
+    /**
+     * Returns an <code>XMLCipher</code> that implements no specific
+     * transformation, and can therefore only be used for decrypt or
+     * unwrap operations where the encryption method is defined in the
+     * <code>EncryptionMethod</code> element.
+     *
+     * Allows the caller to specify a provider that will be used for
+     * cryptographic operations.
+     *
+     * @param provider          the JCE provider that supplies the transformation
+     * @return the XMLCipher
+     * @throws XMLEncryptionException
+     */
+    public static XMLCipher getProviderInstance(String provider) throws XMLEncryptionException {
+        LOG.debug("Getting XMLCipher with provider");
+        return new XMLCipher(null, provider, null, createSerializer(true));
+    }
+
+    /**
+     * Initializes this cipher with a key.
+     * <p>
+     * The cipher is initialized for one of the following four operations:
+     * encryption, decryption, key wrapping or key unwrapping, depending on the
+     * value of opmode.
+     *
+     * For WRAP and ENCRYPT modes, this also initialises the internal
+     * EncryptedKey or EncryptedData (with a CipherValue)
+     * structure that will be used during the ensuing operations.  This
+     * can be obtained (in order to modify KeyInfo elements etc. prior to
+     * finalising the encryption) by calling
+     * {@link #getEncryptedData} or {@link #getEncryptedKey}.
+     *
+     * @param opmode the operation mode of this cipher (this is one of the
+     *   following: ENCRYPT_MODE, DECRYPT_MODE, WRAP_MODE or UNWRAP_MODE)
+     * @param key
+     * @see javax.crypto.Cipher#init(int, java.security.Key)
+     * @throws XMLEncryptionException
+     */
+    public void init(int opmode, Key key) throws XMLEncryptionException {
+        LOG.debug("Initializing XMLCipher...");
+
+        ek = null;
+        ed = null;
+
+        switch (opmode) {
+
+        case ENCRYPT_MODE :
+            LOG.debug("opmode = ENCRYPT_MODE");
+            ed = createEncryptedData(CipherData.VALUE_TYPE, "NO VALUE YET");
+            break;
+        case DECRYPT_MODE :
+            LOG.debug("opmode = DECRYPT_MODE");
+            break;
+        case WRAP_MODE :
+            LOG.debug("opmode = WRAP_MODE");
+            ek = createEncryptedKey(CipherData.VALUE_TYPE, "NO VALUE YET");
+            break;
+        case UNWRAP_MODE :
+            LOG.debug("opmode = UNWRAP_MODE");
+            break;
+        default :
+            LOG.error("Mode unexpectedly invalid");
+            throw new XMLEncryptionException("Invalid mode in init");
+        }
+
+        cipherMode = opmode;
+        this.key = key;
+    }
+
+    /**
+     * Set whether secure validation is enabled or not. The default is false.
+     */
+    public void setSecureValidation(boolean secureValidation) {
+        this.secureValidation = secureValidation;
+    }
+
+    /**
+     * This method is used to add a custom {@link KeyResolverSpi} to an XMLCipher.
+     * These KeyResolvers are used in KeyInfo objects in DECRYPT and
+     * UNWRAP modes.
+     *
+     * @param keyResolver
+     */
+    public void registerInternalKeyResolver(KeyResolverSpi keyResolver) {
+        if (internalKeyResolvers == null) {
+            internalKeyResolvers = new ArrayList<>();
+        }
+        internalKeyResolvers.add(keyResolver);
+    }
+
+    /**
+     * Get the EncryptedData being built
+     * <p>
+     * Returns the EncryptedData being built during an ENCRYPT operation.
+     * This can then be used by applications to add KeyInfo elements and
+     * set other parameters.
+     *
+     * @return The EncryptedData being built
+     */
+    public EncryptedData getEncryptedData() {
+        // Sanity checks
+        LOG.debug("Returning EncryptedData");
+        return ed;
+    }
+
+    /**
+     * Get the EncryptedData being build
+     *
+     * Returns the EncryptedData being built during an ENCRYPT operation.
+     * This can then be used by applications to add KeyInfo elements and
+     * set other parameters.
+     *
+     * @return The EncryptedData being built
+     */
+    public EncryptedKey getEncryptedKey() {
+        // Sanity checks
+        LOG.debug("Returning EncryptedKey");
+        return ek;
+    }
+
+    /**
+     * Set a Key Encryption Key.
+     * <p>
+     * The Key Encryption Key (KEK) is used for encrypting/decrypting
+     * EncryptedKey elements.  By setting this separately, the XMLCipher
+     * class can know whether a key applies to the data part or wrapped key
+     * part of an encrypted object.
+     *
+     * @param kek The key to use for de/encrypting key data
+     */
+
+    public void setKEK(Key kek) {
+        this.kek = kek;
+    }
+
+    /**
+     * Martial an EncryptedData
+     *
+     * Takes an EncryptedData object and returns a DOM Element that
+     * represents the appropriate <code>EncryptedData</code>
+     * <p>
+     * <b>Note:</b> This should only be used in cases where the context
+     * document has been passed in via a call to doFinal.
+     *
+     * @param encryptedData EncryptedData object to martial
+     * @return the DOM <code>Element</code> representing the passed in
+     * object
+     */
+    public Element martial(EncryptedData encryptedData) {
+        return factory.toElement(encryptedData);
+    }
+
+    /**
+     * Martial an EncryptedData
+     *
+     * Takes an EncryptedData object and returns a DOM Element that
+     * represents the appropriate <code>EncryptedData</code>
+     *
+     * @param context The document that will own the returned nodes
+     * @param encryptedData EncryptedData object to martial
+     * @return the DOM <code>Element</code> representing the passed in
+     * object
+     */
+    public Element martial(Document context, EncryptedData encryptedData) {
+        contextDocument = context;
+        return factory.toElement(encryptedData);
+    }
+
+    /**
+     * Martial an EncryptedKey
+     *
+     * Takes an EncryptedKey object and returns a DOM Element that
+     * represents the appropriate <code>EncryptedKey</code>
+     *
+     * <p>
+     * <b>Note:</b> This should only be used in cases where the context
+     * document has been passed in via a call to doFinal.
+     *
+     * @param encryptedKey EncryptedKey object to martial
+     * @return the DOM <code>Element</code> representing the passed in
+     * object
+     */
+    public Element martial(EncryptedKey encryptedKey) {
+        return factory.toElement(encryptedKey);
+    }
+
+    /**
+     * Martial an EncryptedKey
+     *
+     * Takes an EncryptedKey object and returns a DOM Element that
+     * represents the appropriate <code>EncryptedKey</code>
+     *
+     * @param context The document that will own the created nodes
+     * @param encryptedKey EncryptedKey object to martial
+     * @return the DOM <code>Element</code> representing the passed in
+     * object
+     */
+    public Element martial(Document context, EncryptedKey encryptedKey) {
+        contextDocument = context;
+        return factory.toElement(encryptedKey);
+    }
+
+    /**
+     * Martial a ReferenceList
+     *
+     * Takes a ReferenceList object and returns a DOM Element that
+     * represents the appropriate <code>ReferenceList</code>
+     *
+     * <p>
+     * <b>Note:</b> This should only be used in cases where the context
+     * document has been passed in via a call to doFinal.
+     *
+     * @param referenceList ReferenceList object to martial
+     * @return the DOM <code>Element</code> representing the passed in
+     * object
+     */
+    public Element martial(ReferenceList referenceList) {
+        return factory.toElement(referenceList);
+    }
+
+    /**
+     * Martial a ReferenceList
+     *
+     * Takes a ReferenceList object and returns a DOM Element that
+     * represents the appropriate <code>ReferenceList</code>
+     *
+     * @param context The document that will own the created nodes
+     * @param referenceList ReferenceList object to martial
+     * @return the DOM <code>Element</code> representing the passed in
+     * object
+     */
+    public Element martial(Document context, ReferenceList referenceList) {
+        contextDocument = context;
+        return factory.toElement(referenceList);
+    }
+
+    /**
+     * Encrypts an <code>Element</code> and replaces it with its encrypted
+     * counterpart in the context <code>Document</code>, that is, the
+     * <code>Document</code> specified when one calls
+     * {@link #getInstance(String) getInstance}.
+     *
+     * @param element the <code>Element</code> to encrypt.
+     * @return the context <code>Document</code> with the encrypted
+     *   <code>Element</code> having replaced the source <code>Element</code>.
+     *  @throws Exception
+     */
+    private Document encryptElement(Element element) throws Exception{
+        LOG.debug("Encrypting element...");
+        if (null == element) {
+            throw new XMLEncryptionException("empty", "Element unexpectedly null...");
+        }
+        if (cipherMode != ENCRYPT_MODE) {
+            throw new XMLEncryptionException("empty", "XMLCipher unexpectedly not in ENCRYPT_MODE...");
+        }
+
+        if (algorithm == null) {
+            throw new XMLEncryptionException("empty", "XMLCipher instance without transformation specified");
+        }
+        encryptData(contextDocument, element, false);
+
+        Element encryptedElement = factory.toElement(ed);
+
+        Node sourceParent = element.getParentNode();
+        sourceParent.replaceChild(encryptedElement, element);
+
+        return contextDocument;
+    }
+
+    /**
+     * Encrypts a <code>NodeList</code> (the contents of an
+     * <code>Element</code>) and replaces its parent <code>Element</code>'s
+     * content with this the resulting <code>EncryptedType</code> within the
+     * context <code>Document</code>, that is, the <code>Document</code>
+     * specified when one calls
+     * {@link #getInstance(String) getInstance}.
+     *
+     * @param element the <code>NodeList</code> to encrypt.
+     * @return the context <code>Document</code> with the encrypted
+     *   <code>NodeList</code> having replaced the content of the source
+     *   <code>Element</code>.
+     * @throws Exception
+     */
+    private Document encryptElementContent(Element element) throws /* XMLEncryption */Exception {
+        LOG.debug("Encrypting element content...");
+        if (null == element) {
+            throw new XMLEncryptionException("empty", "Element unexpectedly null...");
+        }
+        if (cipherMode != ENCRYPT_MODE) {
+            throw new XMLEncryptionException("empty", "XMLCipher unexpectedly not in ENCRYPT_MODE...");
+        }
+
+        if (algorithm == null) {
+            throw new XMLEncryptionException("empty", "XMLCipher instance without transformation specified");
+        }
+        encryptData(contextDocument, element, true);
+
+        Element encryptedElement = factory.toElement(ed);
+
+        removeContent(element);
+        element.appendChild(encryptedElement);
+
+        return contextDocument;
+    }
+
+    /**
+     * Process a DOM <code>Document</code> node. The processing depends on the
+     * initialization parameters of {@link #init(int, Key) init()}.
+     *
+     * @param context the context <code>Document</code>.
+     * @param source the <code>Document</code> to be encrypted or decrypted.
+     * @return the processed <code>Document</code>.
+     * @throws Exception to indicate any exceptional conditions.
+     */
+    public Document doFinal(Document context, Document source) throws /* XMLEncryption */Exception {
+        LOG.debug("Processing source document...");
+        if (null == source) {
+            throw new XMLEncryptionException("empty", "Source document unexpectedly null...");
+        }
+        return doFinal(context, source.getDocumentElement());
+    }
+
+    /**
+     * Process a DOM <code>Element</code> node. The processing depends on the
+     * initialization parameters of {@link #init(int, Key) init()}.
+     *
+     * @param context the context <code>Document</code>.
+     * @param element the <code>Element</code> to be encrypted.
+     * @return the processed <code>Document</code>.
+     * @throws Exception to indicate any exceptional conditions.
+     */
+    public Document doFinal(Document context, Element element) throws /* XMLEncryption */Exception {
+        LOG.debug("Processing source element...");
+        if (null == context) {
+            throw new XMLEncryptionException("empty", "Context document unexpectedly null...");
+        }
+        if (null == element) {
+            throw new XMLEncryptionException("empty", "Source element unexpectedly null...");
+        }
+
+        contextDocument = context;
+
+        Document result = null;
+
+        switch (cipherMode) {
+        case DECRYPT_MODE:
+            result = decryptElement(element);
+            break;
+        case ENCRYPT_MODE:
+            result = encryptElement(element);
+            break;
+        case UNWRAP_MODE:
+        case WRAP_MODE:
+            break;
+        default:
+            throw new XMLEncryptionException(new IllegalStateException());
+        }
+
+        return result;
+    }
+
+    /**
+     * Process the contents of a DOM <code>Element</code> node. The processing
+     * depends on the initialization parameters of
+     * {@link #init(int, Key) init()}.
+     *
+     * @param context the context <code>Document</code>.
+     * @param element the <code>Element</code> which contents is to be
+     *   encrypted.
+     * @param content
+     * @return the processed <code>Document</code>.
+     * @throws Exception to indicate any exceptional conditions.
+     */
+    public Document doFinal(Document context, Element element, boolean content)
+        throws /* XMLEncryption*/ Exception {
+        LOG.debug("Processing source element...");
+        if (null == context) {
+            throw new XMLEncryptionException("empty", "Context document unexpectedly null...");
+        }
+        if (null == element) {
+            throw new XMLEncryptionException("empty", "Source element unexpectedly null...");
+
+        }
+
+        contextDocument = context;
+
+        Document result = null;
+
+        switch (cipherMode) {
+        case DECRYPT_MODE:
+            if (content) {
+                result = decryptElementContent(element);
+            } else {
+                result = decryptElement(element);
+            }
+            break;
+        case ENCRYPT_MODE:
+            if (content) {
+                result = encryptElementContent(element);
+            } else {
+                result = encryptElement(element);
+            }
+            break;
+        case UNWRAP_MODE:
+        case WRAP_MODE:
+            break;
+        default:
+            throw new XMLEncryptionException(new IllegalStateException());
+        }
+
+        return result;
+    }
+
+    /**
+     * Returns an <code>EncryptedData</code> interface. Use this operation if
+     * you want to have full control over the contents of the
+     * <code>EncryptedData</code> structure.
+     *
+     * This does not change the source document in any way.
+     *
+     * @param context the context <code>Document</code>.
+     * @param element the <code>Element</code> that will be encrypted.
+     * @return the <code>EncryptedData</code>
+     * @throws Exception
+     */
+    public EncryptedData encryptData(Document context, Element element) throws
+        /* XMLEncryption */Exception {
+        return encryptData(context, element, false);
+    }
+
+    /**
+     * Returns an <code>EncryptedData</code> interface. Use this operation if
+     * you want to have full control over the serialization of the element
+     * or element content.
+     *
+     * This does not change the source document in any way.
+     *
+     * @param context the context <code>Document</code>.
+     * @param type a URI identifying type information about the plaintext form
+     *    of the encrypted content (may be <code>null</code>)
+     * @param serializedData the serialized data
+     * @return the <code>EncryptedData</code>
+     * @throws Exception
+     */
+    public EncryptedData encryptData(
+        Document context, String type, InputStream serializedData
+    ) throws Exception {
+        LOG.debug("Encrypting element...");
+        if (null == context) {
+            throw new XMLEncryptionException("empty", "Context document unexpectedly null...");
+        }
+        if (null == serializedData) {
+            throw new XMLEncryptionException("empty", "Serialized data unexpectedly null...");
+        }
+        if (cipherMode != ENCRYPT_MODE) {
+            throw new XMLEncryptionException("empty", "XMLCipher unexpectedly not in ENCRYPT_MODE...");
+        }
+
+        return encryptData(context, null, type, serializedData);
+    }
+
+    /**
+     * Returns an <code>EncryptedData</code> interface. Use this operation if
+     * you want to have full control over the contents of the
+     * <code>EncryptedData</code> structure.
+     *
+     * This does not change the source document in any way.
+     *
+     * @param context the context <code>Document</code>.
+     * @param element the <code>Element</code> that will be encrypted.
+     * @param contentMode <code>true</code> to encrypt element's content only,
+     *    <code>false</code> otherwise
+     * @return the <code>EncryptedData</code>
+     * @throws Exception
+     */
+    public EncryptedData encryptData(
+        Document context, Element element, boolean contentMode
+    ) throws /* XMLEncryption */ Exception {
+        LOG.debug("Encrypting element...");
+        if (null == context) {
+            throw new XMLEncryptionException("empty", "Context document unexpectedly null...");
+        }
+        if (null == element) {
+            throw new XMLEncryptionException("empty", "Element unexpectedly null...");
+        }
+        if (cipherMode != ENCRYPT_MODE) {
+            throw new XMLEncryptionException("empty", "XMLCipher unexpectedly not in ENCRYPT_MODE...");
+        }
+
+        String type = contentMode ? EncryptionConstants.TYPE_CONTENT : EncryptionConstants.TYPE_ELEMENT;
+        return encryptData(context, element, type, null);
+    }
+
+    private EncryptedData encryptData(
+        Document context, Element element, String type, InputStream serializedData
+    ) throws /* XMLEncryption */ Exception {
+        contextDocument = context;
+
+        if (algorithm == null) {
+            throw new XMLEncryptionException("empty", "XMLCipher instance without transformation specified");
+        }
+        if (element != null && element.getParentNode() == null) {
+            throw new XMLEncryptionException("empty", "The element can't be serialized as it has no parent");
+        }
+
+        byte[] serializedOctets = null;
+        if (serializedData == null) {
+            if (EncryptionConstants.TYPE_CONTENT.equals(type)) {
+                if (element == null) {
+                    throw new XMLEncryptionException("empty", "Cannot encrypt null element");
+                }
+                NodeList children = element.getChildNodes();
+                if (null != children) {
+                    serializedOctets = serializer.serializeToByteArray(children);
+                } else {
+                    throw new XMLEncryptionException("empty", "Element has no content.");
+                }
+            } else {
+                serializedOctets = serializer.serializeToByteArray(element);
+            }
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Serialized octets:\n" + new String(serializedOctets, StandardCharsets.UTF_8));
+            }
+        }
+
+        byte[] encryptedBytes = null;
+
+        // Now create the working cipher if none was created already
+        Cipher c;
+        if (contextCipher == null) {
+            c = constructCipher(algorithm, null);
+        } else {
+            c = contextCipher;
+        }
+        // Now perform the encryption
+
+        int ivLen = JCEMapper.getIVLengthFromURI(algorithm) / 8;
+        byte[] iv = XMLSecurityConstants.generateBytes(ivLen);
+        try {
+            AlgorithmParameterSpec paramSpec = constructBlockCipherParameters(algorithm, iv);
+            c.init(cipherMode, key, paramSpec);
+        } catch (InvalidKeyException ike) {
+            throw new XMLEncryptionException(ike);
+        }
+
+        try {
+            if (serializedData != null) {
+                int numBytes;
+                byte[] buf = new byte[8192];
+                try (ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
+                    while ((numBytes = serializedData.read(buf)) != -1) {
+                        byte[] data = c.update(buf, 0, numBytes);
+                        if (data != null) {
+                            baos.write(data);
+                        }
+                    }
+                    baos.write(c.doFinal());
+                    encryptedBytes = baos.toByteArray();
+                }
+            } else {
+                encryptedBytes = c.doFinal(serializedOctets);
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("Expected cipher.outputSize = " +
+                        Integer.toString(c.getOutputSize(serializedOctets.length)));
+                }
+            }
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Actual cipher.outputSize = "
+                             + Integer.toString(encryptedBytes.length));
+            }
+        } catch (IllegalStateException | IllegalBlockSizeException
+                | BadPaddingException | UnsupportedEncodingException e) {
+            throw new XMLEncryptionException(e);
+        }
+
+        // Get IV from Cipher Object. If this is null (see BouncyCastle issue BJA-473) then use
+        // the original IV that was generated
+        if (c.getIV() != null) {
+            iv = c.getIV();
+        }
+        // Now build up to a properly XML Encryption encoded octet stream
+        byte[] finalEncryptedBytes = new byte[iv.length + encryptedBytes.length];
+        System.arraycopy(iv, 0, finalEncryptedBytes, 0, iv.length);
+        System.arraycopy(encryptedBytes, 0, finalEncryptedBytes, iv.length, encryptedBytes.length);
+        String base64EncodedEncryptedOctets = XMLUtils.encodeToString(finalEncryptedBytes);
+
+        LOG.debug("Encrypted octets:\n{}", base64EncodedEncryptedOctets);
+        LOG.debug("Encrypted octets length = {}", base64EncodedEncryptedOctets.length());
+
+        try {
+            CipherData cd = ed.getCipherData();
+            CipherValue cv = cd.getCipherValue();
+            cv.setValue(base64EncodedEncryptedOctets);
+
+            if (type != null) {
+                ed.setType(new URI(type).toString());
+            }
+            EncryptionMethod method =
+                factory.newEncryptionMethod(new URI(algorithm).toString());
+            method.setDigestAlgorithm(digestAlg);
+            ed.setEncryptionMethod(method);
+        } catch (URISyntaxException ex) {
+            throw new XMLEncryptionException(ex);
+        }
+        return ed;
+    }
+
+    /**
+     * Build an <code>AlgorithmParameterSpec</code> instance used to initialize a <code>Cipher</code> instance
+     * for block cipher encryption and decryption.
+     *
+     * @param algorithm the XML encryption algorithm URI
+     * @param iv the initialization vector
+     * @return the newly constructed AlgorithmParameterSpec instance, appropriate for the
+     *         specified algorithm
+     */
+    private AlgorithmParameterSpec constructBlockCipherParameters(String algorithm, byte[] iv) {
+        return XMLCipherUtil.constructBlockCipherParameters(algorithm, iv);
+    }
+
+    /**
+     * Returns an <code>EncryptedData</code> interface. Use this operation if
+     * you want to load an <code>EncryptedData</code> structure from a DOM
+     * structure and manipulate the contents.
+     *
+     * @param context the context <code>Document</code>.
+     * @param element the <code>Element</code> that will be loaded
+     * @throws XMLEncryptionException
+     * @return the <code>EncryptedData</code>
+     */
+    public EncryptedData loadEncryptedData(Document context, Element element)
+        throws XMLEncryptionException {
+        LOG.debug("Loading encrypted element...");
+        if (null == context) {
+            throw new XMLEncryptionException("empty", "Context document unexpectedly null...");
+        }
+        if (null == element) {
+            throw new XMLEncryptionException("empty", "Element unexpectedly null...");
+        }
+        if (cipherMode != DECRYPT_MODE) {
+            throw new XMLEncryptionException("empty", "XMLCipher unexpectedly not in DECRYPT_MODE...");
+        }
+
+        contextDocument = context;
+        ed = factory.newEncryptedData(element);
+
+        return ed;
+    }
+
+    /**
+     * Returns an <code>EncryptedKey</code> interface. Use this operation if
+     * you want to load an <code>EncryptedKey</code> structure from a DOM
+     * structure and manipulate the contents.
+     *
+     * @param context the context <code>Document</code>.
+     * @param element the <code>Element</code> that will be loaded
+     * @return the <code>EncryptedKey</code>
+     * @throws XMLEncryptionException
+     */
+    public EncryptedKey loadEncryptedKey(Document context, Element element)
+        throws XMLEncryptionException {
+        LOG.debug("Loading encrypted key...");
+        if (null == context) {
+            throw new XMLEncryptionException("empty", "Context document unexpectedly null...");
+        }
+        if (null == element) {
+            throw new XMLEncryptionException("empty", "Context document unexpectedly null...");
+        }
+        if (cipherMode != UNWRAP_MODE && cipherMode != DECRYPT_MODE) {
+            throw new XMLEncryptionException("empty",
+                "XMLCipher unexpectedly not in UNWRAP_MODE or DECRYPT_MODE..."
+            );
+        }
+
+        contextDocument = context;
+        ek = factory.newEncryptedKey(element);
+        return ek;
+    }
+
+    /**
+     * Returns an <code>EncryptedKey</code> interface. Use this operation if
+     * you want to load an <code>EncryptedKey</code> structure from a DOM
+     * structure and manipulate the contents.
+     *
+     * Assumes that the context document is the document that owns the element
+     *
+     * @param element the <code>Element</code> that will be loaded
+     * @return the <code>EncryptedKey</code>
+     * @throws XMLEncryptionException
+     */
+    public EncryptedKey loadEncryptedKey(Element element) throws XMLEncryptionException {
+        return loadEncryptedKey(element.getOwnerDocument(), element);
+    }
+
+    /**
+     * Encrypts a key to an EncryptedKey structure
+     *
+     * @param doc the Context document that will be used to general DOM
+     * @param key Key to encrypt (will use previously set KEK to
+     * perform encryption
+     * @return the <code>EncryptedKey</code>
+     * @throws XMLEncryptionException
+     */
+    public EncryptedKey encryptKey(Document doc, Key key) throws XMLEncryptionException {
+        return encryptKey(doc, key, (String) null, null); // Liberty Change: Backport 4.x
+    }
+
+    /**
+     * Encrypts a key to an EncryptedKey structure
+     *
+     * @param doc the Context document that will be used to general DOM
+     * @param key Key to encrypt (will use previously set KEK to
+     * perform encryption
+     * @param mgfAlgorithm The xenc11 MGF Algorithm to use
+     * @param oaepParams The OAEPParams to use
+     * @return the <code>EncryptedKey</code>
+     * @throws XMLEncryptionException
+     */
+    public EncryptedKey encryptKey(
+        Document doc,
+        Key key,
+        String mgfAlgorithm,
+        byte[] oaepParams
+    ) throws XMLEncryptionException {
+        return encryptKey(doc, key, mgfAlgorithm, oaepParams, null);
+    }
+
+    /**
+     * Encrypts a key to an EncryptedKey structure
+     *
+     * @param doc the Context document that will be used to general DOM
+     * @param key Key to encrypt (will use previously set KEK to
+     * perform encryption
+     * @param mgfAlgorithm The xenc11 MGF Algorithm to use
+     * @param oaepParams The OAEPParams to use
+     * @param random The SecureRandom instance to use when initializing the Cipher
+     * @return the <code>EncryptedKey</code>
+     * @throws XMLEncryptionException
+     */
+    public EncryptedKey encryptKey(
+        Document doc,
+        Key key,
+        String mgfAlgorithm,
+        byte[] oaepParams,
+        SecureRandom random
+    ) throws XMLEncryptionException {
+
+	// Liberty Change Start: Backport 4.x
+        OAEPParameterSpec oaepParameters =
+                XMLCipherUtil.constructOAEPParameters(algorithm, digestAlg, mgfAlgorithm, oaepParams);
+        return encryptKey(doc, key, oaepParameters, random);
+    }
+
+    public EncryptedKey encryptKey(
+            Document doc,
+            Key key,
+            AlgorithmParameterSpec params,
+            SecureRandom random
+    ) throws XMLEncryptionException {
+        LOG.debug("Encrypting key using algorithm specs [{0}] ...", params);
+
+        if (null == key) {
+            throw new XMLEncryptionException("empty", "Key unexpectedly null...");
+        }
+        if (cipherMode != WRAP_MODE) {
+            throw new XMLEncryptionException("empty", "XMLCipher unexpectedly not in WRAP_MODE...");
+        }
+        if (algorithm == null) {
+            throw new XMLEncryptionException("empty", "XMLCipher instance without transformation specified");
+        }
+
+        contextDocument = doc;
+
+        byte[] encryptedBytes = null;
+        Cipher c;
+
+        if (contextCipher == null) {
+            // Now create the working cipher
+            c = constructCipher(algorithm, null);
+        } else {
+            c = contextCipher;
+        }
+
+        AlgorithmParameterSpec cipherSpec = null;
+        Key wrapKey = this.key;
+        if (params instanceof OAEPParameterSpec) {
+            cipherSpec = params;
+        } else if (params instanceof KeyAgreementParameters) {
+            KeyAgreementParameters keyAgreementParameter = (KeyAgreementParameters) params;
+            validateAndUpdateKeyAgreementParameterKeys(keyAgreementParameter);
+            // Generate a key using the key Agreement Parameters for the wrap algorithm
+            wrapKey = KeyUtils.aesWrapKeyWithDHGeneratedKey(keyAgreementParameter);
+        } else if (params != null) {
+            throw new XMLEncryptionException("encryption.UnsupportedAlgorithmParameterSpec", params.getClass().getName());
+        }
+
+        // Now perform the encryption
+        try {
+            if (random != null) {
+                if (cipherSpec == null) {
+                    c.init(Cipher.WRAP_MODE, wrapKey, random);
+                } else {
+                    c.init(Cipher.WRAP_MODE, wrapKey, cipherSpec, random);
+                }
+            } else {
+                if (cipherSpec == null) {
+                    c.init(Cipher.WRAP_MODE, wrapKey);
+                } else {
+                    c.init(Cipher.WRAP_MODE, wrapKey, cipherSpec);
+                }
+            }
+            encryptedBytes = c.wrap(key);
+        } catch (InvalidKeyException | IllegalBlockSizeException | InvalidAlgorithmParameterException e) {
+            throw new XMLEncryptionException(e);
+        }
+
+        String base64EncodedEncryptedOctets = XMLUtils.encodeToString(encryptedBytes);
+        LOG.debug("Encrypted key octets:\n{}", base64EncodedEncryptedOctets);
+        LOG.debug("Encrypted key octets length = {}", base64EncodedEncryptedOctets.length());
+
+        CipherValue cv = ek.getCipherData().getCipherValue();
+        cv.setValue(base64EncodedEncryptedOctets);
+
+        try {
+            EncryptionMethod method = factory.newEncryptionMethod(new URI(algorithm).toString());
+            method.setDigestAlgorithm(digestAlg);
+            ek.setEncryptionMethod(method);
+            if (params instanceof OAEPParameterSpec) {
+                OAEPParameterSpec oaepSpec = (OAEPParameterSpec) params;
+                String mgf1Uri = XMLCipherUtil.getMgf1URIForParameter((MGF1ParameterSpec) oaepSpec.getMGFParameters());
+                method.setMGFAlgorithm(mgf1Uri);
+                if (PSource.PSpecified.DEFAULT != oaepSpec.getPSource() && oaepSpec.getPSource() instanceof PSource.PSpecified) {
+                    byte[] pSourceParams = ((PSource.PSpecified) oaepSpec.getPSource()).getValue();
+                    method.setOAEPparams(pSourceParams);
+                }
+            } else if (params instanceof KeyAgreementParameters) {
+                KeyAgreementParameters keyAgreementParameter = (KeyAgreementParameters) params;
+                AgreementMethodImpl agreementMethod = new AgreementMethodImpl(contextDocument, keyAgreementParameter);
+                KeyInfoEnc keyInfo = new KeyInfoEnc(contextDocument);
+                keyInfo.add(agreementMethod);
+                ek.setKeyInfo(keyInfo);
+            }
+			// Liberty Change End
+        } catch (URISyntaxException ex) {
+            throw new XMLEncryptionException(ex);
+        }
+        return ek;
+    }
+
+    /**
+     * Decrypt a key from a passed in EncryptedKey structure
+     *
+     * @param encryptedKey Previously loaded EncryptedKey that needs
+     * to be decrypted.
+     * @param algorithm Algorithm for the decrypted key
+     * @return a key corresponding to the given type
+     * @throws XMLEncryptionException
+     */
+    public Key decryptKey(EncryptedKey encryptedKey, String algorithm)
+        throws XMLEncryptionException {
+        LOG.debug("Decrypting key from previously loaded EncryptedKey...");
+
+        if (cipherMode != UNWRAP_MODE) {
+            throw new XMLEncryptionException("empty", "XMLCipher unexpectedly not in UNWRAP_MODE...");
+        }
+
+        if (algorithm == null) {
+            throw new XMLEncryptionException("empty", "Cannot decrypt a key without knowing the algorithm");
+        }
+
+        if (key == null) {
+            LOG.debug("Trying to find a KEK via key resolvers");
+
+            KeyInfo ki = encryptedKey.getKeyInfo();
+            if (ki != null) {
+                ki.setSecureValidation(secureValidation);
+                try {
+                    String keyWrapAlg = encryptedKey.getEncryptionMethod().getAlgorithm();
+                    String keyType = JCEMapper.getJCEKeyAlgorithmFromURI(keyWrapAlg);
+                    if ("RSA".equals(keyType) || "EC".equals(keyType)) {
+                        key = ki.getPrivateKey();
+                    } else {
+                        key = ki.getSecretKey();
+                    }
+                }
+                catch (Exception e) {
+                    LOG.debug(e.getMessage(), e);
+                }
+            }
+            if (key == null) {
+                LOG.error("XMLCipher::decryptKey unable to resolve a KEK");
+                throw new XMLEncryptionException("empty", "Unable to decrypt without a KEK");
+            }
+        }
+
+        // Obtain the encrypted octets
+        XMLCipherInput cipherInput = new XMLCipherInput(encryptedKey);
+        cipherInput.setSecureValidation(secureValidation);
+        byte[] encryptedBytes = cipherInput.getBytes();
+
+        String jceKeyAlgorithm = JCEMapper.getJCEKeyAlgorithmFromURI(algorithm);
+        LOG.debug("Mei: 1532, decryptKey, JCE Key Algorithm: {}", jceKeyAlgorithm);
+
+        Cipher c;
+        if (contextCipher == null) {
+            // Now create the working cipher
+            c =
+                constructCipher(
+                    encryptedKey.getEncryptionMethod().getAlgorithm(),
+                    encryptedKey.getEncryptionMethod().getDigestAlgorithm()
+                );
+        } else {
+            c = contextCipher;
+        }
+
+        Key ret;
+
+		// Liberty Change Start: Backport 4.x
+        AlgorithmParameterSpec params;
+        try {
+            params = getAlgorithmParameters(encryptedKey);
+        } catch (XMLSecurityException e) {
+            throw new XMLEncryptionException(e);
+        }
+
+        try {
+            if (params == null) {
+                c.init(Cipher.UNWRAP_MODE, key);
+            } else if (params instanceof OAEPParameterSpec) {
+                c.init(Cipher.UNWRAP_MODE, key, params);
+            }
+            if (params instanceof KeyAgreementParameters) {
+                Key wrapKey = KeyUtils.aesWrapKeyWithDHGeneratedKey((KeyAgreementParameters) params);
+                c.init(Cipher.UNWRAP_MODE, wrapKey);
+            }
+            ret = c.unwrap(encryptedBytes, jceKeyAlgorithm, Cipher.SECRET_KEY);
+        } catch (InvalidKeyException | NoSuchAlgorithmException | InvalidAlgorithmParameterException e) {
+            throw new XMLEncryptionException(e);
+        }
+        LOG.debug("Decryption of key type {} OK", algorithm);
+
+        return ret;
+    }
+
+    /**
+     * Method validates and updates if needed the KeyAgreementParameterSpec with the required keys.
+     *
+     * @param keyAgreementParameter KeyAgreementParameterSpec to be validated and updated
+     *                              with the required keys if needed
+     */
+    public void validateAndUpdateKeyAgreementParameterKeys(KeyAgreementParameters keyAgreementParameter) throws XMLEncryptionException {
+        if (keyAgreementParameter == null) {
+            return;
+        }
+        // check if the recipient's public key is set in keyAgreementParameter, if not, use the recipient's public key
+        // specified in XMLCipher instance init method.
+        if (keyAgreementParameter.getRecipientPublicKey() == null && this.key != null) {
+            if (this.key instanceof PublicKey) {
+                LOG.debug("Recipient's public key is not set in keyAgreementParameter, " +
+                        "use the recipient's public key specified in XMLCipher instance init method.");
+                keyAgreementParameter.setRecipientPublicKey((PublicKey) this.key);
+            } else {
+                throw new XMLEncryptionException("algorithms.WrongKeyForThisOperation",
+                        this.key.getClass().getName(), "java.security.PublicKey");
+            }
+        }
+
+        // check if the originator's private key is still null
+        if (keyAgreementParameter.getRecipientPublicKey() == null) {
+            // recipient's public key is mandatory for key agreement algorithm.
+            throw new XMLEncryptionException("encryption.nokey");
+        }
+
+        if (keyAgreementParameter.getOriginatorPrivateKey() == null) {
+            LOG.debug("Originator's private key is not set in keyAgreementParameter, " +
+                    "generate an ephemeral key for the originator's private key.");
+            KeyPair originatorKeyPair = KeyUtils.generateEphemeralDHKeyPair(
+                    keyAgreementParameter.getRecipientPublicKey(), null);
+            keyAgreementParameter.setOriginatorKeyPair(originatorKeyPair);
+        }
+    }
+
+    /**
+     *  Method resolves the EncryptedKey  using the EncryptedKeyResolver
+     *
+     * @param encryptedKey
+     * @return
+     * @throws XMLEncryptionException
+     */
+    private AlgorithmParameterSpec getAlgorithmParameters(EncryptedKey encryptedKey) throws XMLSecurityException {
+        if (encryptedKey == null
+            || encryptedKey.getEncryptionMethod() == null
+            || encryptedKey.getEncryptionMethod().getAlgorithm() == null) {
+            LOG.debug("EncryptedKey key algorithm is null");
+            return null;
+        }
+
+        EncryptionMethod encMethod = encryptedKey.getEncryptionMethod();
+        String encryptionAlgorithm = encMethod.getAlgorithm();
+
+        if (XMLCipher.RSA_OAEP.equals(encryptionAlgorithm)
+                || XMLCipher.RSA_OAEP_11.equals(encryptionAlgorithm)) {
+            LOG.debug("EncryptedKey key algorithm is RSA OAEP");
+            return  XMLCipherUtil.constructOAEPParameters(
+                    encryptionAlgorithm, encMethod.getDigestAlgorithm(),
+                    encMethod.getMGFAlgorithm(), encMethod.getOAEPparams());
+        }
+
+        KeyInfoEnc keyInfo = encryptedKey.getKeyInfo() instanceof KeyInfoEnc ? (KeyInfoEnc) encryptedKey.getKeyInfo(): null;
+        return constructKeyAgreementParameters(keyInfo, encryptionAlgorithm);
+    }
+
+    /**
+     * The method validates whether key agreement data is present and checks if
+     * the provided key is of type PrivateKey. If both conditions are met, it
+     * proceeds to extract the KeyAgreementParameters for key derivation; otherwise, it returns null
+     *
+     * @param keyInfo   the KeyInfoEnc object containing the key agreement data
+     * @param encryptionAlgorithm the encryption algorithm
+     *
+     * @return KeyAgreementParameters object containing the key agreement data
+     *       or null if the key agreement data is not present or the provided key is not a PrivateKey
+     */
+    private KeyAgreementParameters constructKeyAgreementParameters(KeyInfoEnc keyInfo,
+                                                                   String encryptionAlgorithm) throws XMLSecurityException {
+
+        if (keyInfo == null || !keyInfo.containsAgreementMethod() ) {
+            LOG.debug("EncryptedKey key does not contain AgreementMethod data");
+            return null;
+        }
+
+        if (!(this.key instanceof PrivateKey)) {
+            LOG.info("The EncryptedKey key is using Key agreement data, " +
+                    "but provided key is not a PrivateKey. Skipping Key Agreement data processing.");
+            // do not throw error because of the legacy reasons to allow users to resolve
+            // the encryption Key manually and provide the derived key to XMLCipher
+            // @see <A HREF="https://issues.apache.org/jira/browse/SANTUARIO-616">SANTUARIO-616</A>
+            return null;
+        }
+        // resolve the agreement method
+        LOG.debug("EncryptedKey key is using Key agreement data");
+        AgreementMethod agreementMethod = keyInfo.itemAgreementMethod(0);
+        return XMLCipherUtil.constructRecipientKeyAgreementParameters(encryptionAlgorithm,
+                agreementMethod, (PrivateKey) this.key);
+		// Liberty Change End
+    }
+
+    /**
+     * Construct a Cipher object
+     */
+    private Cipher constructCipher(String algorithm, String digestAlgorithm) throws XMLEncryptionException {
+        
+        // Liberty Change Start:
+        //if (CryptoUtils.isFips140_3Enabled() && XMLCipher.SHA1.equals(digestAlgorithm)) {
+        //   algorithm = CryptoUtils.isFips140_3Enabled() 
+        //                ? "http://www.w3.org/2001/04/xmlenc#sha256"
+        //               : "http://www.w3.org/2000/09/xmldsig#sha1";
+        //}     
+        // Liberty Change End
+
+        String jceAlgorithm = JCEMapper.translateURItoJCEID(algorithm);
+        LOG.debug("JCE Algorithm = {} " + jceAlgorithm); // Liberty Change: Backport 4.x
+
+        Cipher c;
+        try {
+            if (requestedJCEProvider == null) {
+                c = Cipher.getInstance(jceAlgorithm);
+            } else {
+                c = Cipher.getInstance(jceAlgorithm, requestedJCEProvider);
+            }
+        } catch (NoSuchAlgorithmException nsae) {
+            // Check to see if an RSA OAEP MGF-1 with SHA-1 algorithm was requested
+            // Some JDKs don't support RSA/ECB/OAEPPadding
+            c = constructCipher(algorithm, digestAlgorithm, nsae);
+        } catch (NoSuchProviderException | NoSuchPaddingException e) {
+            throw new XMLEncryptionException(e);
+        }
+
+        return c;
+    }
+
+    private Cipher constructCipher(String algorithm, String digestAlgorithm, Exception nsae) throws XMLEncryptionException {
+        if (!XMLCipher.RSA_OAEP.equals(algorithm)) {
+            throw new XMLEncryptionException(nsae);
+        }
+
+        if (digestAlgorithm == null
+            || MessageDigestAlgorithm.ALGO_ID_DIGEST_SHA1.equals(digestAlgorithm)) {
+            try {
+                if (requestedJCEProvider == null) {
+                    return Cipher.getInstance("RSA/ECB/OAEPWithSHA1AndMGF1Padding");
+                } else {
+                    return Cipher.getInstance("RSA/ECB/OAEPWithSHA1AndMGF1Padding", requestedJCEProvider);
+                }
+            } catch (Exception ex) {
+                throw new XMLEncryptionException(ex);
+            }
+        } else if (MessageDigestAlgorithm.ALGO_ID_DIGEST_SHA224.equals(digestAlgorithm)) {
+            try {
+                if (requestedJCEProvider == null) {
+                    return Cipher.getInstance("RSA/ECB/OAEPWithSHA-224andMGF1Padding");
+                } else {
+                    return Cipher.getInstance("RSA/ECB/OAEPWithSHA-224andMGF1Padding", requestedJCEProvider);
+                }
+            } catch (Exception ex) {
+                throw new XMLEncryptionException(ex);
+            }
+        } else if (MessageDigestAlgorithm.ALGO_ID_DIGEST_SHA256.equals(digestAlgorithm)) {
+            try {
+                if (requestedJCEProvider == null) {
+                    return Cipher.getInstance("RSA/ECB/OAEPWithSHA-256AndMGF1Padding");
+                } else {
+                    return Cipher.getInstance("RSA/ECB/OAEPWithSHA-256AndMGF1Padding", requestedJCEProvider);
+                }
+            } catch (Exception ex) {
+                throw new XMLEncryptionException(ex);
+            }
+        } else if (MessageDigestAlgorithm.ALGO_ID_DIGEST_SHA384.equals(digestAlgorithm)) {
+            try {
+                if (requestedJCEProvider == null) {
+                    return Cipher.getInstance("RSA/ECB/OAEPWithSHA-384AndMGF1Padding");
+                } else {
+                    return Cipher.getInstance("RSA/ECB/OAEPWithSHA-384AndMGF1Padding", requestedJCEProvider);
+                }
+            } catch (Exception ex) {
+                throw new XMLEncryptionException(ex);
+            }
+        } else if (MessageDigestAlgorithm.ALGO_ID_DIGEST_SHA512.equals(digestAlgorithm)) {
+            try {
+                if (requestedJCEProvider == null) {
+                    return Cipher.getInstance("RSA/ECB/OAEPWithSHA-512AndMGF1Padding");
+                } else {
+                    return Cipher.getInstance("RSA/ECB/OAEPWithSHA-512AndMGF1Padding", requestedJCEProvider);
+                }
+            } catch (Exception ex) {
+                throw new XMLEncryptionException(ex);
+            }
+        } else {
+            throw new XMLEncryptionException(nsae);
+        }
+    }
+
+    /**
+     * Decrypt a key from a passed in EncryptedKey structure.  This version
+     * is used mainly internally, when  the cipher already has an
+     * EncryptedData loaded.  The algorithm URI will be read from the
+     * EncryptedData
+     *
+     * @param encryptedKey Previously loaded EncryptedKey that needs
+     * to be decrypted.
+     * @return a key corresponding to the given type
+     * @throws XMLEncryptionException
+     */
+    public Key decryptKey(EncryptedKey encryptedKey) throws XMLEncryptionException {
+        return decryptKey(encryptedKey, ed.getEncryptionMethod().getAlgorithm());
+    }
+
+    /**
+     * Removes the contents of a <code>Node</code>.
+     *
+     * @param node the <code>Node</code> to clear.
+     */
+    private static void removeContent(Node node) {
+        while (node.hasChildNodes()) {
+            node.removeChild(node.getFirstChild());
+        }
+    }
+
+    /**
+     * Decrypts <code>EncryptedData</code> in a single-part operation.
+     *
+     * @param element the <code>EncryptedData</code> to decrypt.
+     * @return the <code>Node</code> as a result of the decrypt operation.
+     * @throws XMLEncryptionException
+     */
+    private Document decryptElement(Element element) throws XMLEncryptionException {
+        LOG.debug("Decrypting element...");
+
+        if (element == null) {
+            throw new XMLEncryptionException("empty", "Cannot decrypt null element");
+        } else if (element.getParentNode() == null) {
+            throw new XMLEncryptionException("empty", "The element can't be serialized as it has no parent");
+        }
+
+        if (cipherMode != DECRYPT_MODE) {
+            throw new XMLEncryptionException("empty", "XMLCipher unexpectedly not in DECRYPT_MODE...");
+        }
+
+        byte[] octets = decryptToByteArray(element);
+
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Decrypted octets:\n" + new String(octets));
+        }
+
+        Node sourceParent = element.getParentNode();
+        try {
+            Node decryptedNode = serializer.deserialize(octets, sourceParent);
+
+            // The de-serialiser returns a node whose children we need to take on.
+            if (sourceParent != null && Node.DOCUMENT_NODE == sourceParent.getNodeType()) {
+                // If this is a content decryption, this may have problems
+                contextDocument.removeChild(contextDocument.getDocumentElement());
+                contextDocument.appendChild(decryptedNode);
+            } else if (sourceParent != null) {
+                sourceParent.replaceChild(decryptedNode, element);
+            }
+        } catch (IOException ex) {
+            throw new XMLEncryptionException(ex);
+        }
+
+        return contextDocument;
+    }
+
+    /**
+     *
+     * @param element
+     * @return the <code>Node</code> as a result of the decrypt operation.
+     * @throws XMLEncryptionException
+     */
+    private Document decryptElementContent(Element element) throws XMLEncryptionException {
+        Element e =
+            (Element) element.getElementsByTagNameNS(
+                EncryptionConstants.EncryptionSpecNS,
+                EncryptionConstants._TAG_ENCRYPTEDDATA
+            ).item(0);
+
+        if (null == e) {
+            throw new XMLEncryptionException("empty", "No EncryptedData child element.");
+        }
+
+        return decryptElement(e);
+    }
+
+    /**
+     * Decrypt an EncryptedData element to a byte array.
+     *
+     * When passed in an EncryptedData node, returns the decryption
+     * as a byte array.
+     *
+     * Does not modify the source document.
+     * @param element
+     * @return the bytes resulting from the decryption
+     * @throws XMLEncryptionException
+     */
+    public byte[] decryptToByteArray(Element element) throws XMLEncryptionException {
+        LOG.debug("Decrypting to ByteArray...");
+
+        if (cipherMode != DECRYPT_MODE) {
+            throw new XMLEncryptionException("empty", "XMLCipher unexpectedly not in DECRYPT_MODE...");
+        }
+
+        EncryptedData encryptedData = factory.newEncryptedData(element);
+        String encMethodAlgorithm = encryptedData.getEncryptionMethod().getAlgorithm();
+
+        if (key == null) {
+            KeyInfo ki = encryptedData.getKeyInfo();
+            if (ki != null) {
+                try {
+                    // Add an EncryptedKey resolver
+                    EncryptedKeyResolver resolver = new EncryptedKeyResolver(encMethodAlgorithm, kek, internalKeyResolvers);
+                    ki.registerInternalKeyResolver(resolver);
+                    ki.setSecureValidation(secureValidation);
+                    key = ki.getSecretKey();
+                } catch (KeyResolverException kre) {
+                    LOG.debug(kre.getMessage() + " " + kre); // Liberty Change: Backport 4.x
+                }
+            }
+
+            if (key == null) {
+                LOG.error(
+                    "XMLCipher::decryptElement unable to resolve a decryption key"
+                );
+                throw new XMLEncryptionException("empty", "encryption.nokey");
+            }
+        }
+
+        // Obtain the encrypted octets
+        XMLCipherInput cipherInput = new XMLCipherInput(encryptedData);
+        cipherInput.setSecureValidation(secureValidation);
+        byte[] encryptedBytes = cipherInput.getBytes();
+
+        // Now create the working cipher
+        String jceAlgorithm =
+            JCEMapper.translateURItoJCEID(encMethodAlgorithm);
+        LOG.debug("JCE Algorithm = {} " + jceAlgorithm); // Liberty Change: Backport 4.x
+
+        Cipher c;
+        try {
+            if (requestedJCEProvider == null) {
+                c = Cipher.getInstance(jceAlgorithm);
+            } else {
+                c = Cipher.getInstance(jceAlgorithm, requestedJCEProvider);
+            }
+        } catch (NoSuchAlgorithmException | NoSuchProviderException | NoSuchPaddingException e) {
+            throw new XMLEncryptionException(e);
+        }
+
+        int ivLen = JCEMapper.getIVLengthFromURI(encMethodAlgorithm) / 8;
+        byte[] ivBytes = new byte[ivLen];
+
+        // You may be able to pass the entire piece in to IvParameterSpec
+        // and it will only take the first x bytes, but no way to be certain
+        // that this will work for every JCE provider, so lets copy the
+        // necessary bytes into a dedicated array.
+
+        System.arraycopy(encryptedBytes, 0, ivBytes, 0, ivLen);
+
+        String blockCipherAlg = algorithm;
+        if (blockCipherAlg == null) {
+            blockCipherAlg = encMethodAlgorithm;
+        }
+        AlgorithmParameterSpec paramSpec = constructBlockCipherParameters(blockCipherAlg, ivBytes);
+      
+        try {
+            c.init(cipherMode, key, paramSpec);
+        } catch (InvalidKeyException | InvalidAlgorithmParameterException e) {
+            throw new XMLEncryptionException(e);
+        }
+
+        try {
+            return c.doFinal(encryptedBytes, ivLen, encryptedBytes.length - ivLen);
+        } catch (IllegalBlockSizeException | BadPaddingException e) {
+            throw new XMLEncryptionException(e);
+        }
+    }
+
+    /*
+     * Expose the interface for creating XML Encryption objects
+     */
+
+    /**
+     * Creates an <code>EncryptedData</code> <code>Element</code>.
+     *
+     * The newEncryptedData and newEncryptedKey methods create fairly complete
+     * elements that are immediately useable.  All the other create* methods
+     * return bare elements that still need to be built upon.
+     *<p>
+     * An EncryptionMethod will still need to be added however
+     *
+     * @param type Either REFERENCE_TYPE or VALUE_TYPE - defines what kind of
+     * CipherData this EncryptedData will contain.
+     * @param value the Base 64 encoded, encrypted text to wrap in the
+     *   <code>EncryptedData</code> or the URI to set in the CipherReference
+     * (usage will depend on the <code>type</code>
+     * @return the <code>EncryptedData</code> <code>Element</code>.
+     *
+     * <!--
+     * <EncryptedData Id[OPT] Type[OPT] MimeType[OPT] Encoding[OPT]>
+     *     <EncryptionMethod/>[OPT]
+     *     <ds:KeyInfo>[OPT]
+     *         <EncryptedKey/>[OPT]
+     *         <AgreementMethod/>[OPT]
+     *         <ds:KeyName/>[OPT]
+     *         <ds:RetrievalMethod/>[OPT]
+     *         <ds:[MUL]/>[OPT]
+     *     </ds:KeyInfo>
+     *     <CipherData>[MAN]
+     *         <CipherValue/> XOR <CipherReference/>
+     *     </CipherData>
+     *     <EncryptionProperties/>[OPT]
+     * </EncryptedData>
+     * -->
+     * @throws XMLEncryptionException
+     */
+    public EncryptedData createEncryptedData(int type, String value) throws XMLEncryptionException {
+        EncryptedData result = null;
+        CipherData data = null;
+
+        if (CipherData.REFERENCE_TYPE == type) {
+            CipherReference cipherReference = factory.newCipherReference(value);
+            data = factory.newCipherData(type);
+            data.setCipherReference(cipherReference);
+            result = factory.newEncryptedData(data);
+        } else if (CipherData.VALUE_TYPE == type) {
+            CipherValue cipherValue = factory.newCipherValue(value);
+            data = factory.newCipherData(type);
+            data.setCipherValue(cipherValue);
+            result = factory.newEncryptedData(data);
+        }
+
+        return result;
+    }
+
+    /**
+     * Creates an <code>EncryptedKey</code> <code>Element</code>.
+     *
+     * The newEncryptedData and newEncryptedKey methods create fairly complete
+     * elements that are immediately useable.  All the other create* methods
+     * return bare elements that still need to be built upon.
+     *<p>
+     * An EncryptionMethod will still need to be added however
+     *
+     * @param type Either REFERENCE_TYPE or VALUE_TYPE - defines what kind of
+     * CipherData this EncryptedData will contain.
+     * @param value the Base 64 encoded, encrypted text to wrap in the
+     *   <code>EncryptedKey</code> or the URI to set in the CipherReference
+     * (usage will depend on the <code>type</code>
+     * @return the <code>EncryptedKey</code> <code>Element</code>.
+     *
+     * <!--
+     * <EncryptedKey Id[OPT] Type[OPT] MimeType[OPT] Encoding[OPT]>
+     *     <EncryptionMethod/>[OPT]
+     *     <ds:KeyInfo>[OPT]
+     *         <EncryptedKey/>[OPT]
+     *         <AgreementMethod/>[OPT]
+     *         <ds:KeyName/>[OPT]
+     *         <ds:RetrievalMethod/>[OPT]
+     *         <ds:[MUL]/>[OPT]
+     *     </ds:KeyInfo>
+     *     <CipherData>[MAN]
+     *         <CipherValue/> XOR <CipherReference/>
+     *     </CipherData>
+     *     <EncryptionProperties/>[OPT]
+     * </EncryptedData>
+     * -->
+     * @throws XMLEncryptionException
+     */
+    public EncryptedKey createEncryptedKey(int type, String value) throws XMLEncryptionException {
+        EncryptedKey result = null;
+        CipherData data = null;
+
+        if (CipherData.REFERENCE_TYPE == type) {
+            CipherReference cipherReference = factory.newCipherReference(value);
+            data = factory.newCipherData(type);
+            data.setCipherReference(cipherReference);
+            result = factory.newEncryptedKey(data);
+        } else if (CipherData.VALUE_TYPE == type) {
+            CipherValue cipherValue = factory.newCipherValue(value);
+            data = factory.newCipherData(type);
+            data.setCipherValue(cipherValue);
+            result = factory.newEncryptedKey(data);
+        }
+
+        return result;
+    }
+
+    /**
+     * Create an AgreementMethod object
+     *
+     * @param algorithm Algorithm of the agreement method
+     * @return a new <code>AgreementMethod</code>
+     */
+    public AgreementMethod createAgreementMethod(String algorithm) {
+        return factory.newAgreementMethod(algorithm);
+    }
+
+    /**
+     * Create a CipherData object
+     *
+     * @param type Type of this CipherData (either VALUE_TUPE or
+     * REFERENCE_TYPE)
+     * @return a new <code>CipherData</code>
+     */
+    public CipherData createCipherData(int type) {
+        return factory.newCipherData(type);
+    }
+
+    /**
+     * Create a CipherReference object
+     *
+     * @param uri The URI that the reference will refer
+     * @return a new <code>CipherReference</code>
+     */
+    public CipherReference createCipherReference(String uri) {
+        return factory.newCipherReference(uri);
+    }
+
+    /**
+     * Create a CipherValue element
+     *
+     * @param value The value to set the ciphertext to
+     * @return a new <code>CipherValue</code>
+     */
+    public CipherValue createCipherValue(String value) {
+        return factory.newCipherValue(value);
+    }
+
+    /**
+     * Create an EncryptionMethod object
+     *
+     * @param algorithm Algorithm for the encryption
+     * @return a new <code>EncryptionMethod</code>
+     */
+    public EncryptionMethod createEncryptionMethod(String algorithm) {
+        return factory.newEncryptionMethod(algorithm);
+    }
+
+    /**
+     * Create an EncryptionProperties element
+     * @return a new <code>EncryptionProperties</code>
+     */
+    public EncryptionProperties createEncryptionProperties() {
+        return factory.newEncryptionProperties();
+    }
+
+    /**
+     * Create a new EncryptionProperty element
+     * @return a new <code>EncryptionProperty</code>
+     */
+    public EncryptionProperty createEncryptionProperty() {
+        return factory.newEncryptionProperty();
+    }
+
+    /**
+     * Create a new ReferenceList object
+     * @param type ReferenceList.DATA_REFERENCE or ReferenceList.KEY_REFERENCE
+     * @return a new <code>ReferenceList</code>
+     */
+    public ReferenceList createReferenceList(int type) {
+        return factory.newReferenceList(type);
+    }
+
+    /**
+     * Create a new Transforms object
+     * <p>
+     * <b>Note</b>: A context document <i>must</i> have been set
+     * elsewhere (possibly via a call to doFinal).  If not, use the
+     * createTransforms(Document) method.
+     * @return a new <code>Transforms</code>
+     */
+    public Transforms createTransforms() {
+        return factory.newTransforms();
+    }
+
+    /**
+     * Create a new Transforms object
+     *
+     * Because the handling of Transforms is currently done in the signature
+     * code, the creation of a Transforms object <b>requires</b> a
+     * context document.
+     *
+     * @param doc Document that will own the created Transforms node
+     * @return a new <code>Transforms</code>
+     */
+    public Transforms createTransforms(Document doc) {
+        return factory.newTransforms(doc);
+    }
+
+    /**
+     *
+     */
+    private class Factory {
+        /**
+         * @param algorithm
+         * @return a new AgreementMethod
+         */
+        AgreementMethod newAgreementMethod(String algorithm)  {
+            return new AgreementMethodImpl(contextDocument, algorithm); // Liberty Change: Backport 4.x
+        }
+
+        /**
+         * @param type
+         * @return a new CipherData
+         *
+         */
+        CipherData newCipherData(int type) {
+            return new CipherDataImpl(type);
+        }
+
+        /**
+         * @param uri
+         * @return a new CipherReference
+         */
+        CipherReference newCipherReference(String uri)  {
+            return new CipherReferenceImpl(uri);
+        }
+
+        /**
+         * @param value
+         * @return a new CipherValue
+         */
+        CipherValue newCipherValue(String value) {
+            return new CipherValueImpl(value);
+        }
+
+        /*
+        CipherValue newCipherValue(byte[] value) {
+            return new CipherValueImpl(value);
+        }
+         */
+
+        /**
+         * @param data
+         * @return a new EncryptedData
+         */
+        EncryptedData newEncryptedData(CipherData data) {
+            return new EncryptedDataImpl(data);
+        }
+
+        /**
+         * @param data
+         * @return a new EncryptedKey
+         */
+        EncryptedKey newEncryptedKey(CipherData data) {
+            return new EncryptedKeyImpl(data);
+        }
+
+        /**
+         * @param algorithm
+         * @return a new EncryptionMethod
+         */
+        EncryptionMethod newEncryptionMethod(String algorithm) {
+            return new EncryptionMethodImpl(algorithm);
+        }
+
+        /**
+         * @return a new EncryptionProperties
+         */
+        EncryptionProperties newEncryptionProperties() {
+            return new EncryptionPropertiesImpl();
+        }
+
+        /**
+         * @return a new EncryptionProperty
+         */
+        EncryptionProperty newEncryptionProperty() {
+            return new EncryptionPropertyImpl();
+        }
+
+        /**
+         * @param type ReferenceList.DATA_REFERENCE or ReferenceList.KEY_REFERENCE
+         * @return a new ReferenceList
+         */
+        ReferenceList newReferenceList(int type) {
+            return new ReferenceListImpl(type);
+        }
+
+        /**
+         * @return a new Transforms
+         */
+        Transforms newTransforms() {
+            return new TransformsImpl();
+        }
+
+        /**
+         * @param doc
+         * @return a new Transforms
+         */
+        Transforms newTransforms(Document doc) {
+            return new TransformsImpl(doc);
+        }
+
+        /**
+         * @param element
+         * @return a new CipherData
+         * @throws XMLEncryptionException
+         */
+        CipherData newCipherData(Element element) throws XMLEncryptionException {
+            if (null == element) {
+                throw new NullPointerException("element is null");
+            }
+
+            int type = 0;
+            Element e = null;
+            if (element.getElementsByTagNameNS(
+                EncryptionConstants.EncryptionSpecNS,
+                EncryptionConstants._TAG_CIPHERVALUE).getLength() > 0
+            ) {
+                type = CipherData.VALUE_TYPE;
+                e = (Element) element.getElementsByTagNameNS(
+                    EncryptionConstants.EncryptionSpecNS,
+                    EncryptionConstants._TAG_CIPHERVALUE).item(0);
+            } else if (element.getElementsByTagNameNS(
+                EncryptionConstants.EncryptionSpecNS,
+                EncryptionConstants._TAG_CIPHERREFERENCE).getLength() > 0) {
+                type = CipherData.REFERENCE_TYPE;
+                e = (Element) element.getElementsByTagNameNS(
+                    EncryptionConstants.EncryptionSpecNS,
+                    EncryptionConstants._TAG_CIPHERREFERENCE).item(0);
+            }
+
+            CipherData result = newCipherData(type);
+            if (type == CipherData.VALUE_TYPE) {
+                result.setCipherValue(newCipherValue(e));
+            } else if (type == CipherData.REFERENCE_TYPE) {
+                result.setCipherReference(newCipherReference(e));
+            }
+
+            return result;
+        }
+
+        /**
+         * @param element
+         * @return a new CipherReference
+         * @throws XMLEncryptionException
+         *
+         */
+        CipherReference newCipherReference(Element element) throws XMLEncryptionException {
+
+            Attr uriAttr =
+                element.getAttributeNodeNS(null, EncryptionConstants._ATT_URI);
+            CipherReference result = new CipherReferenceImpl(uriAttr);
+
+            // Find any Transforms
+            NodeList transformsElements =
+                element.getElementsByTagNameNS(
+                    EncryptionConstants.EncryptionSpecNS, EncryptionConstants._TAG_TRANSFORMS);
+            Element transformsElement = (Element) transformsElements.item(0);
+
+            if (transformsElement != null) {
+                LOG.debug("Creating a DSIG based Transforms element");
+                try {
+                    result.setTransforms(new TransformsImpl(transformsElement));
+                } catch (XMLSecurityException e) {
+                    throw new XMLEncryptionException(e);
+                }
+            }
+
+            return result;
+        }
+
+        /**
+         * @param element
+         * @return a new CipherValue
+         */
+        CipherValue newCipherValue(Element element) {
+            String value = XMLUtils.getFullTextChildrenFromNode(element);
+
+            return newCipherValue(value);
+        }
+
+        /**
+         * @param element
+         * @return a new EncryptedData
+         * @throws XMLEncryptionException
+         *
+         */
+        EncryptedData newEncryptedData(Element element) throws XMLEncryptionException {
+            EncryptedData result = null;
+
+            NodeList dataElements =
+                element.getElementsByTagNameNS(
+                    EncryptionConstants.EncryptionSpecNS, EncryptionConstants._TAG_CIPHERDATA);
+
+            // Need to get the last CipherData found, as earlier ones will
+            // be for elements in the KeyInfo lists
+
+            Element dataElement =
+                (Element) dataElements.item(dataElements.getLength() - 1);
+
+            CipherData data = newCipherData(dataElement);
+
+            result = newEncryptedData(data);
+
+            result.setId(element.getAttributeNS(null, EncryptionConstants._ATT_ID));
+            result.setType(element.getAttributeNS(null, EncryptionConstants._ATT_TYPE));
+            result.setMimeType(element.getAttributeNS(null, EncryptionConstants._ATT_MIMETYPE));
+            result.setEncoding(element.getAttributeNS(null, Constants._ATT_ENCODING));
+
+            Element encryptionMethodElement =
+                (Element) element.getElementsByTagNameNS(
+                    EncryptionConstants.EncryptionSpecNS,
+                    EncryptionConstants._TAG_ENCRYPTIONMETHOD).item(0);
+            if (null != encryptionMethodElement) {
+                result.setEncryptionMethod(newEncryptionMethod(encryptionMethodElement));
+            }
+
+            // BFL 16/7/03 - simple implementation
+            // TODO: Work out how to handle relative URI
+
+            Element keyInfoElement =
+                (Element) element.getElementsByTagNameNS(
+                    Constants.SignatureSpecNS, Constants._TAG_KEYINFO).item(0);
+            if (null != keyInfoElement) {
+                KeyInfo ki = newKeyInfo(keyInfoElement);
+                result.setKeyInfo(ki);
+            }
+
+            Element encryptionPropertiesElement =
+                (Element) element.getElementsByTagNameNS(
+                    EncryptionConstants.EncryptionSpecNS,
+                    EncryptionConstants._TAG_ENCRYPTIONPROPERTIES).item(0);
+            if (null != encryptionPropertiesElement) {
+                result.setEncryptionProperties(
+                    newEncryptionProperties(encryptionPropertiesElement)
+                );
+            }
+
+            return result;
+        }
+
+        /**
+         * @param element
+         * @return a new EncryptedKey
+         * @throws XMLEncryptionException
+         */
+        EncryptedKey newEncryptedKey(Element element) throws XMLEncryptionException {
+            EncryptedKey result = null;
+            NodeList dataElements =
+                element.getElementsByTagNameNS(
+                    EncryptionConstants.EncryptionSpecNS, EncryptionConstants._TAG_CIPHERDATA);
+            Element dataElement =
+                (Element) dataElements.item(dataElements.getLength() - 1);
+
+            CipherData data = newCipherData(dataElement);
+            result = newEncryptedKey(data);
+
+            result.setId(element.getAttributeNS(null, EncryptionConstants._ATT_ID));
+            result.setType(element.getAttributeNS(null, EncryptionConstants._ATT_TYPE));
+            result.setMimeType(element.getAttributeNS(null, EncryptionConstants._ATT_MIMETYPE));
+            result.setEncoding(element.getAttributeNS(null, Constants._ATT_ENCODING));
+            result.setRecipient(element.getAttributeNS(null, EncryptionConstants._ATT_RECIPIENT));
+
+            Element encryptionMethodElement =
+                (Element) element.getElementsByTagNameNS(
+                    EncryptionConstants.EncryptionSpecNS,
+                    EncryptionConstants._TAG_ENCRYPTIONMETHOD).item(0);
+            if (null != encryptionMethodElement) {
+                result.setEncryptionMethod(newEncryptionMethod(encryptionMethodElement));
+            }
+
+            Element keyInfoElement =
+                (Element) element.getElementsByTagNameNS(
+                    Constants.SignatureSpecNS, Constants._TAG_KEYINFO).item(0);
+            if (null != keyInfoElement) {
+                KeyInfo ki = newKeyInfo(keyInfoElement);
+                result.setKeyInfo(ki);
+            }
+
+            Element encryptionPropertiesElement =
+                (Element) element.getElementsByTagNameNS(
+                    EncryptionConstants.EncryptionSpecNS,
+                    EncryptionConstants._TAG_ENCRYPTIONPROPERTIES).item(0);
+            if (null != encryptionPropertiesElement) {
+                result.setEncryptionProperties(
+                    newEncryptionProperties(encryptionPropertiesElement)
+                );
+            }
+
+            Element referenceListElement =
+                (Element) element.getElementsByTagNameNS(
+                    EncryptionConstants.EncryptionSpecNS,
+                    EncryptionConstants._TAG_REFERENCELIST).item(0);
+            if (null != referenceListElement) {
+                result.setReferenceList(newReferenceList(referenceListElement));
+            }
+
+            Element carriedNameElement =
+                (Element) element.getElementsByTagNameNS(
+                    EncryptionConstants.EncryptionSpecNS,
+                    EncryptionConstants._TAG_CARRIEDKEYNAME).item(0);
+            if (null != carriedNameElement) {
+                result.setCarriedName(carriedNameElement.getFirstChild().getNodeValue());
+            }
+
+            return result;
+        }
+
+        /**
+         * @param element
+         * @return a new KeyInfo
+         * @throws XMLEncryptionException
+         */
+        KeyInfo newKeyInfo(Element element) throws XMLEncryptionException {
+            try {
+                KeyInfoEnc ki = new KeyInfoEnc(element, null); // Liberty Change: Backport 4.x
+                ki.setSecureValidation(secureValidation);
+                if (internalKeyResolvers != null) {
+                    int size = internalKeyResolvers.size();
+                    for (int i = 0; i < size; i++) {
+                        ki.registerInternalKeyResolver(internalKeyResolvers.get(i));
+                    }
+                }
+                return ki;
+            } catch (XMLSecurityException xse) {
+                throw new XMLEncryptionException(xse, "KeyInfo.error");
+            }
+        }
+
+        /**
+         * @param element
+         * @return a new EncryptionMethod
+         */
+        EncryptionMethod newEncryptionMethod(Element element) {
+            String encAlgorithm = element.getAttributeNS(null, EncryptionConstants._ATT_ALGORITHM);
+            EncryptionMethod result = newEncryptionMethod(encAlgorithm);
+
+            Element keySizeElement =
+                (Element) element.getElementsByTagNameNS(
+                    EncryptionConstants.EncryptionSpecNS,
+                    EncryptionConstants._TAG_KEYSIZE).item(0);
+            if (null != keySizeElement) {
+                result.setKeySize(
+                    Integer.parseInt(
+                        keySizeElement.getFirstChild().getNodeValue()));
+            }
+
+            Element oaepParamsElement =
+                (Element) element.getElementsByTagNameNS(
+                    EncryptionConstants.EncryptionSpecNS,
+                    EncryptionConstants._TAG_OAEPPARAMS).item(0);
+            if (null != oaepParamsElement) {
+                String oaepParams = oaepParamsElement.getFirstChild().getNodeValue();
+                result.setOAEPparams(XMLUtils.decode(oaepParams.getBytes(StandardCharsets.UTF_8)));
+            }
+
+            Element digestElement =
+                (Element) element.getElementsByTagNameNS(
+                    Constants.SignatureSpecNS, Constants._TAG_DIGESTMETHOD).item(0);
+            if (digestElement != null) {
+                String digestAlgorithm = digestElement.getAttributeNS(null, "Algorithm");
+                result.setDigestAlgorithm(digestAlgorithm);
+            }
+
+            Element mgfElement =
+                (Element) element.getElementsByTagNameNS(
+                    EncryptionConstants.EncryptionSpec11NS, EncryptionConstants._TAG_MGF).item(0);
+            if (mgfElement != null && !XMLCipher.RSA_OAEP.equals(algorithm)) {
+                String mgfAlgorithm = mgfElement.getAttributeNS(null, "Algorithm");
+                result.setMGFAlgorithm(mgfAlgorithm);
+            }
+
+            // TODO: Make this mess work
+            // <any namespace='##other' minOccurs='0' maxOccurs='unbounded'/>
+
+            return result;
+        }
+
+        /**
+         * @param element
+         * @return a new EncryptionProperties
+         */
+        EncryptionProperties newEncryptionProperties(Element element) {
+            EncryptionProperties result = newEncryptionProperties();
+
+            result.setId(element.getAttributeNS(null, EncryptionConstants._ATT_ID));
+
+            NodeList encryptionPropertyList =
+                element.getElementsByTagNameNS(
+                    EncryptionConstants.EncryptionSpecNS,
+                    EncryptionConstants._TAG_ENCRYPTIONPROPERTY);
+            int length = encryptionPropertyList.getLength();
+            for (int i = 0; i < length; i++) {
+                Node n = encryptionPropertyList.item(i);
+                if (null != n) {
+                    result.addEncryptionProperty(newEncryptionProperty((Element) n));
+                }
+            }
+
+            return result;
+        }
+
+        /**
+         * @param element
+         * @return a new EncryptionProperty
+         */
+        EncryptionProperty newEncryptionProperty(Element element) {
+            EncryptionProperty result = newEncryptionProperty();
+
+            result.setTarget(element.getAttributeNS(null, EncryptionConstants._ATT_TARGET));
+            result.setId(element.getAttributeNS(null, EncryptionConstants._ATT_ID));
+            // TODO: Make this lot work...
+            // <anyAttribute namespace="http://www.w3.org/XML/1998/namespace"/>
+
+            // TODO: Make this work...
+            // <any namespace='##other' processContents='lax'/>
+
+            return result;
+        }
+
+        /**
+         * @param element
+         * @return a new ReferenceList
+         */
+        ReferenceList newReferenceList(Element element) {
+            int type = 0;
+            if (null != element.getElementsByTagNameNS(
+                EncryptionConstants.EncryptionSpecNS,
+                EncryptionConstants._TAG_DATAREFERENCE).item(0)) {
+                type = ReferenceList.DATA_REFERENCE;
+            } else if (null != element.getElementsByTagNameNS(
+                EncryptionConstants.EncryptionSpecNS,
+                EncryptionConstants._TAG_KEYREFERENCE).item(0)) {
+                type = ReferenceList.KEY_REFERENCE;
+            }
+
+            ReferenceList result = new ReferenceListImpl(type);
+            NodeList list = null;
+            if (ReferenceList.DATA_REFERENCE == type) {
+                list =
+                    element.getElementsByTagNameNS(
+                        EncryptionConstants.EncryptionSpecNS,
+                        EncryptionConstants._TAG_DATAREFERENCE);
+                int drLength = list.getLength();
+                for (int i = 0; i < drLength; i++) {
+                    String uri = ((Element) list.item(i)).getAttributeNS(null, "URI");
+                    result.add(result.newDataReference(uri));
+                }
+            } else if (ReferenceList.KEY_REFERENCE == type) {
+                list =
+                    element.getElementsByTagNameNS(
+                        EncryptionConstants.EncryptionSpecNS,
+                        EncryptionConstants._TAG_KEYREFERENCE);
+                int krLength = list.getLength();
+                for (int i = 0; i < krLength; i++) {
+                    String uri = ((Element) list.item(i)).getAttributeNS(null, "URI");
+                    result.add(result.newKeyReference(uri));
+                }
+            }
+
+            return result;
+        }
+
+        /**
+         * @param encryptedData
+         * @return the XML Element form of that EncryptedData
+         */
+        Element toElement(EncryptedData encryptedData) {
+            return ((EncryptedDataImpl) encryptedData).toElement();
+        }
+
+        /**
+         * @param encryptedKey
+         * @return the XML Element form of that EncryptedKey
+         */
+        Element toElement(EncryptedKey encryptedKey) {
+            return ((EncryptedKeyImpl) encryptedKey).toElement();
+        }
+
+        /**
+         * @param referenceList
+         * @return the XML Element form of that ReferenceList
+         */
+        Element toElement(ReferenceList referenceList) {
+            return ((ReferenceListImpl) referenceList).toElement();
+        }
+
+
+
+        private class CipherDataImpl implements CipherData {
+            private static final String valueMessage =
+                "Data type is reference type.";
+            private static final String referenceMessage =
+                "Data type is value type.";
+            private CipherValue cipherValue;
+            private CipherReference cipherReference;
+            private int cipherType = Integer.MIN_VALUE;
+
+            /**
+             * @param type
+             */
+            public CipherDataImpl(int type) {
+                cipherType = type;
+            }
+
+            /** {@inheritDoc} */
+            @Override
+            public CipherValue getCipherValue() {
+                return cipherValue;
+            }
+
+            /** {@inheritDoc} */
+            @Override
+            public void setCipherValue(CipherValue value) throws XMLEncryptionException {
+
+                if (cipherType == REFERENCE_TYPE) {
+                    throw new XMLEncryptionException(new UnsupportedOperationException(valueMessage));
+                }
+
+                cipherValue = value;
+            }
+
+            /** {@inheritDoc} */
+            @Override
+            public CipherReference getCipherReference() {
+                return cipherReference;
+            }
+
+            /** {@inheritDoc} */
+            @Override
+            public void setCipherReference(CipherReference reference) throws
+            XMLEncryptionException {
+                if (cipherType == VALUE_TYPE) {
+                    throw new XMLEncryptionException(
+                        new UnsupportedOperationException(referenceMessage)
+                    );
+                }
+
+                cipherReference = reference;
+            }
+
+            /** {@inheritDoc} */
+            @Override
+            public int getDataType() {
+                return cipherType;
+            }
+
+            Element toElement() {
+                Element result =
+                    XMLUtils.createElementInEncryptionSpace(
+                        contextDocument, EncryptionConstants._TAG_CIPHERDATA
+                    );
+                if (cipherType == VALUE_TYPE) {
+                    result.appendChild(((CipherValueImpl) cipherValue).toElement());
+                } else if (cipherType == REFERENCE_TYPE) {
+                    result.appendChild(((CipherReferenceImpl) cipherReference).toElement());
+                }
+
+                return result;
+            }
+        }
+
+        private class CipherReferenceImpl implements CipherReference {
+            private String referenceURI;
+            private Transforms referenceTransforms;
+            private Attr referenceNode;
+
+            /**
+             * @param uri
+             */
+            public CipherReferenceImpl(String uri) {
+                /* Don't check validity of URI as may be "" */
+                referenceURI = uri;
+                referenceNode = null;
+            }
+
+            /**
+             * @param uri
+             */
+            public CipherReferenceImpl(Attr uri) {
+                referenceURI = uri.getNodeValue();
+                referenceNode = uri;
+            }
+
+            /** {@inheritDoc} */
+            @Override
+            public String getURI() {
+                return referenceURI;
+            }
+
+            /** {@inheritDoc} */
+            @Override
+            public Attr getURIAsAttr() {
+                return referenceNode;
+            }
+
+            /** {@inheritDoc} */
+            @Override
+            public Transforms getTransforms() {
+                return referenceTransforms;
+            }
+
+            /** {@inheritDoc} */
+            @Override
+            public void setTransforms(Transforms transforms) {
+                referenceTransforms = transforms;
+            }
+
+            Element toElement() {
+                Element result =
+                    XMLUtils.createElementInEncryptionSpace(
+                        contextDocument, EncryptionConstants._TAG_CIPHERREFERENCE
+                    );
+                result.setAttributeNS(null, EncryptionConstants._ATT_URI, referenceURI);
+                if (null != referenceTransforms) {
+                    result.appendChild(((TransformsImpl) referenceTransforms).toElement());
+                }
+
+                return result;
+            }
+        }
+
+        private class CipherValueImpl implements CipherValue {
+            private String cipherValue;
+
+            /**
+             * @param value
+             */
+            public CipherValueImpl(String value) {
+                cipherValue = value;
+            }
+
+            /** {@inheritDoc} */
+            @Override
+            public String getValue() {
+                return cipherValue;
+            }
+
+            /** {@inheritDoc} */
+            @Override
+            public void setValue(String value) {
+                cipherValue = value;
+            }
+
+            Element toElement() {
+                Element result =
+                    XMLUtils.createElementInEncryptionSpace(
+                        contextDocument, EncryptionConstants._TAG_CIPHERVALUE
+                    );
+                result.appendChild(contextDocument.createTextNode(cipherValue));
+
+                return result;
+            }
+        }
+
+        private class EncryptedDataImpl extends EncryptedTypeImpl implements EncryptedData {
+
+            /**
+             * @param data
+             */
+            public EncryptedDataImpl(CipherData data) {
+                super(data);
+            }
+
+            Element toElement() {
+                Element result =
+                    ElementProxy.createElementForFamily(
+                        contextDocument, EncryptionConstants.EncryptionSpecNS,
+                        EncryptionConstants._TAG_ENCRYPTEDDATA
+                    );
+
+                if (null != super.getId()) {
+                    result.setAttributeNS(null, EncryptionConstants._ATT_ID, super.getId());
+                }
+                if (null != super.getType()) {
+                    result.setAttributeNS(null, EncryptionConstants._ATT_TYPE, super.getType());
+                }
+                if (null != super.getMimeType()) {
+                    result.setAttributeNS(
+                        null, EncryptionConstants._ATT_MIMETYPE, super.getMimeType()
+                    );
+                }
+                if (null != super.getEncoding()) {
+                    result.setAttributeNS(
+                        null, EncryptionConstants._ATT_ENCODING, super.getEncoding()
+                    );
+                }
+                if (null != super.getEncryptionMethod()) {
+                    result.appendChild(
+                        ((EncryptionMethodImpl)super.getEncryptionMethod()).toElement()
+                    );
+                }
+                if (null != super.getKeyInfo()) {
+                    result.appendChild(super.getKeyInfo().getElement().cloneNode(true));
+                }
+
+                result.appendChild(((CipherDataImpl) super.getCipherData()).toElement());
+                if (null != super.getEncryptionProperties()) {
+                    result.appendChild(((EncryptionPropertiesImpl)
+                        super.getEncryptionProperties()).toElement());
+                }
+
+                return result;
+            }
+        }
+
+        private class EncryptedKeyImpl extends EncryptedTypeImpl implements EncryptedKey {
+            private String keyRecipient;
+            private ReferenceList referenceList;
+            private String carriedName;
+
+            /**
+             * @param data
+             */
+            public EncryptedKeyImpl(CipherData data) {
+                super(data);
+            }
+
+            /** {@inheritDoc} */
+            @Override
+            public String getRecipient() {
+                return keyRecipient;
+            }
+
+            /** {@inheritDoc} */
+            @Override
+            public void setRecipient(String recipient) {
+                keyRecipient = recipient;
+            }
+
+            /** {@inheritDoc} */
+            @Override
+            public ReferenceList getReferenceList() {
+                return referenceList;
+            }
+
+            /** {@inheritDoc} */
+            @Override
+            public void setReferenceList(ReferenceList list) {
+                referenceList = list;
+            }
+
+            /** {@inheritDoc} */
+            @Override
+            public String getCarriedName() {
+                return carriedName;
+            }
+
+            /** {@inheritDoc} */
+            @Override
+            public void setCarriedName(String name) {
+                carriedName = name;
+            }
+
+            Element toElement() {
+                Element result =
+                    ElementProxy.createElementForFamily(
+                        contextDocument, EncryptionConstants.EncryptionSpecNS,
+                        EncryptionConstants._TAG_ENCRYPTEDKEY
+                    );
+
+                if (null != super.getId()) {
+                    result.setAttributeNS(null, EncryptionConstants._ATT_ID, super.getId());
+                }
+                if (null != super.getType()) {
+                    result.setAttributeNS(null, EncryptionConstants._ATT_TYPE, super.getType());
+                }
+                if (null != super.getMimeType()) {
+                    result.setAttributeNS(
+                        null, EncryptionConstants._ATT_MIMETYPE, super.getMimeType()
+                    );
+                }
+                if (null != super.getEncoding()) {
+                    result.setAttributeNS(null, Constants._ATT_ENCODING, super.getEncoding());
+                }
+                if (null != getRecipient()) {
+                    result.setAttributeNS(
+                        null, EncryptionConstants._ATT_RECIPIENT, getRecipient()
+                    );
+                }
+                if (null != super.getEncryptionMethod()) {
+                    result.appendChild(((EncryptionMethodImpl)
+                        super.getEncryptionMethod()).toElement());
+                }
+                if (null != super.getKeyInfo()) {
+                    result.appendChild(super.getKeyInfo().getElement().cloneNode(true));
+                }
+                result.appendChild(((CipherDataImpl) super.getCipherData()).toElement());
+                if (null != super.getEncryptionProperties()) {
+                    result.appendChild(((EncryptionPropertiesImpl)
+                        super.getEncryptionProperties()).toElement());
+                }
+                if (referenceList != null && !referenceList.isEmpty()) {
+                    result.appendChild(((ReferenceListImpl)getReferenceList()).toElement());
+                }
+                if (null != carriedName) {
+                    Element element =
+                        ElementProxy.createElementForFamily(
+                            contextDocument,
+                            EncryptionConstants.EncryptionSpecNS,
+                            EncryptionConstants._TAG_CARRIEDKEYNAME
+                        );
+                    Node node = contextDocument.createTextNode(carriedName);
+                    element.appendChild(node);
+                    result.appendChild(element);
+                }
+
+                return result;
+            }
+        }
+
+        private abstract class EncryptedTypeImpl {
+            private String id;
+            private String type;
+            private String mimeType;
+            private String encoding;
+            private EncryptionMethod encryptionMethod;
+            private KeyInfo keyInfo;
+            private CipherData cipherData;
+            private EncryptionProperties encryptionProperties;
+
+            /**
+             * Constructor.
+             * @param data
+             */
+            protected EncryptedTypeImpl(CipherData data) {
+                cipherData = data;
+            }
+
+            /**
+             *
+             * @return the Id
+             */
+            public String getId() {
+                return id;
+            }
+
+            /**
+             *
+             * @param id
+             */
+            public void setId(String id) {
+                this.id = id;
+            }
+
+            /**
+             *
+             * @return the type
+             */
+            public String getType() {
+                return type;
+            }
+
+            /**
+             *
+             * @param type
+             */
+            public void setType(String type) {
+                if (type == null || type.length() == 0) {
+                    this.type = null;
+                } else {
+                    URI tmpType = null;
+                    try {
+                        tmpType = new URI(type);
+                    } catch (URISyntaxException ex) {
+                        throw (IllegalArgumentException)
+                                new IllegalArgumentException().initCause(ex);
+                    }
+                    this.type = tmpType.toString();
+                }
+            }
+
+            /**
+             *
+             * @return the MimeType
+             */
+            public String getMimeType() {
+                return mimeType;
+            }
+            /**
+             *
+             * @param type
+             */
+            public void setMimeType(String type) {
+                mimeType = type;
+            }
+
+            /**
+             *
+             * @return the encoding
+             */
+            public String getEncoding() {
+                return encoding;
+            }
+
+            /**
+             *
+             * @param encoding
+             */
+            public void setEncoding(String encoding) {
+                if (encoding == null || encoding.length() == 0) {
+                    this.encoding = null;
+                } else {
+                    URI tmpEncoding = null;
+                    try {
+                        tmpEncoding = new URI(encoding);
+                    } catch (URISyntaxException ex) {
+                        throw (IllegalArgumentException)
+                                new IllegalArgumentException().initCause(ex);
+                    }
+                    this.encoding = tmpEncoding.toString();
+                }
+            }
+
+            /**
+             *
+             * @return the EncryptionMethod
+             */
+            public EncryptionMethod getEncryptionMethod() {
+                return encryptionMethod;
+            }
+
+            /**
+             *
+             * @param method
+             */
+            public void setEncryptionMethod(EncryptionMethod method) {
+                encryptionMethod = method;
+            }
+
+            /**
+             *
+             * @return the KeyInfo
+             */
+            public KeyInfo getKeyInfo() {
+                return keyInfo;
+            }
+
+            /**
+             *
+             * @param info
+             */
+            public void setKeyInfo(KeyInfo info) {
+                keyInfo = info;
+            }
+
+            /**
+             *
+             * @return the CipherData
+             */
+            public CipherData getCipherData() {
+                return cipherData;
+            }
+
+            /**
+             *
+             * @return the EncryptionProperties
+             */
+            public EncryptionProperties getEncryptionProperties() {
+                return encryptionProperties;
+            }
+
+            /**
+             *
+             * @param properties
+             */
+            public void setEncryptionProperties(EncryptionProperties properties) {
+                encryptionProperties = properties;
+            }
+        }
+
+        private class EncryptionMethodImpl implements EncryptionMethod {
+            private String algorithm;
+            private int keySize = Integer.MIN_VALUE;
+            private byte[] oaepParams;
+            private List<Element> encryptionMethodInformation;
+            private String digestAlgorithm;
+            private String mgfAlgorithm;
+
+            /**
+             * Constructor.
+             * @param algorithm
+             */
+            public EncryptionMethodImpl(String algorithm) {
+                URI tmpAlgorithm = null;
+                try {
+                    tmpAlgorithm = new URI(algorithm);
+                } catch (URISyntaxException ex) {
+                    throw (IllegalArgumentException)
+                            new IllegalArgumentException().initCause(ex);
+                }
+                this.algorithm = tmpAlgorithm.toString();
+                encryptionMethodInformation = new LinkedList<>();
+            }
+
+            /** {@inheritDoc} */
+            @Override
+            public String getAlgorithm() {
+                return algorithm;
+            }
+
+            /** {@inheritDoc} */
+            @Override
+            public int getKeySize() {
+                return keySize;
+            }
+
+            /** {@inheritDoc} */
+            @Override
+            public void setKeySize(int size) {
+                keySize = size;
+            }
+
+            /** {@inheritDoc} */
+            @Override
+            public byte[] getOAEPparams() {
+                return oaepParams;
+            }
+
+            /** {@inheritDoc} */
+            @Override
+            public void setOAEPparams(byte[] params) {
+                oaepParams = params;
+            }
+
+            /** {@inheritDoc} */
+            @Override
+            public void setDigestAlgorithm(String digestAlgorithm) {
+                this.digestAlgorithm = digestAlgorithm;
+            }
+
+            /** {@inheritDoc} */
+            @Override
+            public String getDigestAlgorithm() {
+                return digestAlgorithm;
+            }
+
+            /** {@inheritDoc} */
+            @Override
+            public void setMGFAlgorithm(String mgfAlgorithm) {
+                this.mgfAlgorithm = mgfAlgorithm;
+            }
+
+            /** {@inheritDoc} */
+            @Override
+            public String getMGFAlgorithm() {
+                return mgfAlgorithm;
+            }
+
+            /** {@inheritDoc} */
+            @Override
+            public Iterator<Element> getEncryptionMethodInformation() {
+                return encryptionMethodInformation.iterator();
+            }
+
+            /** {@inheritDoc} */
+            @Override
+            public void addEncryptionMethodInformation(Element info) {
+                encryptionMethodInformation.add(info);
+            }
+
+            /** {@inheritDoc} */
+            @Override
+            public void removeEncryptionMethodInformation(Element info) {
+                encryptionMethodInformation.remove(info);
+            }
+
+            Element toElement() {
+                Element result =
+                    XMLUtils.createElementInEncryptionSpace(
+                        contextDocument, EncryptionConstants._TAG_ENCRYPTIONMETHOD
+                    );
+                result.setAttributeNS(null, EncryptionConstants._ATT_ALGORITHM, algorithm);
+                if (keySize > 0) {
+                    result.appendChild(
+                        XMLUtils.createElementInEncryptionSpace(
+                            contextDocument, EncryptionConstants._TAG_KEYSIZE
+                    ).appendChild(contextDocument.createTextNode(String.valueOf(keySize))));
+                }
+                if (null != oaepParams) {
+                    Element oaepElement =
+                        XMLUtils.createElementInEncryptionSpace(
+                            contextDocument, EncryptionConstants._TAG_OAEPPARAMS
+                        );
+                    oaepElement.appendChild(contextDocument.createTextNode(
+                        XMLUtils.encodeToString(oaepParams)));
+                    result.appendChild(oaepElement);
+                }
+                if (digestAlgorithm != null) {
+                    Element digestElement =
+                        XMLUtils.createElementInSignatureSpace(contextDocument, Constants._TAG_DIGESTMETHOD);
+                    digestElement.setAttributeNS(null, "Algorithm", digestAlgorithm);
+                    digestElement.setAttributeNS(
+                        Constants.NamespaceSpecNS,
+                        "xmlns:" + ElementProxy.getDefaultPrefix(Constants.SignatureSpecNS),
+                        Constants.SignatureSpecNS
+                    );
+                    result.appendChild(digestElement);
+                }
+
+                if (mgfAlgorithm != null && !XMLCipher.RSA_OAEP.equals(algorithm)) { // Liberty Change: Backport 4.x
+                    Element mgfElement =
+                        XMLUtils.createElementInEncryption11Space(
+                            contextDocument, EncryptionConstants._TAG_MGF
+                        );
+                    mgfElement.setAttributeNS(null, "Algorithm", mgfAlgorithm);
+                    mgfElement.setAttributeNS(
+                        Constants.NamespaceSpecNS,
+                        "xmlns:" + ElementProxy.getDefaultPrefix(EncryptionConstants.EncryptionSpec11NS),
+                        EncryptionConstants.EncryptionSpec11NS
+                    );
+                    result.appendChild(mgfElement);
+                }
+                Iterator<Element> itr = encryptionMethodInformation.iterator();
+                while (itr.hasNext()) {
+                    result.appendChild(itr.next());
+                }
+
+
+                return result;
+            }
+        }
+
+        private class EncryptionPropertiesImpl implements EncryptionProperties {
+            private String id;
+            private List<EncryptionProperty> encryptionProperties;
+
+            /**
+             * Constructor.
+             */
+            public EncryptionPropertiesImpl() {
+                encryptionProperties = new LinkedList<>();
+            }
+
+            /** {@inheritDoc} */
+            @Override
+            public String getId() {
+                return id;
+            }
+
+            /** {@inheritDoc} */
+            @Override
+            public void setId(String id) {
+                this.id = id;
+            }
+
+            /** {@inheritDoc} */
+            @Override
+            public Iterator<EncryptionProperty> getEncryptionProperties() {
+                return encryptionProperties.iterator();
+            }
+
+            /** {@inheritDoc} */
+            @Override
+            public void addEncryptionProperty(EncryptionProperty property) {
+                encryptionProperties.add(property);
+            }
+
+            /** {@inheritDoc} */
+            @Override
+            public void removeEncryptionProperty(EncryptionProperty property) {
+                encryptionProperties.remove(property);
+            }
+
+            Element toElement() {
+                Element result =
+                    XMLUtils.createElementInEncryptionSpace(
+                        contextDocument, EncryptionConstants._TAG_ENCRYPTIONPROPERTIES
+                    );
+                if (null != id) {
+                    result.setAttributeNS(null, EncryptionConstants._ATT_ID, id);
+                }
+                Iterator<EncryptionProperty> itr = getEncryptionProperties();
+                while (itr.hasNext()) {
+                    result.appendChild(((EncryptionPropertyImpl)itr.next()).toElement());
+                }
+
+                return result;
+            }
+        }
+
+        private class EncryptionPropertyImpl implements EncryptionProperty {
+            private String target;
+            private String id;
+            private Map<String, String> attributeMap = new HashMap<>();
+            private List<Element> encryptionInformation;
+
+            /**
+             * Constructor.
+             */
+            public EncryptionPropertyImpl() {
+                encryptionInformation = new LinkedList<>();
+            }
+
+            /** {@inheritDoc} */
+            @Override
+            public String getTarget() {
+                return target;
+            }
+
+            /** {@inheritDoc} */
+            @Override
+            public void setTarget(String target) {
+                if (target == null || target.length() == 0) {
+                    this.target = null;
+                } else if (target.charAt(0) == '#') {
+                    /*
+                     * This is a same document URI reference. Do not parse,
+                     * because it has no scheme.
+                     */
+                    this.target = target;
+                } else {
+                    URI tmpTarget = null;
+                    try {
+                        tmpTarget = new URI(target);
+                    } catch (URISyntaxException ex) {
+                        throw (IllegalArgumentException)
+                                new IllegalArgumentException().initCause(ex);
+                    }
+                    this.target = tmpTarget.toString();
+                }
+            }
+
+            /** {@inheritDoc} */
+            @Override
+            public String getId() {
+                return id;
+            }
+
+            /** {@inheritDoc} */
+            @Override
+            public void setId(String id) {
+                this.id = id;
+            }
+
+            /** {@inheritDoc} */
+            @Override
+            public String getAttribute(String attribute) {
+                return attributeMap.get(attribute);
+            }
+
+            /** {@inheritDoc} */
+            @Override
+            public void setAttribute(String attribute, String value) {
+                attributeMap.put(attribute, value);
+            }
+
+            /** {@inheritDoc} */
+            @Override
+            public Iterator<Element> getEncryptionInformation() {
+                return encryptionInformation.iterator();
+            }
+
+            /** {@inheritDoc} */
+            @Override
+            public void addEncryptionInformation(Element info) {
+                encryptionInformation.add(info);
+            }
+
+            /** {@inheritDoc} */
+            @Override
+            public void removeEncryptionInformation(Element info) {
+                encryptionInformation.remove(info);
+            }
+
+            Element toElement() {
+                Element result =
+                    XMLUtils.createElementInEncryptionSpace(
+                        contextDocument, EncryptionConstants._TAG_ENCRYPTIONPROPERTY
+                    );
+                if (null != target) {
+                    result.setAttributeNS(null, EncryptionConstants._ATT_TARGET, target);
+                }
+                if (null != id) {
+                    result.setAttributeNS(null, EncryptionConstants._ATT_ID, id);
+                }
+
+                if (!attributeMap.isEmpty()) {
+                    for (Entry<String, String> entry : attributeMap.entrySet()) {
+                        result.setAttributeNS(Constants.XML_LANG_SPACE_SpecNS,
+                                              entry.getKey(), entry.getValue());
+                    }
+                }
+
+                if (!encryptionInformation.isEmpty()) {
+                    for (Element element : encryptionInformation) {
+                        result.appendChild(element);
+                    }
+                }
+
+                return result;
+            }
+        }
+
+        private class TransformsImpl extends org.apache.xml.security.transforms.Transforms
+            implements Transforms {
+
+            /**
+             * Construct Transforms
+             */
+            public TransformsImpl() {
+                super(contextDocument);
+            }
+
+            /**
+             *
+             * @param doc
+             */
+            public TransformsImpl(Document doc) {
+                if (doc == null) {
+                    throw new RuntimeException("Document is null");
+                }
+
+                setDocument(doc);
+                setElement(createElementForFamilyLocal(
+                        this.getBaseNamespace(), this.getBaseLocalName()
+                    )
+                );
+            }
+
+            /**
+             *
+             * @param element
+             * @throws XMLSignatureException
+             * @throws InvalidTransformException
+             * @throws XMLSecurityException
+             * @throws TransformationException
+             */
+            public TransformsImpl(Element element)
+                throws XMLSignatureException, InvalidTransformException,
+                    XMLSecurityException, TransformationException {
+                super(element, "");
+            }
+
+            /**
+             *
+             * @return the XML Element form of that Transforms
+             */
+            public Element toElement() {
+                if (getDocument() == null) {
+                    setDocument(contextDocument);
+                }
+
+                return getElement();
+            }
+
+            /** {@inheritDoc} */
+            @Override
+            public org.apache.xml.security.transforms.Transforms getDSTransforms() {
+                return this;
+            }
+
+            // Over-ride the namespace
+            /** {@inheritDoc} */
+            @Override
+            public String getBaseNamespace() {
+                return EncryptionConstants.EncryptionSpecNS;
+            }
+        }
+
+        private class ReferenceListImpl implements ReferenceList {
+            private Class<?> sentry;
+            private List<Reference> references;
+
+            /**
+             * Constructor.
+             * @param type
+             */
+            public ReferenceListImpl(int type) {
+                if (type == ReferenceList.DATA_REFERENCE) {
+                    sentry = DataReference.class;
+                } else if (type == ReferenceList.KEY_REFERENCE) {
+                    sentry = KeyReference.class;
+                } else {
+                    throw new IllegalArgumentException();
+                }
+                references = new LinkedList<>();
+            }
+
+            /** {@inheritDoc} */
+            @Override
+            public void add(Reference reference) {
+                if (!reference.getClass().equals(sentry)) {
+                    throw new IllegalArgumentException();
+                }
+                references.add(reference);
+            }
+
+            /** {@inheritDoc} */
+            @Override
+            public void remove(Reference reference) {
+                if (!reference.getClass().equals(sentry)) {
+                    throw new IllegalArgumentException();
+                }
+                references.remove(reference);
+            }
+
+            /** {@inheritDoc} */
+            @Override
+            public int size() {
+                return references.size();
+            }
+
+            /** {@inheritDoc} */
+            @Override
+            public boolean isEmpty() {
+                return references.isEmpty();
+            }
+
+            /** {@inheritDoc} */
+            @Override
+            public Iterator<Reference> getReferences() {
+                return references.iterator();
+            }
+
+            Element toElement() {
+                Element result =
+                    ElementProxy.createElementForFamily(
+                        contextDocument,
+                        EncryptionConstants.EncryptionSpecNS,
+                        EncryptionConstants._TAG_REFERENCELIST
+                    );
+                Iterator<Reference> eachReference = references.iterator();
+                while (eachReference.hasNext()) {
+				
+                    Reference reference = eachReference.next();
+                    result.appendChild(((ReferenceImpl)reference).toElement());
+                }
+                return result;
+            }
+
+            /** {@inheritDoc} */
+            @Override
+            public Reference newDataReference(String uri) {
+                return new DataReference(uri);
+            }
+
+            /** {@inheritDoc} */
+            @Override
+            public Reference newKeyReference(String uri) {
+                return new KeyReference(uri);
+            }
+
+            /**
+             * <code>ReferenceImpl</code> is an implementation of
+             * <code>Reference</code>.
+             *
+             * @see Reference
+             */
+            private abstract class ReferenceImpl implements Reference {
+                private String uri;
+                private List<Element> referenceInformation;
+
+                ReferenceImpl(String uri) {
+                    this.uri = uri;
+                    referenceInformation = new LinkedList<>();
+                }
+
+                /** {@inheritDoc} */
+                @Override
+                public abstract String getType();
+
+                /** {@inheritDoc} */
+                @Override
+                public String getURI() {
+                    return uri;
+                }
+
+                /** {@inheritDoc} */
+                @Override
+                public Iterator<Element> getElementRetrievalInformation() {
+                    return referenceInformation.iterator();
+                }
+
+                /** {@inheritDoc} */
+                @Override
+                public void setURI(String uri) {
+                    this.uri = uri;
+                }
+
+                /** {@inheritDoc} */
+                @Override
+                public void removeElementRetrievalInformation(Element node) {
+                    referenceInformation.remove(node);
+                }
+
+                /** {@inheritDoc} */
+                @Override
+                public void addElementRetrievalInformation(Element node) {
+                    referenceInformation.add(node);
+                }
+
+                /**
+                 * @return the XML Element form of that Reference
+                 */
+                public Element toElement() {
+                    String tagName = getType();
+                    Element result =
+                        ElementProxy.createElementForFamily(
+                            contextDocument,
+                            EncryptionConstants.EncryptionSpecNS,
+                            tagName
+                        );
+                    result.setAttributeNS(null, EncryptionConstants._ATT_URI, uri);
+
+                    // TODO: Need to martial referenceInformation
+                    // Figure out how to make this work..
+                    // <any namespace="##other" minOccurs="0" maxOccurs="unbounded"/>
+
+                    return result;
+                }
+            }
+
+            private class DataReference extends ReferenceImpl {
+
+                DataReference(String uri) {
+                    super(uri);
+                }
+
+                /** {@inheritDoc} */
+                @Override
+                public String getType() {
+                    return EncryptionConstants._TAG_DATAREFERENCE;
+                }
+            }
+
+            private class KeyReference extends ReferenceImpl {
+
+                KeyReference(String uri) {
+                    super(uri);
+                }
+
+                /** {@inheritDoc} */
+                @Override
+                public String getType() {
+                    return EncryptionConstants._TAG_KEYREFERENCE;
+                }
+            }
+        }
+    }
+
+    private static boolean haveFunctionalIdentityTransformer() {
+        final String xml =
+                "<a:e1 xmlns:a=\"a\" xmlns:b=\"b\">"
+                        + "<a xmlns=\"a\" xmlns:b=\"b\"/>"
+                        + "</a:e1>";
+
+        try {
+            final javax.xml.transform.dom.DOMResult domResult = new javax.xml.transform.dom.DOMResult();
+            final javax.xml.transform.TransformerFactory transformerFactory =
+                    javax.xml.transform.TransformerFactory.newInstance();
+            transformerFactory.newTransformer().transform(
+                    new javax.xml.transform.stream.StreamSource(
+                            new java.io.ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8))), domResult);
+
+            boolean result = false;
+            if (domResult.getNode().getFirstChild().getFirstChild().hasAttributes()
+                && domResult.getNode().getFirstChild().getFirstChild().getAttributes().getLength() >= 2) {
+                result = "http://www.w3.org/2000/xmlns/".equals(
+                    domResult.getNode().getFirstChild().getFirstChild().getAttributes().item(1).getNamespaceURI());
+            }
+            LOG.debug("Have functional IdentityTransformer: {}", result);
+            return result;
+
+        } catch (Exception e) {
+            LOG.debug(e.getMessage(), e);
+            return false;
+        }
+    }
+}

--- a/dev/com.ibm.ws.org.apache.santuario.xmlsec.2.2.0/src/org/apache/xml/security/encryption/XMLCipherUtil.java
+++ b/dev/com.ibm.ws.org.apache.santuario.xmlsec.2.2.0/src/org/apache/xml/security/encryption/XMLCipherUtil.java
@@ -65,7 +65,6 @@ public final class XMLCipherUtil {
                 || EncryptionConstants.ALGO_ID_BLOCKCIPHER_AES256_GCM.equals(algorithm)) {
             return constructBlockCipherParametersForGCMAlgorithm(algorithm, iv);
         } else {
-            LOG.debug("Saw non-AES-GCM mode block cipher, returning IvParameterSpec: {}", algorithm);
             return new IvParameterSpec(iv);
         }
     }
@@ -74,7 +73,6 @@ public final class XMLCipherUtil {
         if (gcmAlgorithm) {
             return constructBlockCipherParametersForGCMAlgorithm("AES/GCM/NoPadding", iv);
         } else {
-            LOG.debug("Saw non-AES-GCM mode block cipher, returning IvParameterSpec");
             return new IvParameterSpec(iv);
         }
     }
@@ -84,7 +82,6 @@ public final class XMLCipherUtil {
             // This override allows to support Java 1.7+ with (usually older versions of) third-party security
             // providers which support or even require GCM via IvParameterSpec rather than GCMParameterSpec,
             // e.g. BouncyCastle <= 1.49 (really <= 1.50 due to a semi-related bug).
-            LOG.debug("Saw AES-GCM block cipher, using IvParameterSpec due to system property override: {}", algorithm);
             return new IvParameterSpec(iv);
         }
 
@@ -116,24 +113,33 @@ public final class XMLCipherUtil {
         if (XMLCipher.RSA_OAEP.equals(encryptionAlgorithmURI)
                 || XMLCipher.RSA_OAEP_11.equals(encryptionAlgorithmURI)) {
 
-            // Liberty Change Start: set FIPS default
+             // Liberty Change Start: set FIPS default
             String jceDigestAlgorithm = CryptoUtils.isFips140_3Enabled() ? "SHA-256" : "SHA-1";
             digestAlgorithmURI = CryptoUtils.isFips140_3Enabled() 
-                   ? "http://www.w3.org/2001/04/xmlenc#sha256"
-                   : "http://www.w3.org/2000/09/xmldsig#sha1";
+                                  ? "http://www.w3.org/2001/04/xmlenc#sha256"
+                                  : "http://www.w3.org/2000/09/xmldsig#sha1";
             // Liberty Change End
+
             if (digestAlgorithmURI != null) {
                 jceDigestAlgorithm = JCEMapper.translateURItoJCEID(digestAlgorithmURI);
             }
 
+            // Liberty Change Start: set FIPS default
+            mgfAlgorithmURI = CryptoUtils.isFips140_3Enabled() 
+                               ? "http://www.w3.org/2009/xmlenc11#mgf1sha256"
+                               : "http://www.w3.org/2009/xmlenc11#mgf1sha1";
+            // Liberty Change End
+
             PSource.PSpecified pSource = oaepParams == null ?
                     PSource.PSpecified.DEFAULT : new PSource.PSpecified(oaepParams);
-
+       
             // Liberty Change Start: set FIPS default
             MGF1ParameterSpec mgfParameterSpec = CryptoUtils.isFips140_3Enabled() ? new MGF1ParameterSpec("SHA-256") : new MGF1ParameterSpec("SHA-1");
             // Liberty Change End
+
             if (XMLCipher.RSA_OAEP_11.equals(encryptionAlgorithmURI)) {
                 mgfParameterSpec = constructMGF1Parameter(mgfAlgorithmURI);
+                LOG.debug("line 142, mgfParameterSpec, mgfAlgorithmURI is:  " +mgfParameterSpec +mgfAlgorithmURI);
             }
             return new OAEPParameterSpec(jceDigestAlgorithm, "MGF1", mgfParameterSpec, pSource);
         }
@@ -160,7 +166,8 @@ public final class XMLCipherUtil {
             LOG.debug( "MGF1 algorithm URI is null or empty. Using SHA-1 as default.");
             return new MGF1ParameterSpec("SHA-1");
            }
-        } // Liberty Change End
+        }
+        // Liberty Change End
 
         switch (mgh1AlgorithmURI) {
             case EncryptionConstants.MGF1_SHA1:

--- a/dev/com.ibm.ws.org.apache.santuario.xmlsec.2.2.0/src/org/apache/xml/security/encryption/XMLCipherUtil.java
+++ b/dev/com.ibm.ws.org.apache.santuario.xmlsec.2.2.0/src/org/apache/xml/security/encryption/XMLCipherUtil.java
@@ -1,0 +1,328 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.xml.security.encryption;
+
+import org.apache.xml.security.algorithms.JCEMapper;
+import org.apache.xml.security.encryption.keys.content.derivedKey.ConcatKDFParamsImpl;
+import org.apache.xml.security.encryption.keys.content.derivedKey.HKDFParamsImpl;
+import org.apache.xml.security.encryption.keys.content.derivedKey.KDFParams;
+import org.apache.xml.security.encryption.params.ConcatKDFParams;
+import org.apache.xml.security.encryption.params.HKDFParams;
+import org.apache.xml.security.encryption.params.KeyAgreementParameters;
+import org.apache.xml.security.encryption.params.KeyDerivationParameters;
+import org.apache.xml.security.exceptions.XMLSecurityException;
+import org.apache.xml.security.utils.EncryptionConstants;
+import org.apache.xml.security.utils.KeyUtils;
+
+import com.ibm.ws.common.crypto.CryptoUtils;
+
+import javax.crypto.spec.GCMParameterSpec;
+import javax.crypto.spec.IvParameterSpec;
+import javax.crypto.spec.OAEPParameterSpec;
+import javax.crypto.spec.PSource;
+import java.security.*;
+import java.security.spec.AlgorithmParameterSpec;
+import java.security.spec.MGF1ParameterSpec;
+import java.util.Base64;
+
+public final class XMLCipherUtil {
+
+    private static final org.slf4j.Logger LOG =
+        org.slf4j.LoggerFactory.getLogger(XMLCipherUtil.class);
+
+    private static final boolean gcmUseIvParameterSpec =
+        AccessController.doPrivileged((PrivilegedAction<Boolean>)
+            () -> Boolean.getBoolean("org.apache.xml.security.cipher.gcm.useIvParameterSpec"));
+
+    /**
+     * Build an <code>AlgorithmParameterSpec</code> instance used to initialize a <code>Cipher</code> instance
+     * for block cipher encryption and decryption.
+     *
+     * @param algorithm the XML encryption algorithm URI
+     * @param iv the initialization vector
+     * @return the newly constructed AlgorithmParameterSpec instance, appropriate for the
+     *         specified algorithm
+     */
+    public static AlgorithmParameterSpec constructBlockCipherParameters(String algorithm, byte[] iv) {
+        if (EncryptionConstants.ALGO_ID_BLOCKCIPHER_AES128_GCM.equals(algorithm)
+                || EncryptionConstants.ALGO_ID_BLOCKCIPHER_AES192_GCM.equals(algorithm)
+                || EncryptionConstants.ALGO_ID_BLOCKCIPHER_AES256_GCM.equals(algorithm)) {
+            return constructBlockCipherParametersForGCMAlgorithm(algorithm, iv);
+        } else {
+            LOG.debug("Saw non-AES-GCM mode block cipher, returning IvParameterSpec: {}", algorithm);
+            return new IvParameterSpec(iv);
+        }
+    }
+
+    public static AlgorithmParameterSpec constructBlockCipherParameters(boolean gcmAlgorithm, byte[] iv) {
+        if (gcmAlgorithm) {
+            return constructBlockCipherParametersForGCMAlgorithm("AES/GCM/NoPadding", iv);
+        } else {
+            LOG.debug("Saw non-AES-GCM mode block cipher, returning IvParameterSpec");
+            return new IvParameterSpec(iv);
+        }
+    }
+
+    private static AlgorithmParameterSpec constructBlockCipherParametersForGCMAlgorithm(String algorithm, byte[] iv) {
+        if (gcmUseIvParameterSpec) {
+            // This override allows to support Java 1.7+ with (usually older versions of) third-party security
+            // providers which support or even require GCM via IvParameterSpec rather than GCMParameterSpec,
+            // e.g. BouncyCastle <= 1.49 (really <= 1.50 due to a semi-related bug).
+            LOG.debug("Saw AES-GCM block cipher, using IvParameterSpec due to system property override: {}", algorithm);
+            return new IvParameterSpec(iv);
+        }
+
+        LOG.debug("Saw AES-GCM block cipher, attempting to create GCMParameterSpec: {}", algorithm);
+
+        GCMParameterSpec gcmSpec = new GCMParameterSpec(128, iv);
+        LOG.debug("Successfully created GCMParameterSpec");
+        return gcmSpec;
+    }
+
+
+	// Liberty Change Start: Backport 4.x
+    /**
+     * Method buildOAEPParameters from given parameters and returns OAEPParameterSpec. If encryptionAlgorithmURI is
+     * not RSA_OAEP or RSA_OAEP_11, null is returned.
+     *
+     * @param encryptionAlgorithmURI the encryption algorithm URI (RSA_OAEP or RSA_OAEP_11)
+     * @param digestAlgorithmURI     the digest algorithm URI
+     * @param mgfAlgorithmURI        the MGF algorithm URI if encryptionAlgorithmURI is RSA_OAEP_11, otherwise parameter is ignored
+     * @param oaepParams             the OAEP parameters bytes
+     * @return OAEPParameterSpec or null if encryptionAlgorithmURI is not RSA_OAEP or RSA_OAEP_11
+     */
+    public static OAEPParameterSpec constructOAEPParameters(
+            String encryptionAlgorithmURI,
+            String digestAlgorithmURI,
+            String mgfAlgorithmURI,
+            byte[] oaepParams
+    ) {
+        if (XMLCipher.RSA_OAEP.equals(encryptionAlgorithmURI)
+                || XMLCipher.RSA_OAEP_11.equals(encryptionAlgorithmURI)) {
+
+            // Liberty Change Start: set FIPS default
+            String jceDigestAlgorithm = CryptoUtils.isFips140_3Enabled() ? "SHA-256" : "SHA-1";
+            digestAlgorithmURI = CryptoUtils.isFips140_3Enabled() 
+                   ? "http://www.w3.org/2001/04/xmlenc#sha256"
+                   : "http://www.w3.org/2000/09/xmldsig#sha1";
+            // Liberty Change End
+            if (digestAlgorithmURI != null) {
+                jceDigestAlgorithm = JCEMapper.translateURItoJCEID(digestAlgorithmURI);
+            }
+
+            PSource.PSpecified pSource = oaepParams == null ?
+                    PSource.PSpecified.DEFAULT : new PSource.PSpecified(oaepParams);
+
+            // Liberty Change Start: set FIPS default
+            MGF1ParameterSpec mgfParameterSpec = CryptoUtils.isFips140_3Enabled() ? new MGF1ParameterSpec("SHA-256") : new MGF1ParameterSpec("SHA-1");
+            // Liberty Change End
+            if (XMLCipher.RSA_OAEP_11.equals(encryptionAlgorithmURI)) {
+                mgfParameterSpec = constructMGF1Parameter(mgfAlgorithmURI);
+            }
+            return new OAEPParameterSpec(jceDigestAlgorithm, "MGF1", mgfParameterSpec, pSource);
+        }
+        return null;
+    }
+
+    /**
+     * Create MGF1ParameterSpec for the given algorithm URI
+     *
+     * @param mgh1AlgorithmURI the algorithm URI. If null or empty, SHA-1 is used as default MGF1 digest algorithm.
+     * @return the MGF1ParameterSpec for the given algorithm URI
+     */
+    public static MGF1ParameterSpec constructMGF1Parameter(String mgh1AlgorithmURI) {
+        LOG.debug("Creating MGF1ParameterSpec for " + mgh1AlgorithmURI);
+        // Liberty Change Start: set FIPS default
+        if (CryptoUtils.isFips140_3Enabled()) {
+           if (mgh1AlgorithmURI == null || mgh1AlgorithmURI.isEmpty()) {
+            LOG.debug( "MGF1 algorithm URI is null or empty. Using SHA-256 as default.");
+            return new MGF1ParameterSpec("SHA-256");
+           } 
+        }
+        else {
+           if (mgh1AlgorithmURI == null || mgh1AlgorithmURI.isEmpty()) {
+            LOG.debug( "MGF1 algorithm URI is null or empty. Using SHA-1 as default.");
+            return new MGF1ParameterSpec("SHA-1");
+           }
+        } // Liberty Change End
+
+        switch (mgh1AlgorithmURI) {
+            case EncryptionConstants.MGF1_SHA1:
+                return new MGF1ParameterSpec("SHA-1");
+            case EncryptionConstants.MGF1_SHA224:
+                return new MGF1ParameterSpec("SHA-224");
+            case EncryptionConstants.MGF1_SHA256:
+                return new MGF1ParameterSpec("SHA-256");
+            case EncryptionConstants.MGF1_SHA384:
+                return new MGF1ParameterSpec("SHA-384");
+            case EncryptionConstants.MGF1_SHA512:
+                return new MGF1ParameterSpec("SHA-512");
+            default:
+               LOG.debug("Unsupported MGF algorithm: [{0}] Using SHA-1 as default.", mgh1AlgorithmURI);
+                return new MGF1ParameterSpec("SHA-1");
+        }
+    }
+
+    /**
+     * Get the MGF1 algorithm URI for the given MGF1ParameterSpec
+     *
+     * @param parameterSpec the MGF1ParameterSpec
+     * @return the MGF1 algorithm URI for the given MGF1ParameterSpec
+     */
+    public static String getMgf1URIForParameter(MGF1ParameterSpec parameterSpec) {
+        String digestAlgorithm = parameterSpec.getDigestAlgorithm();
+        LOG.debug("Get MGF1 URI for digest algorithm [{0}]", digestAlgorithm);
+        switch (digestAlgorithm) {
+            case "SHA-1":
+                return EncryptionConstants.MGF1_SHA1;
+            case "SHA-224":
+                return EncryptionConstants.MGF1_SHA224;
+            case "SHA-256":
+                return EncryptionConstants.MGF1_SHA256;
+            case "SHA-384":
+                return EncryptionConstants.MGF1_SHA384;
+            case "SHA-512":
+                return EncryptionConstants.MGF1_SHA512;
+            default:
+                LOG.debug("Unknown hash algorithm: [{0}]  for MGF1", digestAlgorithm);
+                return EncryptionConstants.MGF1_SHA1;
+        }
+    }
+
+    /**
+     * Construct an KeyAgreementParameterSpec object from the given parameters
+     *
+     * @param keyWrapAlgoURI         key wrap algorithm
+     * @param agreementMethod        agreement method
+     * @param keyAgreementPrivateKey private key to derive the shared secret in case of Diffie-Hellman key agreements
+     */
+    public static KeyAgreementParameters constructRecipientKeyAgreementParameters(String keyWrapAlgoURI,
+                                                                                  AgreementMethod agreementMethod,
+                                                                                  PrivateKey keyAgreementPrivateKey
+    ) throws XMLSecurityException {
+        String agreementAlgorithmURI = agreementMethod.getAlgorithm();
+        int keyLength = KeyUtils.getAESKeyBitSizeForWrapAlgorithm(keyWrapAlgoURI);
+
+        KeyDerivationMethod keyDerivationMethod = agreementMethod.getKeyDerivationMethod();
+        if (keyDerivationMethod == null) {
+            throw new XMLEncryptionException("Key Derivation Algorithm is not specified");
+        }
+        KeyDerivationParameters kdp = constructKeyDerivationParameter(keyDerivationMethod, keyLength);
+
+        return constructAgreementParameters(
+                agreementAlgorithmURI, KeyAgreementParameters.ActorType.RECIPIENT, kdp,
+                keyAgreementPrivateKey, agreementMethod.getOriginatorKeyInfo().getPublicKey());
+    }
+
+    /**
+     * Construct an KeyAgreementParameterSpec object from the given parameters
+     *
+     * @param agreementAlgorithmURI  agreement algorithm URI
+     * @param actorType              the actor type (originator or recipient)
+     * @param keyDerivationParameter key derivation parameters (e.g. ConcatKDFParams for ConcatKDF key derivation)
+     * @param keyAgreementPrivateKey private key to derive the shared secret in case of Diffie-Hellman key agreements
+     * @param keyAgreementPublicKey  public key to derive the shared secret in case of Diffie-Hellman key agreements
+     */
+    public static KeyAgreementParameters constructAgreementParameters(String agreementAlgorithmURI,
+                                                                      KeyAgreementParameters.ActorType actorType,
+                                                                      KeyDerivationParameters keyDerivationParameter,
+                                                                      PrivateKey keyAgreementPrivateKey,
+                                                                      PublicKey keyAgreementPublicKey) {
+        KeyAgreementParameters ecdhKeyAgreementParameters = new KeyAgreementParameters(
+                actorType,
+                agreementAlgorithmURI, keyDerivationParameter);
+        if (actorType == KeyAgreementParameters.ActorType.RECIPIENT) {
+            ecdhKeyAgreementParameters.setRecipientPrivateKey(keyAgreementPrivateKey);
+            ecdhKeyAgreementParameters.setOriginatorPublicKey(keyAgreementPublicKey);
+        } else {
+            ecdhKeyAgreementParameters.setOriginatorPrivateKey(keyAgreementPrivateKey);
+            ecdhKeyAgreementParameters.setRecipientPublicKey(keyAgreementPublicKey);
+        }
+
+        return ecdhKeyAgreementParameters;
+    }
+
+    /**
+     * Construct a KeyDerivationParameter object from the given keyDerivationMethod data
+     * and keyBitLength.
+     *
+     * @param keyDerivationMethod element with the key derivation method data
+     * @param keyBitLength        expected derived key length in bits
+     * @return KeyDerivationParameters data
+     * @throws XMLEncryptionException if KDFParams cannot be created or the
+     * KDF URI is not supported or the key derivation parameters are invalid
+     */
+    public static KeyDerivationParameters constructKeyDerivationParameter(KeyDerivationMethod keyDerivationMethod,
+                                                                          int keyBitLength) throws XMLEncryptionException {
+        String keyDerivationAlgorithm = keyDerivationMethod.getAlgorithm();
+        KDFParams kdfParams;
+        try {
+            kdfParams = keyDerivationMethod.getKDFParams();
+        } catch (XMLSecurityException e) {
+            throw new XMLEncryptionException(e);
+        }
+        if (EncryptionConstants.ALGO_ID_KEYDERIVATION_CONCATKDF.equals(keyDerivationAlgorithm)) {
+            if (!(kdfParams instanceof ConcatKDFParamsImpl)) {
+                throw new XMLEncryptionException("KeyDerivation.InvalidParametersType", keyDerivationAlgorithm, ConcatKDFParamsImpl.class.getName());
+            }
+            ConcatKDFParamsImpl concatKDFParams = (ConcatKDFParamsImpl) kdfParams;
+            return ConcatKDFParams.createBuilder(keyBitLength, concatKDFParams.getDigestMethod())
+                    .algorithmID(concatKDFParams.getAlgorithmId())
+                    .partyUInfo(concatKDFParams.getPartyUInfo())
+                    .partyVInfo(concatKDFParams.getPartyVInfo())
+                    .suppPubInfo(concatKDFParams.getSuppPubInfo())
+                    .suppPrivInfo(concatKDFParams.getSuppPrivInfo())
+                    .build();
+
+        } else if (EncryptionConstants.ALGO_ID_KEYDERIVATION_HKDF.equals(keyDerivationAlgorithm)) {
+            if (!(kdfParams instanceof HKDFParamsImpl)) {
+                throw new XMLEncryptionException("KeyDerivation.InvalidParametersType", keyDerivationAlgorithm, HKDFParamsImpl.class.getName());
+            }
+            HKDFParamsImpl hKDFParams = (HKDFParamsImpl) kdfParams;
+            return HKDFParams.createBuilder(keyBitLength, hKDFParams.getPRFAlgorithm())
+                    .salt(hKDFParams.getSalt() != null ? Base64.getDecoder().decode(hKDFParams.getSalt()) : null)
+                    .info(hKDFParams.getInfo() != null ? Base64.getDecoder().decode(hKDFParams.getInfo()) : null)
+                    .build();
+        }
+        throw new XMLEncryptionException("unknownAlgorithm", keyDerivationAlgorithm);
+    }
+
+    /**
+     * Method hexStringToByteArray converts hex string to byte array.
+     *
+     * @param hexString the hex string to convert
+     * @return the byte array of the input param, empty array if the hex string is empty, or null if input param is null
+     */
+    public static byte[] hexStringToByteArray(String hexString) {
+        if (hexString == null){
+            return null;
+        }
+        if (hexString.isEmpty()) {
+            return new byte[0];
+        }
+        int len = hexString.length();
+        byte[] data = new byte[len / 2];
+        for (int i = 0; i < len; i += 2) {
+            data[i / 2] = (byte) ((Character.digit(hexString.charAt(i), 16) << 4)
+                    + Character.digit(hexString.charAt(i+1), 16));
+        }
+        return data;
+    }
+	// Liberty Change End 
+}

--- a/dev/com.ibm.ws.org.apache.wss4j.ws.security.common/src/org/apache/wss4j/common/crypto/AlgorithmSuiteValidator.java
+++ b/dev/com.ibm.ws.org.apache.wss4j.ws.security.common/src/org/apache/wss4j/common/crypto/AlgorithmSuiteValidator.java
@@ -32,6 +32,8 @@ import org.apache.wss4j.common.ext.WSSecurityException;
 import org.apache.xml.security.exceptions.DERDecodingException;
 import org.apache.xml.security.utils.DERDecoderUtils;
 import org.apache.xml.security.utils.KeyUtils;
+import com.ibm.ws.common.crypto.CryptoUtils;
+
 
 /**
  * Validate signature/encryption/etc. algorithms against an AlgorithmSuite policy.
@@ -90,6 +92,14 @@ public class AlgorithmSuiteValidator {
         String signatureMethod =
             xmlSignature.getSignedInfo().getSignatureMethod().getAlgorithm();
         checkSignatureMethod(signatureMethod);
+        LOG.warn("Mei: line 95, signatureMethod is " + signatureMethod);
+        // Liberty Change Start: set FIPS Digest
+        //To use Basic256Sha256 algorithm suite in policy, we need to use same signatureMethod fips and no-fips
+        //not needed?if (signatureMethod.equals("http://www.w3.org/2001/04/xmldsig-more#hmac-sha384")) {
+        //    signatureMethod = "http://www.w3.org/2001/04/xmldsig-more#hmac-sha256";
+        //    LOG.warn("Mei: line 100, signatureMethod is " + signatureMethod);
+        //}
+        // Liberty Change End
 
         // C14n Algorithm
         String c14nMethod =
@@ -100,7 +110,20 @@ public class AlgorithmSuiteValidator {
             Reference reference = (Reference)refObject;
             // Digest Algorithm
             String digestMethod = reference.getDigestMethod().getAlgorithm();
+            LOG.debug("Mei: line 112 no fips, digestMethod is: " +digestMethod);
+
+            // Liberty Change Start: set FIPS Digest
+            //if (CryptoUtils.isFips140_3Enabled() && digestMethod.equals("http://www.w3.org/2000/09/xmldsig#sha1")) {
+            //To use Basic256Sha256 algorithm suite in policy, we need to use same digest fips and no-fips
+            if (digestMethod.equals("http://www.w3.org/2000/09/xmldsig#sha1")) {
+                digestMethod = "http://www.w3.org/2001/04/xmlenc#sha256";
+                LOG.warn("Mei: line 119, digestMethod is " + digestMethod);
+            }
+            // Liberty Change End
+
             Set<String> allowedDigestAlgorithms = algorithmSuite.getDigestAlgorithms();
+             LOG.debug("Mei: line 115 no fips, allowedDigestAlgorithms is: " +allowedDigestAlgorithms);
+
             if (!allowedDigestAlgorithms.isEmpty()
                     && !allowedDigestAlgorithms.contains(digestMethod)) {
                 LOG.warn(
@@ -181,6 +204,7 @@ public class AlgorithmSuiteValidator {
         String symmetricAlgorithm
     ) throws WSSecurityException {
         Set<String> encryptionMethods = algorithmSuite.getEncryptionMethods();
+        LOG.warn("Mei: line 185, encryptionMethods is  " +encryptionMethods);
         if (!encryptionMethods.isEmpty()
             && !encryptionMethods.contains(symmetricAlgorithm)) {
             LOG.warn(

--- a/dev/com.ibm.ws.org.apache.wss4j.ws.security.common/src/org/apache/wss4j/common/derivedKey/P_SHA1.java
+++ b/dev/com.ibm.ws.org.apache.wss4j.ws.security.common/src/org/apache/wss4j/common/derivedKey/P_SHA1.java
@@ -1,0 +1,132 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.wss4j.common.derivedKey;
+
+/**
+ *
+ <pre>
+ P_SHA-1 DEFINITION
+ ==================
+ <b>P_SHA-1(secret, seed)</b> =
+ HMAC_SHA-1(secret, A(1) + seed) +
+ HMAC_SHA-1(secret, A(2) + seed) +
+ HMAC_SHA-1(secret, A(3) + seed) + ...
+ <i>Where + indicates concatenation.</i>
+ <br>
+ A() is defined as:
+ A(0) = seed
+ A(i) = HMAC_SHA-1(secret, A(i-1))
+ <br>
+ <i>Source : RFC 2246 - The TLS Protocol Version 1.0
+ Section 5. HMAC and the pseudorandom function</i>
+ </pre>
+ */
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import javax.security.auth.DestroyFailedException;
+
+import org.apache.wss4j.common.ext.WSSecurityException;
+
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+
+import com.ibm.ws.common.crypto.CryptoUtils;
+
+public class P_SHA1 implements DerivationAlgorithm {
+
+    private static final org.slf4j.Logger LOG =
+        org.slf4j.LoggerFactory.getLogger(P_SHA1.class);
+
+    @Override
+    public byte[] createKey(byte[] secret, byte[] seed, int offset, long length)
+            throws WSSecurityException {
+
+        try {
+            // Liberty Change Start: set FIPS default
+            Mac mac = CryptoUtils.isFips140_3Enabled() ? Mac.getInstance("HmacSHA256") : Mac.getInstance("HmacSHA1");
+            // Liberty Change End
+ 
+            LOG.debug("Mei: line 67, mac is " +mac);
+            length = CryptoUtils.isFips140_3Enabled() ? 24 : 16;
+            byte[] tempBytes = pHash(secret, seed, mac, offset + (int) length);
+           
+            byte[] key = new byte[(int) length];
+            LOG.debug("Mei: line 71, key is " +key);
+            LOG.debug("Mei: line 72, key.length is " +key.length);
+            System.arraycopy(tempBytes, offset, key, 0, key.length);
+            LOG.debug("Mei: line 74, after arraycopy, key is " +key);
+
+            return key;
+        } catch (NoSuchAlgorithmException | InvalidKeyException e) {
+            throw new WSSecurityException(WSSecurityException.ErrorCode.FAILURE, e, "errorInKeyDerivation");
+        }
+    }
+
+    /**
+     * P_hash as defined in RFC 2246 for TLS.
+     *
+     * @param secret is the key for the HMAC
+     * @param seed the seed value to start the generation - A(0)
+     * @param mac the HMAC algorithm
+     * @param required number of bytes to generate
+     * @return a byte array that contains a secret key
+     * @throws InvalidKeyException
+     */
+    private static byte[] pHash(byte[] secret, byte[] seed, Mac mac, int required)
+            throws InvalidKeyException {
+ 
+        required =  CryptoUtils.isFips140_3Enabled() ? 24 : 16;
+        
+        LOG.debug("Mei: line 96, after fips required is " +required);
+        byte[] out = new byte[required];
+        int offset = 0, tocpy;
+        byte[] a = seed; // a(0) is the seed
+        byte[] tmp;
+
+        // Liberty Change Start: set FIPS default
+        SecretKeySpec key = CryptoUtils.isFips140_3Enabled() ? new SecretKeySpec(secret, "HMACSHA256") : new SecretKeySpec(secret, "HMACSHA1");
+        // Liberty Change End
+        LOG.debug("Mei: line 105, key is " +key);
+        mac.init(key);
+
+        int bytesRequired = required;
+        LOG.debug("Mei: line 109, bytesRequired is " +bytesRequired);
+        while (bytesRequired > 0) {
+            mac.update(a);
+            a = mac.doFinal();
+            mac.update(a);
+            mac.update(seed);
+            tmp = mac.doFinal();
+            tocpy = Math.min(bytesRequired, tmp.length);
+            LOG.debug("Mei: line 117, tocpy is " +tocpy);
+            System.arraycopy(tmp, 0, out, offset, tocpy);
+            offset += tocpy;
+            bytesRequired -= tocpy;
+        }
+
+        try {
+               key.destroy();
+        } catch (DestroyFailedException e) {
+               LOG.debug("Error destroying key: {}", e.getMessage());
+        }
+        return out;
+    }
+}

--- a/dev/com.ibm.ws.org.apache.wss4j.ws.security.common/src/org/apache/wss4j/common/derivedKey/P_SHA1.java-org
+++ b/dev/com.ibm.ws.org.apache.wss4j.ws.security.common/src/org/apache/wss4j/common/derivedKey/P_SHA1.java-org
@@ -1,0 +1,116 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.wss4j.common.derivedKey;
+
+/**
+ *
+ <pre>
+ P_SHA-1 DEFINITION
+ ==================
+ <b>P_SHA-1(secret, seed)</b> =
+ HMAC_SHA-1(secret, A(1) + seed) +
+ HMAC_SHA-1(secret, A(2) + seed) +
+ HMAC_SHA-1(secret, A(3) + seed) + ...
+ <i>Where + indicates concatenation.</i>
+ <br>
+ A() is defined as:
+ A(0) = seed
+ A(i) = HMAC_SHA-1(secret, A(i-1))
+ <br>
+ <i>Source : RFC 2246 - The TLS Protocol Version 1.0
+ Section 5. HMAC and the pseudorandom function</i>
+ </pre>
+ */
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import javax.security.auth.DestroyFailedException;
+
+import org.apache.wss4j.common.ext.WSSecurityException;
+
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+
+public class P_SHA1 implements DerivationAlgorithm {
+
+    private static final org.slf4j.Logger LOG =
+        org.slf4j.LoggerFactory.getLogger(P_SHA1.class);
+
+    @Override
+    public byte[] createKey(byte[] secret, byte[] seed, int offset, long length)
+            throws WSSecurityException {
+
+        try {
+            Mac mac = Mac.getInstance("HmacSHA1");
+
+            byte[] tempBytes = pHash(secret, seed, mac, offset + (int) length);
+
+            byte[] key = new byte[(int) length];
+
+            System.arraycopy(tempBytes, offset, key, 0, key.length);
+
+            return key;
+        } catch (NoSuchAlgorithmException | InvalidKeyException e) {
+            throw new WSSecurityException(WSSecurityException.ErrorCode.FAILURE, e, "errorInKeyDerivation");
+        }
+    }
+
+    /**
+     * P_hash as defined in RFC 2246 for TLS.
+     *
+     * @param secret is the key for the HMAC
+     * @param seed the seed value to start the generation - A(0)
+     * @param mac the HMAC algorithm
+     * @param required number of bytes to generate
+     * @return a byte array that contains a secret key
+     * @throws InvalidKeyException
+     */
+    private static byte[] pHash(byte[] secret, byte[] seed, Mac mac, int required)
+            throws InvalidKeyException {
+
+        byte[] out = new byte[required];
+        int offset = 0, tocpy;
+        byte[] a = seed; // a(0) is the seed
+        byte[] tmp;
+
+        SecretKeySpec key = new SecretKeySpec(secret, "HMACSHA1");
+        mac.init(key);
+
+        int bytesRequired = required;
+        while (bytesRequired > 0) {
+            mac.update(a);
+            a = mac.doFinal();
+            mac.update(a);
+            mac.update(seed);
+            tmp = mac.doFinal();
+            tocpy = Math.min(bytesRequired, tmp.length);
+            System.arraycopy(tmp, 0, out, offset, tocpy);
+            offset += tocpy;
+            bytesRequired -= tocpy;
+        }
+
+        try {
+            key.destroy();
+        } catch (DestroyFailedException e) {
+            LOG.debug("Error destroying key: {}", e.getMessage());
+        }
+        return out;
+    }
+}

--- a/dev/com.ibm.ws.org.apache.wss4j.ws.security.common/src/org/apache/wss4j/common/util/KeyUtils.java
+++ b/dev/com.ibm.ws.org.apache.wss4j.ws.security.common/src/org/apache/wss4j/common/util/KeyUtils.java
@@ -44,7 +44,11 @@ public final class KeyUtils {
     private static final int MAX_SYMMETRIC_KEY_SIZE = 1024;
     private static final Map<String, Integer> DEFAULT_DERIVED_KEY_LENGTHS = new HashMap<>();
 
-    public static final String RSA_ECB_OAEPWITH_SHA1_AND_MGF1_PADDING = "RSA/ECB/OAEPWithSHA1AndMGF1Padding";
+    // Liberty Change Start: set FIPS default
+    public static final String oaepAlgorithm = CryptoUtils.isFips140_3Enabled() 
+                    ? "RSA/ECB/OAEPWithSHA-256AndMGF1Padding"
+                    : "RSA/ECB/OAEPWithSHA1AndMGF1Padding";
+    // Liberty Change End
 
     /**
      * A cached MessageDigest object
@@ -153,6 +157,13 @@ public final class KeyUtils {
      */
     public static Cipher getCipherInstance(String cipherAlgo)
         throws WSSecurityException {
+        // Liberty Change Start: set FIPS default for RSA-OAEP algorithm
+        if (XMLCipher.RSA_OAEP.equals(cipherAlgo) || XMLCipher.RSA_OAEP_11.equals(cipherAlgo)) {
+            cipherAlgo = CryptoUtils.isFips140_3Enabled() 
+                          ? "http://www.w3.org/2009/xmlenc11#rsa-oaep"
+                          : "http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p";
+        }
+        // Liberty Change End
         return getCipherInstance(cipherAlgo, null);
     }
 
@@ -165,6 +176,14 @@ public final class KeyUtils {
      */
     public static Cipher getCipherInstance(String cipherAlgo, String provider)
             throws WSSecurityException {
+        // Liberty Change Start: set FIPS default for RSA-OAEP algorithm
+        if (XMLCipher.RSA_OAEP.equals(cipherAlgo) || XMLCipher.RSA_OAEP_11.equals(cipherAlgo)) {
+           cipherAlgo = CryptoUtils.isFips140_3Enabled()
+                        ? "http://www.w3.org/2009/xmlenc11#rsa-oaep"
+                        : "http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p";
+        }
+        // Liberty Change End
+        
         String keyAlgorithm = JCEMapper.translateURItoJCEID(cipherAlgo);
         if (keyAlgorithm == null) {
             throw new WSSecurityException(
@@ -185,31 +204,35 @@ public final class KeyUtils {
                 return Cipher.getInstance(keyAlgorithm, provider);
             }
         } catch (NoSuchPaddingException | NoSuchAlgorithmException e) {
-            if (XMLCipher.RSA_OAEP.equals(cipherAlgo)) {
-                // Check to see if an RSA OAEP MGF-1 with SHA-1 algorithm was requested
+            // Liberty Change Start: set condition if RSA_OAEP or RSA_OAEP_11 is used
+            if (XMLCipher.RSA_OAEP.equals(cipherAlgo) || XMLCipher.RSA_OAEP_11.equals(cipherAlgo)) {
+            // Liberty Change End
+                // Check to see if an RSA OAEP MGF-1 algorithm was requested
                 // Some JCE implementations don't support RSA/ECB/OAEPPadding (e.g. nCipherKM of Thales)
+
+                // Liberty Change Start: to use oaepAlgorithm          
                 try {
                     if (provider == null) {
-                        return Cipher.getInstance(RSA_ECB_OAEPWITH_SHA1_AND_MGF1_PADDING);
+                        return Cipher.getInstance(oaepAlgorithm);
                     } else {
-                        return Cipher.getInstance(RSA_ECB_OAEPWITH_SHA1_AND_MGF1_PADDING, provider);
+                        return Cipher.getInstance(oaepAlgorithm, provider);
                     }
                 } catch (NoSuchProviderException ex1) {
                     throw new WSSecurityException(
                         WSSecurityException.ErrorCode.UNSUPPORTED_ALGORITHM, ex1, "unsupportedKeyTransp",
                         new Object[]{
                             "No such provider \"" + JCEMapper.getProviderId() + "\" for \""
-                                + RSA_ECB_OAEPWITH_SHA1_AND_MGF1_PADDING + "\""
+                                + oaepAlgorithm + "\""
                         });
                 } catch (NoSuchPaddingException ex1) {
                     throw new WSSecurityException(
                         WSSecurityException.ErrorCode.UNSUPPORTED_ALGORITHM, e, "unsupportedKeyTransp",
-                        new Object[]{"No such padding: \"" + RSA_ECB_OAEPWITH_SHA1_AND_MGF1_PADDING + "\""});
+                        new Object[]{"No such padding: \"" + oaepAlgorithm + "\""});
                 } catch (NoSuchAlgorithmException ex1) {
                     throw new WSSecurityException(
                         WSSecurityException.ErrorCode.UNSUPPORTED_ALGORITHM, e, "unsupportedKeyTransp",
-                        new Object[]{"No such algorithm: \"" + RSA_ECB_OAEPWITH_SHA1_AND_MGF1_PADDING + "\""});
-                }
+                        new Object[]{"No such algorithm: \"" + oaepAlgorithm + "\""});
+                } // Liberty Change End
             } else {
                 if (e instanceof NoSuchAlgorithmException) {    //NOPMD
                     throw new WSSecurityException(

--- a/dev/com.ibm.ws.org.apache.wss4j.ws.security.common/src/org/apache/wss4j/common/util/KeyUtils.java
+++ b/dev/com.ibm.ws.org.apache.wss4j.ws.security.common/src/org/apache/wss4j/common/util/KeyUtils.java
@@ -77,14 +77,27 @@ public final class KeyUtils {
      * @return the key length
      */
     public static int getKeyLength(String algorithm) throws WSSecurityException {
+
+        LOG.debug("Mei: line 80, algorithm is: " +algorithm); 
+        // Liberty Change Start: set FIPS Digest
+        //To use Basic256Sha256 algorithm suite in policy, we need to use same signatureMethod fips and no-fips
+        if (algorithm.equals("http://www.w3.org/2001/04/xmldsig-more#hmac-sha384")) {
+            algorithm = "http://www.w3.org/2001/04/xmldsig-more#hmac-sha256";
+            LOG.warn("Mei: line 86, algorithm is " + algorithm);
+        }
+        // Liberty Change End
+
         if (algorithm == null) {
             return 0;
         }
 
         int size = JCEMapper.getKeyLengthFromURI(algorithm);
+        LOG.debug("Mei: line 88, size is: " +size);
+
         if (size == 0 && DEFAULT_DERIVED_KEY_LENGTHS.containsKey(algorithm)) {
             // Use a default derived key length for algorithms such as HMAC-SHA1, if none is specified
             size = DEFAULT_DERIVED_KEY_LENGTHS.get(algorithm);
+           LOG.debug("Mei: line 93, if size =0 and default containsKey algorithm, then size=DEFAULT_DERIVED_KEY_LENGTHS.get(algorithm) : " +size);
         }
 
         return size / 8;
@@ -95,6 +108,9 @@ public final class KeyUtils {
      */
     public static SecretKey prepareSecretKey(String algorithm, byte[] rawKey) {
         // Do an additional check on the keysize required by the encryption algorithm
+
+        LOG.debug("Mei: line 99, algorithm is: " +algorithm); //http://www.w3.org/2001/04/xmldsig-more#hmac-sha384  
+           
         int size = 0;
         try {
             size = JCEMapper.getKeyLengthFromURI(algorithm) / 8;
@@ -102,20 +118,26 @@ public final class KeyUtils {
             // ignore - some unknown (to JCEMapper) encryption algorithm
             LOG.debug(e.getMessage());
         }
+        LOG.debug("Mei: line 115, size is: " +size);  //0
         String keyAlgorithm = JCEMapper.getJCEKeyAlgorithmFromURI(algorithm);
+        LOG.debug("Mei: line 117, keyAlgorithm is: " +keyAlgorithm); //empty
+
         SecretKeySpec keySpec;
         if (size > 0 && !algorithm.endsWith("gcm") && !algorithm.contains("hmac-")) {
+            LOG.debug("Mei: line 121, size > 0");
             keySpec =
                 new SecretKeySpec(
                     rawKey, 0, rawKey.length > size ? size : rawKey.length, keyAlgorithm
                 );
         } else if (rawKey.length > MAX_SYMMETRIC_KEY_SIZE) {
             // Prevent a possible attack where a huge secret key is specified
+            LOG.debug("Mei: line 128, rawKey.length > MAX_SYMMETRIC_KEY_SIZE ");
             keySpec =
                 new SecretKeySpec(
                     rawKey, 0, MAX_SYMMETRIC_KEY_SIZE, keyAlgorithm
                 );
         } else {
+            LOG.debug("Mei: line 134, else() ");
             keySpec = new SecretKeySpec(rawKey, keyAlgorithm);
         }
         return keySpec;
@@ -126,7 +148,35 @@ public final class KeyUtils {
             //
             // Assume AES as default, so initialize it
             //
+
+//this caused ICC_AES_GCM_EnDecryptFinal
+            // Liberty Change Start: set FIPS default
+            //if (XMLCipher.AES_128.equals(algorithm) || XMLCipher.AES_256.equals(algorithm)) {
+            //    algorithm = CryptoUtils.isFips140_3Enabled()
+            //                ? "http://www.w3.org/2009/xmlenc11#aes256-gcm"
+            //                : "http://www.w3.org/2001/04/xmlenc#aes256-cbc";
+            //}       
+            // Liberty Change End
+
+            // Liberty Change Start: set FIPS default
+            if (XMLCipher.AES_128.equals(algorithm)) {
+                algorithm = CryptoUtils.isFips140_3Enabled()
+                            ? "http://www.w3.org/2009/xmlenc11#aes128-gcm"
+                            : "http://www.w3.org/2001/04/xmlenc#aes128-cbc";
+            }       
+            // Liberty Change End
+
+            // Liberty Change Start: set FIPS default
+            if (XMLCipher.AES_256.equals(algorithm)) {
+                algorithm = CryptoUtils.isFips140_3Enabled()
+                            ? "http://www.w3.org/2009/xmlenc11#aes256-gcm"
+                            : "http://www.w3.org/2001/04/xmlenc#aes256-cbc";
+            }       
+            // Liberty Change End
+            
+            LOG.debug("Mei line 141, algorithm is: " +algorithm); //http://www.w3.org/2009/xmlenc11#aes128-gcm //http://www.w3.org/2001/04/xmlenc#aes128-cbc
             String keyAlgorithm = JCEMapper.getJCEKeyAlgorithmFromURI(algorithm);
+            LOG.debug("Mei line 142, keyAlgorithm is: " +keyAlgorithm); //AES
             if (keyAlgorithm == null || keyAlgorithm.length() == 0) {
                 keyAlgorithm = JCEMapper.translateURItoJCEID(algorithm);
             }
@@ -158,12 +208,14 @@ public final class KeyUtils {
     public static Cipher getCipherInstance(String cipherAlgo)
         throws WSSecurityException {
         // Liberty Change Start: set FIPS default for RSA-OAEP algorithm
-        if (XMLCipher.RSA_OAEP.equals(cipherAlgo) || XMLCipher.RSA_OAEP_11.equals(cipherAlgo)) {
+        if (XMLCipher.RSA_OAEP.equals(cipherAlgo) || XMLCipher.RSA_OAEP_11.equals(cipherAlgo) 
+              || XMLCipher.RSA_v1dot5.equals(cipherAlgo)) {
             cipherAlgo = CryptoUtils.isFips140_3Enabled() 
                           ? "http://www.w3.org/2009/xmlenc11#rsa-oaep"
                           : "http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p";
-        }
+        } 
         // Liberty Change End
+
         return getCipherInstance(cipherAlgo, null);
     }
 
@@ -176,12 +228,14 @@ public final class KeyUtils {
      */
     public static Cipher getCipherInstance(String cipherAlgo, String provider)
             throws WSSecurityException {
+        
         // Liberty Change Start: set FIPS default for RSA-OAEP algorithm
-        if (XMLCipher.RSA_OAEP.equals(cipherAlgo) || XMLCipher.RSA_OAEP_11.equals(cipherAlgo)) {
+        if (XMLCipher.RSA_OAEP.equals(cipherAlgo) || XMLCipher.RSA_OAEP_11.equals(cipherAlgo) 
+             || XMLCipher.RSA_v1dot5.equals(cipherAlgo)) {
            cipherAlgo = CryptoUtils.isFips140_3Enabled()
                         ? "http://www.w3.org/2009/xmlenc11#rsa-oaep"
                         : "http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p";
-        }
+        } 
         // Liberty Change End
         
         String keyAlgorithm = JCEMapper.translateURItoJCEID(cipherAlgo);
@@ -205,7 +259,8 @@ public final class KeyUtils {
             }
         } catch (NoSuchPaddingException | NoSuchAlgorithmException e) {
             // Liberty Change Start: set condition if RSA_OAEP or RSA_OAEP_11 is used
-            if (XMLCipher.RSA_OAEP.equals(cipherAlgo) || XMLCipher.RSA_OAEP_11.equals(cipherAlgo)) {
+            if (XMLCipher.RSA_OAEP.equals(cipherAlgo) || XMLCipher.RSA_OAEP_11.equals(cipherAlgo)
+                 || XMLCipher.RSA_v1dot5.equals(cipherAlgo))  {
             // Liberty Change End
                 // Check to see if an RSA OAEP MGF-1 algorithm was requested
                 // Some JCE implementations don't support RSA/ECB/OAEPPadding (e.g. nCipherKM of Thales)

--- a/dev/com.ibm.ws.org.apache.wss4j.ws.security.common/src/org/apache/wss4j/common/util/UsernameTokenUtil.java
+++ b/dev/com.ibm.ws.org.apache.wss4j.ws.security.common/src/org/apache/wss4j/common/util/UsernameTokenUtil.java
@@ -76,6 +76,7 @@ public final class UsernameTokenUtil {
                 WSSecurityException.ErrorCode.FAILURE, e, "decoding.general"
             );
         }
+        
         //
         // Make the first hash round with start value
         //

--- a/dev/com.ibm.ws.org.apache.wss4j.ws.security.dom/bnd.bnd
+++ b/dev/com.ibm.ws.org.apache.wss4j.ws.security.dom/bnd.bnd
@@ -29,4 +29,5 @@ instrument.classesExcludes: org/apache/wss4j/dom/util/*.class, \
  com.ibm.ws.org.slf4j.api;version=latest, \
  com.ibm.ws.org.apache.santuario.xmlsec.2.2.0;version=latest, \
  io.openliberty.org.opensaml.opensaml.core;version=latest, \
- com.ibm.websphere.appserver.spi.logging;version=latest
+ com.ibm.websphere.appserver.spi.logging;version=latest, \
+ com.ibm.ws.kernel.service;version=latest

--- a/dev/com.ibm.ws.org.apache.wss4j.ws.security.dom/src/org/apache/wss4j/dom/message/WSSecDKSign.java
+++ b/dev/com.ibm.ws.org.apache.wss4j.ws.security.dom/src/org/apache/wss4j/dom/message/WSSecDKSign.java
@@ -1,0 +1,398 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.wss4j.dom.message;
+
+import java.security.NoSuchProviderException;
+import java.security.Provider;
+import java.util.List;
+
+import javax.xml.crypto.XMLStructure;
+import javax.xml.crypto.dom.DOMStructure;
+import javax.xml.crypto.dsig.CanonicalizationMethod;
+import javax.xml.crypto.dsig.SignatureMethod;
+import javax.xml.crypto.dsig.SignedInfo;
+import javax.xml.crypto.dsig.XMLSignContext;
+import javax.xml.crypto.dsig.XMLSignature;
+import javax.xml.crypto.dsig.XMLSignatureFactory;
+import javax.xml.crypto.dsig.dom.DOMSignContext;
+import javax.xml.crypto.dsig.keyinfo.KeyInfo;
+import javax.xml.crypto.dsig.keyinfo.KeyInfoFactory;
+import javax.xml.crypto.dsig.spec.C14NMethodParameterSpec;
+import javax.xml.crypto.dsig.spec.ExcC14NParameterSpec;
+
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+
+import org.apache.wss4j.common.WSEncryptionPart;
+import org.apache.wss4j.common.derivedKey.ConversationConstants;
+import org.apache.wss4j.common.ext.WSSecurityException;
+import org.apache.wss4j.common.token.Reference;
+import org.apache.wss4j.common.token.SecurityTokenReference;
+import org.apache.wss4j.common.util.KeyUtils;
+import org.apache.wss4j.common.util.XMLUtils;
+import org.apache.wss4j.dom.WSConstants;
+import org.apache.wss4j.dom.WSDocInfo;
+import org.apache.wss4j.dom.transform.STRTransform;
+import org.apache.wss4j.dom.util.WSSecurityUtil;
+
+import com.ibm.ws.common.crypto.CryptoUtils;
+
+/**
+ * Builder to sign with derived keys
+ */
+public class WSSecDKSign extends WSSecDerivedKeyBase {
+
+    private static final org.slf4j.Logger LOG =
+        org.slf4j.LoggerFactory.getLogger(WSSecDKSign.class);
+
+    private String sigAlgo = WSConstants.HMAC_SHA1;
+
+    // Liberty Change Start: set FIPS default for digest algorithm
+    private String digestAlgo = CryptoUtils.isFips140_3Enabled() ? WSConstants.SHA256 : WSConstants.SHA1;
+    // Liberty Change End
+
+    private String canonAlgo = WSConstants.C14N_EXCL_OMIT_COMMENTS;
+    private byte[] signatureValue;
+
+    private String keyInfoUri;
+    private SecurityTokenReference secRef;
+    private String strUri;
+    private WSDocInfo wsDocInfo;
+
+    private XMLSignatureFactory signatureFactory;
+    private XMLSignature sig;
+    private KeyInfo keyInfo;
+    private CanonicalizationMethod c14nMethod;
+    private int derivedKeyLength = -1;
+    private boolean addInclusivePrefixes = true;
+
+    public WSSecDKSign(WSSecHeader securityHeader) {
+        super(securityHeader);
+        init(null);
+    }
+
+    public WSSecDKSign(Document doc) {
+        this(doc, null);
+    }
+
+    public WSSecDKSign(Document doc, Provider provider) {
+        super(doc);
+        init(provider);
+    }
+
+    private void init(Provider provider) {
+        if (provider == null) {
+            // Try to install the Santuario Provider - fall back to the JDK provider if this does
+            // not work
+            try {
+                signatureFactory = XMLSignatureFactory.getInstance("DOM", "ApacheXMLDSig");
+            } catch (NoSuchProviderException ex) {
+                signatureFactory = XMLSignatureFactory.getInstance("DOM");
+            }
+        } else {
+            signatureFactory = XMLSignatureFactory.getInstance("DOM", provider);
+        }
+    }
+
+    public Document build(byte[] ephemeralKey) throws WSSecurityException {
+
+        prepare(ephemeralKey);
+        if (getParts().isEmpty()) {
+            getParts().add(WSSecurityUtil.getDefaultEncryptionPart(getDocument()));
+        } else {
+            for (WSEncryptionPart part : getParts()) {
+                if ("STRTransform".equals(part.getName()) && part.getId() == null) {
+                    part.setId(strUri);
+                }
+            }
+        }
+
+        List<javax.xml.crypto.dsig.Reference> referenceList = addReferencesToSign(getParts());
+        computeSignature(referenceList);
+
+        //
+        // prepend elements in the right order to the security header
+        //
+        prependDKElementToHeader();
+
+        return getDocument();
+    }
+
+    public void prepare(byte[] ephemeralKey) throws WSSecurityException {
+        super.prepare(ephemeralKey);
+        wsDocInfo = new WSDocInfo(getDocument());
+        sig = null;
+
+        try {
+            C14NMethodParameterSpec c14nSpec = null;
+            if (addInclusivePrefixes && canonAlgo.equals(WSConstants.C14N_EXCL_OMIT_COMMENTS)) {
+                Element securityHeaderElement = getSecurityHeader().getSecurityHeaderElement();
+                List<String> prefixes =
+                    getInclusivePrefixes(securityHeaderElement, false);
+                c14nSpec = new ExcC14NParameterSpec(prefixes);
+            }
+
+           c14nMethod = signatureFactory.newCanonicalizationMethod(canonAlgo, c14nSpec);
+        } catch (Exception ex) {
+            LOG.error("", ex);
+            throw new WSSecurityException(
+                WSSecurityException.ErrorCode.FAILED_SIGNATURE, ex, "noXMLSig"
+            );
+        }
+
+        keyInfoUri = getIdAllocator().createSecureId("KI-", keyInfo);
+
+        secRef = new SecurityTokenReference(getDocument());
+        strUri = getIdAllocator().createSecureId("STR-", secRef);
+        secRef.setID(strUri);
+        if (addWSUNamespace) {
+            secRef.addWSUNamespace();
+        }
+
+        Reference ref = new Reference(getDocument());
+        ref.setURI("#" + getId());
+        String ns =
+            ConversationConstants.getWSCNs(getWscVersion())
+            + ConversationConstants.TOKEN_TYPE_DERIVED_KEY_TOKEN;
+        ref.setValueType(ns);
+        secRef.setReference(ref);
+
+        XMLStructure structure = new DOMStructure(secRef.getElement());
+        wsDocInfo.addTokenElement(secRef.getElement(), false);
+        KeyInfoFactory keyInfoFactory = signatureFactory.getKeyInfoFactory();
+        keyInfo =
+            keyInfoFactory.newKeyInfo(
+                java.util.Collections.singletonList(structure), keyInfoUri
+            );
+
+    }
+
+    /**
+     * Returns the SignatureElement.
+     * The method can be called any time after <code>prepare()</code>.
+     * @return The DOM Element of the signature.
+     */
+    public Element getSignatureElement() {
+        Element securityHeaderElement = getSecurityHeader().getSecurityHeaderElement();
+        return
+            XMLUtils.getDirectChildElement(
+                securityHeaderElement, WSConstants.SIG_LN, WSConstants.SIG_NS
+            );
+    }
+
+    /**
+     * This method adds references to the Signature.
+     *
+     * @param references The list of references to sign
+     * @throws WSSecurityException
+     */
+    public List<javax.xml.crypto.dsig.Reference> addReferencesToSign(
+        List<WSEncryptionPart> references
+    ) throws WSSecurityException {
+        return
+            addReferencesToSign(
+                getDocument(),
+                references,
+                wsDocInfo,
+                signatureFactory,
+                addInclusivePrefixes,
+                digestAlgo
+            );
+    }
+
+    /**
+     * Compute the Signature over the references.
+     *
+     * After references are set this method computes the Signature for them.
+     * This method can be called any time after the references were set. See
+     * <code>addReferencesToSign()</code>.
+     *
+     * @throws WSSecurityException
+     */
+    public void computeSignature(
+        List<javax.xml.crypto.dsig.Reference> referenceList
+    ) throws WSSecurityException {
+        computeSignature(referenceList, true, null);
+    }
+
+    /**
+     * Compute the Signature over the references.
+     *
+     * After references are set this method computes the Signature for them.
+     * This method can be called any time after the references were set. See
+     * <code>addReferencesToSign()</code>.
+     *
+     * @throws WSSecurityException
+     */
+    public void computeSignature(
+        List<javax.xml.crypto.dsig.Reference> referenceList,
+        boolean prepend,
+        Element siblingElement
+    ) throws WSSecurityException {
+        try {
+            java.security.Key key = getDerivedKey(sigAlgo);
+            SignatureMethod signatureMethod =
+                signatureFactory.newSignatureMethod(sigAlgo, null);
+            SignedInfo signedInfo =
+                signatureFactory.newSignedInfo(c14nMethod, signatureMethod, referenceList);
+
+            sig = signatureFactory.newXMLSignature(
+                    signedInfo,
+                    keyInfo,
+                    null,
+                    getIdAllocator().createId("SIG-", null),
+                    null);
+
+            //
+            // Figure out where to insert the signature element
+            //
+            XMLSignContext signContext = null;
+            Element securityHeaderElement = getSecurityHeader().getSecurityHeaderElement();
+            if (prepend) {
+                if (siblingElement == null) {
+                    siblingElement = (Element)securityHeaderElement.getFirstChild();
+                }
+                if (siblingElement == null) {
+                    signContext = new DOMSignContext(key, securityHeaderElement);
+                } else {
+                    signContext = new DOMSignContext(key, securityHeaderElement, siblingElement);
+                }
+            } else {
+                signContext = new DOMSignContext(key, securityHeaderElement);
+            }
+
+            signContext.putNamespacePrefix(WSConstants.SIG_NS, WSConstants.SIG_PREFIX);
+            if (WSConstants.C14N_EXCL_OMIT_COMMENTS.equals(canonAlgo)) {
+                signContext.putNamespacePrefix(
+                    WSConstants.C14N_EXCL_OMIT_COMMENTS,
+                    WSConstants.C14N_EXCL_OMIT_COMMENTS_PREFIX
+                );
+            }
+            signContext.setProperty(STRTransform.TRANSFORM_WS_DOC_INFO, wsDocInfo);
+            wsDocInfo.setCallbackLookup(callbackLookup);
+
+            // Add the elements to sign to the Signature Context
+            wsDocInfo.setTokensOnContext((DOMSignContext)signContext);
+
+            sig.sign(signContext);
+
+            signatureValue = sig.getSignatureValue().getValue();
+        } catch (Exception ex) {
+            LOG.error(ex.getMessage(), ex);
+            throw new WSSecurityException(
+                WSSecurityException.ErrorCode.FAILED_SIGNATURE, ex
+            );
+        }
+    }
+
+    protected int getDerivedKeyLength() throws WSSecurityException {
+        return derivedKeyLength > 0 ? derivedKeyLength : KeyUtils.getKeyLength(sigAlgo);
+    }
+
+    public void setDerivedKeyLength(int keyLength) {
+        derivedKeyLength = keyLength;
+    }
+
+    /**
+     * Set the signature algorithm to use. The default is WSConstants.SHA1.
+     * @param algorithm the signature algorithm to use.
+     */
+    public void setSignatureAlgorithm(String algorithm) {
+        sigAlgo = algorithm;
+    }
+
+    /**
+     * @return the signature algorithm to use
+     */
+    public String getSignatureAlgorithm() {
+        return sigAlgo;
+    }
+
+    /**
+     * Returns the the value of wsu:Id attribute of the Signature element.
+     *
+     * @return Return the wsu:Id of this token or null if the signature has not been generated.
+     */
+    public String getSignatureId() {
+        if (sig == null) {
+            return null;
+        }
+        return sig.getId();
+    }
+
+    /**
+     * Set the digest algorithm to use. The default is WSConstants.SHA1.
+     * @param algorithm the digest algorithm to use.
+     */
+    public void setDigestAlgorithm(String algorithm) {
+        digestAlgo = algorithm;
+    }
+
+    /**
+     * @return the digest algorithm to use
+     */
+    public String getDigestAlgorithm() {
+        return digestAlgo;
+    }
+
+    /**
+     * @return Returns the signatureValue.
+     */
+    public byte[] getSignatureValue() {
+        return signatureValue;
+    }
+
+    /**
+     * Set the canonicalization method to use.
+     *
+     * If the canonicalization method is not set then the recommended Exclusive
+     * XML Canonicalization is used by default Refer to WSConstants which
+     * algorithms are supported.
+     *
+     * @param algo Is the name of the signature algorithm
+     * @see WSConstants#C14N_OMIT_COMMENTS
+     * @see WSConstants#C14N_WITH_COMMENTS
+     * @see WSConstants#C14N_EXCL_OMIT_COMMENTS
+     * @see WSConstants#C14N_EXCL_WITH_COMMENTS
+     */
+    public void setSigCanonicalization(String algo) {
+        canonAlgo = algo;
+    }
+
+    /**
+     * Get the canonicalization method.
+     *
+     * If the canonicalization method was not set then Exclusive XML
+     * Canonicalization is used by default.
+     *
+     * @return The string describing the canonicalization algorithm.
+     */
+    public String getSigCanonicalization() {
+        return canonAlgo;
+    }
+
+    public boolean isAddInclusivePrefixes() {
+        return addInclusivePrefixes;
+    }
+
+    public void setAddInclusivePrefixes(boolean addInclusivePrefixes) {
+        this.addInclusivePrefixes = addInclusivePrefixes;
+    }
+}

--- a/dev/com.ibm.ws.org.apache.wss4j.ws.security.dom/src/org/apache/wss4j/dom/message/WSSecEncryptedKey.java
+++ b/dev/com.ibm.ws.org.apache.wss4j.ws.security.dom/src/org/apache/wss4j/dom/message/WSSecEncryptedKey.java
@@ -76,12 +76,8 @@ public class WSSecEncryptedKey extends WSSecBase {
     /**
      * Algorithm used to encrypt the ephemeral key
      */
-    // Liberty Change Start: set FIPS default
-    private String keyEncAlgo = CryptoUtils.isFips140_3Enabled() 
-                    ? WSConstants.KEYTRANSPORT_RSAOAEP_XENC11 
-                    : WSConstants.KEYTRANSPORT_RSAOAEP;
-    // Liberty Change End
-
+    private String keyEncAlgo = WSConstants.KEYTRANSPORT_RSAOAEP;
+    
     // Liberty Change Start: Backport 4.x
     /**
      * Key agreement method algorithm used to encrypt the transport key.
@@ -279,6 +275,18 @@ public class WSSecEncryptedKey extends WSSecBase {
      */
     protected void createEncryptedKeyElement(X509Certificate remoteCert, Crypto crypto, KeyAgreementParameters dhSpec)
             throws WSSecurityException {
+
+        // Liberty Change Start: set FIPS default
+        if (WSConstants.KEYTRANSPORT_RSAOAEP.equals(keyEncAlgo)
+                    || WSConstants.KEYTRANSPORT_RSAOAEP_XENC11.equals(keyEncAlgo)
+                    || WSConstants.KEYTRANSPORT_RSA15.equals(keyEncAlgo)) {
+            keyEncAlgo = CryptoUtils.isFips140_3Enabled() 
+                     ? "http://www.w3.org/2009/xmlenc11#rsa-oaep"
+                     : "http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p";
+        }
+        LOG.debug("Before createEncryptedKey(), keyEncAlgo is: " +keyEncAlgo);
+        // Liberty Change End
+
         encryptedKeyElement = createEncryptedKey(getDocument(), keyEncAlgo);
         if (encKeyId == null || encKeyId.isEmpty()) {
             encKeyId = IDGenerator.generateID("EK-");
@@ -460,6 +468,18 @@ public class WSSecEncryptedKey extends WSSecBase {
      *  4) Create the CipherValue element structure and insert the encrypted session key
      */
     protected void createEncryptedKeyElement(Key key) throws WSSecurityException {
+
+        // Liberty Change Start: set FIPS default
+        if (WSConstants.KEYTRANSPORT_RSAOAEP.equals(keyEncAlgo)
+                    || WSConstants.KEYTRANSPORT_RSAOAEP_XENC11.equals(keyEncAlgo)
+                    || WSConstants.KEYTRANSPORT_RSA15.equals(keyEncAlgo)) {
+            keyEncAlgo = CryptoUtils.isFips140_3Enabled() 
+                     ? "http://www.w3.org/2009/xmlenc11#rsa-oaep"
+                     : "http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p";
+        }
+        LOG.debug("Before createEncryptedKey(), keyEncAlgo is " +keyEncAlgo);
+        // Liberty Change End
+
         encryptedKeyElement = createEncryptedKey(getDocument(), keyEncAlgo);
         if (encKeyId == null || encKeyId.isEmpty()) {
             encKeyId = IDGenerator.generateID("EK-");
@@ -698,16 +718,31 @@ public class WSSecEncryptedKey extends WSSecBase {
 
     private byte[] encryptSymmetricKey(Key encryptingKey, SecretKey keyToBeEncrypted)
         throws WSSecurityException {
+   
+         // Liberty Change Start: set FIPS default
+         if (WSConstants.KEYTRANSPORT_RSAOAEP.equals(keyEncAlgo)
+                    || WSConstants.KEYTRANSPORT_RSAOAEP_XENC11.equals(keyEncAlgo)
+                    || WSConstants.KEYTRANSPORT_RSA15.equals(keyEncAlgo)) {
+            keyEncAlgo = CryptoUtils.isFips140_3Enabled() 
+                     ? "http://www.w3.org/2009/xmlenc11#rsa-oaep"
+                     : "http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p";
+            
+        }
+        LOG.debug("Before KeyUtils.getCipherInstance(), keyEncAlgo is " +keyEncAlgo);
+        // Liberty Change End
+
         Cipher cipher = KeyUtils.getCipherInstance(keyEncAlgo);
         try {
             OAEPParameterSpec oaepParameterSpec = null;
             if (WSConstants.KEYTRANSPORT_RSAOAEP.equals(keyEncAlgo)
-                    || WSConstants.KEYTRANSPORT_RSAOAEP_XENC11.equals(keyEncAlgo)) {
+                    || WSConstants.KEYTRANSPORT_RSAOAEP_XENC11.equals(keyEncAlgo)
+                    || WSConstants.KEYTRANSPORT_RSA15.equals(keyEncAlgo)) {    
                 oaepParameterSpec = XMLCipherUtil.constructOAEPParameters(keyEncAlgo, digestAlgo, mgfAlgo, null);
             }
             if (oaepParameterSpec == null) {
                 cipher.init(Cipher.WRAP_MODE, encryptingKey);
             } else {
+                LOG.debug("Before cipher.init(), encryptingKey is " +encryptingKey);  
                 cipher.init(Cipher.WRAP_MODE, encryptingKey, oaepParameterSpec);
             }
         } catch (InvalidKeyException | InvalidAlgorithmParameterException e) {
@@ -757,6 +792,7 @@ public class WSSecEncryptedKey extends WSSecBase {
             doc.createElementNS(WSConstants.ENC_NS, WSConstants.ENC_PREFIX + ":EncryptionMethod");
         encryptionMethod.setAttributeNS(null, "Algorithm", keyTransportAlgo);
 
+        LOG.debug("Before XMLUtils.createElementInSignatureSpace(), keyEncAlgo is " +keyEncAlgo);
         if ((WSConstants.KEYTRANSPORT_RSAOAEP_XENC11.equals(keyEncAlgo) || WSConstants.KEYTRANSPORT_RSAOAEP.equals(
                 keyEncAlgo)) && digestAlgo != null) {
             Element digestElement =

--- a/dev/com.ibm.ws.org.apache.wss4j.ws.security.dom/src/org/apache/wss4j/dom/message/WSSecEncryptedKey.java
+++ b/dev/com.ibm.ws.org.apache.wss4j.ws.security.dom/src/org/apache/wss4j/dom/message/WSSecEncryptedKey.java
@@ -44,6 +44,8 @@ import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Text;
 
+import com.ibm.ws.common.crypto.CryptoUtils;
+
 import javax.crypto.Cipher;
 import javax.crypto.IllegalBlockSizeException;
 import javax.crypto.SecretKey;
@@ -74,7 +76,12 @@ public class WSSecEncryptedKey extends WSSecBase {
     /**
      * Algorithm used to encrypt the ephemeral key
      */
-    private String keyEncAlgo = WSConstants.KEYTRANSPORT_RSAOAEP;
+    // Liberty Change Start: set FIPS default
+    private String keyEncAlgo = CryptoUtils.isFips140_3Enabled() 
+                    ? WSConstants.KEYTRANSPORT_RSAOAEP_XENC11 
+                    : WSConstants.KEYTRANSPORT_RSAOAEP;
+    // Liberty Change End
+
     // Liberty Change Start: Backport 4.x
     /**
      * Key agreement method algorithm used to encrypt the transport key.
@@ -100,13 +107,17 @@ public class WSSecEncryptedKey extends WSSecBase {
      * Digest Algorithm to be used with RSA-OAEP. The default is SHA-1 (which is not
      * written out unless it is explicitly configured).
      */
-    private String digestAlgo;
+    // Liberty Change Start: set FIPS default
+    private String digestAlgo = CryptoUtils.isFips140_3Enabled() ? "SHA-256" : "SHA-1";
+    // Liberty Change End
 
     /**
      * MGF Algorithm to be used with RSA-OAEP. The default is MGF-SHA-1 (which is not
      * written out unless it is explicitly configured).
      */
-    private String mgfAlgo;
+    // Liberty Change Start: set FIPS default
+    private String mgfAlgo = CryptoUtils.isFips140_3Enabled() ? "MGF-SHA-256" : "MGF-SHA-1";
+    // Liberty Change End
 
     /**
      * xenc:EncryptedKey element
@@ -694,7 +705,6 @@ public class WSSecEncryptedKey extends WSSecBase {
                     || WSConstants.KEYTRANSPORT_RSAOAEP_XENC11.equals(keyEncAlgo)) {
                 oaepParameterSpec = XMLCipherUtil.constructOAEPParameters(keyEncAlgo, digestAlgo, mgfAlgo, null);
             }
-            
             if (oaepParameterSpec == null) {
                 cipher.init(Cipher.WRAP_MODE, encryptingKey);
             } else {

--- a/dev/com.ibm.ws.org.apache.wss4j.ws.security.dom/src/org/apache/wss4j/dom/message/WSSecSignature.java
+++ b/dev/com.ibm.ws.org.apache.wss4j.ws.security.dom/src/org/apache/wss4j/dom/message/WSSecSignature.java
@@ -1,0 +1,1015 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.wss4j.dom.message;
+
+import java.security.NoSuchProviderException;
+import java.security.Provider;
+import java.security.PublicKey;
+import java.security.cert.CertificateEncodingException;
+import java.security.cert.X509Certificate;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import javax.xml.crypto.XMLStructure;
+import javax.xml.crypto.dom.DOMStructure;
+import javax.xml.crypto.dsig.CanonicalizationMethod;
+import javax.xml.crypto.dsig.SignatureMethod;
+import javax.xml.crypto.dsig.SignedInfo;
+import javax.xml.crypto.dsig.XMLSignContext;
+import javax.xml.crypto.dsig.XMLSignature;
+import javax.xml.crypto.dsig.XMLSignatureFactory;
+import javax.xml.crypto.dsig.dom.DOMSignContext;
+import javax.xml.crypto.dsig.keyinfo.KeyInfo;
+import javax.xml.crypto.dsig.keyinfo.KeyInfoFactory;
+import javax.xml.crypto.dsig.keyinfo.KeyValue;
+import javax.xml.crypto.dsig.spec.C14NMethodParameterSpec;
+import javax.xml.crypto.dsig.spec.ExcC14NParameterSpec;
+
+import org.apache.wss4j.common.WSEncryptionPart;
+import org.apache.wss4j.common.WSS4JConstants;
+import org.apache.wss4j.common.crypto.Crypto;
+import org.apache.wss4j.common.crypto.CryptoType;
+import org.apache.wss4j.common.crypto.DERDecoder;
+import org.apache.wss4j.common.ext.WSSecurityException;
+import org.apache.wss4j.common.token.BinarySecurity;
+import org.apache.wss4j.common.token.DOMX509Data;
+import org.apache.wss4j.common.token.DOMX509IssuerSerial;
+import org.apache.wss4j.common.token.PKIPathSecurity;
+import org.apache.wss4j.common.token.Reference;
+import org.apache.wss4j.common.token.SecurityTokenReference;
+import org.apache.wss4j.common.token.X509Security;
+import org.apache.wss4j.common.util.AttachmentUtils;
+import org.apache.wss4j.common.util.KeyUtils;
+import org.apache.wss4j.common.util.XMLUtils;
+import org.apache.wss4j.dom.WSConstants;
+import org.apache.wss4j.dom.WSDocInfo;
+import org.apache.wss4j.dom.message.token.KerberosSecurity;
+import org.apache.wss4j.dom.transform.STRTransform;
+import org.apache.wss4j.dom.util.WSSecurityUtil;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+
+import com.ibm.ws.common.crypto.CryptoUtils;
+
+/**
+ * Creates a Signature according to WS Specification, X509 profile.
+ *
+ * This class is a re-factored implementation of the previous WSS4J class
+ * <code>WSSignEnvelope</code>. This new class allows better control of
+ * the process to create a Signature and to add it to the Security header.
+ *
+ * The flexibility and fine granular control is required to implement a handler
+ * that uses WSSecurityPolicy files to control the setup of a Security header.
+ */
+public class WSSecSignature extends WSSecSignatureBase {
+
+    private static final org.slf4j.Logger LOG =
+        org.slf4j.LoggerFactory.getLogger(WSSecSignature.class);
+
+    protected XMLSignatureFactory signatureFactory;
+    protected KeyInfo keyInfo;
+    protected CanonicalizationMethod c14nMethod;
+    protected XMLSignature sig;
+    protected byte[] secretKey;
+    protected String strUri;
+    protected Element bstToken;
+    protected String keyInfoUri;
+    protected String certUri;
+    protected byte[] signatureValue;
+
+    private boolean useSingleCert = true;
+    private String sigAlgo;
+    //not used?  Liberty Change Start: set FIPS default for signature algorithm
+    //private String sigAlgo = CryptoUtils.isFips140_3Enabled() 
+    //                         ? "http://www.w3.org/2001/04/xmldsig-more#hmac-sha256" 
+    //                         : "http://www.w3.org/2001/04/xmldsig-more#hmac-sha384";
+    // Liberty Change End
+
+    private String canonAlgo = WSConstants.C14N_EXCL_OMIT_COMMENTS;
+    private SecurityTokenReference secRef;
+    private String customTokenValueType;
+    private String customTokenId;
+    private String encrKeySha1value;
+    private Crypto crypto;
+
+    // Liberty Change Start: set FIPS default for digest algorithm
+    private String digestAlgo = CryptoUtils.isFips140_3Enabled() ? WSConstants.SHA256 : WSConstants.SHA1;
+    // Liberty Change End
+
+    private X509Certificate useThisCert;
+    private boolean useCustomSecRef;
+    private boolean bstAddedToSecurityHeader;
+    private boolean includeSignatureToken;
+    private boolean addInclusivePrefixes = true;
+    private Element customKeyInfoElement;
+    private Provider signatureProvider;
+
+    // Liberty Change Start: Backport 4.x
+    public WSSecSignature(WSSecHeader securityHeader) {
+        this(securityHeader, null);
+    }
+
+    public WSSecSignature(WSSecHeader securityHeader, Provider provider) {
+        super(securityHeader);
+        init(provider);
+    }
+    // Liberty Change End
+
+    public WSSecSignature(Document doc) {
+        this(doc, null);
+    }
+
+    public WSSecSignature(Document doc, Provider provider) {
+        super(doc);
+        init(provider);
+    }
+
+    private void init(Provider provider) {
+        if (provider == null) {
+            // Try to install the Santuario Provider - fall back to the JDK provider if this does
+            // not work
+            try {
+                signatureFactory = XMLSignatureFactory.getInstance("DOM", "ApacheXMLDSig");
+            } catch (NoSuchProviderException ex) {
+                signatureFactory = XMLSignatureFactory.getInstance("DOM");
+            }
+        } else {
+            signatureFactory = XMLSignatureFactory.getInstance("DOM", provider);
+        }
+    }
+
+    /**
+     * Initialize a WSSec Signature.
+     *
+     * The method sets up and initializes a WSSec Signature structure after the
+     * relevant information was set. After setup of the references to elements
+     * to sign may be added. After all references are added they can be signed.
+     *
+     * This method does not add the Signature element to the security header.
+     * See <code>prependSignatureElementToHeader()</code> method.
+     *
+     * @param cr An instance of the Crypto API to handle keystore and certificates
+     * @throws WSSecurityException
+     */
+    public void prepare(Crypto cr)
+        throws WSSecurityException {
+        //
+        // Gather some info about the document to process and store it for
+        // retrieval
+        //
+        crypto = cr;
+        WSDocInfo wsDocInfo = getWsDocInfo();
+        if (wsDocInfo == null) {
+            wsDocInfo = new WSDocInfo(getDocument());
+            super.setWsDocInfo(wsDocInfo);
+        }
+        wsDocInfo.setCrypto(cr);
+
+        //
+        // At first get the security token (certificate) according to the parameters.
+        //
+        X509Certificate[] certs = getSigningCerts();
+
+        try {
+            C14NMethodParameterSpec c14nSpec = null;
+            if (addInclusivePrefixes && canonAlgo.equals(WSConstants.C14N_EXCL_OMIT_COMMENTS)) {
+                Element securityHeaderElement = getSecurityHeader().getSecurityHeaderElement();
+                List<String> prefixes =
+                    getInclusivePrefixes(securityHeaderElement, false);
+                c14nSpec = new ExcC14NParameterSpec(prefixes);
+            }
+
+           c14nMethod = signatureFactory.newCanonicalizationMethod(canonAlgo, c14nSpec);
+        } catch (Exception ex) {
+            LOG.error("", ex);
+            throw new WSSecurityException(
+                WSSecurityException.ErrorCode.FAILED_SIGNATURE, ex, "noXMLSig"
+            );
+        }
+
+        keyInfoUri = getIdAllocator().createSecureId("KI-", keyInfo);
+        if (!useCustomSecRef && customKeyInfoElement == null) {
+            secRef = new SecurityTokenReference(getDocument());
+            strUri = getIdAllocator().createSecureId("STR-", secRef);
+            secRef.addWSSENamespace();
+            secRef.addWSUNamespace();
+            secRef.setID(strUri);
+
+            //
+            // Get an initialized XMLSignature element.
+            //
+
+            //
+            // Prepare and setup the token references for this Signature
+            //
+            switch (keyIdentifierType) {
+            case WSConstants.BST_DIRECT_REFERENCE:
+                Reference ref = new Reference(getDocument());
+                ref.setURI("#" + certUri);
+
+                addBST(certs);
+                if (!useSingleCert) {
+                    secRef.addTokenType(PKIPathSecurity.PKI_TYPE);
+                    ref.setValueType(PKIPathSecurity.PKI_TYPE);
+                } else {
+                    ref.setValueType(X509Security.X509_V3_TYPE);
+                }
+                secRef.setReference(ref);
+                break;
+
+                case WSConstants.ISSUER_SERIAL:
+                    addIssuerSerial(certs,false);
+                    break;
+
+                case WSConstants.ISSUER_SERIAL_QUOTE_FORMAT:
+                    addIssuerSerial(certs,true);
+                    break;
+
+                case WSConstants.X509_KEY_IDENTIFIER:
+                secRef.setKeyIdentifier(certs[0]);
+                break;
+
+            case WSConstants.SKI_KEY_IDENTIFIER:
+                secRef.setKeyIdentifierSKI(certs[0], crypto);
+
+                if (includeSignatureToken) {
+                    addBST(certs);
+                }
+                break;
+
+            case WSConstants.THUMBPRINT_IDENTIFIER:
+                secRef.setKeyIdentifierThumb(certs[0]);
+
+                if (includeSignatureToken) {
+                    addBST(certs);
+                }
+                break;
+
+            case WSConstants.ENCRYPTED_KEY_SHA1_IDENTIFIER:
+                if (encrKeySha1value != null) {
+                    secRef.setKeyIdentifierEncKeySHA1(encrKeySha1value);
+                } else {
+                    byte[] digestBytes = KeyUtils.generateDigest(secretKey);
+                    secRef.setKeyIdentifierEncKeySHA1(org.apache.xml.security.utils.XMLUtils.encodeToString(digestBytes));
+                }
+                secRef.addTokenType(WSConstants.WSS_ENC_KEY_VALUE_TYPE);
+                break;
+
+            case WSConstants.CUSTOM_SYMM_SIGNING :
+                Reference refCust = new Reference(getDocument());
+                if (WSConstants.WSS_SAML_KI_VALUE_TYPE.equals(customTokenValueType)) {
+                    secRef.addTokenType(WSConstants.WSS_SAML_TOKEN_TYPE);
+                    refCust.setValueType(customTokenValueType);
+                } else if (WSConstants.WSS_SAML2_KI_VALUE_TYPE.equals(customTokenValueType)) {
+                    secRef.addTokenType(WSConstants.WSS_SAML2_TOKEN_TYPE);
+                } else if (WSConstants.WSS_ENC_KEY_VALUE_TYPE.equals(customTokenValueType)) {
+                    secRef.addTokenType(WSConstants.WSS_ENC_KEY_VALUE_TYPE);
+                    refCust.setValueType(customTokenValueType);
+                } else if (KerberosSecurity.isKerberosToken(customTokenValueType)) {
+                    secRef.addTokenType(customTokenValueType);
+                    refCust.setValueType(customTokenValueType);
+                } else {
+                    refCust.setValueType(customTokenValueType);
+                }
+                refCust.setURI("#" + customTokenId);
+                secRef.setReference(refCust);
+                break;
+
+            case WSConstants.CUSTOM_SYMM_SIGNING_DIRECT :
+                Reference refCustd = new Reference(getDocument());
+                if (WSConstants.WSS_SAML_KI_VALUE_TYPE.equals(customTokenValueType)) {
+                    secRef.addTokenType(WSConstants.WSS_SAML_TOKEN_TYPE);
+                    refCustd.setValueType(customTokenValueType);
+                } else if (WSConstants.WSS_SAML2_KI_VALUE_TYPE.equals(customTokenValueType)) {
+                    secRef.addTokenType(WSConstants.WSS_SAML2_TOKEN_TYPE);
+                } else if (WSConstants.WSS_ENC_KEY_VALUE_TYPE.equals(customTokenValueType)) {
+                    secRef.addTokenType(WSConstants.WSS_ENC_KEY_VALUE_TYPE);
+                    refCustd.setValueType(customTokenValueType);
+                } else if (KerberosSecurity.isKerberosToken(customTokenValueType)) {
+                    secRef.addTokenType(customTokenValueType);
+                    refCustd.setValueType(customTokenValueType);
+                } else {
+                    refCustd.setValueType(customTokenValueType);
+                }
+                refCustd.setURI(customTokenId);
+                secRef.setReference(refCustd);
+                break;
+
+            case WSConstants.CUSTOM_KEY_IDENTIFIER:
+                if (WSConstants.WSS_SAML_KI_VALUE_TYPE.equals(customTokenValueType)) {
+                    secRef.setKeyIdentifier(customTokenValueType, customTokenId);
+                    secRef.addTokenType(WSConstants.WSS_SAML_TOKEN_TYPE);
+                } else if (WSConstants.WSS_SAML2_KI_VALUE_TYPE.equals(customTokenValueType)) {
+                    secRef.setKeyIdentifier(customTokenValueType, customTokenId);
+                    secRef.addTokenType(WSConstants.WSS_SAML2_TOKEN_TYPE);
+                } else if (WSConstants.WSS_ENC_KEY_VALUE_TYPE.equals(customTokenValueType)) {
+                    secRef.setKeyIdentifier(customTokenValueType, customTokenId, true);
+                    secRef.addTokenType(WSConstants.WSS_ENC_KEY_VALUE_TYPE);
+                } else if (SecurityTokenReference.ENC_KEY_SHA1_URI.equals(customTokenValueType)) {
+                    secRef.setKeyIdentifier(customTokenValueType, customTokenId, true);
+                    secRef.addTokenType(WSConstants.WSS_ENC_KEY_VALUE_TYPE);
+                } else if (WSConstants.WSS_KRB_KI_VALUE_TYPE.equals(customTokenValueType)) {
+                    secRef.setKeyIdentifier(customTokenValueType, customTokenId, true);
+                    secRef.addTokenType(WSConstants.WSS_GSS_KRB_V5_AP_REQ);
+                }
+                break;
+
+            case WSConstants.KEY_VALUE:
+                PublicKey publicKey = certs[0].getPublicKey();
+
+                try {
+                    KeyInfoFactory keyInfoFactory = signatureFactory.getKeyInfoFactory();
+                    KeyValue keyValue = keyInfoFactory.newKeyValue(publicKey);
+                    keyInfo =
+                        keyInfoFactory.newKeyInfo(Collections.singletonList(keyValue), keyInfoUri);
+                } catch (java.security.KeyException ex) {
+                    LOG.error("", ex);
+                    throw new WSSecurityException(
+                        WSSecurityException.ErrorCode.FAILED_SIGNATURE, ex, "noXMLSig"
+                    );
+                }
+                break;
+            default:
+                throw new WSSecurityException(WSSecurityException.ErrorCode.FAILURE, "unsupportedKeyId");
+            }
+        }
+
+        if (keyIdentifierType != WSConstants.KEY_VALUE) {
+            marshalKeyInfo(wsDocInfo);
+        }
+    }
+
+    private void addIssuerSerial(X509Certificate[] certs,boolean isCommaDelimited) throws WSSecurityException {
+        String issuer = certs[0].getIssuerX500Principal().getName();
+        java.math.BigInteger serialNumber = certs[0].getSerialNumber();
+
+        DOMX509IssuerSerial domIssuerSerial
+                = new DOMX509IssuerSerial(getDocument(), issuer, serialNumber, isCommaDelimited);
+        DOMX509Data domX509Data = new DOMX509Data(getDocument(), domIssuerSerial);
+        secRef.setUnknownElement(domX509Data.getElement());
+
+        if (includeSignatureToken) {
+            addBST(certs);
+        }
+    }
+
+    protected void marshalKeyInfo(WSDocInfo wsDocInfo) throws WSSecurityException {
+        List<XMLStructure> kiChildren = null;
+        if (customKeyInfoElement == null) {
+            XMLStructure structure = new DOMStructure(secRef.getElement());
+            wsDocInfo.addTokenElement(secRef.getElement(), false);
+            kiChildren = Collections.singletonList(structure);
+        } else {
+            Node kiChild = customKeyInfoElement.getFirstChild();
+            kiChildren = new ArrayList<>();
+            while (kiChild != null) {
+                kiChildren.add(new DOMStructure(kiChild));
+                kiChild = kiChild.getNextSibling();
+            }
+        }
+
+        KeyInfoFactory keyInfoFactory = signatureFactory.getKeyInfoFactory();
+        keyInfo = keyInfoFactory.newKeyInfo(kiChildren, keyInfoUri);
+    }
+
+    /**
+     * Builds a signed soap envelope.
+     *
+     * This is a convenience method and for backward compatibility. The method
+     * creates a Signature and puts it into the Security header. It does so by
+     * calling the single functions in order to perform a <i>one shot signature</i>.
+     *
+     * @param cr An instance of the Crypto API to handle keystore and certificates
+     * @return A signed SOAP envelope as <code>Document</code>
+     * @throws WSSecurityException
+     */
+    public Document build(Crypto cr)
+        throws WSSecurityException {
+
+        LOG.debug("Beginning signing...");
+
+        prepare(cr);
+        if (getParts().isEmpty()) {
+            getParts().add(WSSecurityUtil.getDefaultEncryptionPart(getDocument()));
+        } else {
+            for (WSEncryptionPart part : getParts()) {
+                if (part.getId() == null && "STRTransform".equals(part.getName())) {
+                    part.setId(strUri);
+                } else if ("KeyInfo".equals(part.getName()) && WSConstants.SIG_NS.equals(part.getNamespace())
+                    && part.getElement() == null) {
+                    // Special code to sign the KeyInfo
+                    part.setId(keyInfoUri);
+                }
+            }
+        }
+
+        List<javax.xml.crypto.dsig.Reference> referenceList = addReferencesToSign(getParts());
+
+        computeSignature(referenceList);
+
+        //
+        // if we have a BST prepend it in front of the Signature according to
+        // strict layout rules.
+        //
+        if (bstToken != null) {
+            prependBSTElementToHeader();
+        }
+
+        return getDocument();
+    }
+
+
+    /**
+     * This method adds references to the Signature.
+     *
+     * @param references The list of references to sign
+     * @throws WSSecurityException
+     */
+    public List<javax.xml.crypto.dsig.Reference> addReferencesToSign(
+        List<WSEncryptionPart> references
+    ) throws WSSecurityException {
+        return
+            addReferencesToSign(
+                getDocument(),
+                references,
+                getWsDocInfo(),
+                signatureFactory,
+                addInclusivePrefixes,
+                digestAlgo
+            );
+    }
+
+    /**
+     * Returns the SignatureElement.
+     * The method can be called any time after <code>prepare()</code>.
+     * @return The DOM Element of the signature.
+     */
+    public Element getSignatureElement() {
+        Element securityHeaderElement = getSecurityHeader().getSecurityHeaderElement();
+        return
+            XMLUtils.getDirectChildElement(
+                securityHeaderElement, WSConstants.SIG_LN, WSConstants.SIG_NS
+            );
+    }
+
+    /**
+     * Add a BinarySecurityToken
+     */
+    private void addBST(X509Certificate[] certs) throws WSSecurityException {
+        if (storeBytesInAttachment) {
+            bstToken =
+                getDocument().createElementNS(WSS4JConstants.WSSE_NS, "wsse:BinarySecurityToken");
+            bstToken.setAttributeNS(null, "EncodingType", WSS4JConstants.BASE64_ENCODING);
+            bstToken.setAttributeNS(WSS4JConstants.WSU_NS, WSS4JConstants.WSU_PREFIX + ":Id", certUri);
+            if (addWSUNamespace) {
+                bstToken.setAttributeNS(XMLUtils.XMLNS_NS, "xmlns:" + WSConstants.WSU_PREFIX, WSConstants.WSU_NS);
+            }
+
+            byte[] certBytes = null;
+            if (!useSingleCert) {
+                bstToken.setAttributeNS(null, "ValueType", PKIPathSecurity.PKI_TYPE);
+                certBytes = crypto.getBytesFromCertificates(certs);
+            } else {
+                bstToken.setAttributeNS(null, "ValueType", X509Security.X509_V3_TYPE);
+                try {
+                    certBytes = certs[0].getEncoded();
+                } catch (CertificateEncodingException e) {
+                    throw new WSSecurityException(
+                        WSSecurityException.ErrorCode.SECURITY_TOKEN_UNAVAILABLE, e, "encodeError"
+                    );
+                }
+            }
+
+            final String attachmentId = getIdAllocator().createId("", getDocument());
+            AttachmentUtils.storeBytesInAttachment(bstToken, getDocument(), attachmentId,
+                                                  certBytes, attachmentCallbackHandler);
+            getWsDocInfo().addTokenElement(bstToken, false);
+        } else {
+            BinarySecurity binarySecurity = null;
+            if (!useSingleCert) {
+                binarySecurity = new PKIPathSecurity(getDocument());
+                ((PKIPathSecurity) binarySecurity).setX509Certificates(certs, crypto);
+            } else {
+                binarySecurity = new X509Security(getDocument());
+                ((X509Security) binarySecurity).setX509Certificate(certs[0]);
+            }
+            binarySecurity.setID(certUri);
+            if (addWSUNamespace) {
+                binarySecurity.addWSUNamespace();
+            }
+            bstToken = binarySecurity.getElement();
+            getWsDocInfo().addTokenElement(bstToken, false);
+        }
+
+        bstAddedToSecurityHeader = false;
+    }
+
+    /**
+     * Prepend the BinarySecurityToken to the elements already in the Security
+     * header.
+     *
+     * The method can be called any time after <code>prepare()</code>.
+     * This allows to insert the BST element at any position in the Security
+     * header.
+     */
+    public void prependBSTElementToHeader() {
+        if (bstToken != null && !bstAddedToSecurityHeader) {
+            Element securityHeaderElement = getSecurityHeader().getSecurityHeaderElement();
+            WSSecurityUtil.prependChildElement(securityHeaderElement, bstToken);
+            bstAddedToSecurityHeader = true;
+        }
+    }
+
+    /**
+     * Append the BinarySecurityToken to the security header.
+     */
+    public void appendBSTElementToHeader() {
+        if (bstToken != null && !bstAddedToSecurityHeader) {
+            Element securityHeaderElement = getSecurityHeader().getSecurityHeaderElement();
+            securityHeaderElement.appendChild(bstToken);
+            bstAddedToSecurityHeader = true;
+        }
+    }
+
+    /**
+     * Compute the Signature over the references. The signature element will be
+     * prepended to the security header.
+     *
+     * This method can be called any time after the references were set. See
+     * <code>addReferencesToSign()</code>.
+     *
+     * @param referenceList The list of references to sign
+     *
+     * @throws WSSecurityException
+     */
+    public void computeSignature(
+        List<javax.xml.crypto.dsig.Reference> referenceList
+    ) throws WSSecurityException {
+        computeSignature(referenceList, true, null);
+    }
+
+    /**
+     * Compute the Signature over the references.
+     *
+     * This method can be called any time after the references were set. See
+     * <code>addReferencesToSign()</code>.
+     *
+     * @param referenceList The list of references to sign
+     * @param prepend Whether to prepend the signature element to the security header
+     * @param siblingElement If prepending, then prepend before this sibling Element
+     *
+     * @throws WSSecurityException
+     */
+    public void computeSignature(
+        List<javax.xml.crypto.dsig.Reference> referenceList,
+        boolean prepend,
+        Element siblingElement
+    ) throws WSSecurityException {
+
+        if (CryptoUtils.isFips140_3Enabled() && sigAlgo.equals("http://www.w3.org/2001/04/xmldsig-more#hmac-sha384")) {
+            String sigAlgo = "http://www.w3.org/2001/04/xmldsig-more#hmac-sha256";
+        }
+                             
+        try {
+            LOG.debug("Mei: line 593 sigAlgo is: " +sigAlgo);
+            java.security.Key key;
+            if (secretKey == null) {
+                key = crypto.getPrivateKey(user, password);
+            } else {
+                LOG.debug("Mei: line 598, secretKey not null, sigAlgo is: " +sigAlgo); 
+                key = KeyUtils.prepareSecretKey(sigAlgo, secretKey);
+            }
+            SignatureMethod signatureMethod =
+                signatureFactory.newSignatureMethod(sigAlgo, null);
+            LOG.debug("Mei: line 603, signatureMethod is: " +signatureMethod); 
+            SignedInfo signedInfo =
+                signatureFactory.newSignedInfo(c14nMethod, signatureMethod, referenceList);
+
+            sig = signatureFactory.newXMLSignature(
+                    signedInfo,
+                    keyInfo,
+                    null,
+                    getIdAllocator().createId("SIG-", null),
+                    null);
+
+            //
+            // Figure out where to insert the signature element
+            //
+            XMLSignContext signContext = null;
+            Element securityHeaderElement = getSecurityHeader().getSecurityHeaderElement();
+            if (prepend) {
+                if (siblingElement == null) {
+                    Node child = securityHeaderElement.getFirstChild();
+                    while (child != null && child.getNodeType() != Node.ELEMENT_NODE) {
+                        child = child.getNextSibling();
+                    }
+                    siblingElement = (Element)child;
+                }
+                if (siblingElement == null) {
+                    signContext = new DOMSignContext(key, securityHeaderElement);
+                } else {
+                    signContext = new DOMSignContext(key, securityHeaderElement, siblingElement);
+                }
+            } else {
+                signContext = new DOMSignContext(key, securityHeaderElement);
+            }
+            if (signatureProvider != null) {
+                signContext.setProperty("org.jcp.xml.dsig.internal.dom.SignatureProvider", signatureProvider);
+            }
+
+            signContext.putNamespacePrefix(WSConstants.SIG_NS, WSConstants.SIG_PREFIX);
+            if (WSConstants.C14N_EXCL_OMIT_COMMENTS.equals(canonAlgo)) {
+                signContext.putNamespacePrefix(
+                    WSConstants.C14N_EXCL_OMIT_COMMENTS,
+                    WSConstants.C14N_EXCL_OMIT_COMMENTS_PREFIX
+                );
+            }
+            signContext.setProperty(STRTransform.TRANSFORM_WS_DOC_INFO, getWsDocInfo());
+            getWsDocInfo().setCallbackLookup(callbackLookup);
+
+            // Add the elements to sign to the Signature Context
+            getWsDocInfo().setTokensOnContext((DOMSignContext)signContext);
+            sig.sign(signContext);
+
+            signatureValue = sig.getSignatureValue().getValue();
+            LOG.debug("Mei: line 642, signatureValue is: " +signatureValue);      
+
+            cleanup();
+        } catch (Exception ex) {
+            LOG.error(ex.getMessage(), ex);
+            throw new WSSecurityException(
+                WSSecurityException.ErrorCode.FAILED_SIGNATURE, ex
+            );
+        }
+    }
+
+    /**
+     * Set the single cert flag.
+     *
+     * @param useSingleCert
+     */
+    public void setUseSingleCertificate(boolean useSingleCert) {
+        this.useSingleCert = useSingleCert;
+    }
+
+    /**
+     * Get the single cert flag.
+     *
+     * @return A boolean if single certificate is set.
+     */
+    public boolean isUseSingleCertificate() {
+        return useSingleCert;
+    }
+
+    /**
+     * Set the name (uri) of the signature encryption algorithm to use.
+     *
+     * If the algorithm is not set then an automatic detection of the signature
+     * algorithm to use is performed during the <code>prepare()</code>
+     * method. Refer to WSConstants which algorithms are supported.
+     *
+     * @param algo the name of the signature algorithm
+     * @see WSConstants#RSA
+     * @see WSConstants#DSA
+     */
+    public void setSignatureAlgorithm(String algo) {
+        sigAlgo = algo;
+    }
+
+    /**
+     * Get the name (uri) of the signature algorithm that is being used.
+     *
+     * Call this method after <code>prepare</code> to get the information
+     * which signature algorithm was automatically detected if no signature
+     * algorithm was preset.
+     *
+     * @return the identifier URI of the signature algorithm
+     */
+    public String getSignatureAlgorithm() {
+        return sigAlgo;
+    }
+
+    /**
+     * Set the canonicalization method to use.
+     *
+     * If the canonicalization method is not set then the recommended Exclusive
+     * XML Canonicalization is used by default. Refer to WSConstants which
+     * algorithms are supported.
+     *
+     * @param algo Is the name of the signature algorithm
+     * @see WSConstants#C14N_OMIT_COMMENTS
+     * @see WSConstants#C14N_WITH_COMMENTS
+     * @see WSConstants#C14N_EXCL_OMIT_COMMENTS
+     * @see WSConstants#C14N_EXCL_WITH_COMMENTS
+     */
+    public void setSigCanonicalization(String algo) {
+        canonAlgo = algo;
+    }
+
+    /**
+     * Get the canonicalization method.
+     *
+     * If the canonicalization method was not set then Exclusive XML
+     * Canonicalization is used by default.
+     *
+     * @return The string describing the canonicalization algorithm.
+     */
+    public String getSigCanonicalization() {
+        return canonAlgo;
+    }
+
+    /**
+     * @return the digest algorithm to use
+     */
+    public String getDigestAlgo() {
+        return digestAlgo;
+    }
+
+    /**
+     * Set the string that defines which digest algorithm to use.
+     * The default is WSConstants.SHA1.
+     *
+     * @param digestAlgo the digestAlgo to set
+     */
+    public void setDigestAlgo(String digestAlgo) {
+        this.digestAlgo = digestAlgo;
+    }
+
+
+    /**
+     * Returns the computed Signature value.
+     *
+     * Call this method after <code>computeSignature()</code> or <code>build()</code>
+     * methods were called.
+     *
+     * @return Returns the signatureValue.
+     */
+    public byte[] getSignatureValue() {
+        return signatureValue;
+    }
+
+    /**
+     * Get the id generated during <code>prepare()</code>.
+     *
+     * Returns the the value of wsu:Id attribute of the Signature element.
+     *
+     * @return Return the wsu:Id of this token or null if <code>prepare()</code>
+     *         was not called before.
+     */
+    public String getId() {
+        if (sig == null) {
+            return null;
+        }
+        return sig.getId();
+    }
+
+    /**
+     * Get the id of the BST generated during <code>prepare()</code>.
+     *
+     * @return Returns the the value of wsu:Id attribute of the
+     * BinaruSecurityToken element.
+     */
+    public String getBSTTokenId() {
+        if (bstToken == null) {
+            return null;
+        }
+        return bstToken.getAttributeNS(WSS4JConstants.WSU_NS, "Id");
+    }
+
+    /**
+     * Set the secret key to use
+     * @param secretKey the secret key to use
+     */
+    public void setSecretKey(byte[] secretKey) {
+        this.secretKey = secretKey;
+    }
+
+    /**
+     * Set the custom token value type to use
+     * @param customTokenValueType the custom token value type to use
+     */
+    public void setCustomTokenValueType(String customTokenValueType) {
+        this.customTokenValueType = customTokenValueType;
+    }
+
+    /**
+     * Set the custom token id
+     * @param customTokenId the custom token id
+     */
+    public void setCustomTokenId(String customTokenId) {
+        this.customTokenId = customTokenId;
+    }
+
+    public String getCustomTokenId() {
+        return this.customTokenId;
+    }
+
+    /**
+     * Set the encrypted key sha1 value
+     * @param encrKeySha1value the encrypted key sha1 value
+     */
+    public void setEncrKeySha1value(String encrKeySha1value) {
+        this.encrKeySha1value = encrKeySha1value;
+    }
+
+    /**
+     * Set the X509 Certificate to use
+     * @param cer the X509 Certificate to use
+     */
+    public void setX509Certificate(X509Certificate cer) {
+        this.useThisCert = cer;
+    }
+
+    /**
+     * Returns the BST Token element.
+     * The method can be called any time after <code>prepare()</code>.
+     * @return the BST Token element
+     */
+    public Element getBinarySecurityTokenElement() {
+        return bstToken;
+    }
+
+    /**
+     * @return the URI associated with the SecurityTokenReference
+     * (must be called after {@link #prepare(Document, Crypto)}
+     */
+    public String getSecurityTokenReferenceURI() {
+        return strUri;
+    }
+
+    /**
+     * Get the SecurityTokenReference to be used in the KeyInfo element.
+     */
+    public SecurityTokenReference getSecurityTokenReference() {
+        return secRef;
+    }
+
+    /**
+     * Set the SecurityTokenReference to be used in the KeyInfo element. If this
+     * method is not called, a SecurityTokenRefence will be generated.
+     */
+    public void setSecurityTokenReference(SecurityTokenReference secRef) {
+        useCustomSecRef = true;
+        this.secRef = secRef;
+    }
+
+    /**
+     * Set up the X509 Certificate(s) for signing.
+     */
+    private X509Certificate[] getSigningCerts() throws WSSecurityException {
+        X509Certificate[] certs = null;
+        if (!(keyIdentifierType == WSConstants.CUSTOM_SYMM_SIGNING
+            || keyIdentifierType == WSConstants.CUSTOM_SYMM_SIGNING_DIRECT
+            || keyIdentifierType == WSConstants.ENCRYPTED_KEY_SHA1_IDENTIFIER
+            || keyIdentifierType == WSConstants.CUSTOM_KEY_IDENTIFIER)) {
+            if (useThisCert == null) {
+                CryptoType cryptoType = new CryptoType(CryptoType.TYPE.ALIAS);
+                cryptoType.setAlias(user);
+                if (crypto == null) {
+                    throw new WSSecurityException(WSSecurityException.ErrorCode.FAILURE, "noSigCryptoFile");
+                }
+                certs = crypto.getX509Certificates(cryptoType);
+            } else {
+                certs = new X509Certificate[] {useThisCert};
+            }
+            if (certs == null || certs.length <= 0) {
+                throw new WSSecurityException(
+                        WSSecurityException.ErrorCode.FAILURE,
+                        "noUserCertsFound",
+                        new Object[] {user, "signature"});
+            }
+            certUri = getIdAllocator().createSecureId("X509-", certs[0]);
+            //
+            // If no signature algorithm was set try to detect it according to the
+            // data stored in the certificate.
+            //
+            if (sigAlgo == null) {
+                String pubKeyAlgo = certs[0].getPublicKey().getAlgorithm();
+                LOG.debug("Automatic signature algorithm detection: {}", pubKeyAlgo);
+                if (pubKeyAlgo.equalsIgnoreCase("DSA")) {
+                    sigAlgo = WSConstants.DSA;
+                } else if (pubKeyAlgo.equalsIgnoreCase("RSA")) {
+                    sigAlgo = WSConstants.RSA;
+                } else if (pubKeyAlgo.equalsIgnoreCase("EC")) {
+                    sigAlgo = WSConstants.ECDSA_SHA256;
+                // Liberty Change Start: Backport 4.x
+                } else if (pubKeyAlgo.equalsIgnoreCase("Ed25519")) {
+                    sigAlgo = WSConstants.ED25519;
+                } else if (pubKeyAlgo.equalsIgnoreCase("ED448")) {
+                    sigAlgo = WSConstants.ED448;
+                } else if (pubKeyAlgo.equalsIgnoreCase("EdDSA")) {
+                    sigAlgo = getSigAlgorithmForEdDSAKey(certs[0].getPublicKey());
+                // Liberty Change End
+                } else {
+                    throw new WSSecurityException(
+                        WSSecurityException.ErrorCode.FAILURE,
+                        "unknownSignatureAlgorithm",
+                        new Object[] {pubKeyAlgo});
+                }
+            }
+        }
+        return certs;
+    }
+
+    // Liberty Change Start: Backport 4.x
+    /**
+     * The method returns EdDSA signature algorithm URI for public key type (Ed25519 or Ed448).
+     *
+     * @param publicKey the public key to get the algorithm from
+     * @return the signature algorithm URI (ED25519 or ED448) for the EdDSA public key
+     * @throws WSSecurityException if the algorithm cannot be determined
+     */
+    private static String getSigAlgorithmForEdDSAKey(PublicKey publicKey) throws WSSecurityException {
+
+        if (!"x.509".equalsIgnoreCase(publicKey.getFormat())) {
+            throw new WSSecurityException(WSSecurityException.ErrorCode.FAILURE, "unknownAlgorithm",
+                    new Object[]{"Unknown cert format!"});
+        }
+
+        DERDecoder decoder = new DERDecoder(publicKey.getEncoded());
+        // find TYPE_OBJECT_IDENTIFIER (OID) for the public key algorithm
+        decoder.expect(decoder.TYPE_SEQUENCE);
+        decoder.getLength();
+        decoder.expect(decoder.TYPE_SEQUENCE);
+        decoder.getLength();
+        decoder.expect(decoder.TYPE_OBJECT_IDENTIFIER);
+        int size = decoder.getLength();
+        if (size != 3) {
+            LOG.debug("Invalid ECDSA Public key OID byte size: [{}]", size);
+            throw new WSSecurityException(WSSecurityException.ErrorCode.INVALID_SECURITY, "invalidCert");
+        }
+
+        //  The first two nodes 1.3 of the OID are encoded onto a single byte. The first node is multiplied by 40
+        //  and the result is added to the value of the second node 3 which gives 43 or 0x2B.
+        decoder.expect(43);
+        // The second byte is expected 101 from the OID 1.3.101 (EdDSA)
+        decoder.expect(101);
+        // The third byte defines algorithm 112 is for Ed25519 and 113 is for Ed448
+        byte algDef = decoder.getBytes(1)[0];
+        switch (algDef) {
+            case 112:
+                return WSConstants.ED25519;
+            case 113:
+                return WSConstants.ED448;
+            default:
+                throw new WSSecurityException(WSSecurityException.ErrorCode.INVALID_SECURITY, "unknownAlgorithm",
+                        new Object[]{"Invalid ECDSA Public key OID!"});
+        }
+    }
+    // Liberty Change End
+
+    public boolean isIncludeSignatureToken() {
+        return includeSignatureToken;
+    }
+
+    public void setIncludeSignatureToken(boolean includeSignatureToken) {
+        this.includeSignatureToken = includeSignatureToken;
+    }
+
+    public boolean isAddInclusivePrefixes() {
+        return addInclusivePrefixes;
+    }
+
+    public void setAddInclusivePrefixes(boolean addInclusivePrefixes) {
+        this.addInclusivePrefixes = addInclusivePrefixes;
+    }
+
+    public void setCustomKeyInfoElement(Element keyInfoElement) {
+        this.customKeyInfoElement = keyInfoElement;
+    }
+
+    public Element getCustomKeyInfoElement() {
+        return customKeyInfoElement;
+    }
+
+    public Provider getSignatureProvider() {
+        return signatureProvider;
+    }
+
+    public void setSignatureProvider(Provider signatureProvider) {
+        this.signatureProvider = signatureProvider;
+    }
+
+    public String getKeyInfoUri() {
+        return keyInfoUri;
+    }
+}

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/FATSuite.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/FATSuite.java
@@ -65,12 +65,7 @@ public class FATSuite {
     /*@formatter:off*/
     @ClassRule
     //issue 23060
-    public static RepeatTests r = RepeatTests.with(new EmptyAction().fullFATOnly())
-                    .andWith(new RepeatWithEE7cbh20().fullFATOnly())
-                    .andWith(FeatureReplacementAction.EE8_FEATURES().fullFATOnly())
-                    .andWith(FeatureReplacementAction.EE9_FEATURES())
-                    .andWith(FeatureReplacementAction.EE10_FEATURES())
-                    .andWith(FeatureReplacementAction.EE11_FEATURES());
+    public static RepeatTests r = RepeatTests.with(new EmptyAction().fullFATOnly());
     /*@formatter:on*/
 
 }

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/semeruFips140_3CustomProfile.properties
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/semeruFips140_3CustomProfile.properties
@@ -5,14 +5,11 @@ RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.extends = RestrictedSecurity
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.2 = sun.security.provider.Sun [+ \
     {KeyStore, JKS, *, ModuleAndFullClassName:java.base/java.security.KeyStore}, \
     {MessageDigest, SHA-1, *, ModuleAndFullClassName:java.base/java.security.KeyStore}, \
-    {MessageDigest, SHA-1, *, FullClassName:org.apache.wss4j.dom.message.WSSecEncryptedKey}, \
     {MessageDigest, SHA-1, *, FullClassName:org.apache.wss4j.common.derivedKey.P_SHA1}, \
     {MessageDigest, SHA-1, *, FullClassName:org.apache.wss4j.dom.message.WSSecSignature}, \
     {MessageDigest, SHA-1, *, FullClassName:org.apache.wss4j.dom.message.WSSecDKSign}, \
-    {MessageDigest, SHA-1, *, FullClassName:org.apache.wss4j.dom.processor.EncryptedKeyProcessor}, \
     {MessageDigest, SHA-1, *, FullClassName:org.apache.wss4j.dom.processor.SignatureProcessor}]
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.4 = com.sun.crypto.provider.SunJCE [+ \
-    {Cipher, RSA, *, FullClassName:org.apache.wss4j.common.util.KeyUtils}, \
     {Cipher, AES, *, FullClassName:org.apache.wss4j.dom.message.Encryptor}, \
     {Cipher, AES, *, FullClassName:org.apache.wss4j.dom.util.EncryptionUtils}, \
     {Mac, HmacSHA1, *, FullClassName:org.apache.wss4j.common.derivedKey.P_SHA1}, \

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/test-applications/WSSampleSei/resources/WEB-INF/wsdl/Echo.wsdl
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/test-applications/WSSampleSei/resources/WEB-INF/wsdl/Echo.wsdl
@@ -88,7 +88,7 @@
                             <!-- sp:IncludeTimestamp / -->
                             <sp:AlgorithmSuite>
                                 <wsp:Policy>
-                                    <sp:Basic128 />
+                                    <sp:Basic256Sha256 />
                                 </wsp:Policy>
                             </sp:AlgorithmSuite>
                         </wsp:Policy>
@@ -151,7 +151,7 @@
                   <sp:IncludeTimestamp />
                   <sp:AlgorithmSuite>
                     <wsp:Policy>
-                      <sp:Basic128 />
+                      <sp:Basic256Sha256 />
                     </wsp:Policy>
                   </sp:AlgorithmSuite>
                 </wsp:Policy>
@@ -214,7 +214,7 @@
                   <sp:IncludeTimestamp />
                   <sp:AlgorithmSuite>
                     <wsp:Policy>
-                      <sp:Basic128 />
+                      <sp:Basic256Sha256 />
                     </wsp:Policy>
                   </sp:AlgorithmSuite>
                 </wsp:Policy>
@@ -281,7 +281,7 @@
                   <sp:OnlySignEntireHeadersAndBody />
                   <sp:AlgorithmSuite>
                     <wsp:Policy>
-                      <sp:Basic128 />
+                      <sp:Basic256Sha256 />
                     </wsp:Policy>
                   </sp:AlgorithmSuite>
                 </wsp:Policy>
@@ -377,7 +377,7 @@
                   <sp:EncryptSignature />
                   <sp:AlgorithmSuite>
                     <wsp:Policy>
-                      <sp:Basic128 />
+                      <sp:Basic256Sha256 />
                     </wsp:Policy>
                   </sp:AlgorithmSuite>
                 </wsp:Policy>
@@ -443,7 +443,7 @@
                   </sp:ProtectionToken>
                   <sp:AlgorithmSuite>
                     <wsp:Policy>
-                      <sp:Basic128 />
+                      <sp:Basic256Sha256 />
                     </wsp:Policy>
                   </sp:AlgorithmSuite>
                   <sp:Layout>
@@ -537,7 +537,7 @@
                   </sp:ProtectionToken>
                   <sp:AlgorithmSuite>
                     <wsp:Policy>
-                      <sp:Basic128 />
+                      <sp:Basic256Sha256 />
                     </wsp:Policy>
                   </sp:AlgorithmSuite>
                   <sp:Layout>

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/test-applications/WSSampleSei/resources/WEB-INF/wsdl/EchoBsp.wsdl
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/test-applications/WSSampleSei/resources/WEB-INF/wsdl/EchoBsp.wsdl
@@ -84,7 +84,7 @@
             <ns1:AlgorithmSuite>
                <wsp:Policy>
                   <!--ns1:XPathFilter20/ -->
-                  <ns1:Basic256Sha256Rsa15/>
+                  <ns1:Basic256Sha256/>
                </wsp:Policy>
             </ns1:AlgorithmSuite>
             <ns1:InitiatorToken>
@@ -138,7 +138,7 @@
             <ns1:AlgorithmSuite>
                <wsp:Policy>
                   <!--ns1:XPathFilter20/ -->
-                  <ns1:Basic256Sha256Rsa15/>
+                  <ns1:Basic256Sha256/>
                </wsp:Policy>
             </ns1:AlgorithmSuite>
             <ns1:InitiatorToken>
@@ -224,7 +224,7 @@
             <ns1:AlgorithmSuite>
                <wsp:Policy>
                   <!-- ns1:XPathFilter20/ -->
-                  <ns1:Basic256Sha256Rsa15/>
+                  <ns1:Basic256Sha256/>
                </wsp:Policy>
             </ns1:AlgorithmSuite>
             <ns1:InitiatorToken>
@@ -280,7 +280,7 @@
             <ns1:AlgorithmSuite>
                <wsp:Policy>
                   <!-- ns1:XPathFilter20/ -->
-                  <ns1:Basic256Sha256Rsa15/>
+                  <ns1:Basic256Sha256/>
                </wsp:Policy>
             </ns1:AlgorithmSuite>
             <ns1:InitiatorToken>
@@ -362,7 +362,7 @@
             <ns1:AlgorithmSuite>
                <wsp:Policy>
                   <!-- ns1:XPathFilter20/ -->
-                  <ns1:Basic256Sha256Rsa15/>
+                  <ns1:Basic256Sha256/>
                </wsp:Policy>
             </ns1:AlgorithmSuite>
             <ns1:InitiatorToken>
@@ -416,7 +416,7 @@
             <ns1:AlgorithmSuite>
                <wsp:Policy>
                   <!-- ns1:XPathFilter20/ -->
-                  <ns1:Basic256Sha256Rsa15/>
+                  <ns1:Basic256Sha256/>
                </wsp:Policy>
             </ns1:AlgorithmSuite>
             <ns1:InitiatorToken>
@@ -493,7 +493,7 @@
             <ns1:AlgorithmSuite>
                <wsp:Policy>
                   <!-- ns1:XPathFilter20/ -->
-                  <ns1:Basic256Sha256Rsa15/>
+                  <ns1:Basic256Sha256/>
                </wsp:Policy>
             </ns1:AlgorithmSuite>
             <ns1:InitiatorToken>
@@ -546,7 +546,7 @@
             <ns1:AlgorithmSuite>
                <wsp:Policy>
                   <!-- ns1:XPathFilter20/ -->
-                  <ns1:Basic256Sha256Rsa15/>
+                  <ns1:Basic256Sha256/>
                </wsp:Policy>
             </ns1:AlgorithmSuite>
             <ns1:InitiatorToken>

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/test-applications/WSSampleSei/resources/WEB-INF/wsdl/EchoX509.wsdl
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/test-applications/WSSampleSei/resources/WEB-INF/wsdl/EchoX509.wsdl
@@ -74,7 +74,7 @@
                   </sp:RecipientToken>
                   <sp:AlgorithmSuite>
                      <wsp:Policy>
-                        <sp:Basic256Sha256Rsa15/>
+                        <sp:Basic256Sha256/>
                      </wsp:Policy>
                   </sp:AlgorithmSuite>
                   <sp:InitiatorToken>
@@ -143,7 +143,7 @@
                   </sp:RecipientToken>
                   <sp:AlgorithmSuite>
                      <wsp:Policy>
-                        <sp:Basic256Sha256Rsa15/>
+                        <sp:Basic256Sha256/>
                      </wsp:Policy>
                   </sp:AlgorithmSuite>
                   <sp:InitiatorToken>
@@ -236,7 +236,7 @@
                   </sp:RecipientToken>
                   <sp:AlgorithmSuite>
                      <wsp:Policy>
-                        <sp:Basic256Sha256Rsa15/>
+                        <sp:Basic256Sha256/>
                      </wsp:Policy>
                   </sp:AlgorithmSuite>
                   <sp:InitiatorToken>
@@ -295,7 +295,7 @@
                   </sp:RecipientToken>
                   <sp:AlgorithmSuite>
                      <wsp:Policy>
-                        <sp:Basic256Sha256Rsa15/>
+                        <sp:Basic256Sha256/>
                      </wsp:Policy>
                   </sp:AlgorithmSuite>
                   <sp:InitiatorToken>
@@ -378,7 +378,7 @@
                   </sp:RecipientToken>
                   <sp:AlgorithmSuite>
                      <wsp:Policy>
-                        <sp:Basic256Sha256Rsa15/>
+                        <sp:Basic256Sha256/>
                      </wsp:Policy>
                   </sp:AlgorithmSuite>
                   <sp:InitiatorToken>
@@ -442,7 +442,7 @@
                   </sp:RecipientToken>
                   <sp:AlgorithmSuite>
                      <wsp:Policy>
-                        <sp:Basic256Sha256Rsa15/>
+                        <sp:Basic256Sha256/>
                      </wsp:Policy>
                   </sp:AlgorithmSuite>
                   <sp:InitiatorToken>

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/test-applications/WSSampleSeiClient/resources/WEB-INF/wsdl/Echo.wsdl
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/test-applications/WSSampleSeiClient/resources/WEB-INF/wsdl/Echo.wsdl
@@ -86,7 +86,7 @@
                             <!-- sp:IncludeTimestamp / -->
                             <sp:AlgorithmSuite>
                                 <wsp:Policy>
-                                    <sp:Basic128 />
+                                    <sp:Basic256Sha256 />
                                 </wsp:Policy>
                             </sp:AlgorithmSuite>
                         </wsp:Policy>
@@ -149,7 +149,7 @@
                   <sp:IncludeTimestamp />
                   <sp:AlgorithmSuite>
                     <wsp:Policy>
-                      <sp:Basic128 />
+                      <sp:Basic256Sha256 />
                     </wsp:Policy>
                   </sp:AlgorithmSuite>
                 </wsp:Policy>
@@ -212,7 +212,7 @@
                   <sp:IncludeTimestamp />
                   <sp:AlgorithmSuite>
                     <wsp:Policy>
-                      <sp:Basic128 />
+                      <sp:Basic256Sha256 />
                     </wsp:Policy>
                   </sp:AlgorithmSuite>
                 </wsp:Policy>
@@ -279,7 +279,7 @@
                   <sp:OnlySignEntireHeadersAndBody />
                   <sp:AlgorithmSuite>
                     <wsp:Policy>
-                      <sp:Basic128 />
+                      <sp:Basic256Sha256 />
                     </wsp:Policy>
                   </sp:AlgorithmSuite>
                 </wsp:Policy>
@@ -375,7 +375,7 @@
                   <sp:EncryptSignature />
                   <sp:AlgorithmSuite>
                     <wsp:Policy>
-                      <sp:Basic128 />
+                      <sp:Basic256Sha256 />
                     </wsp:Policy>
                   </sp:AlgorithmSuite>
                 </wsp:Policy>
@@ -441,7 +441,7 @@
                   </sp:ProtectionToken>
                   <sp:AlgorithmSuite>
                     <wsp:Policy>
-                      <sp:Basic128 />
+                      <sp:Basic256Sha256 />
                     </wsp:Policy>
                   </sp:AlgorithmSuite>
                   <sp:Layout>
@@ -535,7 +535,7 @@
                   </sp:ProtectionToken>
                   <sp:AlgorithmSuite>
                     <wsp:Policy>
-                      <sp:Basic128 />
+                      <sp:Basic256Sha256 />
                     </wsp:Policy>
                   </sp:AlgorithmSuite>
                   <sp:Layout>

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.2/semeruFips140_3CustomProfile.properties
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.2/semeruFips140_3CustomProfile.properties
@@ -7,14 +7,10 @@ RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.2 = sun.securit
     {KeyStore, JKS, *, ModuleAndFullClassName:java.base/java.security.KeyStore}, \
     {MessageDigest, SHA-1, *, ModuleAndFullClassName:java.base/java.security.KeyStore}, \
     {MessageDigest, SHA-1, *, FullClassName:org.apache.wss4j.common.crypto.CryptoBase}, \
-    {MessageDigest, SHA-1, *, FullClassName:org.apache.wss4j.dom.message.WSSecEncryptedKey}, \
-    {MessageDigest, SHA-1, *, FullClassName:org.apache.wss4j.common.derivedKey.P_SHA1}, \
     {MessageDigest, SHA-1, *, FullClassName:org.apache.wss4j.dom.message.WSSecSignature}, \
     {MessageDigest, SHA-1, *, FullClassName:org.apache.wss4j.dom.message.WSSecDKSign}, \
-    {MessageDigest, SHA-1, *, FullClassName:org.apache.wss4j.dom.processor.EncryptedKeyProcessor}, \
     {MessageDigest, SHA-1, *, FullClassName:org.apache.wss4j.dom.processor.SignatureProcessor}]
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.4 = com.sun.crypto.provider.SunJCE [+ \
-    {Cipher, RSA, *, FullClassName:org.apache.wss4j.common.util.KeyUtils}, \
     {Cipher, AES, *, FullClassName:org.apache.wss4j.dom.message.Encryptor}, \
     {Cipher, AES, *, FullClassName:org.apache.wss4j.dom.util.EncryptionUtils}, \
     {Cipher, DESede, *, FullClassName:org.apache.wss4j.dom.message.Encryptor}, \

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.2/semeruFips140_3CustomProfile.properties
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.2/semeruFips140_3CustomProfile.properties
@@ -7,6 +7,7 @@ RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.2 = sun.securit
     {KeyStore, JKS, *, ModuleAndFullClassName:java.base/java.security.KeyStore}, \
     {MessageDigest, SHA-1, *, ModuleAndFullClassName:java.base/java.security.KeyStore}, \
     {MessageDigest, SHA-1, *, FullClassName:org.apache.wss4j.common.crypto.CryptoBase}, \
+    {MessageDigest, SHA-1, *, FullClassName:org.apache.wss4j.common.derivedKey.P_SHA1}, \
     {MessageDigest, SHA-1, *, FullClassName:org.apache.wss4j.dom.message.WSSecSignature}, \
     {MessageDigest, SHA-1, *, FullClassName:org.apache.wss4j.dom.message.WSSecDKSign}, \
     {MessageDigest, SHA-1, *, FullClassName:org.apache.wss4j.dom.processor.SignatureProcessor}]

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/fat/src/com/ibm/ws/wssecurity/fat/cxf/x509token/CxfX509EncTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/fat/src/com/ibm/ws/wssecurity/fat/cxf/x509token/CxfX509EncTests.java
@@ -21,6 +21,7 @@ import org.junit.After;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.junit.Rule;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
 import com.ibm.websphere.simplicity.config.ServerConfiguration;
@@ -38,6 +39,8 @@ import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
 import componenttest.rules.repeater.EmptyAction;
+import componenttest.rules.SkipJavaSemeruWithFipsEnabled;
+import componenttest.rules.SkipJavaSemeruWithFipsEnabled.SkipJavaSemeruWithFipsEnabledRule;
 import componenttest.topology.impl.LibertyFileManager;
 import componenttest.topology.impl.LibertyServer;
 
@@ -56,6 +59,9 @@ public class CxfX509EncTests extends CommonTests {
 
     @Server(serverName)
     public static LibertyServer server;
+
+    @Rule
+    public static final SkipJavaSemeruWithFipsEnabled skipJavaSemeruWithFipsEnabled = new SkipJavaSemeruWithFipsEnabled("com.ibm.ws.wssecurity_fat.x509enc");
 
     protected static String portNumber = "";
     protected static String checkPort = "";
@@ -401,6 +407,8 @@ public class CxfX509EncTests extends CommonTests {
      *
      */
 
+    //To use compliant algorithm with FIPS enabled, the test result will always pass; therefore not applicable for negative testing
+    @SkipJavaSemeruWithFipsEnabledRule
     @Test
     //issue 230606
     @ExpectedFFDC(value = { "org.apache.wss4j.common.ext.WSSecurityException" }, repeatAction = { EmptyAction.ID, RepeatWithEE7cbh20.ID })

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/override/autoFVT/cxfclient-policies/WSS11Signature_Elements.wsdl
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/override/autoFVT/cxfclient-policies/WSS11Signature_Elements.wsdl
@@ -39,7 +39,7 @@
                </sp:RecipientSignatureToken>
                <sp:AlgorithmSuite>
                  <wsp:Policy>
-                   <sp:Basic128/>
+                   <sp:Basic256Sha256/>
                  </wsp:Policy>
                </sp:AlgorithmSuite>
                <sp:Layout>
@@ -90,7 +90,7 @@
                </sp:RecipientSignatureToken>
                <sp:AlgorithmSuite>
                  <wsp:Policy>
-                   <sp:Basic128/>
+                   <sp:Basic256Sha256/>
                  </wsp:Policy>
                </sp:AlgorithmSuite>
                <sp:Layout>
@@ -143,7 +143,7 @@
                </sp:RecipientSignatureToken>
                <sp:AlgorithmSuite>
                  <wsp:Policy>
-                   <sp:Basic128/>
+                   <sp:Basic256Sha256/>
                  </wsp:Policy>
                </sp:AlgorithmSuite>
                <sp:Layout>
@@ -196,7 +196,7 @@
                </sp:RecipientSignatureToken>
                <sp:AlgorithmSuite>
                  <wsp:Policy>
-                   <sp:Basic128/>
+                   <sp:Basic256Sha256/>
                  </wsp:Policy>
                </sp:AlgorithmSuite>
                <sp:Layout>
@@ -249,7 +249,7 @@
                </sp:RecipientSignatureToken>
                <sp:AlgorithmSuite>
                  <wsp:Policy>
-                   <sp:Basic128/>
+                   <sp:Basic256Sha256/>
                  </wsp:Policy>
                </sp:AlgorithmSuite>
                <sp:Layout>
@@ -300,7 +300,7 @@
                </sp:RecipientSignatureToken>
                <sp:AlgorithmSuite>
                  <wsp:Policy>
-                   <sp:Basic128/>
+                   <sp:Basic256Sha256/>
                  </wsp:Policy>
                </sp:AlgorithmSuite>
                <sp:Layout>

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/override/autoFVT/cxfclient-policies/WSS11Signature_reqSigMismatch.wsdl
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/override/autoFVT/cxfclient-policies/WSS11Signature_reqSigMismatch.wsdl
@@ -39,7 +39,7 @@
                </sp:RecipientSignatureToken>
                <sp:AlgorithmSuite>
                  <wsp:Policy>
-                   <sp:Basic128/>
+                   <sp:Basic256Sha256/>
                  </wsp:Policy>
                </sp:AlgorithmSuite>
                <sp:Layout>
@@ -92,7 +92,7 @@
                </sp:RecipientSignatureToken>
                <sp:AlgorithmSuite>
                  <wsp:Policy>
-                   <sp:Basic128/>
+                   <sp:Basic256Sha256/>
                  </wsp:Policy>
                </sp:AlgorithmSuite>
                <sp:Layout>
@@ -145,7 +145,7 @@
                </sp:RecipientSignatureToken>
                <sp:AlgorithmSuite>
                  <wsp:Policy>
-                   <sp:Basic128/>
+                   <sp:Basic256Sha256/>
                  </wsp:Policy>
                </sp:AlgorithmSuite>
                <sp:Layout>
@@ -206,7 +206,7 @@
              </sp:RecipientEncryptionToken>
              <sp:AlgorithmSuite>
                 <wsp:Policy>
-                   <sp:Basic128Rsa15/>
+                   <sp:Basic256Sha256Rsa15/>
                 </wsp:Policy>
              </sp:AlgorithmSuite>
              <sp:Layout>
@@ -248,7 +248,7 @@
                </sp:RecipientEncryptionToken>
                <sp:AlgorithmSuite>
                  <wsp:Policy>
-                   <sp:Basic128/>
+                   <sp:Basic256Sha256/>
                  </wsp:Policy>
                </sp:AlgorithmSuite>
                <sp:Layout>
@@ -310,7 +310,7 @@
              </sp:RecipientEncryptionToken>
              <sp:AlgorithmSuite>
                 <wsp:Policy>
-                   <sp:Basic128Rsa15/>
+                   <sp:Basic256Sha256Rsa15/>
                 </wsp:Policy>
              </sp:AlgorithmSuite>
              <sp:Layout>

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/override/autoFVT/cxfclient-policies/X509XmlEnc2.wsdl
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/override/autoFVT/cxfclient-policies/X509XmlEnc2.wsdl
@@ -66,7 +66,7 @@
                                                                                      
                   <sp:AlgorithmSuite>
                      <wsp:Policy>
-                        <sp:Basic128/>
+                        <sp:Basic256Sha256/>
                      </wsp:Policy>
                   </sp:AlgorithmSuite>
                   <sp:Layout>
@@ -215,7 +215,7 @@
                                                    
                   <sp:AlgorithmSuite>
                      <wsp:Policy>
-                        <sp:Basic128Rsa15/>
+                        <sp:Basic256Sha256Rsa15/>
                      </wsp:Policy>
                   </sp:AlgorithmSuite>
                   <sp:Layout>

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/semeruFips140_3CustomProfile.properties
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/semeruFips140_3CustomProfile.properties
@@ -7,11 +7,9 @@ RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.2 = sun.securit
     {KeyStore, JKS, *, ModuleAndFullClassName:java.base/java.security.KeyStore}, \
     {MessageDigest, SHA-1, *, ModuleAndFullClassName:java.base/java.security.KeyStore}, \
     {MessageDigest, SHA-1, *, FullClassName:org.apache.wss4j.common.crypto.CryptoBase}, \
-    {MessageDigest, SHA-1, *, FullClassName:org.apache.wss4j.dom.message.WSSecEncryptedKey}, \
     {MessageDigest, SHA-1, *, FullClassName:org.apache.wss4j.common.derivedKey.P_SHA1}, \
     {MessageDigest, SHA-1, *, FullClassName:org.apache.wss4j.dom.message.WSSecSignature}, \
     {MessageDigest, SHA-1, *, FullClassName:org.apache.wss4j.dom.message.WSSecDKSign}, \
-    {MessageDigest, SHA-1, *, FullClassName:org.apache.wss4j.dom.processor.EncryptedKeyProcessor}, \
     {MessageDigest, SHA-1, *, FullClassName:org.apache.wss4j.dom.processor.SignatureProcessor}, \
     {MessageDigest, MD5, *, FullClassName:org.apache.wss4j.dom.message.WSSecSignature}, \
     {MessageDigest, MD5, *, FullClassName:org.apache.wss4j.dom.processor.EncryptedKeyProcessor}]
@@ -19,7 +17,6 @@ RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.4 = com.sun.cry
     {AlgorithmParameters, PBEWithMD5AndDES, *, FullClassName:org.apache.wss4j.dom.message.WSSecSignature}, \
     {AlgorithmParameters, PBEWithMD5AndDES, *, FullClassName:org.apache.wss4j.dom.processor.EncryptedKeyProcessor}, \
     {KeyStore, JCEKS, *, FullClassName:org.apache.wss4j.common.crypto.Merlin}, \
-    {Cipher, RSA, *, FullClassName:org.apache.wss4j.common.util.KeyUtils}, \
     {Cipher, AES, *, FullClassName:org.apache.wss4j.dom.message.Encryptor}, \
     {Cipher, AES, *, FullClassName:org.apache.wss4j.dom.util.EncryptionUtils}, \
     {Cipher, DESede, *, FullClassName:org.apache.wss4j.dom.message.Encryptor}, \

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/test-applications/wss11sig/resources/WEB-INF/WSS11Signature.wsdl
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/test-applications/wss11sig/resources/WEB-INF/WSS11Signature.wsdl
@@ -39,7 +39,7 @@
                </sp:RecipientSignatureToken>
                <sp:AlgorithmSuite>
                  <wsp:Policy>
-                   <sp:Basic128/>
+                   <sp:Basic256Sha256/>
                  </wsp:Policy>
                </sp:AlgorithmSuite>
                <sp:Layout>
@@ -90,7 +90,7 @@
                </sp:RecipientSignatureToken>
                <sp:AlgorithmSuite>
                  <wsp:Policy>
-                   <sp:Basic128/>
+                   <sp:Basic256Sha256/>
                  </wsp:Policy>
                </sp:AlgorithmSuite>
                <sp:Layout>
@@ -143,7 +143,7 @@
                </sp:RecipientToken>
                <sp:AlgorithmSuite>
                  <wsp:Policy>
-                   <sp:Basic128/>
+                   <sp:Basic256Sha256/>
                  </wsp:Policy>
                </sp:AlgorithmSuite>
                <sp:Layout>
@@ -195,7 +195,7 @@
                </sp:RecipientSignatureToken>
               <sp:AlgorithmSuite>
                  <wsp:Policy>
-                   <sp:Basic128/>
+                   <sp:Basic256Sha256/>
                  </wsp:Policy>
                </sp:AlgorithmSuite>
                <sp:Layout>
@@ -251,7 +251,7 @@
                </sp:RecipientSignatureToken>
                <sp:AlgorithmSuite>
                  <wsp:Policy>
-                   <sp:Basic128/>
+                   <sp:Basic256Sha256/>
                  </wsp:Policy>
                </sp:AlgorithmSuite>
                <sp:Layout>
@@ -309,7 +309,7 @@
                </sp:RecipientSignatureToken>
                <sp:AlgorithmSuite>
                  <wsp:Policy>
-                   <sp:Basic128/>
+                   <sp:Basic256Sha256/>
                  </wsp:Policy>
                </sp:AlgorithmSuite>
                <sp:Layout>
@@ -367,7 +367,7 @@
                </sp:RecipientToken>
                <sp:AlgorithmSuite>
                  <wsp:Policy>
-                   <sp:Basic128/>
+                   <sp:Basic256Sha256/>
                  </wsp:Policy>
                </sp:AlgorithmSuite>
                <sp:Layout>
@@ -423,7 +423,7 @@
                </sp:RecipientSignatureToken>
                <sp:AlgorithmSuite>
                  <wsp:Policy>
-                   <sp:Basic128/>
+                   <sp:Basic256Sha256/>
                  </wsp:Policy>
                </sp:AlgorithmSuite>
                <sp:Layout>
@@ -480,7 +480,7 @@
                </sp:RecipientSignatureToken>
                <sp:AlgorithmSuite>
                  <wsp:Policy>
-                   <sp:Basic128/>
+                   <sp:Basic256Sha256/>
                  </wsp:Policy>
                </sp:AlgorithmSuite>
                <sp:Layout>

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/test-applications/x509enc/resources/WEB-INF/X509XmlEnc2.wsdl
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.3/test-applications/x509enc/resources/WEB-INF/X509XmlEnc2.wsdl
@@ -129,7 +129,7 @@
                                                    
                   <sp:AlgorithmSuite>
                      <wsp:Policy>
-                        <sp:Basic128/>
+                        <sp:Basic256Sha256/>
                      </wsp:Policy>
                   </sp:AlgorithmSuite>
                   <sp:Layout>
@@ -187,7 +187,7 @@
                                                    
                   <sp:AlgorithmSuite>
                      <wsp:Policy>
-                        <sp:Basic128Rsa15/>
+                        <sp:Basic256Sha256/>
                      </wsp:Policy>
                   </sp:AlgorithmSuite>
                   <sp:Layout>

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.4/semeruFips140_3CustomProfile.properties
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.4/semeruFips140_3CustomProfile.properties
@@ -7,14 +7,11 @@ RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.2 = sun.securit
     {KeyStore, JKS, *, ModuleAndFullClassName:java.base/java.security.KeyStore}, \
     {MessageDigest, SHA-1, *, ModuleAndFullClassName:java.base/java.security.KeyStore}, \
     {MessageDigest, SHA-1, *, FullClassName:org.apache.wss4j.common.crypto.CryptoBase}, \
-    {MessageDigest, SHA-1, *, FullClassName:org.apache.wss4j.dom.message.WSSecEncryptedKey}, \
     {MessageDigest, SHA-1, *, FullClassName:org.apache.wss4j.common.derivedKey.P_SHA1}, \
     {MessageDigest, SHA-1, *, FullClassName:org.apache.wss4j.dom.message.WSSecSignature}, \
     {MessageDigest, SHA-1, *, FullClassName:org.apache.wss4j.dom.message.WSSecDKSign}, \
-    {MessageDigest, SHA-1, *, FullClassName:org.apache.wss4j.dom.processor.EncryptedKeyProcessor}, \
     {MessageDigest, SHA-1, *, FullClassName:org.apache.wss4j.dom.processor.SignatureProcessor}]
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.4 = com.sun.crypto.provider.SunJCE [+ \
-    {Cipher, RSA, *, FullClassName:org.apache.wss4j.common.util.KeyUtils}, \
     {Cipher, AES, *, FullClassName:org.apache.wss4j.dom.message.Encryptor}, \
     {Cipher, AES, *, FullClassName:org.apache.wss4j.dom.util.EncryptionUtils}, \
     {Cipher, DESede, *, FullClassName:org.apache.wss4j.dom.message.Encryptor}, \

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.1/override/autoFVT/cxfclient-policies/ClientAsymOmitRecipientToken.wsdl
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.1/override/autoFVT/cxfclient-policies/ClientAsymOmitRecipientToken.wsdl
@@ -32,7 +32,7 @@
 						<sp:IncludeTimestamp />
 						<sp:AlgorithmSuite>
 							<wsp:Policy>
-								<sp:Basic128 />
+								<sp:Basic256Sha256 />
 							</wsp:Policy>
 						</sp:AlgorithmSuite>
 					</wsp:Policy>
@@ -101,7 +101,7 @@
 						<sp:EncryptSignature />
 						<sp:AlgorithmSuite>
 							<wsp:Policy>
-								<sp:Basic128 />
+								<sp:Basic256Sha256 />
 							</wsp:Policy>
 						</sp:AlgorithmSuite>
 					</wsp:Policy>
@@ -154,7 +154,7 @@
 						</sp:ProtectionToken>
 						<sp:AlgorithmSuite>
 							<wsp:Policy>
-								<sp:Basic128 />
+								<sp:Basic256Sha256 />
 							</wsp:Policy>
 						</sp:AlgorithmSuite>
 						<sp:Layout>

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.1/semeruFips140_3CustomProfile.properties
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.1/semeruFips140_3CustomProfile.properties
@@ -9,6 +9,5 @@ RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.2 = sun.securit
     {MessageDigest, SHA-1, *, ModuleAndFullClassName:java.base/java.security.KeyStore}, \
     {MessageDigest, SHA-1, *, FullClassName:org.apache.wss4j.dom.message.WSSecSignature}, \
     {MessageDigest, SHA-1, *, FullClassName:org.apache.wss4j.dom.processor.SignatureProcessor}]
-RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.4 = com.sun.crypto.provider.SunJCE [+ \
-    {Cipher, AES, *, FullClassName:org.apache.xml.security.encryption.XMLCipher}]
+
 

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.1/semeruFips140_3CustomProfile.properties
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.1/semeruFips140_3CustomProfile.properties
@@ -8,10 +8,7 @@ RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.2 = sun.securit
     {KeyStore, JKS, *, ModuleAndFullClassName:java.base/java.security.KeyStore}, \
     {MessageDigest, SHA-1, *, ModuleAndFullClassName:java.base/java.security.KeyStore}, \
     {MessageDigest, SHA-1, *, FullClassName:org.apache.wss4j.dom.message.WSSecSignature}, \
-    {MessageDigest, SHA-1, *, FullClassName:org.apache.wss4j.dom.message.WSSecEncryptedKey}, \
-    {MessageDigest, SHA-1, *, FullClassName:org.apache.wss4j.dom.processor.EncryptedKeyProcessor}, \
     {MessageDigest, SHA-1, *, FullClassName:org.apache.wss4j.dom.processor.SignatureProcessor}]
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.4 = com.sun.crypto.provider.SunJCE [+ \
-    {Cipher, RSA, *, FullClassName:org.apache.wss4j.common.util.KeyUtils}, \
     {Cipher, AES, *, FullClassName:org.apache.xml.security.encryption.XMLCipher}]
 

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.1/test-applications/samltoken/resources/WEB-INF/SamlTokenWebSvc.wsdl
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.1/test-applications/samltoken/resources/WEB-INF/SamlTokenWebSvc.wsdl
@@ -48,7 +48,7 @@
                         <!-- sp:IncludeTimestamp/ -->
                         <sp:AlgorithmSuite>
                             <wsp:Policy>
-                                <sp:Basic128 />
+                                <sp:Basic256Sha256 />
                             </wsp:Policy>
                         </sp:AlgorithmSuite>
                     </wsp:Policy>
@@ -187,7 +187,7 @@
                          </sp:ProtectionToken>
                          <sp:AlgorithmSuite>
                              <wsp:Policy>
-                                 <sp:Basic128/>
+                                 <sp:Basic256Sha256/>
                              </wsp:Policy>
                          </sp:AlgorithmSuite>
                          <sp:Layout>
@@ -266,7 +266,7 @@
                          </sp:ProtectionToken>
                          <sp:AlgorithmSuite>
                              <wsp:Policy>
-                                 <sp:Basic128/>
+                                 <sp:Basic256Sha256/>
                              </wsp:Policy>
                          </sp:AlgorithmSuite>
                          <sp:Layout>
@@ -338,7 +338,7 @@
                          </sp:ProtectionToken>
                          <sp:AlgorithmSuite>
                              <wsp:Policy>
-                                 <sp:Basic128/>
+                                 <sp:Basic256Sha256/>
                              </wsp:Policy>
                          </sp:AlgorithmSuite>
                          <sp:Layout>
@@ -419,7 +419,7 @@
                         </sp:RecipientToken>
                         <sp:AlgorithmSuite>
                             <wsp:Policy>
-                                <sp:Basic128/>
+                                <sp:Basic256Sha256/>
                             </wsp:Policy>
                         </sp:AlgorithmSuite>
                         <sp:Layout>
@@ -503,7 +503,7 @@
                         </sp:RecipientToken>
                         <sp:AlgorithmSuite>
                             <wsp:Policy>
-                                <sp:Basic128/>
+                                <sp:Basic256Sha256/>
                             </wsp:Policy>
                         </sp:AlgorithmSuite>
                         <sp:Layout>
@@ -583,7 +583,7 @@
                         </sp:RecipientToken>
                         <sp:AlgorithmSuite>
                             <wsp:Policy>
-                                <sp:Basic128/>
+                                <sp:Basic256Sha256/>
                             </wsp:Policy>
                         </sp:AlgorithmSuite>
                         <sp:Layout>
@@ -670,7 +670,7 @@
              </sp:RecipientSignatureToken>
              <sp:AlgorithmSuite>
                 <wsp:Policy>
-                   <sp:Basic128/>
+                   <sp:Basic256Sha256/>
                 </wsp:Policy>
              </sp:AlgorithmSuite>
              <sp:Layout>

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.1/test-applications/samlwsstemplates/resources/WEB-INF/WSSSAMLTemplatesTest.wsdl
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.1/test-applications/samlwsstemplates/resources/WEB-INF/WSSSAMLTemplatesTest.wsdl
@@ -32,7 +32,7 @@
 						<sp:IncludeTimestamp />
 						<sp:AlgorithmSuite>
 							<wsp:Policy>
-								<sp:Basic128 />
+								<sp:Basic256Sha256 />
 							</wsp:Policy>
 						</sp:AlgorithmSuite>
 					</wsp:Policy>
@@ -99,7 +99,7 @@
 						<sp:EncryptSignature />
 						<sp:AlgorithmSuite>
 							<wsp:Policy>
-								<sp:Basic128 />
+								<sp:Basic256Sha256 />
 							</wsp:Policy>
 						</sp:AlgorithmSuite>
 					</wsp:Policy>
@@ -152,7 +152,7 @@
 						</sp:ProtectionToken>
 						<sp:AlgorithmSuite>
 							<wsp:Policy>
-								<sp:Basic128 />
+								<sp:Basic256Sha256 />
 							</wsp:Policy>
 						</sp:AlgorithmSuite>
 						<sp:Layout>

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.2/semeruFips140_3CustomProfile.properties
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.2/semeruFips140_3CustomProfile.properties
@@ -9,6 +9,4 @@ RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.2 = sun.securit
     {MessageDigest, SHA-1, *, ModuleAndFullClassName:java.base/java.security.KeyStore}, \
     {MessageDigest, SHA-1, *, FullClassName:org.apache.wss4j.dom.message.WSSecSignature}, \
     {MessageDigest, SHA-1, *, FullClassName:org.apache.wss4j.dom.processor.SignatureProcessor}]
-RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.4 = com.sun.crypto.provider.SunJCE [+ \
-    {Cipher, AES, *, FullClassName:org.apache.xml.security.encryption.XMLCipher}]
 

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.2/semeruFips140_3CustomProfile.properties
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.2/semeruFips140_3CustomProfile.properties
@@ -8,10 +8,7 @@ RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.2 = sun.securit
     {KeyStore, JKS, *, ModuleAndFullClassName:java.base/java.security.KeyStore}, \
     {MessageDigest, SHA-1, *, ModuleAndFullClassName:java.base/java.security.KeyStore}, \
     {MessageDigest, SHA-1, *, FullClassName:org.apache.wss4j.dom.message.WSSecSignature}, \
-    {MessageDigest, SHA-1, *, FullClassName:org.apache.wss4j.dom.message.WSSecEncryptedKey}, \
-    {MessageDigest, SHA-1, *, FullClassName:org.apache.wss4j.dom.processor.EncryptedKeyProcessor}, \
     {MessageDigest, SHA-1, *, FullClassName:org.apache.wss4j.dom.processor.SignatureProcessor}]
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.4 = com.sun.crypto.provider.SunJCE [+ \
-    {Cipher, RSA, *, FullClassName:org.apache.wss4j.common.util.KeyUtils}, \
     {Cipher, AES, *, FullClassName:org.apache.xml.security.encryption.XMLCipher}]
 

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.2/test-applications/samlcallertoken/resources/WEB-INF/samlcallertoken.wsdl
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.2/test-applications/samlcallertoken/resources/WEB-INF/samlcallertoken.wsdl
@@ -51,7 +51,7 @@
                         <!-- sp:IncludeTimestamp / -->
                         <sp:AlgorithmSuite>
                             <wsp:Policy>
-                                <sp:Basic128 />
+                                <sp:Basic256Sha256 />
                             </wsp:Policy>
                         </sp:AlgorithmSuite>
                     </wsp:Policy>
@@ -184,7 +184,7 @@
                          </sp:ProtectionToken>
                          <sp:AlgorithmSuite>
                              <wsp:Policy>
-                                 <sp:Basic128/>
+                                 <sp:Basic256Sha256/>
                              </wsp:Policy>
                          </sp:AlgorithmSuite>
                          <sp:Layout>
@@ -262,7 +262,7 @@
                          </sp:ProtectionToken>
                          <sp:AlgorithmSuite>
                              <wsp:Policy>
-                                 <sp:Basic128/>
+                                 <sp:Basic256Sha256/>
                              </wsp:Policy>
                          </sp:AlgorithmSuite>
                          <sp:Layout>
@@ -334,7 +334,7 @@
                          </sp:ProtectionToken>
                          <sp:AlgorithmSuite>
                              <wsp:Policy>
-                                 <sp:Basic128/>
+                                 <sp:Basic256Sha256/>
                              </wsp:Policy>
                          </sp:AlgorithmSuite>
                          <sp:Layout>
@@ -415,7 +415,7 @@
                         </sp:RecipientToken>
                         <sp:AlgorithmSuite>
                             <wsp:Policy>
-                                <sp:Basic128/>
+                                <sp:Basic256Sha256/>
                             </wsp:Policy>
                         </sp:AlgorithmSuite>
                         <sp:Layout>
@@ -499,7 +499,7 @@
                         </sp:RecipientToken>
                         <sp:AlgorithmSuite>
                             <wsp:Policy>
-                                <sp:Basic128/>
+                                <sp:Basic256Sha256/>
                             </wsp:Policy>
                         </sp:AlgorithmSuite>
                         <sp:Layout>
@@ -579,7 +579,7 @@
                         </sp:RecipientToken>
                         <sp:AlgorithmSuite>
                             <wsp:Policy>
-                                <sp:Basic128/>
+                                <sp:Basic256Sha256/>
                             </wsp:Policy>
                         </sp:AlgorithmSuite>
                         <sp:Layout>
@@ -657,7 +657,7 @@
                         <!-- sp:IncludeTimestamp/ -->
                         <sp:AlgorithmSuite>
                             <wsp:Policy>
-                                <sp:Basic128 />
+                                <sp:Basic256Sha256 />
                             </wsp:Policy>
                         </sp:AlgorithmSuite>
                     </wsp:Policy>
@@ -686,7 +686,7 @@
                          </sp:ProtectionToken>
                          <sp:AlgorithmSuite>
                              <wsp:Policy>
-                                 <sp:Basic128/>
+                                 <sp:Basic256Sha256/>
                              </wsp:Policy>
                          </sp:AlgorithmSuite>
                          <sp:Layout>

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.2/test-applications/samltoken/resources/WEB-INF/SamlTokenWebSvc.wsdl
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.2/test-applications/samltoken/resources/WEB-INF/SamlTokenWebSvc.wsdl
@@ -48,7 +48,7 @@
                         <!-- sp:IncludeTimestamp/ -->
                         <sp:AlgorithmSuite>
                             <wsp:Policy>
-                                <sp:Basic128 />
+                                <sp:Basic256Sha256 />
                             </wsp:Policy>
                         </sp:AlgorithmSuite>
                     </wsp:Policy>
@@ -187,7 +187,7 @@
                          </sp:ProtectionToken>
                          <sp:AlgorithmSuite>
                              <wsp:Policy>
-                                 <sp:Basic128/>
+                                 <sp:Basic256Sha256/>
                              </wsp:Policy>
                          </sp:AlgorithmSuite>
                          <sp:Layout>
@@ -265,7 +265,7 @@
                          </sp:ProtectionToken>
                          <sp:AlgorithmSuite>
                              <wsp:Policy>
-                                 <sp:Basic128/>
+                                 <sp:Basic256Sha256/>
                              </wsp:Policy>
                          </sp:AlgorithmSuite>
                          <sp:Layout>
@@ -337,7 +337,7 @@
                          </sp:ProtectionToken>
                          <sp:AlgorithmSuite>
                              <wsp:Policy>
-                                 <sp:Basic128/>
+                                 <sp:Basic256Sha256/>
                              </wsp:Policy>
                          </sp:AlgorithmSuite>
                          <sp:Layout>
@@ -418,7 +418,7 @@
                         </sp:RecipientToken>
                         <sp:AlgorithmSuite>
                             <wsp:Policy>
-                                <sp:Basic128/>
+                                <sp:Basic256Sha256/>
                             </wsp:Policy>
                         </sp:AlgorithmSuite>
                         <sp:Layout>
@@ -502,7 +502,7 @@
                         </sp:RecipientToken>
                         <sp:AlgorithmSuite>
                             <wsp:Policy>
-                                <sp:Basic128/>
+                                <sp:Basic256Sha256/>
                             </wsp:Policy>
                         </sp:AlgorithmSuite>
                         <sp:Layout>
@@ -582,7 +582,7 @@
                         </sp:RecipientToken>
                         <sp:AlgorithmSuite>
                             <wsp:Policy>
-                                <sp:Basic128/>
+                                <sp:Basic256Sha256/>
                             </wsp:Policy>
                         </sp:AlgorithmSuite>
                         <sp:Layout>
@@ -669,7 +669,7 @@
              </sp:RecipientSignatureToken>
              <sp:AlgorithmSuite>
                 <wsp:Policy>
-                   <sp:Basic128/>
+                   <sp:Basic256Sha256/>
                 </wsp:Policy>
              </sp:AlgorithmSuite>
              <sp:Layout>

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.3/semeruFips140_3CustomProfile.properties
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.3/semeruFips140_3CustomProfile.properties
@@ -8,10 +8,7 @@ RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.2 = sun.securit
     {KeyStore, JKS, *, ModuleAndFullClassName:java.base/java.security.KeyStore}, \
     {MessageDigest, SHA-1, *, ModuleAndFullClassName:java.base/java.security.KeyStore}, \
     {MessageDigest, SHA-1, *, FullClassName:org.apache.wss4j.dom.message.WSSecSignature}, \
-    {MessageDigest, SHA-1, *, FullClassName:org.apache.wss4j.dom.message.WSSecEncryptedKey}, \
-    {MessageDigest, SHA-1, *, FullClassName:org.apache.wss4j.dom.processor.EncryptedKeyProcessor}, \
     {MessageDigest, SHA-1, *, FullClassName:org.apache.wss4j.dom.processor.SignatureProcessor}]
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.4 = com.sun.crypto.provider.SunJCE [+ \
-    {Cipher, RSA, *, FullClassName:org.apache.wss4j.common.util.KeyUtils}, \
     {Cipher, AES, *, FullClassName:org.apache.xml.security.encryption.XMLCipher}]
 

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.3/semeruFips140_3CustomProfile.properties
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.3/semeruFips140_3CustomProfile.properties
@@ -9,6 +9,3 @@ RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.2 = sun.securit
     {MessageDigest, SHA-1, *, ModuleAndFullClassName:java.base/java.security.KeyStore}, \
     {MessageDigest, SHA-1, *, FullClassName:org.apache.wss4j.dom.message.WSSecSignature}, \
     {MessageDigest, SHA-1, *, FullClassName:org.apache.wss4j.dom.processor.SignatureProcessor}]
-RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.4 = com.sun.crypto.provider.SunJCE [+ \
-    {Cipher, AES, *, FullClassName:org.apache.xml.security.encryption.XMLCipher}]
-

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.3/test-applications/samlcallertoken/resources/WEB-INF/samlcallertoken.wsdl
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.3/test-applications/samlcallertoken/resources/WEB-INF/samlcallertoken.wsdl
@@ -51,7 +51,7 @@
                         <!-- sp:IncludeTimestamp / -->
                         <sp:AlgorithmSuite>
                             <wsp:Policy>
-                                <sp:Basic128 />
+                                <sp:Basic256Sha256 />
                             </wsp:Policy>
                         </sp:AlgorithmSuite>
                     </wsp:Policy>
@@ -184,7 +184,7 @@
                          </sp:ProtectionToken>
                          <sp:AlgorithmSuite>
                              <wsp:Policy>
-                                 <sp:Basic128/>
+                                 <sp:Basic256Sha256/>
                              </wsp:Policy>
                          </sp:AlgorithmSuite>
                          <sp:Layout>
@@ -262,7 +262,7 @@
                          </sp:ProtectionToken>
                          <sp:AlgorithmSuite>
                              <wsp:Policy>
-                                 <sp:Basic128/>
+                                 <sp:Basic256Sha256/>
                              </wsp:Policy>
                          </sp:AlgorithmSuite>
                          <sp:Layout>
@@ -334,7 +334,7 @@
                          </sp:ProtectionToken>
                          <sp:AlgorithmSuite>
                              <wsp:Policy>
-                                 <sp:Basic128/>
+                                 <sp:Basic256Sha256/>
                              </wsp:Policy>
                          </sp:AlgorithmSuite>
                          <sp:Layout>
@@ -415,7 +415,7 @@
                         </sp:RecipientToken>
                         <sp:AlgorithmSuite>
                             <wsp:Policy>
-                                <sp:Basic128/>
+                                <sp:Basic256Sha256/>
                             </wsp:Policy>
                         </sp:AlgorithmSuite>
                         <sp:Layout>
@@ -499,7 +499,7 @@
                         </sp:RecipientToken>
                         <sp:AlgorithmSuite>
                             <wsp:Policy>
-                                <sp:Basic128/>
+                                <sp:Basic256Sha256/>
                             </wsp:Policy>
                         </sp:AlgorithmSuite>
                         <sp:Layout>
@@ -579,7 +579,7 @@
                         </sp:RecipientToken>
                         <sp:AlgorithmSuite>
                             <wsp:Policy>
-                                <sp:Basic128/>
+                                <sp:Basic256Sha256/>
                             </wsp:Policy>
                         </sp:AlgorithmSuite>
                         <sp:Layout>
@@ -657,7 +657,7 @@
                         <!-- sp:IncludeTimestamp/ -->
                         <sp:AlgorithmSuite>
                             <wsp:Policy>
-                                <sp:Basic128 />
+                                <sp:Basic256Sha256 />
                             </wsp:Policy>
                         </sp:AlgorithmSuite>
                     </wsp:Policy>
@@ -686,7 +686,7 @@
                          </sp:ProtectionToken>
                          <sp:AlgorithmSuite>
                              <wsp:Policy>
-                                 <sp:Basic128/>
+                                 <sp:Basic256Sha256/>
                              </wsp:Policy>
                          </sp:AlgorithmSuite>
                          <sp:Layout>

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.3/test-applications/samltoken/resources/WEB-INF/SamlTokenWebSvc.wsdl
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.3/test-applications/samltoken/resources/WEB-INF/SamlTokenWebSvc.wsdl
@@ -48,7 +48,7 @@
                         <!-- sp:IncludeTimestamp/ -->
                         <sp:AlgorithmSuite>
                             <wsp:Policy>
-                                <sp:Basic128 />
+                                <sp:Basic256Sha256 />
                             </wsp:Policy>
                         </sp:AlgorithmSuite>
                     </wsp:Policy>
@@ -187,7 +187,7 @@
                          </sp:ProtectionToken>
                          <sp:AlgorithmSuite>
                              <wsp:Policy>
-                                 <sp:Basic128/>
+                                 <sp:Basic256Sha256/>
                              </wsp:Policy>
                          </sp:AlgorithmSuite>
                          <sp:Layout>
@@ -265,7 +265,7 @@
                          </sp:ProtectionToken>
                          <sp:AlgorithmSuite>
                              <wsp:Policy>
-                                 <sp:Basic128/>
+                                 <sp:Basic256Sha256/>
                              </wsp:Policy>
                          </sp:AlgorithmSuite>
                          <sp:Layout>
@@ -337,7 +337,7 @@
                          </sp:ProtectionToken>
                          <sp:AlgorithmSuite>
                              <wsp:Policy>
-                                 <sp:Basic128/>
+                                 <sp:Basic256Sha256/>
                              </wsp:Policy>
                          </sp:AlgorithmSuite>
                          <sp:Layout>
@@ -418,7 +418,7 @@
                         </sp:RecipientToken>
                         <sp:AlgorithmSuite>
                             <wsp:Policy>
-                                <sp:Basic128/>
+                                <sp:Basic256Sha256/>
                             </wsp:Policy>
                         </sp:AlgorithmSuite>
                         <sp:Layout>
@@ -502,7 +502,7 @@
                         </sp:RecipientToken>
                         <sp:AlgorithmSuite>
                             <wsp:Policy>
-                                <sp:Basic128/>
+                                <sp:Basic256Sha256/>
                             </wsp:Policy>
                         </sp:AlgorithmSuite>
                         <sp:Layout>
@@ -582,7 +582,7 @@
                         </sp:RecipientToken>
                         <sp:AlgorithmSuite>
                             <wsp:Policy>
-                                <sp:Basic128/>
+                                <sp:Basic256Sha256/>
                             </wsp:Policy>
                         </sp:AlgorithmSuite>
                         <sp:Layout>
@@ -669,7 +669,7 @@
              </sp:RecipientSignatureToken>
              <sp:AlgorithmSuite>
                 <wsp:Policy>
-                   <sp:Basic128/>
+                   <sp:Basic256Sha256/>
                 </wsp:Policy>
              </sp:AlgorithmSuite>
              <sp:Layout>

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.5/override/autoFVT/cxfclient-policies/ClientAsymOmitEncr.wsdl
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.5/override/autoFVT/cxfclient-policies/ClientAsymOmitEncr.wsdl
@@ -48,7 +48,7 @@
                         <!-- sp:IncludeTimestamp/ -->
                         <sp:AlgorithmSuite>
                             <wsp:Policy>
-                                <sp:Basic128 />
+                                <sp:Basic256Sha256 />
                             </wsp:Policy>
                         </sp:AlgorithmSuite>
                     </wsp:Policy>
@@ -187,7 +187,7 @@
                          </sp:ProtectionToken>
                          <sp:AlgorithmSuite>
                              <wsp:Policy>
-                                 <sp:Basic128/>
+                                 <sp:Basic256Sha256/>
                              </wsp:Policy>
                          </sp:AlgorithmSuite>
                          <sp:Layout>
@@ -265,7 +265,7 @@
                          </sp:ProtectionToken>
                          <sp:AlgorithmSuite>
                              <wsp:Policy>
-                                 <sp:Basic128/>
+                                 <sp:Basic256Sha256/>
                              </wsp:Policy>
                          </sp:AlgorithmSuite>
                          <sp:Layout>
@@ -337,7 +337,7 @@
                          </sp:ProtectionToken>
                          <sp:AlgorithmSuite>
                              <wsp:Policy>
-                                 <sp:Basic128/>
+                                 <sp:Basic256Sha256/>
                              </wsp:Policy>
                          </sp:AlgorithmSuite>
                          <sp:Layout>
@@ -418,7 +418,7 @@
                         </sp:RecipientToken>
                         <sp:AlgorithmSuite>
                             <wsp:Policy>
-                                <sp:Basic128/>
+                                <sp:Basic256Sha256/>
                             </wsp:Policy>
                         </sp:AlgorithmSuite>
                         <sp:Layout>
@@ -502,7 +502,7 @@
                         </sp:RecipientToken>
                         <sp:AlgorithmSuite>
                             <wsp:Policy>
-                                <sp:Basic128/>
+                                <sp:Basic256Sha256/>
                             </wsp:Policy>
                         </sp:AlgorithmSuite>
                         <sp:Layout>
@@ -582,7 +582,7 @@
                         </sp:RecipientToken>
                         <sp:AlgorithmSuite>
                             <wsp:Policy>
-                                <sp:Basic128/>
+                                <sp:Basic256Sha256/>
                             </wsp:Policy>
                         </sp:AlgorithmSuite>
                         <sp:Layout>
@@ -669,7 +669,7 @@
              </sp:RecipientSignatureToken>
              <sp:AlgorithmSuite>
                 <wsp:Policy>
-                   <sp:Basic128/>
+                   <sp:Basic256Sha256/>
                 </wsp:Policy>
              </sp:AlgorithmSuite>
              <sp:Layout>

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.5/override/autoFVT/cxfclient-policies/ClientAsymOmitEncrKeepSign.wsdl
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.5/override/autoFVT/cxfclient-policies/ClientAsymOmitEncrKeepSign.wsdl
@@ -48,7 +48,7 @@
                         <!-- sp:IncludeTimestamp/ -->
                         <sp:AlgorithmSuite>
                             <wsp:Policy>
-                                <sp:Basic128 />
+                                <sp:Basic256Sha256 />
                             </wsp:Policy>
                         </sp:AlgorithmSuite>
                     </wsp:Policy>
@@ -187,7 +187,7 @@
                          </sp:ProtectionToken>
                          <sp:AlgorithmSuite>
                              <wsp:Policy>
-                                 <sp:Basic128/>
+                                 <sp:Basic256Sha256/>
                              </wsp:Policy>
                          </sp:AlgorithmSuite>
                          <sp:Layout>
@@ -265,7 +265,7 @@
                          </sp:ProtectionToken>
                          <sp:AlgorithmSuite>
                              <wsp:Policy>
-                                 <sp:Basic128/>
+                                 <sp:Basic256Sha256/>
                              </wsp:Policy>
                          </sp:AlgorithmSuite>
                          <sp:Layout>
@@ -337,7 +337,7 @@
                          </sp:ProtectionToken>
                          <sp:AlgorithmSuite>
                              <wsp:Policy>
-                                 <sp:Basic128/>
+                                 <sp:Basic256Sha256/>
                              </wsp:Policy>
                          </sp:AlgorithmSuite>
                          <sp:Layout>
@@ -418,7 +418,7 @@
                         </sp:RecipientToken>
                         <sp:AlgorithmSuite>
                             <wsp:Policy>
-                                <sp:Basic128/>
+                                <sp:Basic256Sha256/>
                             </wsp:Policy>
                         </sp:AlgorithmSuite>
                         <sp:Layout>
@@ -502,7 +502,7 @@
                         </sp:RecipientToken>
                         <sp:AlgorithmSuite>
                             <wsp:Policy>
-                                <sp:Basic128/>
+                                <sp:Basic256Sha256/>
                             </wsp:Policy>
                         </sp:AlgorithmSuite>
                         <sp:Layout>
@@ -582,7 +582,7 @@
                         </sp:RecipientToken>
                         <sp:AlgorithmSuite>
                             <wsp:Policy>
-                                <sp:Basic128/>
+                                <sp:Basic256Sha256/>
                             </wsp:Policy>
                         </sp:AlgorithmSuite>
                         <sp:Layout>
@@ -669,7 +669,7 @@
              </sp:RecipientSignatureToken>
              <sp:AlgorithmSuite>
                 <wsp:Policy>
-                   <sp:Basic128/>
+                   <sp:Basic256Sha256/>
                 </wsp:Policy>
              </sp:AlgorithmSuite>
              <sp:Layout>

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.5/override/autoFVT/cxfclient-policies/ClientAsymOmitSign.wsdl
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.5/override/autoFVT/cxfclient-policies/ClientAsymOmitSign.wsdl
@@ -48,7 +48,7 @@
                         <!-- sp:IncludeTimestamp/ -->
                         <sp:AlgorithmSuite>
                             <wsp:Policy>
-                                <sp:Basic128 />
+                                <sp:Basic256Sha256 />
                             </wsp:Policy>
                         </sp:AlgorithmSuite>
                     </wsp:Policy>
@@ -187,7 +187,7 @@
                          </sp:ProtectionToken>
                          <sp:AlgorithmSuite>
                              <wsp:Policy>
-                                 <sp:Basic128/>
+                                 <sp:Basic256Sha256/>
                              </wsp:Policy>
                          </sp:AlgorithmSuite>
                          <sp:Layout>
@@ -265,7 +265,7 @@
                          </sp:ProtectionToken>
                          <sp:AlgorithmSuite>
                              <wsp:Policy>
-                                 <sp:Basic128/>
+                                 <sp:Basic256Sha256/>
                              </wsp:Policy>
                          </sp:AlgorithmSuite>
                          <sp:Layout>
@@ -337,7 +337,7 @@
                          </sp:ProtectionToken>
                          <sp:AlgorithmSuite>
                              <wsp:Policy>
-                                 <sp:Basic128/>
+                                 <sp:Basic256Sha256/>
                              </wsp:Policy>
                          </sp:AlgorithmSuite>
                          <sp:Layout>
@@ -418,7 +418,7 @@
                         </sp:RecipientToken>
                         <sp:AlgorithmSuite>
                             <wsp:Policy>
-                                <sp:Basic128/>
+                                <sp:Basic256Sha256/>
                             </wsp:Policy>
                         </sp:AlgorithmSuite>
                         <sp:Layout>
@@ -502,7 +502,7 @@
                         </sp:RecipientToken>
                         <sp:AlgorithmSuite>
                             <wsp:Policy>
-                                <sp:Basic128/>
+                                <sp:Basic256Sha256/>
                             </wsp:Policy>
                         </sp:AlgorithmSuite>
                         <sp:Layout>
@@ -582,7 +582,7 @@
                         </sp:RecipientToken>
                         <sp:AlgorithmSuite>
                             <wsp:Policy>
-                                <sp:Basic128/>
+                                <sp:Basic256Sha256/>
                             </wsp:Policy>
                         </sp:AlgorithmSuite>
                         <sp:Layout>
@@ -669,7 +669,7 @@
              </sp:RecipientSignatureToken>
              <sp:AlgorithmSuite>
                 <wsp:Policy>
-                   <sp:Basic128/>
+                   <sp:Basic256Sha256/>
                 </wsp:Policy>
              </sp:AlgorithmSuite>
              <sp:Layout>

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.5/override/autoFVT/cxfclient-policies/ClientAsymOmitSignKeepEncr.wsdl
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.5/override/autoFVT/cxfclient-policies/ClientAsymOmitSignKeepEncr.wsdl
@@ -48,7 +48,7 @@
                         <!-- sp:IncludeTimestamp/ -->
                         <sp:AlgorithmSuite>
                             <wsp:Policy>
-                                <sp:Basic128 />
+                                <sp:Basic256Sha256 />
                             </wsp:Policy>
                         </sp:AlgorithmSuite>
                     </wsp:Policy>
@@ -187,7 +187,7 @@
                          </sp:ProtectionToken>
                          <sp:AlgorithmSuite>
                              <wsp:Policy>
-                                 <sp:Basic128/>
+                                 <sp:Basic256Sha256/>
                              </wsp:Policy>
                          </sp:AlgorithmSuite>
                          <sp:Layout>
@@ -265,7 +265,7 @@
                          </sp:ProtectionToken>
                          <sp:AlgorithmSuite>
                              <wsp:Policy>
-                                 <sp:Basic128/>
+                                 <sp:Basic256Sha256/>
                              </wsp:Policy>
                          </sp:AlgorithmSuite>
                          <sp:Layout>
@@ -337,7 +337,7 @@
                          </sp:ProtectionToken>
                          <sp:AlgorithmSuite>
                              <wsp:Policy>
-                                 <sp:Basic128/>
+                                 <sp:Basic256Sha256/>
                              </wsp:Policy>
                          </sp:AlgorithmSuite>
                          <sp:Layout>
@@ -418,7 +418,7 @@
                         </sp:RecipientToken>
                         <sp:AlgorithmSuite>
                             <wsp:Policy>
-                                <sp:Basic128/>
+                                <sp:Basic256Sha256/>
                             </wsp:Policy>
                         </sp:AlgorithmSuite>
                         <sp:Layout>
@@ -502,7 +502,7 @@
                         </sp:RecipientToken>
                         <sp:AlgorithmSuite>
                             <wsp:Policy>
-                                <sp:Basic128/>
+                                <sp:Basic256Sha256/>
                             </wsp:Policy>
                         </sp:AlgorithmSuite>
                         <sp:Layout>
@@ -582,7 +582,7 @@
                         </sp:RecipientToken>
                         <sp:AlgorithmSuite>
                             <wsp:Policy>
-                                <sp:Basic128/>
+                                <sp:Basic256Sha256/>
                             </wsp:Policy>
                         </sp:AlgorithmSuite>
                         <sp:Layout>
@@ -669,7 +669,7 @@
              </sp:RecipientSignatureToken>
              <sp:AlgorithmSuite>
                 <wsp:Policy>
-                   <sp:Basic128/>
+                   <sp:Basic256Sha256/>
                 </wsp:Policy>
              </sp:AlgorithmSuite>
              <sp:Layout>

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.5/override/autoFVT/cxfclient-policies/ClientSymOmitEncr.wsdl
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.5/override/autoFVT/cxfclient-policies/ClientSymOmitEncr.wsdl
@@ -48,7 +48,7 @@
                         <!-- sp:IncludeTimestamp/ -->
                         <sp:AlgorithmSuite>
                             <wsp:Policy>
-                                <sp:Basic128 />
+                                <sp:Basic256Sha256 />
                             </wsp:Policy>
                         </sp:AlgorithmSuite>
                     </wsp:Policy>
@@ -187,7 +187,7 @@
                          </sp:ProtectionToken>
                          <sp:AlgorithmSuite>
                              <wsp:Policy>
-                                 <sp:Basic128/>
+                                 <sp:Basic256Sha256/>
                              </wsp:Policy>
                          </sp:AlgorithmSuite>
                          <sp:Layout>
@@ -265,7 +265,7 @@
                          </sp:ProtectionToken>
                          <sp:AlgorithmSuite>
                              <wsp:Policy>
-                                 <sp:Basic128/>
+                                 <sp:Basic256Sha256/>
                              </wsp:Policy>
                          </sp:AlgorithmSuite>
                          <sp:Layout>
@@ -337,7 +337,7 @@
                          </sp:ProtectionToken>
                          <sp:AlgorithmSuite>
                              <wsp:Policy>
-                                 <sp:Basic128/>
+                                 <sp:Basic256Sha256/>
                              </wsp:Policy>
                          </sp:AlgorithmSuite>
                          <sp:Layout>
@@ -418,7 +418,7 @@
                         </sp:RecipientToken>
                         <sp:AlgorithmSuite>
                             <wsp:Policy>
-                                <sp:Basic128/>
+                                <sp:Basic256Sha256/>
                             </wsp:Policy>
                         </sp:AlgorithmSuite>
                         <sp:Layout>
@@ -502,7 +502,7 @@
                         </sp:RecipientToken>
                         <sp:AlgorithmSuite>
                             <wsp:Policy>
-                                <sp:Basic128/>
+                                <sp:Basic256Sha256/>
                             </wsp:Policy>
                         </sp:AlgorithmSuite>
                         <sp:Layout>
@@ -582,7 +582,7 @@
                         </sp:RecipientToken>
                         <sp:AlgorithmSuite>
                             <wsp:Policy>
-                                <sp:Basic128/>
+                                <sp:Basic256Sha256/>
                             </wsp:Policy>
                         </sp:AlgorithmSuite>
                         <sp:Layout>
@@ -669,7 +669,7 @@
              </sp:RecipientSignatureToken>
              <sp:AlgorithmSuite>
                 <wsp:Policy>
-                   <sp:Basic128/>
+                   <sp:Basic256Sha256/>
                 </wsp:Policy>
              </sp:AlgorithmSuite>
              <sp:Layout>

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.5/override/autoFVT/cxfclient-policies/ClientSymOmitEncrKeepSign.wsdl
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.5/override/autoFVT/cxfclient-policies/ClientSymOmitEncrKeepSign.wsdl
@@ -48,7 +48,7 @@
                         <!-- sp:IncludeTimestamp/ -->
                         <sp:AlgorithmSuite>
                             <wsp:Policy>
-                                <sp:Basic128 />
+                                <sp:Basic256Sha256 />
                             </wsp:Policy>
                         </sp:AlgorithmSuite>
                     </wsp:Policy>
@@ -187,7 +187,7 @@
                          </sp:ProtectionToken>
                          <sp:AlgorithmSuite>
                              <wsp:Policy>
-                                 <sp:Basic128/>
+                                 <sp:Basic256Sha256/>
                              </wsp:Policy>
                          </sp:AlgorithmSuite>
                          <sp:Layout>
@@ -265,7 +265,7 @@
                          </sp:ProtectionToken>
                          <sp:AlgorithmSuite>
                              <wsp:Policy>
-                                 <sp:Basic128/>
+                                 <sp:Basic256Sha256/>
                              </wsp:Policy>
                          </sp:AlgorithmSuite>
                          <sp:Layout>
@@ -337,7 +337,7 @@
                          </sp:ProtectionToken>
                          <sp:AlgorithmSuite>
                              <wsp:Policy>
-                                 <sp:Basic128/>
+                                 <sp:Basic256Sha256/>
                              </wsp:Policy>
                          </sp:AlgorithmSuite>
                          <sp:Layout>
@@ -418,7 +418,7 @@
                         </sp:RecipientToken>
                         <sp:AlgorithmSuite>
                             <wsp:Policy>
-                                <sp:Basic128/>
+                                <sp:Basic256Sha256/>
                             </wsp:Policy>
                         </sp:AlgorithmSuite>
                         <sp:Layout>
@@ -502,7 +502,7 @@
                         </sp:RecipientToken>
                         <sp:AlgorithmSuite>
                             <wsp:Policy>
-                                <sp:Basic128/>
+                                <sp:Basic256Sha256/>
                             </wsp:Policy>
                         </sp:AlgorithmSuite>
                         <sp:Layout>
@@ -582,7 +582,7 @@
                         </sp:RecipientToken>
                         <sp:AlgorithmSuite>
                             <wsp:Policy>
-                                <sp:Basic128/>
+                                <sp:Basic256Sha256/>
                             </wsp:Policy>
                         </sp:AlgorithmSuite>
                         <sp:Layout>
@@ -669,7 +669,7 @@
              </sp:RecipientSignatureToken>
              <sp:AlgorithmSuite>
                 <wsp:Policy>
-                   <sp:Basic128/>
+                   <sp:Basic256Sha256/>
                 </wsp:Policy>
              </sp:AlgorithmSuite>
              <sp:Layout>

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.5/override/autoFVT/cxfclient-policies/ClientSymOmitSign.wsdl
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.5/override/autoFVT/cxfclient-policies/ClientSymOmitSign.wsdl
@@ -187,7 +187,7 @@
                          </sp:ProtectionToken>
                          <sp:AlgorithmSuite>
                              <wsp:Policy>
-                                 <sp:Basic128/>
+                                 <sp:Basic256Sha256/>
                              </wsp:Policy>
                          </sp:AlgorithmSuite>
                          <sp:Layout>

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.5/override/autoFVT/cxfclient-policies/ClientSymOmitSignKeepEncr.wsdl
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.5/override/autoFVT/cxfclient-policies/ClientSymOmitSignKeepEncr.wsdl
@@ -48,7 +48,7 @@
                         <!-- sp:IncludeTimestamp/ -->
                         <sp:AlgorithmSuite>
                             <wsp:Policy>
-                                <sp:Basic128 />
+                                <sp:Basic256Sha256 />
                             </wsp:Policy>
                         </sp:AlgorithmSuite>
                     </wsp:Policy>
@@ -187,7 +187,7 @@
                          </sp:ProtectionToken>
                          <sp:AlgorithmSuite>
                              <wsp:Policy>
-                                 <sp:Basic128/>
+                                 <sp:Basic256Sha256/>
                              </wsp:Policy>
                          </sp:AlgorithmSuite>
                          <sp:Layout>
@@ -265,7 +265,7 @@
                          </sp:ProtectionToken>
                          <sp:AlgorithmSuite>
                              <wsp:Policy>
-                                 <sp:Basic128/>
+                                 <sp:Basic256Sha256/>
                              </wsp:Policy>
                          </sp:AlgorithmSuite>
                          <sp:Layout>
@@ -337,7 +337,7 @@
                          </sp:ProtectionToken>
                          <sp:AlgorithmSuite>
                              <wsp:Policy>
-                                 <sp:Basic128/>
+                                 <sp:Basic256Sha256/>
                              </wsp:Policy>
                          </sp:AlgorithmSuite>
                          <sp:Layout>
@@ -418,7 +418,7 @@
                         </sp:RecipientToken>
                         <sp:AlgorithmSuite>
                             <wsp:Policy>
-                                <sp:Basic128/>
+                                <sp:Basic256Sha256/>
                             </wsp:Policy>
                         </sp:AlgorithmSuite>
                         <sp:Layout>
@@ -502,7 +502,7 @@
                         </sp:RecipientToken>
                         <sp:AlgorithmSuite>
                             <wsp:Policy>
-                                <sp:Basic128/>
+                                <sp:Basic256Sha256/>
                             </wsp:Policy>
                         </sp:AlgorithmSuite>
                         <sp:Layout>
@@ -582,7 +582,7 @@
                         </sp:RecipientToken>
                         <sp:AlgorithmSuite>
                             <wsp:Policy>
-                                <sp:Basic128/>
+                                <sp:Basic256Sha256/>
                             </wsp:Policy>
                         </sp:AlgorithmSuite>
                         <sp:Layout>
@@ -669,7 +669,7 @@
              </sp:RecipientSignatureToken>
              <sp:AlgorithmSuite>
                 <wsp:Policy>
-                   <sp:Basic128/>
+                   <sp:Basic256Sha256/>
                 </wsp:Policy>
              </sp:AlgorithmSuite>
              <sp:Layout>

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.5/semeruFips140_3CustomProfile.properties
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.5/semeruFips140_3CustomProfile.properties
@@ -9,6 +9,4 @@ RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.2 = sun.securit
     {MessageDigest, SHA-1, *, ModuleAndFullClassName:java.base/java.security.KeyStore}, \
     {MessageDigest, SHA-1, *, FullClassName:org.apache.wss4j.dom.message.WSSecSignature}, \
     {MessageDigest, SHA-1, *, FullClassName:org.apache.wss4j.dom.processor.SignatureProcessor}]
-RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.4 = com.sun.crypto.provider.SunJCE [+ \
-    {Cipher, AES, *, FullClassName:org.apache.xml.security.encryption.XMLCipher}]
 

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.5/semeruFips140_3CustomProfile.properties
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.5/semeruFips140_3CustomProfile.properties
@@ -8,10 +8,7 @@ RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.2 = sun.securit
     {KeyStore, JKS, *, ModuleAndFullClassName:java.base/java.security.KeyStore}, \
     {MessageDigest, SHA-1, *, ModuleAndFullClassName:java.base/java.security.KeyStore}, \
     {MessageDigest, SHA-1, *, FullClassName:org.apache.wss4j.dom.message.WSSecSignature}, \
-    {MessageDigest, SHA-1, *, FullClassName:org.apache.wss4j.dom.message.WSSecEncryptedKey}, \
-    {MessageDigest, SHA-1, *, FullClassName:org.apache.wss4j.dom.processor.EncryptedKeyProcessor}, \
     {MessageDigest, SHA-1, *, FullClassName:org.apache.wss4j.dom.processor.SignatureProcessor}]
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.4 = com.sun.crypto.provider.SunJCE [+ \
-    {Cipher, RSA, *, FullClassName:org.apache.wss4j.common.util.KeyUtils}, \
     {Cipher, AES, *, FullClassName:org.apache.xml.security.encryption.XMLCipher}]
 

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.5/test-applications/samltoken/resources/WEB-INF/SamlTokenWebSvc.wsdl
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.5/test-applications/samltoken/resources/WEB-INF/SamlTokenWebSvc.wsdl
@@ -48,7 +48,7 @@
                         <!-- sp:IncludeTimestamp/ -->
                         <sp:AlgorithmSuite>
                             <wsp:Policy>
-                                <sp:Basic128 />
+                                <sp:Basic256Sha256 />
                             </wsp:Policy>
                         </sp:AlgorithmSuite>
                     </wsp:Policy>
@@ -187,7 +187,7 @@
                          </sp:ProtectionToken>
                          <sp:AlgorithmSuite>
                              <wsp:Policy>
-                                 <sp:Basic128/>
+                                 <sp:Basic256Sha256/>
                              </wsp:Policy>
                          </sp:AlgorithmSuite>
                          <sp:Layout>
@@ -266,7 +266,7 @@
                          </sp:ProtectionToken>
                          <sp:AlgorithmSuite>
                              <wsp:Policy>
-                                 <sp:Basic128/>
+                                 <sp:Basic256Sha256/>
                              </wsp:Policy>
                          </sp:AlgorithmSuite>
                          <sp:Layout>
@@ -338,7 +338,7 @@
                          </sp:ProtectionToken>
                          <sp:AlgorithmSuite>
                              <wsp:Policy>
-                                 <sp:Basic128/>
+                                 <sp:Basic256Sha256/>
                              </wsp:Policy>
                          </sp:AlgorithmSuite>
                          <sp:Layout>
@@ -419,7 +419,7 @@
                         </sp:RecipientToken>
                         <sp:AlgorithmSuite>
                             <wsp:Policy>
-                                <sp:Basic128/>
+                                <sp:Basic256Sha256/>
                             </wsp:Policy>
                         </sp:AlgorithmSuite>
                         <sp:Layout>
@@ -503,7 +503,7 @@
                         </sp:RecipientToken>
                         <sp:AlgorithmSuite>
                             <wsp:Policy>
-                                <sp:Basic128/>
+                                <sp:Basic256Sha256/>
                             </wsp:Policy>
                         </sp:AlgorithmSuite>
                         <sp:Layout>
@@ -583,7 +583,7 @@
                         </sp:RecipientToken>
                         <sp:AlgorithmSuite>
                             <wsp:Policy>
-                                <sp:Basic128/>
+                                <sp:Basic256Sha256/>
                             </wsp:Policy>
                         </sp:AlgorithmSuite>
                         <sp:Layout>
@@ -670,7 +670,7 @@
              </sp:RecipientSignatureToken>
              <sp:AlgorithmSuite>
                 <wsp:Policy>
-                   <sp:Basic128/>
+                   <sp:Basic256Sha256/>
                 </wsp:Policy>
              </sp:AlgorithmSuite>
              <sp:Layout>

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.6/override/autoFVT/cxfclient-policies/ClientAsymOmitInitiatorTokenWithEP.wsdl
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.6/override/autoFVT/cxfclient-policies/ClientAsymOmitInitiatorTokenWithEP.wsdl
@@ -52,7 +52,7 @@
 						<sp:EncryptSignature />
 						<sp:AlgorithmSuite>
 							<wsp:Policy>
-								<sp:Basic128 />
+								<sp:Basic256Sha256 />
 							</wsp:Policy>
 						</sp:AlgorithmSuite>
 					</wsp:Policy>

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.6/override/autoFVT/cxfclient-policies/ClientAsymOmitRecipientTokenWithEP.wsdl
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.6/override/autoFVT/cxfclient-policies/ClientAsymOmitRecipientTokenWithEP.wsdl
@@ -51,7 +51,7 @@
 						<sp:EncryptSignature />
 						<sp:AlgorithmSuite>
 							<wsp:Policy>
-								<sp:Basic128 />
+								<sp:Basic256Sha256 />
 							</wsp:Policy>
 						</sp:AlgorithmSuite>
 					</wsp:Policy>

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.6/semeruFips140_3CustomProfile.properties
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.6/semeruFips140_3CustomProfile.properties
@@ -8,10 +8,7 @@ RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.2 = sun.securit
     {KeyStore, JKS, *, ModuleAndFullClassName:java.base/java.security.KeyStore}, \
     {MessageDigest, SHA-1, *, ModuleAndFullClassName:java.base/java.security.KeyStore}, \
     {MessageDigest, SHA-1, *, FullClassName:org.apache.wss4j.dom.message.WSSecSignature}, \
-    {MessageDigest, SHA-1, *, FullClassName:org.apache.wss4j.dom.message.WSSecEncryptedKey}, \
-    {MessageDigest, SHA-1, *, FullClassName:org.apache.wss4j.dom.processor.EncryptedKeyProcessor}, \
     {MessageDigest, SHA-1, *, FullClassName:org.apache.wss4j.dom.processor.SignatureProcessor}]
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.4 = com.sun.crypto.provider.SunJCE [+ \
-    {Cipher, RSA, *, FullClassName:org.apache.wss4j.common.util.KeyUtils}, \
     {Cipher, AES, *, FullClassName:org.apache.xml.security.encryption.XMLCipher}]
 

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.6/semeruFips140_3CustomProfile.properties
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.6/semeruFips140_3CustomProfile.properties
@@ -9,6 +9,3 @@ RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.2 = sun.securit
     {MessageDigest, SHA-1, *, ModuleAndFullClassName:java.base/java.security.KeyStore}, \
     {MessageDigest, SHA-1, *, FullClassName:org.apache.wss4j.dom.message.WSSecSignature}, \
     {MessageDigest, SHA-1, *, FullClassName:org.apache.wss4j.dom.processor.SignatureProcessor}]
-RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.4 = com.sun.crypto.provider.SunJCE [+ \
-    {Cipher, AES, *, FullClassName:org.apache.xml.security.encryption.XMLCipher}]
-

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.6/test-applications/samltoken/resources/WEB-INF/SamlTokenWebSvc.wsdl
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.6/test-applications/samltoken/resources/WEB-INF/SamlTokenWebSvc.wsdl
@@ -48,7 +48,7 @@
                         <!-- sp:IncludeTimestamp/ -->
                         <sp:AlgorithmSuite>
                             <wsp:Policy>
-                                <sp:Basic128 />
+                                <sp:Basic256Sha256 />
                             </wsp:Policy>
                         </sp:AlgorithmSuite>
                     </wsp:Policy>
@@ -187,7 +187,7 @@
                          </sp:ProtectionToken>
                          <sp:AlgorithmSuite>
                              <wsp:Policy>
-                                 <sp:Basic128/>
+                                 <sp:Basic256Sha256/>
                              </wsp:Policy>
                          </sp:AlgorithmSuite>
                          <sp:Layout>
@@ -266,7 +266,7 @@
                          </sp:ProtectionToken>
                          <sp:AlgorithmSuite>
                              <wsp:Policy>
-                                 <sp:Basic128/>
+                                 <sp:Basic256Sha256/>
                              </wsp:Policy>
                          </sp:AlgorithmSuite>
                          <sp:Layout>
@@ -338,7 +338,7 @@
                          </sp:ProtectionToken>
                          <sp:AlgorithmSuite>
                              <wsp:Policy>
-                                 <sp:Basic128/>
+                                 <sp:Basic256Sha256/>
                              </wsp:Policy>
                          </sp:AlgorithmSuite>
                          <sp:Layout>
@@ -419,7 +419,7 @@
                         </sp:RecipientToken>
                         <sp:AlgorithmSuite>
                             <wsp:Policy>
-                                <sp:Basic128/>
+                                <sp:Basic256Sha256/>
                             </wsp:Policy>
                         </sp:AlgorithmSuite>
                         <sp:Layout>
@@ -503,7 +503,7 @@
                         </sp:RecipientToken>
                         <sp:AlgorithmSuite>
                             <wsp:Policy>
-                                <sp:Basic128/>
+                                <sp:Basic256Sha256/>
                             </wsp:Policy>
                         </sp:AlgorithmSuite>
                         <sp:Layout>
@@ -583,7 +583,7 @@
                         </sp:RecipientToken>
                         <sp:AlgorithmSuite>
                             <wsp:Policy>
-                                <sp:Basic128/>
+                                <sp:Basic256Sha256/>
                             </wsp:Policy>
                         </sp:AlgorithmSuite>
                         <sp:Layout>
@@ -670,7 +670,7 @@
              </sp:RecipientSignatureToken>
              <sp:AlgorithmSuite>
                 <wsp:Policy>
-                   <sp:Basic128/>
+                   <sp:Basic256Sha256/>
                 </wsp:Policy>
              </sp:AlgorithmSuite>
              <sp:Layout>

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.6/test-applications/samlwsstemplatesclientwithep/resources/WEB-INF/policy-attachments-client.xml
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.6/test-applications/samlwsstemplatesclientwithep/resources/WEB-INF/policy-attachments-client.xml
@@ -32,7 +32,7 @@
 						<sp:IncludeTimestamp />
 						<sp:AlgorithmSuite>
 							<wsp:Policy>
-								<sp:Basic128 />
+								<sp:Basic256Sha256 />
 							</wsp:Policy>
 						</sp:AlgorithmSuite>
 					</wsp:Policy>
@@ -108,7 +108,7 @@
 						<sp:EncryptSignature />
 						<sp:AlgorithmSuite>
 							<wsp:Policy>
-								<sp:Basic128 />
+								<sp:Basic256Sha256 />
 							</wsp:Policy>
 						</sp:AlgorithmSuite>
 					</wsp:Policy>
@@ -170,7 +170,7 @@
                         </sp:ProtectionToken>
                         <sp:AlgorithmSuite>
                             <wsp:Policy>
-                                <sp:Basic128 />
+                                <sp:Basic256Sha256 />
                             </wsp:Policy>
                         </sp:AlgorithmSuite>
                         <sp:Layout>

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.6/test-applications/samlwsstemplateswithep/resources/WEB-INF/policy-attachments-server.xml
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.saml.6/test-applications/samlwsstemplateswithep/resources/WEB-INF/policy-attachments-server.xml
@@ -32,7 +32,7 @@
 						<sp:IncludeTimestamp />
 						<sp:AlgorithmSuite>
 							<wsp:Policy>
-								<sp:Basic128 />
+								<sp:Basic256Sha256 />
 							</wsp:Policy>
 						</sp:AlgorithmSuite>
 					</wsp:Policy>
@@ -111,7 +111,7 @@
 						<sp:EncryptSignature />
 						<sp:AlgorithmSuite>
 							<wsp:Policy>
-								<sp:Basic128 />
+								<sp:Basic256Sha256 />
 							</wsp:Policy>
 						</sp:AlgorithmSuite>
 					</wsp:Policy>
@@ -176,7 +176,7 @@
                         </sp:ProtectionToken>
                         <sp:AlgorithmSuite>
                             <wsp:Policy>
-                                <sp:Basic128 />
+                                <sp:Basic256Sha256 />
                             </wsp:Policy>
                         </sp:AlgorithmSuite>
                         <sp:Layout>

--- a/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyServer.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyServer.java
@@ -7878,7 +7878,8 @@ public class LibertyServer implements LogMonitorClient {
         }
 
         boolean isIBMJVM8 = (serverJavaInfo.majorVersion() == 8) && (serverJavaInfo.VENDOR == Vendor.IBM);
-        boolean isIBMJVMGreaterOrEqualTo11 = (serverJavaInfo.majorVersion() >= 11) && (serverJavaInfo.VENDOR == Vendor.IBM);
+        //boolean isIBMJVMGreaterOrEqualTo11 = (serverJavaInfo.majorVersion() >= 11) && (serverJavaInfo.VENDOR == Vendor.IBM);
+        boolean isIBMJVMGreaterOrEqualTo11 = (serverJavaInfo.majorVersion() >= 11) && (serverJavaInfo.VENDOR == Vendor.OPENJ9);
         if (logOutput && GLOBAL_FIPS_140_3) {
             Log.info(c, methodName, "Liberty server is running JDK version: " + serverJavaInfo.majorVersion()
                                     + " and vendor: " + serverJavaInfo.VENDOR);
@@ -7912,7 +7913,8 @@ public class LibertyServer implements LogMonitorClient {
 
     public boolean isSemeruFIPS140_3EnabledAndSupported() throws IOException {
         JavaInfo serverJavaInfo = JavaInfo.forServer(this);
-        return GLOBAL_FIPS_140_3 && (serverJavaInfo.majorVersion() >= 11) && (serverJavaInfo.VENDOR == Vendor.IBM) && serverLevelFipsEnabled;
+        //return GLOBAL_FIPS_140_3 && (serverJavaInfo.majorVersion() >= 11) && (serverJavaInfo.VENDOR == Vendor.IBM) && serverLevelFipsEnabled;
+        return GLOBAL_FIPS_140_3 && (serverJavaInfo.majorVersion() >= 11) && (serverJavaInfo.VENDOR == Vendor.OPENJ9) && serverLevelFipsEnabled;
     }
 
     public void setServerLevelFips(boolean enabled) {


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).


New semeru version (pre-GA) is fixing the prior RSA-OAEP related exceptions when running ws-security and ws-security SAML FAT with FIPS 140-3 enabled, for example, `NoSuchAlgorithmException: Cannot find any provider supporting RSA/ECB/OAEPWithSHA1AndMGF1Padding`.
In the old semeru version, we added the allowed exception in semeru custom profile to workaround the test failure, e.g., 
```
{MessageDigest, SHA-1, *, FullClassName:org.apache.wss4j.dom.message.WSSecEncryptedKey}, \
{MessageDigest, SHA-1, *, FullClassName:org.apache.wss4j.dom.processor.EncryptedKeyProcessor}, \
{Cipher, RSA, *, FullClassName:org.apache.wss4j.common.util.KeyUtils}, \
```
Although java code is fixing the provider issue to get past the prior error, the new generated error related SHA1 related message digest algorithm will need runtime code update to allow the FIPS compliant algorithms to be used:

1. com.ibm.ws.org.apache.wss4j.ws.security.dom -> WSSecEncryptedKey.java 
2. com.ibm.ws.org.apache.santuario.xmlsec.2.2.0 -> XMLCipherUtil.java
3. com.ibm.ws.org.apache.wss4j.ws.security.common -> KeyUtils.java
