### PR TITLE
update to latest mq docker image

### DIFF
--- a/dev/com.ibm.ws.springboot.fat20_fat/bnd.bnd
+++ b/dev/com.ibm.ws.springboot.fat20_fat/bnd.bnd
@@ -17,7 +17,7 @@ bVersion=1.0
 
 fat.project: true
 
-fat.test.container.images: icr.io/ibm-messaging/mq:9.3.2.0-r2
+fat.test.container.images: icr.io/ibm-messaging/mq:9.4.5.0-r2
 
 tested.features: \
   javaee-7.0, \

--- a/dev/com.ibm.ws.springboot.fat20_fat/fat/src/com/ibm/ws/springboot/support/fat/JmsAbstractTests.java
+++ b/dev/com.ibm.ws.springboot.fat20_fat/fat/src/com/ibm/ws/springboot/support/fat/JmsAbstractTests.java
@@ -41,7 +41,7 @@ import componenttest.topology.utils.HttpUtils.HTTPRequestMethod;
 @SkipIfSysProp(SkipIfSysProp.OS_ZOS)
 public abstract class JmsAbstractTests extends AbstractSpringTests {
 
-    private static final String mqVersion = "9.3.2.0-r2";
+    private static final String mqVersion = "9.4.5.0-r2";
     private static final int MQ_LISTENER_PORT = 1414;
 
     @SuppressWarnings("resource")

--- a/dev/io.openliberty.org.testcontainers/cache/externals
+++ b/dev/io.openliberty.org.testcontainers/cache/externals
@@ -11,7 +11,7 @@ ghcr.io/testcontainers/sshd:1.3.0
 ghcr.io/testcontainers/vnc-recorder:1.4.0
 icr.io/db2_community/db2:12.1.1.0
 icr.io/db2_community/db2:12.1.2.0
-icr.io/ibm-messaging/mq:9.3.2.0-r2
+icr.io/ibm-messaging/mq:9.4.5.0-r2
 infinispan/server:10.0.1.Final
 infinispan/server:13.0.10.Final
 jaegertracing/all-in-one:1.54

--- a/dev/io.openliberty.org.testcontainers/cache/images
+++ b/dev/io.openliberty.org.testcontainers/cache/images
@@ -16,7 +16,7 @@ wasliberty-ghcr-docker-remote/testcontainers/sshd:1.3.0
 wasliberty-ghcr-docker-remote/testcontainers/vnc-recorder:1.4.0
 wasliberty-icr-docker-remote/db2_community/db2:12.1.1.0
 wasliberty-icr-docker-remote/db2_community/db2:12.1.2.0
-wasliberty-icr-docker-remote/ibm-messaging/mq:9.3.2.0-r2
+wasliberty-icr-docker-remote/ibm-messaging/mq:9.4.5.0-r2
 wasliberty-infrastructure-docker/confluentinc/cp-kafka:7.1.1
 wasliberty-infrastructure-docker/elastic/logstash:7.16.3
 wasliberty-infrastructure-docker/fbicodex/spnego-kdc-server:1.0

--- a/dev/io.openliberty.springboot.fat30_fat/bnd.bnd
+++ b/dev/io.openliberty.springboot.fat30_fat/bnd.bnd
@@ -20,7 +20,7 @@ javac.target: 17
 
 fat.project: true
 
-fat.test.container.images: icr.io/ibm-messaging/mq:9.3.2.0-r2
+fat.test.container.images: icr.io/ibm-messaging/mq:9.4.5.0-r2
 
 tested.features: \
   appauthentication-3.0, \

--- a/dev/io.openliberty.springboot.fat30_fat/fat/src/com/ibm/ws/springboot/support/fat/JmsAbstractTests.java
+++ b/dev/io.openliberty.springboot.fat30_fat/fat/src/com/ibm/ws/springboot/support/fat/JmsAbstractTests.java
@@ -42,7 +42,7 @@ import componenttest.topology.utils.HttpUtils.HTTPRequestMethod;
 @SkipIfSysProp(SkipIfSysProp.OS_ZOS)
 public abstract class JmsAbstractTests extends AbstractSpringTests {
 
-    private static final String mqVersion = "9.3.2.0-r2";
+    private static final String mqVersion = "9.4.5.0-r2";
     private static final int MQ_LISTENER_PORT = 1414;
 
     @SuppressWarnings("resource")

--- a/dev/io.openliberty.springboot.fat40_fat/bnd.bnd
+++ b/dev/io.openliberty.springboot.fat40_fat/bnd.bnd
@@ -20,7 +20,7 @@ javac.target: 17
 
 fat.project: true
 
-fat.test.container.images: icr.io/ibm-messaging/mq:9.3.2.0-r2
+fat.test.container.images: icr.io/ibm-messaging/mq:9.4.5.0-r2
 
 src: \
   fat/src,\

--- a/dev/io.openliberty.springboot.fat40_fat/fat/src/com/ibm/ws/springboot/support/fat/JmsAbstractTests.java
+++ b/dev/io.openliberty.springboot.fat40_fat/fat/src/com/ibm/ws/springboot/support/fat/JmsAbstractTests.java
@@ -40,7 +40,7 @@ import componenttest.topology.utils.HttpUtils.HTTPRequestMethod;
 @MinimumJavaLevel(javaLevel = 17)
 public abstract class JmsAbstractTests extends AbstractSpringTests {
 
-    private static final String mqVersion = "9.3.2.0-r2";
+    private static final String mqVersion = "9.4.5.0-r2";
     private static final int MQ_LISTENER_PORT = 1414;
 
     @SuppressWarnings("resource")


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

################################################################################################
This will hopefully resolve https://wasrtc.hursley.ibm.com:9443/jazz/web/projects/WS-CD#action=com.ibm.team.workitem.viewWorkItem&id=305564

There was a known issue with GSKit a while back where their FIPS driver would hang due to not enough entropy (i think). By default we use the fips driver in runmqakm so that turns that off. This is a first guess though, that problem was only known to affect zLinux due to the processor architecture.

The latest version has patches for this issue and local investigation suggest it works