### PR TITLE
Include CWWKS1865W in expected errors for FIPS140-3

### DIFF
--- a/dev/com.ibm.ws.security.registry.basic_fat/fat/src/com/ibm/ws/security/registry/basic/fat/FATTest.java
+++ b/dev/com.ibm.ws.security.registry.basic_fat/fat/src/com/ibm/ws/security/registry/basic/fat/FATTest.java
@@ -238,14 +238,14 @@ public class FATTest {
                 expectedErrors.add(CWWKS1864W_WEAK_ALGORITHM_WARNING);
                 CWWKS1864wAlreadyLoggedForAES = true;
             }
+        }
 
-            //Note: CWWKS1865W will be output after CWWKS1864W
-            if (!!!CWWKS1865wAlreadyLoggedForAES) {
-                assertNotNull("AES password without custom encryption key should cause CWWKS1865W",
-                              server.waitForStringInLog(CWWKS1865W_AES_NO_CUSTOM_KEY_WARNING));
-                expectedErrors.add(CWWKS1865W_AES_NO_CUSTOM_KEY_WARNING);
-                CWWKS1865wAlreadyLoggedForAES = true;
-            }
+        //Note: CWWKS1865W will be output after CWWKS1864W
+        if (!!!CWWKS1865wAlreadyLoggedForAES) {
+            assertNotNull("AES password without custom encryption key should cause CWWKS1865W",
+                    server.waitForStringInLog(CWWKS1865W_AES_NO_CUSTOM_KEY_WARNING));
+            expectedErrors.add(CWWKS1865W_AES_NO_CUSTOM_KEY_WARNING);
+            CWWKS1865wAlreadyLoggedForAES = true;
         }
 
         String password = "superAES256password";

--- a/dev/com.ibm.ws.security.registry.basic_fat/fat/src/com/ibm/ws/security/registry/basic/fat/FATTestFederated.java
+++ b/dev/com.ibm.ws.security.registry.basic_fat/fat/src/com/ibm/ws/security/registry/basic/fat/FATTestFederated.java
@@ -66,6 +66,7 @@ public class FATTestFederated {
     private static boolean CWWKS1864wAlreadyLoggedForHash = false;
     /** CWWKS1864w is only logged one time for AES-128 {aes} passwords per server start */
     private static boolean CWWKS1864wAlreadyLoggedForAES = false;
+    private static boolean CWWKS1865wAlreadyLoggedForAES = false;
 
     /**
      * Updates the sample, which is expected to be at the hard-coded path.
@@ -169,7 +170,12 @@ public class FATTestFederated {
             }
 
             // Add CWWKS1865W for AES passwords without custom encryption key
-            expectedErrors.add(CWWKS1865W_AES_NO_CUSTOM_KEY_WARNING);
+            if (!!!CWWKS1865wAlreadyLoggedForAES) {
+                assertNotNull("AES password without custom encryption key should cause CWWKS1865W",
+                        server.waitForStringInLog(CWWKS1865W_AES_NO_CUSTOM_KEY_WARNING));
+                expectedErrors.add(CWWKS1865W_AES_NO_CUSTOM_KEY_WARNING);
+                CWWKS1865wAlreadyLoggedForAES = true;
+            }
 
             assertEquals("Authentication should succeed.",
                          "defaultUser", servlet.checkPassword("defaultUser", password));
@@ -210,6 +216,14 @@ public class FATTestFederated {
                 expectedErrors.add(CWWKS1864W_WEAK_ALGORITHM_WARNING);
                 CWWKS1864wAlreadyLoggedForAES = true;
             }
+        }
+
+        //Note: CWWKS1865W will be output after CWWKS1864W
+        if (!!!CWWKS1865wAlreadyLoggedForAES) {
+            assertNotNull("AES password without custom encryption key should cause CWWKS1865W",
+                    server.waitForStringInLog(CWWKS1865W_AES_NO_CUSTOM_KEY_WARNING));
+            expectedErrors.add(CWWKS1865W_AES_NO_CUSTOM_KEY_WARNING);
+            CWWKS1865wAlreadyLoggedForAES = true;
         }
 
         String password = "superAES256password";
@@ -374,5 +388,6 @@ public class FATTestFederated {
         server.stopServer(expectedErrors.toArray(new String[0]));
         CWWKS1864wAlreadyLoggedForHash = false;
         CWWKS1864wAlreadyLoggedForAES = false;
+        CWWKS1865wAlreadyLoggedForAES = false;
     }
 }


### PR DESCRIPTION
CWWKS1865W was not added to list of expected warnings/failures if FIPS140-3 is enabled.

Fixes [#308890](https://wasrtc.hursley.ibm.com:9443/jazz/web/projects/WS-CD#action=com.ibm.team.workitem.viewWorkItem&id=308890)
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [ ] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".