### PR TITLE
Added a server restart, whenever the bootstrap props is updated.

### DIFF
--- a/dev/com.ibm.ws.logging_fat/fat/src/com/ibm/ws/logging/fat/ConsoleFormatTest.java
+++ b/dev/com.ibm.ws.logging_fat/fat/src/com/ibm/ws/logging/fat/ConsoleFormatTest.java
@@ -244,6 +244,10 @@ public class ConsoleFormatTest {
             // Restore the initial contents of bootstrap.properties
             FileOutputStream out = getFileOutputStreamForRemoteFile(bootstrapFile, false);
             writeProperties(initialBootstrapProps, out);
+
+            // Restart the default server so the bootstrap properties is restored, to ensure other tests are run correctly.
+            Log.info(c, "testSimpleFormatSetInBootstrapProperties", "Restarting the server...");
+            restoreServer();
         }
     }
 
@@ -279,6 +283,10 @@ public class ConsoleFormatTest {
             // Restore the initial contents of bootstrap.properties
             FileOutputStream out = getFileOutputStreamForRemoteFile(bootstrapFile, false);
             writeProperties(initialBootstrapProps, out);
+
+            // Restart the default server so the bootstrap properties is restored, to ensure other tests are run correctly.
+            Log.info(c, "testSimpleFormatSetInBootstrapProperties", "Restarting the server...");
+            restoreServer();
         }
     }
 


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

Fixes #34556
- Whenever the bootstrap.properties is updated programmatically for a test, we restore the old bootstrap props in a finally block, at the end of the tests. However, we must restart the server to take effect, else the bootstrap props will not be restored.
- Added a server restart in the finally block for each bootstrap prop test case.
