### PR TITLE
Debugging the cdi selection of multiple HAMs from different WARs caus…

### DIFF
--- a/dev/com.ibm.ws.security.javaeesec/src/com/ibm/ws/security/javaeesec/CDIHelper.java
+++ b/dev/com.ibm.ws.security.javaeesec/src/com/ibm/ws/security/javaeesec/CDIHelper.java
@@ -99,4 +99,33 @@ public class CDIHelper {
         }
         return elProcessor;
     }
+
+    /**
+     * Get only the beans visible from the war serving the current request.
+     */
+    @SuppressWarnings("unchecked")
+    public static <T> Set<T> getBeansFromCurrentModuleViaInstance(Class<T> beanClass) {
+        Set<T> beanInstances = new HashSet<T>();
+
+        if (cdiService == null) {
+            return beanInstances;
+        }
+
+        BeanManager beanManager = cdiService.getCurrentModuleBeanManager();
+        if (beanManager == null) {
+            return beanInstances;
+        }
+
+        // look up beans from the instance objhect, add to set and return
+        javax.enterprise.inject.Instance<Object> instance = beanManager.createInstance();
+        if (instance != null) {
+            javax.enterprise.inject.Instance<T> typedInstance = instance.select(beanClass);
+            for (T bean : typedInstance) {
+                beanInstances.add(bean);
+            }
+        }
+
+        return beanInstances;
+    }
+
 }

--- a/dev/io.openliberty.security.jakartasec.4.0.internal/src/io/openliberty/security/jakartasec/handlers/HttpAuthenticationMechanismHandlerImpl.java
+++ b/dev/io.openliberty.security.jakartasec.4.0.internal/src/io/openliberty/security/jakartasec/handlers/HttpAuthenticationMechanismHandlerImpl.java
@@ -288,13 +288,30 @@ public class HttpAuthenticationMechanismHandlerImpl implements HttpAuthenticatio
         Tr.debug(tc, getApplicationName(), msg.toString());
     }
 
+    protected void scanAuthenticationMechanisms(Set<MultiHttpAuthenticationMechanism> multiHttpAuthenticationMechanisms) {
+        CDI cdi = getCDI();
+
+        if (cdi != null) {
+            // module scoping, get only HAMs from the current WAR/module
+            for (HttpAuthenticationMechanism mechanism : CDIHelper.getBeansFromCurrentModuleViaInstance(HttpAuthenticationMechanism.class)) {
+                MultiHttpAuthenticationMechanism multiMechanism = new MultiHttpAuthenticationMechanism(mechanism);
+                multiHttpAuthenticationMechanisms.add(multiMechanism);
+
+                if (tc.isDebugEnabled()) {
+                    Tr.debug(tc, "Found HAM from current module: " +
+                                 multiMechanism.getSimpleName());
+                }
+            }
+        }
+    }
+
     /**
      * Scans for all available HttpAuthenticationMechanism implementations.
      *
      * @param multiHttpAuthenticationMechanisms The set to populate with found mechanisms
      */
     @SuppressWarnings({ "unchecked", "rawtypes" })
-    protected void scanAuthenticationMechanisms(Set<MultiHttpAuthenticationMechanism> multiHttpAuthenticationMechanisms) {
+    protected void scanAuthenticationMechanisms1(Set<MultiHttpAuthenticationMechanism> multiHttpAuthenticationMechanisms) {
 
         Instance<HttpAuthenticationMechanism> httpAuthenticationMechanismInstances = null;
         CDI cdi = getCDI();
@@ -302,6 +319,8 @@ public class HttpAuthenticationMechanismHandlerImpl implements HttpAuthenticatio
         if (cdi != null) {
             httpAuthenticationMechanismInstances = cdi.select(HttpAuthenticationMechanism.class);
         }
+
+        Tr.debug(tc, "DAVE: module name is [" + getModuleName() + "].");
 
         if (httpAuthenticationMechanismInstances != null) {
             for (HttpAuthenticationMechanism httpAuthenticationMechanismInstance : httpAuthenticationMechanismInstances) {


### PR DESCRIPTION
…ing testMultipleModuleWarsOverrideClientCertWithFailOverToAppDefinedFailOverSuccess to fail in bundle com.ibm.ws.security.javaeesec_fat.4


- [X] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [ ] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

