### PR TITLE
update security.saml.sso.* fat test config to support RSA-OAEP

### DIFF
--- a/dev/com.ibm.ws.security.oidc.client_fat.backchannelLogout.saml.1/semeruFips140_3CustomProfile.properties
+++ b/dev/com.ibm.ws.security.oidc.client_fat.backchannelLogout.saml.1/semeruFips140_3CustomProfile.properties
@@ -4,8 +4,4 @@ RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.desc.name = Custom OpenJCEPl
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.extends = RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Liberty
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.2 = sun.security.provider.Sun [+ \
     {KeyStore, JKS, *, ModuleAndFullClassName:java.base/java.security.KeyStore}, \
-    {MessageDigest, SHA-1, *, ModuleAndFullClassName:java.base/java.security.KeyStore}, \
-    {MessageDigest, SHA-1, *, FullClassName:org.apache.xml.security.encryption.XMLCipher}]
-RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.4 = com.sun.crypto.provider.SunJCE [+ \
-    {Cipher, RSA, *, FullClassName:org.apache.xml.security.encryption.XMLCipher}, \
-    {Cipher, AES, *, FullClassName:org.apache.xml.security.encryption.XMLCipher}]
+    {MessageDigest, SHA-1, *, ModuleAndFullClassName:java.base/java.security.KeyStore}]

--- a/dev/com.ibm.ws.security.saml.sso_fat.3/semeruFips140_3CustomProfile.properties
+++ b/dev/com.ibm.ws.security.saml.sso_fat.3/semeruFips140_3CustomProfile.properties
@@ -2,8 +2,4 @@ RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.desc.name = Custom OpenJCEPl
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.extends = RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Liberty
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.2 = sun.security.provider.Sun [+ \
     {KeyStore, JKS, *, ModuleAndFullClassName:java.base/java.security.KeyStore}, \
-    {MessageDigest, SHA-1, *, ModuleAndFullClassName:java.base/java.security.KeyStore}, \
-    {MessageDigest, SHA-1, *, FullClassName:org.apache.xml.security.encryption.XMLCipher}]
-RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.4 = com.sun.crypto.provider.SunJCE [+ \
-    {Cipher, RSA, *, FullClassName:org.apache.xml.security.encryption.XMLCipher}, \
-    {Cipher, AES, *, FullClassName:org.apache.xml.security.encryption.XMLCipher}]
+    {MessageDigest, SHA-1, *, ModuleAndFullClassName:java.base/java.security.KeyStore}]

--- a/dev/com.ibm.ws.security.saml.sso_fat.common/publish/files/serversettings/SAMLServerFiles/localhost/Fed1MetaData.xml.orig
+++ b/dev/com.ibm.ws.security.saml.sso_fat.common/publish/files/serversettings/SAMLServerFiles/localhost/Fed1MetaData.xml.orig
@@ -19,6 +19,7 @@
 <EntityDescriptor xmlns="urn:oasis:names:tc:SAML:2.0:metadata"
 	xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:shibmd="urn:mace:shibboleth:metadata:1.0"
 	xmlns:xml="http://www.w3.org/XML/1998/namespace" xmlns:mdui="urn:oasis:names:tc:SAML:metadata:ui"
+        xmlns:xenc11="http://www.w3.org/2009/xmlenc11#"
 	entityID="https://localhost:xxx_IdpSecurePort_xxx/idp/shibboleth">
 
 	<IDPSSODescriptor
@@ -131,7 +132,11 @@
 					</ds:X509Certificate>
 				</ds:X509Data>
 			</ds:KeyInfo>
-
+                        <!-- use rsa-oaep with sha256 digest and mgf1sha256 -->
+			<EncryptionMethod Algorithm="http://www.w3.org/2009/xmlenc11#rsa-oaep">
+				<ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
+				<xenc11:MGF Algorithm="http://www.w3.org/2009/xmlenc11#mgf1sha256"/>
+			</EncryptionMethod>
 		</KeyDescriptor>
 
 		<ArtifactResolutionService
@@ -253,7 +258,11 @@
 					</ds:X509Certificate>
 				</ds:X509Data>
 			</ds:KeyInfo>
-
+                        <!-- use rsa-oaep with sha256 digest and mgf1sha256 -->
+			<EncryptionMethod Algorithm="http://www.w3.org/2009/xmlenc11#rsa-oaep">
+				<ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
+				<xenc11:MGF Algorithm="http://www.w3.org/2009/xmlenc11#mgf1sha256"/>
+			</EncryptionMethod>
 		</KeyDescriptor>
 
 		<AttributeService Binding="urn:oasis:names:tc:SAML:1.0:bindings:SOAP-binding"

--- a/dev/com.ibm.ws.security.saml.sso_fat.common/shibboleth-idp/4.1.0/conf/relying-party.xml.orig
+++ b/dev/com.ibm.ws.security.saml.sso_fat.common/shibboleth-idp/4.1.0/conf/relying-party.xml.orig
@@ -801,7 +801,7 @@
 				<property name="dataEncryptionAlgorithms">
 					<list>
 						<util:constant
-							static-field="org.opensaml.xmlsec.encryption.support.EncryptionConstants.ALGO_ID_BLOCKCIPHER_AES128" />
+							static-field="org.opensaml.xmlsec.encryption.support.EncryptionConstants.ALGO_ID_BLOCKCIPHER_AES128_GCM" />
 					</list>
 				</property>
 				<property name="keyTransportEncryptionAlgorithms">

--- a/dev/com.ibm.ws.security.saml.sso_fat.common/shibboleth-idp/4.1.0/metadata/customLogout_absExternalURLMetadata.xml.orig
+++ b/dev/com.ibm.ws.security.saml.sso_fat.common/shibboleth-idp/4.1.0/metadata/customLogout_absExternalURLMetadata.xml.orig
@@ -44,6 +44,15 @@
 					</ds:X509Certificate>
 				</ds:X509Data>
 			</ds:KeyInfo>
+                        <!-- use rsa-oaep with sha256 digest and mgf1sha256 -->
+			<md:EncryptionMethod Algorithm="http://www.w3.org/2009/xmlenc11#rsa-oaep"
+                            xmlns:ds="http://www.w3.org/2000/09/xmldsig#"
+                            xmlns:xenc11="http://www.w3.org/2009/xmlenc11#">
+				<ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
+				<xenc11:MGF Algorithm="http://www.w3.org/2009/xmlenc11#mgf1sha256"/>
+			</md:EncryptionMethod>
+                        <!-- use aes128_gcm fips default -->
+                        <md:EncryptionMethod Algorithm="http://www.w3.org/2009/xmlenc11#aes128-gcm"/>
 		</md:KeyDescriptor>
 		<md:SingleLogoutService
 			Location="https://localhost:xxx_SpSecurePort_xxx/ibm/saml20/customLogout_absExternalURL/slo"

--- a/dev/com.ibm.ws.security.saml.sso_fat.common/shibboleth-idp/4.1.0/metadata/customLogout_absLocalURLMetadata.xml.orig
+++ b/dev/com.ibm.ws.security.saml.sso_fat.common/shibboleth-idp/4.1.0/metadata/customLogout_absLocalURLMetadata.xml.orig
@@ -44,6 +44,15 @@
 					</ds:X509Certificate>
 				</ds:X509Data>
 			</ds:KeyInfo>
+                        <!-- use rsa-oaep with sha256 digest and mgf1sha256 -->
+			<md:EncryptionMethod Algorithm="http://www.w3.org/2009/xmlenc11#rsa-oaep"
+                            xmlns:ds="http://www.w3.org/2000/09/xmldsig#"
+                            xmlns:xenc11="http://www.w3.org/2009/xmlenc11#">
+				<ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
+				<xenc11:MGF Algorithm="http://www.w3.org/2009/xmlenc11#mgf1sha256"/>
+			</md:EncryptionMethod>
+                        <!-- use aes128_gcm fips default -->
+                        <md:EncryptionMethod Algorithm="http://www.w3.org/2009/xmlenc11#aes128-gcm"/>
 		</md:KeyDescriptor>
 		<md:SingleLogoutService
 			Location="https://localhost:xxx_SpSecurePort_xxx/ibm/saml20/customLogout_absLocalURL/slo"

--- a/dev/com.ibm.ws.security.saml.sso_fat.common/shibboleth-idp/4.1.0/metadata/customLogout_emptyStringMetadata.xml.orig
+++ b/dev/com.ibm.ws.security.saml.sso_fat.common/shibboleth-idp/4.1.0/metadata/customLogout_emptyStringMetadata.xml.orig
@@ -44,6 +44,15 @@
 					</ds:X509Certificate>
 				</ds:X509Data>
 			</ds:KeyInfo>
+                        <!-- use rsa-oaep with sha256 digest and mgf1sha256 -->
+			<md:EncryptionMethod Algorithm="http://www.w3.org/2009/xmlenc11#rsa-oaep"
+                            xmlns:ds="http://www.w3.org/2000/09/xmldsig#"
+                            xmlns:xenc11="http://www.w3.org/2009/xmlenc11#">
+				<ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
+				<xenc11:MGF Algorithm="http://www.w3.org/2009/xmlenc11#mgf1sha256"/>
+			</md:EncryptionMethod>
+                        <!-- use aes128_gcm fips default -->
+                        <md:EncryptionMethod Algorithm="http://www.w3.org/2009/xmlenc11#aes128-gcm"/>
 		</md:KeyDescriptor>
 		<md:SingleLogoutService
 			Location="https://localhost:xxx_SpSecurePort_xxx/ibm/saml20/customLogout_emptyString/slo"

--- a/dev/com.ibm.ws.security.saml.sso_fat.common/shibboleth-idp/4.1.0/metadata/customLogout_invalidRelativePathMetadata.xml.orig
+++ b/dev/com.ibm.ws.security.saml.sso_fat.common/shibboleth-idp/4.1.0/metadata/customLogout_invalidRelativePathMetadata.xml.orig
@@ -44,6 +44,15 @@
 					</ds:X509Certificate>
 				</ds:X509Data>
 			</ds:KeyInfo>
+                        <!-- use rsa-oaep with sha256 digest and mgf1sha256 -->
+			<md:EncryptionMethod Algorithm="http://www.w3.org/2009/xmlenc11#rsa-oaep"
+                            xmlns:ds="http://www.w3.org/2000/09/xmldsig#"
+                            xmlns:xenc11="http://www.w3.org/2009/xmlenc11#">
+				<ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
+				<xenc11:MGF Algorithm="http://www.w3.org/2009/xmlenc11#mgf1sha256"/>
+			</md:EncryptionMethod>
+                        <!-- use aes128_gcm fips default -->
+                        <md:EncryptionMethod Algorithm="http://www.w3.org/2009/xmlenc11#aes128-gcm"/>
 		</md:KeyDescriptor>
 		<md:SingleLogoutService
 			Location="https://localhost:xxx_SpSecurePort_xxx/ibm/saml20/customLogout_invalidRelativePath/slo"

--- a/dev/com.ibm.ws.security.saml.sso_fat.common/shibboleth-idp/4.1.0/metadata/customLogout_invalidURLMetadata.xml.orig
+++ b/dev/com.ibm.ws.security.saml.sso_fat.common/shibboleth-idp/4.1.0/metadata/customLogout_invalidURLMetadata.xml.orig
@@ -44,6 +44,15 @@
 					</ds:X509Certificate>
 				</ds:X509Data>
 			</ds:KeyInfo>
+                        <!-- use rsa-oaep with sha256 digest and mgf1sha256 -->
+			<md:EncryptionMethod Algorithm="http://www.w3.org/2009/xmlenc11#rsa-oaep"
+                            xmlns:ds="http://www.w3.org/2000/09/xmldsig#"
+                            xmlns:xenc11="http://www.w3.org/2009/xmlenc11#">
+				<ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
+				<xenc11:MGF Algorithm="http://www.w3.org/2009/xmlenc11#mgf1sha256"/>
+			</md:EncryptionMethod>
+                        <!-- use aes128_gcm fips default -->
+                        <md:EncryptionMethod Algorithm="http://www.w3.org/2009/xmlenc11#aes128-gcm"/>
 		</md:KeyDescriptor>
 		<md:SingleLogoutService
 			Location="https://localhost:xxx_SpSecurePort_xxx/ibm/saml20/customLogout_invalidURL/slo"

--- a/dev/com.ibm.ws.security.saml.sso_fat.common/shibboleth-idp/4.1.0/metadata/customLogout_relativePathMetadata.xml.orig
+++ b/dev/com.ibm.ws.security.saml.sso_fat.common/shibboleth-idp/4.1.0/metadata/customLogout_relativePathMetadata.xml.orig
@@ -44,6 +44,15 @@
 					</ds:X509Certificate>
 				</ds:X509Data>
 			</ds:KeyInfo>
+                        <!-- use rsa-oaep with sha256 digest and mgf1sha256 -->
+			<md:EncryptionMethod Algorithm="http://www.w3.org/2009/xmlenc11#rsa-oaep"
+                            xmlns:ds="http://www.w3.org/2000/09/xmldsig#"
+                            xmlns:xenc11="http://www.w3.org/2009/xmlenc11#">
+				<ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
+				<xenc11:MGF Algorithm="http://www.w3.org/2009/xmlenc11#mgf1sha256"/>
+			</md:EncryptionMethod>
+                        <!-- use aes128_gcm fips default -->
+                        <md:EncryptionMethod Algorithm="http://www.w3.org/2009/xmlenc11#aes128-gcm"/>
 		</md:KeyDescriptor>
 		<md:SingleLogoutService
 			Location="https://localhost:xxx_SpSecurePort_xxx/ibm/saml20/customLogout_relativePath/slo"

--- a/dev/com.ibm.ws.security.saml.sso_fat.common/shibboleth-idp/4.1.0/metadata/server2sp1Metadata.xml.orig
+++ b/dev/com.ibm.ws.security.saml.sso_fat.common/shibboleth-idp/4.1.0/metadata/server2sp1Metadata.xml.orig
@@ -50,6 +50,14 @@
 					</ds:X509Certificate>
 				</ds:X509Data>
 			</ds:KeyInfo>
+                        <!-- use rsa-oaep with sha256 digest and mgf1sha256 -->
+			<md:EncryptionMethod Algorithm="http://www.w3.org/2009/xmlenc11#rsa-oaep"
+                            xmlns:ds="http://www.w3.org/2000/09/xmldsig#"
+                            xmlns:xenc11="http://www.w3.org/2009/xmlenc11#">
+				<ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
+				<xenc11:MGF Algorithm="http://www.w3.org/2009/xmlenc11#mgf1sha256"/>
+			</md:EncryptionMethod>
+                        <md:EncryptionMethod Algorithm="http://www.w3.org/2009/xmlenc11#aes128-gcm"/>
 		</md:KeyDescriptor>
 		<md:SingleLogoutService
 			Location="https://localhost:xxx_SpSecurePort2_xxx/ibm/saml20/server2_sp1/slo"

--- a/dev/com.ibm.ws.security.saml.sso_fat.common/shibboleth-idp/4.1.0/metadata/server2sp2Metadata.xml.orig
+++ b/dev/com.ibm.ws.security.saml.sso_fat.common/shibboleth-idp/4.1.0/metadata/server2sp2Metadata.xml.orig
@@ -50,6 +50,14 @@
 					</ds:X509Certificate>
 				</ds:X509Data>
 			</ds:KeyInfo>
+                        <!-- use rsa-oaep with sha256 digest and mgf1sha256 -->
+			<md:EncryptionMethod Algorithm="http://www.w3.org/2009/xmlenc11#rsa-oaep"
+                            xmlns:ds="http://www.w3.org/2000/09/xmldsig#"
+                            xmlns:xenc11="http://www.w3.org/2009/xmlenc11#">
+				<ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
+				<xenc11:MGF Algorithm="http://www.w3.org/2009/xmlenc11#mgf1sha256"/>
+			</md:EncryptionMethod>
+                        <md:EncryptionMethod Algorithm="http://www.w3.org/2009/xmlenc11#aes128-gcm"/>
 		</md:KeyDescriptor>
 		<md:SingleLogoutService
 			Location="https://localhost:xxx_SpSecurePort2_xxx/ibm/saml20/server2_sp2/slo"

--- a/dev/com.ibm.ws.security.saml.sso_fat.common/shibboleth-idp/4.1.0/metadata/sp13Metadata.xml.orig
+++ b/dev/com.ibm.ws.security.saml.sso_fat.common/shibboleth-idp/4.1.0/metadata/sp13Metadata.xml.orig
@@ -49,6 +49,14 @@
 					</ds:X509Certificate>
 				</ds:X509Data>
 			</ds:KeyInfo>
+                        <!-- use rsa-oaep with sha256 digest and mgf1sha256 -->
+			<md:EncryptionMethod Algorithm="http://www.w3.org/2009/xmlenc11#rsa-oaep"
+                                xmlns:ds="http://www.w3.org/2000/09/xmldsig#"
+                                xmlns:xenc11="http://www.w3.org/2009/xmlenc11#">
+				<ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
+				<xenc11:MGF Algorithm="http://www.w3.org/2009/xmlenc11#mgf1sha256"/>
+			</md:EncryptionMethod>
+                        <md:EncryptionMethod Algorithm="http://www.w3.org/2009/xmlenc11#aes128-gcm"/>
 		</md:KeyDescriptor>
 		<md:SingleLogoutService
 			Location="https://localhost:xxx_SpSecurePort_xxx/ibm/saml20/sp13/slo"

--- a/dev/com.ibm.ws.security.saml.sso_fat.common/shibboleth-idp/4.1.0/metadata/sp1Metadata.xml.orig
+++ b/dev/com.ibm.ws.security.saml.sso_fat.common/shibboleth-idp/4.1.0/metadata/sp1Metadata.xml.orig
@@ -49,6 +49,14 @@
 					</ds:X509Certificate>
 				</ds:X509Data>
 			</ds:KeyInfo>
+                        <!-- use rsa-oaep with sha256 digest and mgf1sha256 -->
+			<md:EncryptionMethod Algorithm="http://www.w3.org/2009/xmlenc11#rsa-oaep"
+                            xmlns:ds="http://www.w3.org/2000/09/xmldsig#"
+                            xmlns:xenc11="http://www.w3.org/2009/xmlenc11#">
+				<ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
+				<xenc11:MGF Algorithm="http://www.w3.org/2009/xmlenc11#mgf1sha256"/>
+			</md:EncryptionMethod>
+                        <md:EncryptionMethod Algorithm="http://www.w3.org/2009/xmlenc11#aes128-gcm"/>
 		</md:KeyDescriptor>
 		<md:SingleLogoutService
 			Location="https://localhost:xxx_SpSecurePort_xxx/ibm/saml20/sp1/slo"

--- a/dev/com.ibm.ws.security.saml.sso_fat.common/shibboleth-idp/4.1.0/metadata/sp2Metadata.xml.orig
+++ b/dev/com.ibm.ws.security.saml.sso_fat.common/shibboleth-idp/4.1.0/metadata/sp2Metadata.xml.orig
@@ -49,6 +49,14 @@
 					</ds:X509Certificate>
 				</ds:X509Data>
 			</ds:KeyInfo>
+                        <!-- use rsa-oaep with sha256 digest and mgf1sha256 -->
+			<md:EncryptionMethod Algorithm="http://www.w3.org/2009/xmlenc11#rsa-oaep"
+                            xmlns:ds="http://www.w3.org/2000/09/xmldsig#"
+                            xmlns:xenc11="http://www.w3.org/2009/xmlenc11#">
+				<ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
+				<xenc11:MGF Algorithm="http://www.w3.org/2009/xmlenc11#mgf1sha256"/>
+			</md:EncryptionMethod>
+                        <md:EncryptionMethod Algorithm="http://www.w3.org/2009/xmlenc11#aes128-gcm"/>
 		</md:KeyDescriptor>
 		<md:SingleLogoutService
 			Location="https://localhost:xxx_SpSecurePort_xxx/ibm/saml20/sp2/slo"

--- a/dev/com.ibm.ws.security.saml.sso_fat.common/shibboleth-idp/4.1.0/metadata/sp5Metadata.xml.orig
+++ b/dev/com.ibm.ws.security.saml.sso_fat.common/shibboleth-idp/4.1.0/metadata/sp5Metadata.xml.orig
@@ -49,6 +49,15 @@
 					</ds:X509Certificate>
 				</ds:X509Data>
 			</ds:KeyInfo>
+                        <!-- use rsa-oaep with sha256 digest and mgf1sha256 -->
+			<md:EncryptionMethod Algorithm="http://www.w3.org/2009/xmlenc11#rsa-oaep"
+                            xmlns:ds="http://www.w3.org/2000/09/xmldsig#"
+                            xmlns:xenc11="http://www.w3.org/2009/xmlenc11#">
+				<ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
+				<xenc11:MGF Algorithm="http://www.w3.org/2009/xmlenc11#mgf1sha256"/>
+			</md:EncryptionMethod>
+                        <!-- use aes128_gcm fips default -->
+                        <md:EncryptionMethod Algorithm="http://www.w3.org/2009/xmlenc11#aes128-gcm"/>
 		</md:KeyDescriptor>
 		<md:SingleLogoutService
 			Location="https://localhost:xxx_SpSecurePort_xxx/ibm/saml20/sp5/slo"

--- a/dev/com.ibm.ws.security.saml.sso_fat.common/shibboleth-idp/4.1.0/metadata/spDashMetadata.xml.orig
+++ b/dev/com.ibm.ws.security.saml.sso_fat.common/shibboleth-idp/4.1.0/metadata/spDashMetadata.xml.orig
@@ -49,6 +49,15 @@
 					</ds:X509Certificate>
 				</ds:X509Data>
 			</ds:KeyInfo>
+                        <!-- use rsa-oaep with sha256 digest and mgf1sha256 -->
+			<md:EncryptionMethod Algorithm="http://www.w3.org/2009/xmlenc11#rsa-oaep"
+                            xmlns:ds="http://www.w3.org/2000/09/xmldsig#"
+                            xmlns:xenc11="http://www.w3.org/2009/xmlenc11#">
+				<ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
+				<xenc11:MGF Algorithm="http://www.w3.org/2009/xmlenc11#mgf1sha256"/>
+			</md:EncryptionMethod>
+                        <!-- use aes128_gcm fips default -->
+                        <md:EncryptionMethod Algorithm="http://www.w3.org/2009/xmlenc11#aes128-gcm"/>
 		</md:KeyDescriptor>
 		<md:SingleLogoutService
 			Location="https://localhost:xxx_SpSecurePort_xxx/ibm/saml20/sp-dash/slo"

--- a/dev/com.ibm.ws.security.saml.sso_fat.common/shibboleth-idp/4.1.0/metadata/spOPMetadata.xml.orig
+++ b/dev/com.ibm.ws.security.saml.sso_fat.common/shibboleth-idp/4.1.0/metadata/spOPMetadata.xml.orig
@@ -49,6 +49,14 @@
 					</ds:X509Certificate>
 				</ds:X509Data>
 			</ds:KeyInfo>
+                        <!-- use rsa-oaep with sha256 digest and mgf1sha256 -->
+			<md:EncryptionMethod Algorithm="http://www.w3.org/2009/xmlenc11#rsa-oaep"
+                            xmlns:ds="http://www.w3.org/2000/09/xmldsig#"
+                            xmlns:xenc11="http://www.w3.org/2009/xmlenc11#">
+				<ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
+				<xenc11:MGF Algorithm="http://www.w3.org/2009/xmlenc11#mgf1sha256"/>
+			</md:EncryptionMethod>
+                        <md:EncryptionMethod Algorithm="http://www.w3.org/2009/xmlenc11#aes128-gcm"/>
 		</md:KeyDescriptor>
                 <md:SingleLogoutService
                         Location="https://localhost:xxx_SpSecurePort_xxx/ibm/saml20/spOP/slo"

--- a/dev/com.ibm.ws.security.saml.sso_fat.common/shibboleth-idp/4.1.0/metadata/spUnderscoreMetadata.xml.orig
+++ b/dev/com.ibm.ws.security.saml.sso_fat.common/shibboleth-idp/4.1.0/metadata/spUnderscoreMetadata.xml.orig
@@ -28,6 +28,8 @@
 					</ds:X509Certificate>
 				</ds:X509Data>
 			</ds:KeyInfo>
+                        <!-- use aes128_gcm fips default -->
+                        <md:EncryptionMethod Algorithm="http://www.w3.org/2009/xmlenc11#aes128-gcm"/>
 		</md:KeyDescriptor>
 		<md:KeyDescriptor use="encryption">
 			<ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
@@ -49,6 +51,15 @@
 					</ds:X509Certificate>
 				</ds:X509Data>
 			</ds:KeyInfo>
+                        <!-- use rsa-oaep with sha256 digest and mgf1sha256 -->
+			<md:EncryptionMethod Algorithm="http://www.w3.org/2009/xmlenc11#rsa-oaep"
+                            xmlns:ds="http://www.w3.org/2000/09/xmldsig#"
+                            xmlns:xenc11="http://www.w3.org/2009/xmlenc11#">
+				<ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
+				<xenc11:MGF Algorithm="http://www.w3.org/2009/xmlenc11#mgf1sha256"/>
+			</md:EncryptionMethod>
+                        <!-- use aes128_gcm fips default -->
+                        <md:EncryptionMethod Algorithm="http://www.w3.org/2009/xmlenc11#aes128-gcm"/>
 		</md:KeyDescriptor>
 		<md:AssertionConsumerService
 			Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"

--- a/dev/com.ibm.ws.security.saml.sso_fat.common/shibboleth-idp/4.1.0/metadata/sp_enc_aes128Metadata.xml.orig
+++ b/dev/com.ibm.ws.security.saml.sso_fat.common/shibboleth-idp/4.1.0/metadata/sp_enc_aes128Metadata.xml.orig
@@ -49,6 +49,13 @@
 					</ds:X509Certificate>
 				</ds:X509Data>
 			</ds:KeyInfo>
+                        <!-- use rsa-oaep with sha256 digest and mgf1sha256 -->
+			<md:EncryptionMethod Algorithm="http://www.w3.org/2009/xmlenc11#rsa-oaep"
+                            xmlns:ds="http://www.w3.org/2000/09/xmldsig#"
+                            xmlns:xenc11="http://www.w3.org/2009/xmlenc11#">
+				<ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
+				<xenc11:MGF Algorithm="http://www.w3.org/2009/xmlenc11#mgf1sha256"/>
+			</md:EncryptionMethod>
 		</md:KeyDescriptor>
 		<md:SingleLogoutService
 			Location="https://localhost:xxx_SpSecurePort_xxx/ibm/saml20/sp_enc_aes128/slo"

--- a/dev/com.ibm.ws.security.saml.sso_fat.config.mapToUserRegistry/semeruFips140_3CustomProfile.properties
+++ b/dev/com.ibm.ws.security.saml.sso_fat.config.mapToUserRegistry/semeruFips140_3CustomProfile.properties
@@ -2,8 +2,5 @@ RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.desc.name = Custom OpenJCEPl
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.extends = RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Liberty
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.2 = sun.security.provider.Sun [+ \
     {KeyStore, JKS, *, ModuleAndFullClassName:java.base/java.security.KeyStore}, \
-    {MessageDigest, SHA-1, *, ModuleAndFullClassName:java.base/java.security.KeyStore}, \
-    {MessageDigest, SHA-1, *, FullClassName:org.apache.xml.security.encryption.XMLCipher}]
-RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.4 = com.sun.crypto.provider.SunJCE [+ \
-    {Cipher, RSA, *, FullClassName:org.apache.xml.security.encryption.XMLCipher}, \
-    {Cipher, AES, *, FullClassName:org.apache.xml.security.encryption.XMLCipher}]
+    {MessageDigest, SHA-1, *, ModuleAndFullClassName:java.base/java.security.KeyStore}]
+

--- a/dev/com.ibm.ws.security.saml.sso_fat.jaxrs.config/semeruFips140_3CustomProfile.properties
+++ b/dev/com.ibm.ws.security.saml.sso_fat.jaxrs.config/semeruFips140_3CustomProfile.properties
@@ -2,8 +2,4 @@ RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.desc.name = Custom OpenJCEPl
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.extends = RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Liberty
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.2 = sun.security.provider.Sun [+ \
     {KeyStore, JKS, *, ModuleAndFullClassName:java.base/java.security.KeyStore}, \
-    {MessageDigest, SHA-1, *, ModuleAndFullClassName:java.base/java.security.KeyStore}, \
-    {MessageDigest, SHA-1, *, FullClassName:org.apache.xml.security.encryption.XMLCipher}]
-RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.4 = com.sun.crypto.provider.SunJCE [+ \
-    {Cipher, RSA, *, FullClassName:org.apache.xml.security.encryption.XMLCipher}, \
-    {Cipher, AES, *, FullClassName:org.apache.xml.security.encryption.XMLCipher}]
+    {MessageDigest, SHA-1, *, ModuleAndFullClassName:java.base/java.security.KeyStore}]

--- a/dev/com.ibm.ws.security.saml.sso_fat.jaxrs/semeruFips140_3CustomProfile.properties
+++ b/dev/com.ibm.ws.security.saml.sso_fat.jaxrs/semeruFips140_3CustomProfile.properties
@@ -2,8 +2,4 @@ RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.desc.name = Custom OpenJCEPl
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.extends = RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Liberty
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.2 = sun.security.provider.Sun [+ \
     {KeyStore, JKS, *, ModuleAndFullClassName:java.base/java.security.KeyStore}, \
-    {MessageDigest, SHA-1, *, ModuleAndFullClassName:java.base/java.security.KeyStore}, \
-    {MessageDigest, SHA-1, *, FullClassName:org.apache.xml.security.encryption.XMLCipher}]
-RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.4 = com.sun.crypto.provider.SunJCE [+ \
-    {Cipher, RSA, *, FullClassName:org.apache.xml.security.encryption.XMLCipher}, \
-    {Cipher, AES, *, FullClassName:org.apache.xml.security.encryption.XMLCipher}]
+    {MessageDigest, SHA-1, *, ModuleAndFullClassName:java.base/java.security.KeyStore}]

--- a/dev/com.ibm.ws.security.saml.sso_fat.logout.IDP_initiated/semeruFips140_3CustomProfile.properties
+++ b/dev/com.ibm.ws.security.saml.sso_fat.logout.IDP_initiated/semeruFips140_3CustomProfile.properties
@@ -2,8 +2,5 @@ RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.desc.name = Custom OpenJCEPl
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.extends = RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Liberty
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.2 = sun.security.provider.Sun [+ \
     {KeyStore, JKS, *, ModuleAndFullClassName:java.base/java.security.KeyStore}, \
-    {MessageDigest, SHA-1, *, ModuleAndFullClassName:java.base/java.security.KeyStore}, \
-    {MessageDigest, SHA-1, *, FullClassName:org.apache.xml.security.encryption.XMLCipher}]
-RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.4 = com.sun.crypto.provider.SunJCE [+ \
-    {Cipher, RSA, *, FullClassName:org.apache.xml.security.encryption.XMLCipher}, \
-    {Cipher, AES, *, FullClassName:org.apache.xml.security.encryption.XMLCipher}]
+    {MessageDigest, SHA-1, *, ModuleAndFullClassName:java.base/java.security.KeyStore}]
+

--- a/dev/com.ibm.ws.security.saml.sso_fat.logout.httpServletRequest/semeruFips140_3CustomProfile.properties
+++ b/dev/com.ibm.ws.security.saml.sso_fat.logout.httpServletRequest/semeruFips140_3CustomProfile.properties
@@ -2,8 +2,4 @@ RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.desc.name = Custom OpenJCEPl
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.extends = RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Liberty
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.2 = sun.security.provider.Sun [+ \
     {KeyStore, JKS, *, ModuleAndFullClassName:java.base/java.security.KeyStore}, \
-    {MessageDigest, SHA-1, *, ModuleAndFullClassName:java.base/java.security.KeyStore}, \
-    {MessageDigest, SHA-1, *, FullClassName:org.apache.xml.security.encryption.XMLCipher}]
-RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.4 = com.sun.crypto.provider.SunJCE [+ \
-    {Cipher, RSA, *, FullClassName:org.apache.xml.security.encryption.XMLCipher}, \
-    {Cipher, AES, *, FullClassName:org.apache.xml.security.encryption.XMLCipher}]
+    {MessageDigest, SHA-1, *, ModuleAndFullClassName:java.base/java.security.KeyStore}]

--- a/dev/com.ibm.ws.security.saml.sso_fat.logout.ibm_security_logout/semeruFips140_3CustomProfile.properties
+++ b/dev/com.ibm.ws.security.saml.sso_fat.logout.ibm_security_logout/semeruFips140_3CustomProfile.properties
@@ -2,8 +2,4 @@ RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.desc.name = Custom OpenJCEPl
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.extends = RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Liberty
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.2 = sun.security.provider.Sun [+ \
     {KeyStore, JKS, *, ModuleAndFullClassName:java.base/java.security.KeyStore}, \
-    {MessageDigest, SHA-1, *, ModuleAndFullClassName:java.base/java.security.KeyStore}, \
-    {MessageDigest, SHA-1, *, FullClassName:org.apache.xml.security.encryption.XMLCipher}]
-RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.4 = com.sun.crypto.provider.SunJCE [+ \
-    {Cipher, RSA, *, FullClassName:org.apache.xml.security.encryption.XMLCipher}, \
-    {Cipher, AES, *, FullClassName:org.apache.xml.security.encryption.XMLCipher}]
+    {MessageDigest, SHA-1, *, ModuleAndFullClassName:java.base/java.security.KeyStore}]

--- a/dev/com.ibm.ws.security.saml.sso_fat.logout/semeruFips140_3CustomProfile.properties
+++ b/dev/com.ibm.ws.security.saml.sso_fat.logout/semeruFips140_3CustomProfile.properties
@@ -2,8 +2,5 @@ RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.desc.name = Custom OpenJCEPl
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.extends = RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Liberty
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.2 = sun.security.provider.Sun [+ \
     {KeyStore, JKS, *, ModuleAndFullClassName:java.base/java.security.KeyStore}, \
-    {MessageDigest, SHA-1, *, ModuleAndFullClassName:java.base/java.security.KeyStore}, \
-    {MessageDigest, SHA-1, *, FullClassName:org.apache.xml.security.encryption.XMLCipher}]
-RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.4 = com.sun.crypto.provider.SunJCE [+ \
-    {Cipher, RSA, *, FullClassName:org.apache.xml.security.encryption.XMLCipher}, \
-    {Cipher, AES, *, FullClassName:org.apache.xml.security.encryption.XMLCipher}]
+    {MessageDigest, SHA-1, *, ModuleAndFullClassName:java.base/java.security.KeyStore}]
+

--- a/dev/com.ibm.ws.security.saml.sso_fat/semeruFips140_3CustomProfile.properties
+++ b/dev/com.ibm.ws.security.saml.sso_fat/semeruFips140_3CustomProfile.properties
@@ -1,9 +1,12 @@
+#removed:
+#{MessageDigest, SHA-1, *, FullClassName:org.apache.xml.security.encryption.XMLCipher}
+#RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.4 = com.sun.crypto.provider.SunJCE [+ \
+#    {Cipher, RSA, *, FullClassName:org.apache.xml.security.encryption.XMLCipher}, \
+#    {Cipher, AES, *, FullClassName:org.apache.xml.security.encryption.XMLCipher}]
+
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.desc.name = Custom OpenJCEPlusFIPS Cryptographic Module FIPS 140-3
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.extends = RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Liberty
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.2 = sun.security.provider.Sun [+ \
     {KeyStore, JKS, *, ModuleAndFullClassName:java.base/java.security.KeyStore}, \
-    {MessageDigest, SHA-1, *, ModuleAndFullClassName:java.base/java.security.KeyStore}, \
-    {MessageDigest, SHA-1, *, FullClassName:org.apache.xml.security.encryption.XMLCipher}]
-RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.4 = com.sun.crypto.provider.SunJCE [+ \
-    {Cipher, RSA, *, FullClassName:org.apache.xml.security.encryption.XMLCipher}, \
-    {Cipher, AES, *, FullClassName:org.apache.xml.security.encryption.XMLCipher}]
+    {MessageDigest, SHA-1, *, ModuleAndFullClassName:java.base/java.security.KeyStore}]
+

--- a/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyServer.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyServer.java
@@ -7878,7 +7878,8 @@ public class LibertyServer implements LogMonitorClient {
         }
 
         boolean isIBMJVM8 = (serverJavaInfo.majorVersion() == 8) && (serverJavaInfo.VENDOR == Vendor.IBM);
-        boolean isIBMJVMGreaterOrEqualTo11 = (serverJavaInfo.majorVersion() >= 11) && (serverJavaInfo.VENDOR == Vendor.IBM);
+        //boolean isIBMJVMGreaterOrEqualTo11 = (serverJavaInfo.majorVersion() >= 11) && (serverJavaInfo.VENDOR == Vendor.IBM);
+        boolean isIBMJVMGreaterOrEqualTo11 = (serverJavaInfo.majorVersion() >= 11) && (serverJavaInfo.VENDOR == Vendor.OPENJ9);
         if (logOutput && GLOBAL_FIPS_140_3) {
             Log.info(c, methodName, "Liberty server is running JDK version: " + serverJavaInfo.majorVersion()
                                     + " and vendor: " + serverJavaInfo.VENDOR);
@@ -7912,7 +7913,8 @@ public class LibertyServer implements LogMonitorClient {
 
     public boolean isSemeruFIPS140_3EnabledAndSupported() throws IOException {
         JavaInfo serverJavaInfo = JavaInfo.forServer(this);
-        return GLOBAL_FIPS_140_3 && (serverJavaInfo.majorVersion() >= 11) && (serverJavaInfo.VENDOR == Vendor.IBM) && serverLevelFipsEnabled;
+        //return GLOBAL_FIPS_140_3 && (serverJavaInfo.majorVersion() >= 11) && (serverJavaInfo.VENDOR == Vendor.IBM) && serverLevelFipsEnabled;
+        return GLOBAL_FIPS_140_3 && (serverJavaInfo.majorVersion() >= 11) && (serverJavaInfo.VENDOR == Vendor.OPENJ9) && serverLevelFipsEnabled;
     }
 
     public void setServerLevelFips(boolean enabled) {


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).

New semeru version (current pre-GA under testing) is fixing the prior RSA-OAEP related exceptions when running some of *.security.smal.sso*_fat with FIPS 140-3 enabled, for example,  `Cannot find any provider supporting RSA/ECB/OAEPWithSHA1AndMGF1Padding`.  When running with the old semeru version, we added the allowed exception in semeru fips custom profile to workaround the test failure, e.g.,
```
{MessageDigest, SHA-1, *, FullClassName:org.apache.xml.security.encryption.XMLCipher}
{Cipher, RSA, *, FullClassName:org.apache.xml.security.encryption.XMLCipher}
{Cipher, AES, *, FullClassName:org.apache.xml.security.encryption.XMLCipher}
```

Although java update is fixing the initial provider issue (after removing the above exceptions from custom profile), the new generated error related SHA1 message digest algorithm and AES encryption algorithm require an update in IdP (Shibboleth) configuration (relying-party.xml, sp*metadata.xml).