### PR TITLE
API and basic sorting of null values

### DIFF
--- a/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/CursoredPageImpl.java
+++ b/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/CursoredPageImpl.java
@@ -391,6 +391,9 @@ public class CursoredPageImpl<T> extends PageImpl<T> implements CursoredPage<T> 
                 s.append(sort.isAscending() //
                                 ? sort.ignoreCase() ? " ASC IgnoreCase" : " ASC" //
                                 : sort.ignoreCase() ? " DESC IgnoreCase" : " DESC");
+                String nullOrdering = queryInfo.getNullOrdering(sort, true);
+                if (nullOrdering != null)
+                    s.append(" NULLS ").append(nullOrdering);
             }
 
         s.append(") @").append(Integer.toHexString(hashCode()));

--- a/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/QueryInfo.java
+++ b/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/QueryInfo.java
@@ -427,28 +427,20 @@ public abstract class QueryInfo {
     /**
      * Adds Sort criteria to the end of the tracked list of sort criteria.
      *
-     * @param ignoreCase if ordering is to be independent of case.
-     * @param attribute  name of attribute (@OrderBy value, Sort property,
-     *                       or parsed from OrderBy method name keyword).
-     * @param descending if ordering is to be in descending order
+     * @param orderBy OrderBy annotation from a repository method.
      */
     @Trivial
-    private void addSort(boolean ignoreCase, String attribute, boolean descending) {
+    private void addSort(OrderBy orderBy) {
         if (entityInfo.idClassAttributeAccessors == null ||
-            !ID.equalsIgnoreCase(attribute)) {
-            String name = getAttributeName(attribute, true);
-
-            sorts.add(ignoreCase ? //
-                            descending ? //
-                                            Sort.descIgnoreCase(name) : //
-                                            Sort.ascIgnoreCase(name) : //
-                            descending ? //
-                                            Sort.desc(name) : //
-                                            Sort.asc(name));
+            !ID.equalsIgnoreCase(orderBy.value())) {
+            String expression = getAttributeName(orderBy.value(), true);
+            sorts.add(createSort(expression, orderBy));
         } else {
             // Expand ID(THIS) for composite IdClass into separate attributes
-            for (String name : entityInfo.idClassAttributeAccessors.keySet())
-                addSort(ignoreCase, name, descending);
+            for (String name : entityInfo.idClassAttributeAccessors.keySet()) {
+                name = getAttributeName(name, true);
+                sorts.add(createSort(name, orderBy));
+            }
         }
     }
 
@@ -1113,6 +1105,29 @@ public abstract class QueryInfo {
         setParameters(query, args, deferredConstraints, addedJPQLParams);
         return query;
     }
+
+    /**
+     * Creates a new Sort instance equivalent to the behavior of the given
+     * OrderBy annotation.
+     *
+     * @param expression usually an entity attribute name but might be
+     *                       another type of expression instead.
+     * @param orderBy    annotation found on a repository method.
+     * @return the new Sort instance.
+     */
+    protected abstract <T> Sort<T> createSort(String expression, OrderBy orderBy);
+
+    /**
+     * Creates a new Sort instance with the corresponding entity attribute name
+     * or expression, with all other fields copied from the given Sort instance.
+     *
+     * @param expression usually an entity attribute name but might be
+     *                       another type of expression instead.
+     * @param sort       the Sort from which to copy.
+     * @return an otherwise identical Sort instance, but with the corresponding
+     *         entity attribute name or expression.
+     */
+    protected abstract <T> Sort<T> createSort(String expression, Sort<T> sort);
 
     /**
      * Deletes entities that were found by a find-and-delete operation.
@@ -3259,25 +3274,6 @@ public abstract class QueryInfo {
     protected abstract String getQueryAnnoValue();
 
     /**
-     * Creates a Sort instance with the corresponding entity attribute name
-     * or returns the existing instance if it already matches.
-     *
-     * @param name name provided by the user to sort by.
-     * @param sort the Sort to add.
-     * @return a Sort instance with the corresponding entity attribute name.
-     */
-    @Trivial
-    private <T> Sort<T> getWithAttributeName(String name, Sort<T> sort) {
-        name = getAttributeName(name, true);
-        if (name == sort.property())
-            return sort;
-        else
-            return sort.isAscending() //
-                            ? sort.ignoreCase() ? Sort.ascIgnoreCase(name) : Sort.asc(name) //
-                            : sort.ignoreCase() ? Sort.descIgnoreCase(name) : Sort.desc(name);
-    }
-
-    /**
      * Identifies the repository method type based on life cycle annotations.
      * For example (Insert, Update, Save, Delete, Detach, Merge, ...).
      */
@@ -3443,7 +3439,7 @@ public abstract class QueryInfo {
                     }
 
                 for (int i = 0; i < orderBy.length; i++)
-                    addSort(orderBy[i].ignoreCase(), orderBy[i].value(), orderBy[i].descending());
+                    addSort(orderBy[i]);
 
                 if (sortPositions.length == 0) {
                     sortPositions = NONE_STATIC_SORT_ONLY;
@@ -4516,7 +4512,8 @@ public abstract class QueryInfo {
                 }
             }
 
-            addSort(ignoreCase, attribute, descending);
+            String name = getAttributeName(attribute, true);
+            sorts.add(new Sort<>(name, !descending, ignoreCase));
 
             if (iNext > 0)
                 iNext += (iNext == desc ? 4 : 3);
@@ -5569,15 +5566,21 @@ public abstract class QueryInfo {
             combined = sorts == null ? new ArrayList<>() : new ArrayList<>(sorts);
         while (addIt.hasNext()) {
             Sort<Object> sort = addIt.next();
-            if (sort == null)
+            if (sort == null) {
                 throw new IllegalArgumentException("Sort: null");
-            // IdClass is split up so that it can be possible to create a cursor
-            // that corresponds to sort criteria
-            else if (hasIdClass && ID.equalsIgnoreCase(sort.property()))
-                for (String name : entityInfo.idClassAttributeAccessors.keySet())
-                    combined.add(getWithAttributeName(getAttributeName(name, true), sort));
-            else
-                combined.add(getWithAttributeName(sort.property(), sort));
+            } else if (hasIdClass && ID.equalsIgnoreCase(sort.property())) {
+                // IdClass is split up so that it can be possible to create a cursor
+                // that corresponds to sort criteria
+                for (String name : entityInfo.idClassAttributeAccessors.keySet()) {
+                    name = getAttributeName(name, true);
+                    sort = name == sort.property() ? sort : createSort(name, sort);
+                    combined.add(sort);
+                }
+            } else {
+                String name = getAttributeName(sort.property(), true);
+                sort = name == sort.property() ? sort : createSort(name, sort);
+                combined.add(sort);
+            }
         }
         return combined;
     }
@@ -5598,15 +5601,21 @@ public abstract class QueryInfo {
         if (combined == null && additional.length > 0)
             combined = sorts == null ? new ArrayList<>() : new ArrayList<>(sorts);
         for (Sort<Object> sort : additional) {
-            if (sort == null)
+            if (sort == null) {
                 throw new IllegalArgumentException("Sort: null");
-            // IdClass is split up so that it can be possible to create a cursor
-            // that corresponds to sort criteria
-            else if (hasIdClass && ID.equalsIgnoreCase(sort.property()))
-                for (String name : entityInfo.idClassAttributeAccessors.keySet())
-                    combined.add(getWithAttributeName(getAttributeName(name, true), sort));
-            else
-                combined.add(getWithAttributeName(sort.property(), sort));
+            } else if (hasIdClass && ID.equalsIgnoreCase(sort.property())) {
+                // IdClass is split up so that it can be possible to create a cursor
+                // that corresponds to sort criteria
+                for (String name : entityInfo.idClassAttributeAccessors.keySet()) {
+                    name = getAttributeName(name, true);
+                    sort = name == sort.property() ? sort : createSort(name, sort);
+                    combined.add(sort);
+                }
+            } else {
+                String name = getAttributeName(sort.property(), true);
+                sort = name == sort.property() ? sort : createSort(name, sort);
+                combined.add(sort);
+            }
         }
         return combined;
     }

--- a/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/QueryInfo.java
+++ b/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/QueryInfo.java
@@ -2970,6 +2970,10 @@ public abstract class QueryInfo {
             if (sort.isAscending())
                 q.append(" DESC");
         }
+
+        String nullOrdering = getNullOrdering(sort, sameDirection);
+        if (nullOrdering != null)
+            q.append(" NULLS ").append(nullOrdering);
     }
 
     /**
@@ -3262,6 +3266,17 @@ public abstract class QueryInfo {
                                (methodAnno == null ? null : methodAnno.annotationType()));
         return methodAnno;
     }
+
+    /**
+     * Returns Sort.nullOrdering as a String if FIRST or LAST, otherwise null.
+     *
+     * @param sort          sort criteria.
+     * @param sameDirection indicates to interpret the Sort in the normal direction.
+     *                          Otherwise reverses it (for cursor pagination in the
+     *                          previous page direction).
+     * @return "FIRST", "LAST", or null.
+     */
+    protected abstract String getNullOrdering(Sort<?> sort, boolean sameDirection);
 
     /**
      * Value (representing a JPQL or JCQL query) from the Query annotation or

--- a/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/v1_0/QueryInfo_1_0.java
+++ b/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/v1_0/QueryInfo_1_0.java
@@ -31,8 +31,10 @@ import io.openliberty.data.internal.QueryInfo;
 import io.openliberty.data.internal.QueryType;
 import io.openliberty.data.internal.Util;
 import io.openliberty.data.internal.cdi.RepositoryProducer;
+import jakarta.data.Sort;
 import jakarta.data.repository.Delete;
 import jakarta.data.repository.Insert;
+import jakarta.data.repository.OrderBy;
 import jakarta.data.repository.Query;
 import jakarta.data.repository.Save;
 import jakarta.data.repository.Update;
@@ -104,6 +106,24 @@ public class QueryInfo_1_0 extends QueryInfo {
         if (attrName.charAt(attrName.length() - 1) != ')')
             q.append(o_);
         return q.append(attrName).append("=?").append(prevNumJPQLParams + 1);
+    }
+
+    @Override
+    @Trivial
+    protected <T> Sort<T> createSort(String expression, OrderBy orderBy) {
+        return new Sort<T>( //
+                        expression, //
+                        !orderBy.descending(), //
+                        orderBy.ignoreCase());
+    }
+
+    @Override
+    @Trivial
+    protected <T> Sort<T> createSort(String expression, Sort<T> sort) {
+        return new Sort<>( //
+                        expression, //
+                        sort.isAscending(), //
+                        sort.ignoreCase());
     }
 
     @Override

--- a/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/v1_0/QueryInfo_1_0.java
+++ b/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/v1_0/QueryInfo_1_0.java
@@ -153,6 +153,12 @@ public class QueryInfo_1_0 extends QueryInfo {
 
     @Override
     @Trivial
+    protected String getNullOrdering(Sort<?> sort, boolean sameDirection) {
+        return null;
+    }
+
+    @Override
+    @Trivial
     protected String getQueryAnnoValue() {
         return methodTypeAnno instanceof Query query ? query.value() : null;
     }

--- a/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/v1_1/QueryInfo_1_1.java
+++ b/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/v1_1/QueryInfo_1_1.java
@@ -54,6 +54,7 @@ import io.openliberty.data.repository.update.Assign;
 import io.openliberty.data.repository.update.Divide;
 import io.openliberty.data.repository.update.Multiply;
 import io.openliberty.data.repository.update.SubtractFrom;
+import jakarta.data.Sort;
 import jakarta.data.constraint.AtLeast;
 import jakarta.data.constraint.AtMost;
 import jakarta.data.constraint.Between;
@@ -77,6 +78,7 @@ import jakarta.data.metamodel.NavigableAttribute;
 import jakarta.data.repository.Delete;
 import jakarta.data.repository.Insert;
 import jakarta.data.repository.Is;
+import jakarta.data.repository.OrderBy;
 import jakarta.data.repository.Query;
 import jakarta.data.repository.Save;
 import jakarta.data.repository.Update;
@@ -335,6 +337,26 @@ public class QueryInfo_1_1 extends QueryInfo {
     private static StringBuilder appendParam(StringBuilder q, boolean lower, int num) {
         q.append(lower ? "LOWER(?" : '?').append(num);
         return lower ? q.append(')') : q;
+    }
+
+    @Override
+    @Trivial
+    protected <T> Sort<T> createSort(String expression, OrderBy orderBy) {
+        return new Sort<T>( //
+                        expression, //
+                        !orderBy.descending(), //
+                        orderBy.ignoreCase(), //
+                        orderBy.nullOrdering());
+    }
+
+    @Override
+    @Trivial
+    protected <T> Sort<T> createSort(String expression, Sort<T> sort) {
+        return new Sort<T>( //
+                        expression, //
+                        sort.isAscending(), //
+                        sort.ignoreCase(), //
+                        sort.nullOrdering());
     }
 
     /**

--- a/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/v1_1/QueryInfo_1_1.java
+++ b/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/v1_1/QueryInfo_1_1.java
@@ -55,6 +55,7 @@ import io.openliberty.data.repository.update.Divide;
 import io.openliberty.data.repository.update.Multiply;
 import io.openliberty.data.repository.update.SubtractFrom;
 import jakarta.data.Sort;
+import jakarta.data.Sort.Nulls;
 import jakarta.data.constraint.AtLeast;
 import jakarta.data.constraint.AtMost;
 import jakarta.data.constraint.Between;
@@ -755,6 +756,22 @@ public class QueryInfo_1_1 extends QueryInfo {
         if (trace && tc.isEntryEnabled())
             Tr.exit(this, tc, "getDeferredConstraints", deferred.keySet());
         return deferred;
+    }
+
+    @Override
+    @Trivial
+    protected String getNullOrdering(Sort<?> sort, boolean sameDirection) {
+        switch (sort.nullOrdering()) {
+            case FIRST:
+                return sameDirection ? Nulls.FIRST.name() : Nulls.LAST.name();
+            case LAST:
+                return sameDirection ? Nulls.LAST.name() : Nulls.FIRST.name();
+            case UNSPECIFIED:
+                return null;
+            default:
+                throw new IllegalStateException("Sort.nullOrdering: " +
+                                                sort.nullOrdering());
+        }
     }
 
     @Override

--- a/dev/io.openliberty.jakarta.data.1.1/src/jakarta/data/Sort.java
+++ b/dev/io.openliberty.jakarta.data.1.1/src/jakarta/data/Sort.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022,2023 IBM Corporation and others.
+ * Copyright (c) 2022,2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -15,39 +15,97 @@ package jakarta.data;
 import jakarta.data.messages.Messages;
 
 /**
- * Method signatures copied from jakarta.data.repository.Sort from the Jakarta Data repo.
+ * Method signatures copied from jakarta.data.Sort from the Jakarta Data repo.
  */
 public record Sort<T>(String property,
                 boolean isAscending,
-                boolean ignoreCase) {
+                boolean ignoreCase,
+                Nulls nullOrdering) {
+
+    public enum Nulls {
+        FIRST,
+        LAST,
+        UNSPECIFIED
+    }
 
     public Sort {
         Messages.requireNonNull(property, "property");
+        Messages.requireNonNull(nullOrdering, "nullOrdering");
     }
 
-    public static <T> Sort<T> asc(String property) {
-        return new Sort<>(property, true, false);
+    public Sort(String property, boolean isAscending, boolean ignoreCase) {
+        this(property, //
+             isAscending, //
+             ignoreCase, //
+             Nulls.UNSPECIFIED);
     }
 
-    public static <T> Sort<T> ascIgnoreCase(String property) {
-        return new Sort<>(property, true, true);
+    public static <T> Sort<T> asc(String attribute) {
+        return new Sort<>(attribute, //
+                        true, //
+                        false, //
+                        Nulls.UNSPECIFIED);
     }
 
-    public static <T> Sort<T> desc(String property) {
-        return new Sort<>(property, false, false);
+    public static <T> Sort<T> ascIgnoreCase(String attribute) {
+        return new Sort<>(attribute, //
+                        true, //
+                        true, //
+                        Nulls.UNSPECIFIED);
     }
 
-    public static <T> Sort<T> descIgnoreCase(String property) {
-        return new Sort<>(property, false, true);
+    public static <T> Sort<T> desc(String attribute) {
+        return new Sort<>(attribute, //
+                        false, //
+                        false, //
+                        Nulls.UNSPECIFIED);
     }
 
-    public static <T> Sort<T> of(String property, Direction direction, boolean ignoreCase) {
-        Messages.requireNonNull(direction, "direction");
-
-        return new Sort<>(property, direction.equals(Direction.ASC), ignoreCase);
+    public static <T> Sort<T> descIgnoreCase(String attribute) {
+        return new Sort<>(attribute, //
+                        false, //
+                        true, //
+                        Nulls.UNSPECIFIED);
     }
 
     public boolean isDescending() {
         return !isAscending;
+    }
+
+    public Sort<T> nullsFirst() {
+        return new Sort<>(property, //
+                        isAscending, //
+                        ignoreCase, //
+                        Nulls.FIRST);
+    }
+
+    public Sort<T> nullsLast() {
+        return new Sort<>(property, //
+                        isAscending, //
+                        ignoreCase, //
+                        Nulls.LAST);
+    }
+
+    public static <T> Sort<T> of(String attribute,
+                                 Direction direction,
+                                 boolean ignoreCase) {
+        Messages.requireNonNull(direction, "direction");
+
+        return new Sort<>(attribute, //
+                        Direction.ASC.equals(direction), //
+                        ignoreCase, //
+                        Nulls.UNSPECIFIED);
+    }
+
+    public static <T> Sort<T> of(String attribute,
+                                 Direction direction,
+                                 boolean ignoreCase,
+                                 Nulls nullOrdering) {
+        Messages.requireNonNull(direction, "direction");
+
+        return new Sort<>(attribute, //
+                        Direction.ASC.equals(direction), //
+                        ignoreCase, //
+                        nullOrdering);
     }
 }

--- a/dev/io.openliberty.jakarta.data.1.1/src/jakarta/data/repository/OrderBy.java
+++ b/dev/io.openliberty.jakarta.data.1.1/src/jakarta/data/repository/OrderBy.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2022 IBM Corporation and others.
+ * Copyright (c) 2022,2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -18,66 +18,25 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+import jakarta.data.Sort.Nulls;
+
 /**
- * Annotates a repository method to request sorting of results.<p>
- *
- * If multiple <code>@OrderBy</code> annotations are specified on a
- * repository method, the precedence for sorting follows the order
- * in which the <code>@OrderBy</code> annotations are specified.<p>
- *
- * For example, the following sorts by the <code>lastName</code>
- * attribute and then by the <code>firstName</code> attribute
- * for entities that have the same <code>lastName</code>,<p>
- *
- * <pre>
- * &#64;Where("o.zipCode = ?1")
- * &#64;OrderBy("lastName")
- * &#64;OrderBy("firstName")
- * Person[] getEligibleVoters(int zipCode);
- * </pre>
+ * Method signatures copied from jakarta.data.repository.OrderBy
+ * from the Jakarta Data repo.
  */
 @Repeatable(OrderBy.List.class)
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.METHOD)
 public @interface OrderBy {
-    /**
-     * Indicate whether to use descending (vs ascending) order when sorting
-     * by this attribute.<p>
-     *
-     * The default value of <code>false</code> means ascending sort.<p>
-     *
-     * @return whether to use descending (vs ascending) order.
-     */
+
     boolean descending() default false;
 
-    /**
-     * Indicate whether or not to request case insensitive comparison when
-     * sorting by this attribute.<p>
-     *
-     * The default value of <code>false</code> means that case insensitive
-     * comparison is not requested.<p>
-     *
-     * @return whether or not to request case insensitive comparison.
-     */
     boolean ignoreCase() default false;
 
-    /**
-     * Entity attribute name to sort by.<p>
-     *
-     * For example, with JPQL for relational databases,<p>
-     *
-     * <pre>
-     * &#64;Where("o.lastName = ?1")
-     * &#64;OrderBy("age")
-     * Stream&#60;Person&#62; familyMembersByAge(String lastName);
-     * </pre>
-     */
+    Nulls nullOrdering() default Nulls.UNSPECIFIED;
+
     String value();
 
-    /**
-     * Enables multiple <code>OrderBy</code>
-     * annotations on the same type.
-     */
     @Retention(RetentionPolicy.RUNTIME)
     @Target(ElementType.METHOD)
     public @interface List {


### PR DESCRIPTION
Copy the Data 1.1 API for sorting of NULL values
Update Liberty code to preserve the information on sorting NULL values and apply it when generating the ORDER BY clause of queries.
This should work for most queries, but more will be needed if supporting for cursor pagination to also apply the null ordering to comparisons of cursor values.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
