### PR TITLE
Increased timeout for resolving defect 309560

### DIFF
--- a/dev/com.ibm.ws.jpa.tests.container_hibernate_fat/fat/src/com/ibm/ws/jpa/tests/container_hibernate/TestHibernate.java
+++ b/dev/com.ibm.ws.jpa.tests.container_hibernate_fat/fat/src/com/ibm/ws/jpa/tests/container_hibernate/TestHibernate.java
@@ -61,13 +61,13 @@ public class TestHibernate extends JPAFATServletClient {
         timestart = System.currentTimeMillis();
 
         int appStartTimeout = server.getAppStartTimeout();
-        if (appStartTimeout < (120 * 1000)) {
-            server.setAppStartTimeout(120 * 1000);
+        if (appStartTimeout < (240 * 1000)) {
+            server.setAppStartTimeout(240 * 1000);
         }
 
         int configUpdateTimeout = server.getConfigUpdateTimeout();
-        if (configUpdateTimeout < (120 * 1000)) {
-            server.setConfigUpdateTimeout(120 * 1000);
+        if (configUpdateTimeout < (240 * 1000)) {
+            server.setConfigUpdateTimeout(240 * 1000);
         }
 
         server.startServer();


### PR DESCRIPTION
This PR is for increasing timeout of the test bucket for resolving RTC [defect 309560](https://wasrtc.hursley.ibm.com:9443/jazz/web/projects/WS-CD#action=com.ibm.team.workitem.viewWorkItem&id=309560) 
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

