### PR TITLE
Mark false positive in server_withOidcClientConfig_ee11.xml

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "package-lock.json|.*\\/OSGI-INF\\/.*\\.properties$|.+\\.(nlsprops)$|^dev\\/(.*(_test|_fat)).*\\/ltpa.keys$|^dev\\/com.ibm.ws.openapi.ui\\/swagger-ui\\/dist\\/liberty-swagger-ui-bundle-.*\\.js$|^.secrets.baseline.*|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-04-09T10:53:15Z",
+  "generated_at": "2026-04-14T17:20:47Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -32377,6 +32377,15 @@
       {
         "hashed_secret": "bad4bb67da67759f3da19049f4ab6798ba0ca925",
         "is_secret": false,
+        "is_verified": false,
+        "line_number": 51,
+        "type": "Box Credentials",
+        "verified_result": null
+      }
+    ],
+    "dev/io.openliberty.security.jakartasec.3.0.internal_fat/publish/servers/jakartasec-3.0_fat.rp/configs/server_withOidcClientConfig_ee11.xml": [
+      {
+        "hashed_secret": "bad4bb67da67759f3da19049f4ab6798ba0ca925",
         "is_verified": false,
         "line_number": 51,
         "type": "Box Credentials",

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -32386,6 +32386,7 @@
     "dev/io.openliberty.security.jakartasec.3.0.internal_fat/publish/servers/jakartasec-3.0_fat.rp/configs/server_withOidcClientConfig_ee11.xml": [
       {
         "hashed_secret": "bad4bb67da67759f3da19049f4ab6798ba0ca925",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 51,
         "type": "Box Credentials",


### PR DESCRIPTION
The .secrets.baseline file Alex changed under https://github.com/OpenLiberty/open-liberty/pull/34628 needs a further change, small but important. In the interest of expediting, I cherry-picked his commit and appending to it so that I can deliver https://github.com/OpenLiberty/open-liberty/pull/34582.