### PR TITLE
Increase h2 default frame timeout

### DIFF
--- a/dev/com.ibm.ws.http2.client/src/com/ibm/ws/http2/test/H2StreamResultManager.java
+++ b/dev/com.ibm.ws.http2.client/src/com/ibm/ws/http2/test/H2StreamResultManager.java
@@ -46,13 +46,9 @@ public class H2StreamResultManager {
     private static final String CLASS_NAME = H2StreamResultManager.class.getName();
     private static final Logger LOGGER = Logger.getLogger(CLASS_NAME);
 
-    public H2StreamResultManager() {
+    public H2StreamResultManager(H2Connection h2Connection) {
         this.streamHashtable = new ConcurrentHashMap<Integer, H2StreamResult>();
         this.pushPromiseH2StreamResults = new ConcurrentHashMap<FramePushPromiseClient, H2StreamResult>();
-    }
-
-    public H2StreamResultManager(H2Connection h2Connection) {
-        this();
         this.h2Connection = h2Connection;
 
         if (LOGGER.isLoggable(Level.FINEST))
@@ -83,6 +79,7 @@ public class H2StreamResultManager {
             } else { //it is an expected GoAway, so start finishing test
                 receivedExpectedGoAway = true;
             }
+            h2Connection.goAwayReceived();
         } else if (frame.getFrameType() == FrameTypes.PUSH_PROMISE) {
             //this will update the H2StreamResult to have the right streamID!
             H2StreamResult pushPromisedStreamResults = pushPromiseH2StreamResults.get(frame);

--- a/dev/com.ibm.ws.http2.client/src/com/ibm/ws/http2/test/H2StreamResultManager.java
+++ b/dev/com.ibm.ws.http2.client/src/com/ibm/ws/http2/test/H2StreamResultManager.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2024 IBM Corporation and others.
+ * Copyright (c) 2018, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.http2.client/src/com/ibm/ws/http2/test/connection/H2Connection.java
+++ b/dev/com.ibm.ws.http2.client/src/com/ibm/ws/http2/test/connection/H2Connection.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2024 IBM Corporation and others.
+ * Copyright (c) 2018, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.http2.client/src/com/ibm/ws/http2/test/connection/H2Connection.java
+++ b/dev/com.ibm.ws.http2.client/src/com/ibm/ws/http2/test/connection/H2Connection.java
@@ -95,6 +95,7 @@ public class H2Connection {
     private boolean serverFirstConnectReceived = false;
     private boolean prefaceSent = false;
     private boolean firstConnectSent = false;
+    private boolean goAwayReceived = false;
 
     private final List<Exception> reportedExceptions = Collections.synchronizedList(new ArrayList<Exception>());
 
@@ -920,5 +921,13 @@ public class H2Connection {
 
     public AtomicBoolean getWaitingForACK() {
         return this.waitingForACK;
+    }
+
+    public void goAwayReceived() {
+        goAwayReceived = true;
+    }
+
+    public boolean receivedGoAway() {
+        return goAwayReceived;
     }
 }

--- a/dev/com.ibm.ws.http2.client/src/com/ibm/ws/http2/test/connection/H2TCPReadCallback.java
+++ b/dev/com.ibm.ws.http2.client/src/com/ibm/ws/http2/test/connection/H2TCPReadCallback.java
@@ -10,6 +10,8 @@
 package com.ibm.ws.http2.test.connection;
 
 import java.io.IOException;
+import java.io.EOFException;
+import java.net.SocketException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -23,13 +25,13 @@ import com.ibm.wsspi.tcpchannel.TCPReadRequestContext;
  */
 public class H2TCPReadCallback implements TCPReadCompletedCallback {
 
-    H2Connection h2connetion = null;
+    H2Connection h2connection = null;
 
     private static final String CLASS_NAME = H2TCPReadCallback.class.getName();
     private static final Logger LOGGER = Logger.getLogger(CLASS_NAME);
 
     public H2TCPReadCallback(H2Connection connection) {
-        h2connetion = connection;
+        h2connection = connection;
     }
 
     /*
@@ -39,14 +41,14 @@ public class H2TCPReadCallback implements TCPReadCompletedCallback {
      */
     @Override
     public void complete(VirtualConnection arg0, TCPReadRequestContext tcpReadRequestContext) {
-        if (h2connetion.isClosedCalled()) {
+        if (h2connection.isClosedCalled()) {
             if (LOGGER.isLoggable(Level.FINEST))
-                LOGGER.logp(Level.FINEST, CLASS_NAME, "complete", "H2TCPReadCallback.complete: Recevied callback after connection was closed. Will ignore callback");
+                LOGGER.logp(Level.FINEST, CLASS_NAME, "complete", "H2TCPReadCallback.complete: Received callback after connection was closed. Will ignore callback");
             return;
         }
         if (LOGGER.isLoggable(Level.FINEST))
             LOGGER.logp(Level.FINEST, CLASS_NAME, "complete", "H2TCPReadCallback.complete: Calling processData from callback");
-        h2connetion.processData();
+        h2connection.processData();
     }
 
     /*
@@ -57,11 +59,28 @@ public class H2TCPReadCallback implements TCPReadCompletedCallback {
      */
     @Override
     public void error(VirtualConnection arg0, TCPReadRequestContext arg1, IOException arg2) {
-
-    }
-
-    void processFrame(WsByteBuffer buffer) {
-
+        if (arg2 instanceof SocketException) {
+            // Ignore connection resets
+            SocketException exception = (SocketException) arg2;
+            if (exception.getMessage() != null && exception.getMessage().contains("Connection reset")) {
+                if (LOGGER.isLoggable(Level.FINEST))
+                    LOGGER.logp(Level.FINEST, CLASS_NAME, "error", "H2TCPReadCallback.error: Ignoring Connection Reset for connection " + arg1.getSocket());
+                return;
+            }
+        }
+        if (arg2 instanceof EOFException) {
+            if (LOGGER.isLoggable(Level.FINEST))
+                LOGGER.logp(Level.FINEST, CLASS_NAME, "error", "H2TCPReadCallback.error: Ignoring EOFException in read callback from connection " + arg1.getSocket() + " -> " + arg2);
+                return;
+        }
+        if (LOGGER.isLoggable(Level.FINEST))
+            LOGGER.logp(Level.FINEST, CLASS_NAME, "error", "H2TCPReadCallback.error: Received error callback from connection " + arg1.getSocket() + " -> " + arg2);
+        if (!h2connection.isClosedCalled()) {
+            if (LOGGER.isLoggable(Level.FINEST))
+                LOGGER.logp(Level.FINEST, CLASS_NAME, "error", "H2TCPReadCallback.error: Calling close with encountered exception");
+            h2connection.getReportedExceptions().add(arg2);
+            h2connection.close();
+        }
     }
 
 }

--- a/dev/com.ibm.ws.http2.client/src/com/ibm/ws/http2/test/connection/H2TCPReadCallback.java
+++ b/dev/com.ibm.ws.http2.client/src/com/ibm/ws/http2/test/connection/H2TCPReadCallback.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2024 IBM Corporation and others.
+ * Copyright (c) 2018, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.http2.client/src/com/ibm/ws/http2/test/connection/H2TCPWriteCallback.java
+++ b/dev/com.ibm.ws.http2.client/src/com/ibm/ws/http2/test/connection/H2TCPWriteCallback.java
@@ -13,6 +13,7 @@
 package com.ibm.ws.http2.test.connection;
 
 import java.io.IOException;
+import java.io.EOFException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -25,13 +26,13 @@ import com.ibm.wsspi.tcpchannel.TCPWriteRequestContext;
  */
 public class H2TCPWriteCallback implements TCPWriteCompletedCallback {
 
-    H2Connection h2connetion = null;
+    H2Connection h2connection = null;
 
-    private static final String CLASS_NAME = H2TCPReadCallback.class.getName();
+    private static final String CLASS_NAME = H2TCPWriteCallback.class.getName();
     private static final Logger LOGGER = Logger.getLogger(CLASS_NAME);
 
     public H2TCPWriteCallback(H2Connection connection) {
-        h2connetion = connection;
+        h2connection = connection;
     }
 
     /*
@@ -43,7 +44,7 @@ public class H2TCPWriteCallback implements TCPWriteCompletedCallback {
     public void complete(VirtualConnection arg0, TCPWriteRequestContext arg1) {
         if (LOGGER.isLoggable(Level.FINEST))
             LOGGER.logp(Level.FINEST, CLASS_NAME, "complete", "H2TCPWriteCallback complete");
-        h2connetion.syncWrite();
+        h2connection.syncWrite();
     }
 
     /*
@@ -54,10 +55,19 @@ public class H2TCPWriteCallback implements TCPWriteCompletedCallback {
      */
     @Override
     public void error(VirtualConnection arg0, TCPWriteRequestContext arg1, IOException arg2) {
-        // TODO Auto-generated method stub
-        if (LOGGER.isLoggable(Level.INFO))
-            LOGGER.logp(Level.INFO, CLASS_NAME, "error", "H2TCPWriteCallback error: " + arg2);
-
+        if (arg2 instanceof EOFException) {
+            if (LOGGER.isLoggable(Level.FINEST))
+                LOGGER.logp(Level.FINEST, CLASS_NAME, "error", "H2TCPWriteCallback.error: Ignoring EOFException in callback from connection " + arg1.getSocket() + " -> " + arg2);
+                return;
+        }
+        if (LOGGER.isLoggable(Level.FINEST))
+            LOGGER.logp(Level.FINEST, CLASS_NAME, "error", "H2TCPWriteCallback.error: Received error callback from connection " + arg1.getSocket() + " -> " + arg2);
+        if (!h2connection.isClosedCalled()) {
+            if (LOGGER.isLoggable(Level.FINEST))
+                LOGGER.logp(Level.FINEST, CLASS_NAME, "error", "H2TCPWriteCallback.error: Calling close with encountered exception");
+            h2connection.getReportedExceptions().add(arg2);
+            h2connection.close();
+        }
     }
 
 }

--- a/dev/com.ibm.ws.http2.client/src/com/ibm/ws/http2/test/connection/H2TCPWriteCallback.java
+++ b/dev/com.ibm.ws.http2.client/src/com/ibm/ws/http2/test/connection/H2TCPWriteCallback.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 IBM Corporation and others.
+ * Copyright (c) 2018, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.http2.client/src/com/ibm/ws/http2/test/utils.java
+++ b/dev/com.ibm.ws.http2.client/src/com/ibm/ws/http2/test/utils.java
@@ -18,7 +18,7 @@ import com.ibm.wsspi.bytebuffer.WsByteBuffer;
 
 public class utils {
 
-    public static final int IO_DEFAULT_TIMEOUT = 28000;
+    public static final int IO_DEFAULT_TIMEOUT = 40000;
     public static final int IO_DEFAULT_BUFFER_SIZE = 4090;
 
     public static final byte FRAME_TYPE_DATA = 0x00;

--- a/dev/com.ibm.ws.http2.client/src/com/ibm/ws/http2/test/utils.java
+++ b/dev/com.ibm.ws.http2.client/src/com/ibm/ws/http2/test/utils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2020 IBM Corporation and others.
+ * Copyright (c) 2018, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.transport.http2_fat/test-applications/H2FATDriver.war/src/http2/test/driver/war/servlets/H2FATDriverServlet.java
+++ b/dev/com.ibm.ws.transport.http2_fat/test-applications/H2FATDriver.war/src/http2/test/driver/war/servlets/H2FATDriverServlet.java
@@ -3278,7 +3278,7 @@ public class H2FATDriverServlet extends FATServlet {
         }
         String testName = "testBadPRI";
         CountDownLatch blockUntilConnectionIsDone = new CountDownLatch(1);
-        Http2Client h2Client = getDefaultH2Client(request, response, blockUntilConnectionIsDone);
+        Http2Client h2Client = new Http2Client(request.getParameter("hostName"), Integer.parseInt(request.getParameter("port")), blockUntilConnectionIsDone, defaultTimeoutToSendFrame, 10000L);
 
         h2Client.sendUpgradeHeader(HEADERS_ONLY_URI);
         h2Client.sendClientPreface("Bad-PRI");


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [ ] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

Fixes defect 305152 for when connection errors happen when reading/writing which can cause closed connections while the tests are still running. It also increases the default read timeout for slow machines.
