### PR TITLE
Jakarta Authorization 3.0 and Security 4.0 additional tests and logic

### DIFF
--- a/dev/com.ibm.ws.ejbcontainer.security/bnd.bnd
+++ b/dev/com.ibm.ws.ejbcontainer.security/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017, 2025 IBM Corporation and others.
+# Copyright (c) 2017, 2026 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -34,24 +34,9 @@ Include-Resource: \
   OSGI-INF/metatype=resources/OSGI-INF/metatype, \
   OSGI-INF/l10n=resources/OSGI-INF/l10n
 
-Service-Component: \
-  com.ibm.ws.ejbcontainer.security.internal.EJBSecurityCollaboratorImpl; \
-    implementation:=com.ibm.ws.ejbcontainer.security.internal.EJBSecurityCollaboratorImpl; \
-    provide:='com.ibm.ws.ejbcontainer.EJBSecurityCollaborator,\
-              com.ibm.ws.container.service.metadata.ComponentMetaDataListener'; \
-    activate:=activate; \
-    deactivate:=deactivate; \
-    modified:='modified'; \
-    immediate:=true; \
-    configuration-policy:=optional; \
-    securityService=com.ibm.ws.security.SecurityService; \
-    securityReadyService=com.ibm.ws.security.ready.SecurityReadyService; \
-    unauthenticatedSubjectService=com.ibm.ws.security.authentication.UnauthenticatedSubjectService; \
-    credentialsService=com.ibm.ws.security.credentials.CredentialsService; \
-    eJBJaccService=com.ibm.ws.ejbcontainer.security.jacc.EJBJaccService;\
-    dynamic:='eJBJaccService'; \
-    optional:='eJBJaccService'; \
-    properties:="service.vendor=IBM"
+-dsannotations: \
+  com.ibm.ws.ejbcontainer.security.internal.EJBSecurityCollaboratorImpl, \
+  com.ibm.ws.ejbcontainer.security.internal.EJBDeclaredRolesService
 
 instrument.classesExcludes: com/ibm/ws/ejbcontainer/security/internal/resources/*.class
 

--- a/dev/com.ibm.ws.ejbcontainer.security/src/com/ibm/ws/ejbcontainer/security/internal/EJBDeclaredRolesService.java
+++ b/dev/com.ibm.ws.ejbcontainer.security/src/com/ibm/ws/ejbcontainer/security/internal/EJBDeclaredRolesService.java
@@ -1,0 +1,42 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package com.ibm.ws.ejbcontainer.security.internal;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ConfigurationPolicy;
+
+import com.ibm.ejs.container.BeanMetaData;
+import com.ibm.ejs.container.EJBMethodInfoImpl;
+import com.ibm.ws.security.authorization.DeclaredRolesService;
+
+@Component(service = { DeclaredRolesService.class, EJBDeclaredRolesService.class }, configurationPolicy = ConfigurationPolicy.IGNORE,
+           property = "service.vendor=IBM")
+public class EJBDeclaredRolesService extends DeclaredRolesService {
+    void addDeclaredRoles(BeanMetaData bmd) {
+        Set<String> roles = new HashSet<>();
+        EJBMethodInfoImpl list[][] = { bmd.homeMethodInfos, bmd.localHomeMethodInfos, bmd.methodInfos, bmd.localMethodInfos, bmd.timedMethodInfos, bmd.wsEndpointMethodInfos,
+                                       bmd.lifecycleInterceptorMethodInfos };
+        for (EJBMethodInfoImpl methodInfos[] : list) {
+            if (methodInfos != null && methodInfos.length > 0) {
+                for (EJBMethodInfoImpl methodInfo : methodInfos) {
+                    List<String> rolesAllowed = methodInfo.getRolesAllowed();
+                    if (rolesAllowed != null && rolesAllowed.size() > 0) {
+                        roles.addAll(rolesAllowed);
+                    }
+                }
+            }
+        }
+        super.addDeclaredRoles(bmd.j2eeName.getApplication(), bmd.j2eeName.getModule(), roles);
+    }
+}

--- a/dev/com.ibm.ws.ejbcontainer.security/src/com/ibm/ws/ejbcontainer/security/internal/EJBSecurityCollaboratorImpl.java
+++ b/dev/com.ibm.ws.ejbcontainer.security/src/com/ibm/ws/ejbcontainer/security/internal/EJBSecurityCollaboratorImpl.java
@@ -30,10 +30,18 @@ import javax.security.auth.login.CredentialExpiredException;
 
 import org.osgi.framework.ServiceReference;
 import org.osgi.service.component.ComponentContext;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ConfigurationPolicy;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Modified;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceCardinality;
+import org.osgi.service.component.annotations.ReferencePolicy;
 
 import com.ibm.ejs.container.BeanMetaData;
 import com.ibm.ejs.ras.TraceNLS;
+import com.ibm.websphere.csi.J2EEName;
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.websphere.security.audit.AuditAuthResult;
@@ -75,6 +83,8 @@ import com.ibm.wsspi.kernel.service.utils.AtomicServiceReference;
  */
 
 @SuppressWarnings("deprecation")
+@Component(service = { EJBSecurityCollaborator.class, ComponentMetaDataListener.class }, immediate = true,
+           configurationPolicy = ConfigurationPolicy.OPTIONAL, property = "service.vendor=IBM")
 public class EJBSecurityCollaboratorImpl implements EJBSecurityCollaborator<SecurityCookieImpl>, EJBAuthorizationHelper, ComponentMetaDataListener {
     private static final TraceComponent tc = Tr.register(EJBSecurityCollaboratorImpl.class);
     protected static final String KEY_SECURITY_SERVICE = "securityService";
@@ -88,8 +98,10 @@ public class EJBSecurityCollaboratorImpl implements EJBSecurityCollaborator<Secu
     private final AtomicServiceReference<UnauthenticatedSubjectService> unauthenticatedSubjectServiceRef = new AtomicServiceReference<UnauthenticatedSubjectService>(KEY_UNAUTHENTICATED_SUBJECT_SERVICE);
     private final AtomicServiceReference<EJBJaccService> ejbJaccService = new AtomicServiceReference<EJBJaccService>(KEY_EJB_JACC_SERVICE);
 
-    protected SubjectManager subjectManager;
-    protected CollaboratorUtils collabUtils;
+    protected final SubjectManager subjectManager;
+    protected final CollaboratorUtils collabUtils;
+
+    private final EJBDeclaredRolesService rolesService;
 
     protected AuditManager auditManager;
 
@@ -112,19 +124,19 @@ public class EJBSecurityCollaboratorImpl implements EJBSecurityCollaborator<Secu
         }
     });
 
-    /**
-     * Zero length constructor required by DS.
-     */
-    public EJBSecurityCollaboratorImpl() {
-        this(new SubjectManager());
+    @Activate
+    public EJBSecurityCollaboratorImpl(@Reference EJBDeclaredRolesService rolesService) {
+        this(new SubjectManager(), rolesService);
         this.auditManager = new AuditManager();
     }
 
-    public EJBSecurityCollaboratorImpl(SubjectManager subjectManager) {
+    EJBSecurityCollaboratorImpl(SubjectManager subjectManager, EJBDeclaredRolesService rolesService) {
         this.subjectManager = subjectManager;
         this.collabUtils = new CollaboratorUtils(subjectManager);
+        this.rolesService = rolesService;
     }
 
+    @Reference(name = KEY_CREDENTIAL_SERVICE)
     protected void setCredentialService(ServiceReference<CredentialsService> ref) {
         credServiceRef.setReference(ref);
     }
@@ -133,6 +145,7 @@ public class EJBSecurityCollaboratorImpl implements EJBSecurityCollaborator<Secu
         credServiceRef.unsetReference(ref);
     }
 
+    @Reference(name = KEY_SECURITY_SERVICE)
     protected void setSecurityService(ServiceReference<SecurityService> ref) {
         securityServiceRef.setReference(ref);
     }
@@ -141,7 +154,7 @@ public class EJBSecurityCollaboratorImpl implements EJBSecurityCollaborator<Secu
         securityServiceRef.unsetReference(ref);
     }
 
-    @Reference
+    @Reference(name = KEY_SECURITY_READY_SERVICE)
     protected void setSecurityReadyService(SecurityReadyService ref) {
         this.securityReadyService = ref;
     }
@@ -149,6 +162,7 @@ public class EJBSecurityCollaboratorImpl implements EJBSecurityCollaborator<Secu
     protected void unsetSecurityReadyService(SecurityReadyService ref) {
     }
 
+    @Reference(name = KEY_UNAUTHENTICATED_SUBJECT_SERVICE)
     protected void setUnauthenticatedSubjectService(ServiceReference<UnauthenticatedSubjectService> ref) {
         unauthenticatedSubjectServiceRef.setReference(ref);
     }
@@ -157,6 +171,7 @@ public class EJBSecurityCollaboratorImpl implements EJBSecurityCollaborator<Secu
         unauthenticatedSubjectServiceRef.unsetReference(ref);
     }
 
+    @Reference(name = KEY_EJB_JACC_SERVICE, cardinality = ReferenceCardinality.OPTIONAL, policy = ReferencePolicy.DYNAMIC)
     protected void setEJBJaccService(ServiceReference<EJBJaccService> reference) {
         ejbJaccService.setReference(reference);
         eah = new EJBJaccAuthorizationHelper(ejbJaccService, this);
@@ -167,6 +182,7 @@ public class EJBSecurityCollaboratorImpl implements EJBSecurityCollaborator<Secu
         eah = this;
     }
 
+    @Activate
     protected void activate(ComponentContext cc, Map<String, Object> props) {
         securityServiceRef.activate(cc);
         credServiceRef.activate(cc);
@@ -175,6 +191,7 @@ public class EJBSecurityCollaboratorImpl implements EJBSecurityCollaborator<Secu
         ejbSecConfig = new EJBSecurityConfigImpl(props);
     }
 
+    @Modified
     protected void modified(Map<String, Object> newProperties) {
         EJBSecurityConfig newEjbSecConfig = new EJBSecurityConfigImpl(newProperties);
         // Capture the properties that were changed for our audit record
@@ -183,6 +200,7 @@ public class EJBSecurityCollaboratorImpl implements EJBSecurityCollaborator<Secu
         Tr.audit(tc, "EJB_SECURITY_CONFIGURATION_UPDATED", deltaString);
     }
 
+    @Deactivate
     protected void deactivate(ComponentContext cc) {
         securityServiceRef.deactivate(cc);
         credServiceRef.deactivate(cc);
@@ -755,11 +773,12 @@ public class EJBSecurityCollaboratorImpl implements EJBSecurityCollaborator<Secu
      */
     @Override
     public void componentMetaDataCreated(MetaDataEvent<ComponentMetaData> event) {
-        EJBJaccService js = ejbJaccService.getService();
-        if (js != null) {
-            MetaData metaData = event.getMetaData();
-            if (metaData instanceof BeanMetaData) {
-                BeanMetaData bmd = (BeanMetaData) metaData;
+        MetaData metaData = event.getMetaData();
+        if (metaData instanceof BeanMetaData) {
+            BeanMetaData bmd = (BeanMetaData) metaData;
+            rolesService.addDeclaredRoles(bmd);
+            EJBJaccService js = ejbJaccService.getService();
+            if (js != null) {
                 js.propagateEJBRoles(bmd);
             }
         }
@@ -772,6 +791,11 @@ public class EJBSecurityCollaboratorImpl implements EJBSecurityCollaborator<Secu
      */
     @Override
     public void componentMetaDataDestroyed(MetaDataEvent<ComponentMetaData> event) {
+        ComponentMetaData metaData = event.getMetaData();
+        if (metaData instanceof BeanMetaData) {
+            J2EEName j2eeName = metaData.getJ2EEName();
+            rolesService.removeModule(j2eeName.getApplication(), j2eeName.getModule());
+        }
 
     }
 

--- a/dev/com.ibm.ws.ejbcontainer.security/test/com/ibm/ws/ejbcontainer/security/internal/EJBSecurityCollaboratorImplTest.java
+++ b/dev/com.ibm.ws.ejbcontainer.security/test/com/ibm/ws/ejbcontainer/security/internal/EJBSecurityCollaboratorImplTest.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2022 IBM Corporation and others.
+ * Copyright (c) 2011, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -149,7 +149,7 @@ public class EJBSecurityCollaboratorImplTest {
         createEJBExpectations();
 
         subjectManager = new SubjectManager();
-        ejbSecColl = new EJBSecurityCollaboratorImpl(subjectManager);
+        ejbSecColl = new EJBSecurityCollaboratorImpl(subjectManager, new EJBDeclaredRolesService());
         ejbSecColl.setSecurityService(securityServiceRef);
         ejbSecColl.setCredentialService(credentialsServiceRef);
         ejbSecColl.setUnauthenticatedSubjectService(unauthSubjSrvRef);
@@ -313,7 +313,7 @@ public class EJBSecurityCollaboratorImplTest {
 
     @Test
     public void testConstructor() {
-        EJBSecurityCollaborator<SecurityCookieImpl> ejbSecurityService = new EJBSecurityCollaboratorImpl();
+        EJBSecurityCollaborator<SecurityCookieImpl> ejbSecurityService = new EJBSecurityCollaboratorImpl(new EJBDeclaredRolesService());
         assertNotNull("There must be a EJBSecurityCollaborator Service", ejbSecurityService);
     }
 

--- a/dev/com.ibm.ws.security.authorization.builtin/bnd.bnd
+++ b/dev/com.ibm.ws.security.authorization.builtin/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017, 2023 IBM Corporation and others.
+# Copyright (c) 2017, 2026 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -30,25 +30,10 @@ Private-Package: \
 Include-Resource: \
     OSGI-INF=resources/OSGI-INF
 
-Service-Component: \
-  com.ibm.ws.security.authorization.builtin; \
-    implementation:=com.ibm.ws.security.authorization.builtin.internal.BuiltinAuthorizationService; \
-    provide:=com.ibm.ws.security.authorization.AuthorizationService; \
-    accessDecisionService=com.ibm.ws.security.authorization.AccessDecisionService; \
-    authorizationTableService=com.ibm.ws.security.authorization.AuthorizationTableService; \
-    featureAuthzTableService=com.ibm.ws.security.authorization.FeatureAuthorizationTableService; \
-    configuration-policy:=optional; \
-    optional:='authorizationTableService,featureAuthzTableService'; \
-    dynamic:='authorizationTableService,featureAuthzTableService'; \
-    multiple:='authorizationTableService'; \
-    properties:="service.vendor=IBM,com.ibm.ws.security.authorization.type=Builtin", \
-  accessDecisionService; \
-    implementation:=com.ibm.ws.security.authorization.builtin.internal.BuiltinAccessDecisionService; \
-    provide:=com.ibm.ws.security.authorization.AccessDecisionService; \
-    version=com.ibm.ws.javaee.version.JavaEEVersion?; \
-    greedy:=version; \
-    properties:="service.vendor=IBM"
-    
+-dsannotations: \
+  com.ibm.ws.security.authorization.builtin.internal.BuiltinAuthorizationService, \
+  com.ibm.ws.security.authorization.builtin.internal.BuiltinAccessDecisionService
+
 IBM-Default-Config: OSGI-INF/wlp/defaultInstances.xml
 
 instrument.classesExcludes: com/ibm/ws/security/authorization/builtin/internal/resources/*.class

--- a/dev/com.ibm.ws.security.authorization.builtin/src/com/ibm/ws/security/authorization/builtin/internal/BuiltinAccessDecisionService.java
+++ b/dev/com.ibm.ws.security.authorization.builtin/src/com/ibm/ws/security/authorization/builtin/internal/BuiltinAccessDecisionService.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2011 IBM Corporation and others.
+ * Copyright (c) 2011, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -19,6 +19,11 @@ import javax.security.auth.Subject;
 
 import org.osgi.framework.ServiceReference;
 import org.osgi.framework.Version;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceCardinality;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
@@ -29,6 +34,7 @@ import com.ibm.ws.security.authorization.AccessDecisionService;
  * Built-in access decision service which implements a role-based authorization
  * model.
  */
+@Component(name = "accessDecisionService", service = AccessDecisionService.class, property = "service.vendor=IBM")
 public class BuiltinAccessDecisionService implements AccessDecisionService {
     private static final TraceComponent tc = Tr.register(BuiltinAccessDecisionService.class);
 
@@ -41,6 +47,7 @@ public class BuiltinAccessDecisionService implements AccessDecisionService {
     // '_starstar_' will represent if ** was specified as a defined role
     private static final String STARSTAR_ROLE = "_starstar_";
 
+    @Reference(name = "version", cardinality = ReferenceCardinality.OPTIONAL, policy = ReferencePolicy.DYNAMIC, policyOption = ReferencePolicyOption.GREEDY)
     public synchronized void setVersion(ServiceReference<JavaEEVersion> reference) {
         eeVersionRef = reference;
         eeVersion = Version.parseVersion((String) reference.getProperty("version"));
@@ -53,10 +60,8 @@ public class BuiltinAccessDecisionService implements AccessDecisionService {
         }
     }
 
-    private boolean isEEVersionAtLeast7()
-    {
-        if ((eeVersion.compareTo(JavaEEVersion.VERSION_7_0) >= 0) ||
-            (eeVersion.compareTo(JavaEEVersion.VERSION_8_0) >= 0)) {
+    private boolean isEEVersionAtLeast7() {
+        if ((eeVersion.compareTo(JavaEEVersion.VERSION_7_0) >= 0)) {
             return true;
         }
         return false;
@@ -75,7 +80,7 @@ public class BuiltinAccessDecisionService implements AccessDecisionService {
          * New for Servlet 3.1 "**" means all authenticated users. The subject
          * is checked prior to isGranted() being called. So return true if the
          * subject is not null and if "**" is a required role.
-         * 
+         *
          * If "_starstar_" is passed in that means a user had defined a role called
          * "**". We need to convert "_starstar_" back to "**" before the check
          * against assignedRoles.

--- a/dev/com.ibm.ws.security.authorization.builtin/src/com/ibm/ws/security/authorization/builtin/internal/BuiltinAuthorizationService.java
+++ b/dev/com.ibm.ws.security.authorization.builtin/src/com/ibm/ws/security/authorization/builtin/internal/BuiltinAuthorizationService.java
@@ -26,6 +26,14 @@ import javax.security.auth.login.CredentialExpiredException;
 
 import org.osgi.framework.ServiceReference;
 import org.osgi.service.component.ComponentContext;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ConfigurationPolicy;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceCardinality;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
@@ -35,6 +43,7 @@ import com.ibm.ws.security.AccessIdUtil;
 import com.ibm.ws.security.authorization.AccessDecisionService;
 import com.ibm.ws.security.authorization.AuthorizationService;
 import com.ibm.ws.security.authorization.AuthorizationTableService;
+import com.ibm.ws.security.authorization.DeclaredRolesService;
 import com.ibm.ws.security.authorization.FeatureAuthorizationTableService;
 import com.ibm.ws.security.context.SubjectManager;
 import com.ibm.wsspi.kernel.service.utils.AtomicServiceReference;
@@ -44,15 +53,20 @@ import com.ibm.wsspi.kernel.service.utils.ConcurrentServiceReferenceSet;
  * Built-in authorization service which implements a role-based authorization
  * model.
  */
+
+@Component(name = "com.ibm.ws.security.authorization.builtin", service = AuthorizationService.class,
+           configurationPolicy = ConfigurationPolicy.OPTIONAL, property = { "service.vendor=IBM", "com.ibm.ws.security.authorization.type=Builtin" })
 public class BuiltinAuthorizationService implements AuthorizationService {
     private static final TraceComponent tc = Tr.register(BuiltinAuthorizationService.class);
 
     protected static final String KEY_ACCESS_DECISION_SERVICE = "accessDecisionService";
     protected static final String KEY_AUTHORIZATION_TABLE_SERVICE = "authorizationTableService";
     protected static final String KEY_USE_ROLE_AS_GROUP_NAME = "useRoleAsGroupName";
+    protected static final String KEY_DECLARED_ROLES_SERVICE = "declaredRolesService";
     private final AtomicServiceReference<AccessDecisionService> accessDecisionServiceRef = new AtomicServiceReference<AccessDecisionService>(KEY_ACCESS_DECISION_SERVICE);
     private final ConcurrentServiceReferenceSet<AuthorizationTableService> authorizationTables = new ConcurrentServiceReferenceSet<AuthorizationTableService>(KEY_AUTHORIZATION_TABLE_SERVICE);
     private final ConcurrentServiceReferenceSet<AuthorizationTableService> appBndAuthorizationTables = new ConcurrentServiceReferenceSet<AuthorizationTableService>(KEY_AUTHORIZATION_TABLE_SERVICE);
+    private final ConcurrentServiceReferenceSet<DeclaredRolesService> rolesServices = new ConcurrentServiceReferenceSet<DeclaredRolesService>(KEY_DECLARED_ROLES_SERVICE);
     private final SubjectManager subjManager = new SubjectManager();
     static final String KEY_FEATURE_SECURITY_AUTHZ_SERVICE = "featureAuthzTableService";
     private final AtomicServiceReference<FeatureAuthorizationTableService> featureAuthzTableServiceRef = new AtomicServiceReference<FeatureAuthorizationTableService>(KEY_FEATURE_SECURITY_AUTHZ_SERVICE);
@@ -65,6 +79,7 @@ public class BuiltinAuthorizationService implements AuthorizationService {
     static final String KEY_FEATURE_AUTHORIZATION_TABLE = "com.ibm.ws.webcontainer.security.feature.internal.FeatureAuthorizationTable";
     private final List<String> useRoleAsGroupNameForApps = new ArrayList<String>();
 
+    @Reference(name = KEY_ACCESS_DECISION_SERVICE)
     protected void setAccessDecisionService(ServiceReference<AccessDecisionService> ref) {
         accessDecisionServiceRef.setReference(ref);
     }
@@ -73,6 +88,7 @@ public class BuiltinAuthorizationService implements AuthorizationService {
         accessDecisionServiceRef.unsetReference(ref);
     }
 
+    @Reference(name = KEY_AUTHORIZATION_TABLE_SERVICE, cardinality = ReferenceCardinality.MULTIPLE, policy = ReferencePolicy.DYNAMIC)
     protected void setAuthorizationTableService(ServiceReference<AuthorizationTableService> ref) {
         authorizationTables.addReference(ref);
         String cn = (String) ref.getProperty(KEY_COMPONENT_NAME);
@@ -92,6 +108,7 @@ public class BuiltinAuthorizationService implements AuthorizationService {
         }
     }
 
+    @Reference(name = KEY_FEATURE_SECURITY_AUTHZ_SERVICE, cardinality = ReferenceCardinality.OPTIONAL, policy = ReferencePolicy.DYNAMIC)
     protected void setFeatureAuthzTableService(ServiceReference<FeatureAuthorizationTableService> ref) {
         featureAuthzTableServiceRef.setReference(ref);
     }
@@ -100,20 +117,33 @@ public class BuiltinAuthorizationService implements AuthorizationService {
         featureAuthzTableServiceRef.unsetReference(ref);
     }
 
+    @Reference(name = KEY_DECLARED_ROLES_SERVICE, cardinality = ReferenceCardinality.MULTIPLE, policy = ReferencePolicy.DYNAMIC, policyOption = ReferencePolicyOption.GREEDY)
+    protected void setDeclaredRolesService(ServiceReference<DeclaredRolesService> ref) {
+        rolesServices.addReference(ref);
+    }
+
+    protected void unsetDeclaredRolesService(ServiceReference<DeclaredRolesService> ref) {
+        rolesServices.removeReference(ref);
+    }
+
+    @Activate
     protected void activate(ComponentContext cc, Map<String, Object> properties) {
         accessDecisionServiceRef.activate(cc);
         authorizationTables.activate(cc);
         appBndAuthorizationTables.activate(cc);
         featureAuthzTableServiceRef.activate(cc);
+        rolesServices.activate(cc);
         if (properties != null && properties.containsKey(KEY_USE_ROLE_AS_GROUP_NAME))
             useRoleAsGroupName = (Boolean) properties.get(KEY_USE_ROLE_AS_GROUP_NAME);
     }
 
+    @Deactivate
     protected void deactivate(ComponentContext cc) {
         accessDecisionServiceRef.deactivate(cc);
         authorizationTables.deactivate(cc);
         appBndAuthorizationTables.deactivate(cc);
         featureAuthzTableServiceRef.deactivate(cc);
+        rolesServices.deactivate(cc);
         useRoleAsGroupNameForApps.clear();
     }
 
@@ -213,18 +243,7 @@ public class BuiltinAuthorizationService implements AuthorizationService {
 
     @Override
     public Set<String> getAllDeclaredRolesForResourceForSubject(String resourceName, Subject subject) {
-        Set<String> roles = new HashSet<String>(Collections.EMPTY_SET);
-        WSCredential wsCred = getWSCredentialFromSubject(subject);
-        if (wsCred != null) {
-            String accessId = getAccessId(wsCred);
-            String realmName = getRealmName(wsCred);
-
-            Collection<String> foundRoles = getRolesForAccessId(resourceName, accessId, realmName);
-            if (foundRoles != null) {
-                roles.addAll(foundRoles);
-            }
-        }
-        return roles;
+        return getRolesForSubject(resourceName, subject, true);
     }
 
     /**
@@ -359,49 +378,115 @@ public class BuiltinAuthorizationService implements AuthorizationService {
 
     @Override
     public Set<String> getMappedRoles(String resourceName, Subject subject) {
+        return getRolesForSubject(resourceName, subject, false);
+    }
 
+    private Set<String> getRolesForSubject(String resourceName, Subject subject, boolean onlyDeclaredRoles) {
         WSCredential wsCred = getWSCredentialFromSubject(subject);
 
-        Set<String> roles = new HashSet<>();
-        if (wsCred == null) {
+        Set<String> declaredRoles = null;
+        if (onlyDeclaredRoles) {
+            declaredRoles = new HashSet<>();
+            for (DeclaredRolesService rolesService : rolesServices.services()) {
+                declaredRoles.addAll(rolesService.getDeclaredRoles(resourceName));
+            }
+
+            if (declaredRoles.isEmpty()) {
+                return Collections.emptySet();
+            }
+        }
+
+        boolean isUnAuthenticated = wsCred == null || wsCred.isUnauthenticated();
+
+        if (useRoleAsGroupName && !isAuthzInfoAvailableForApp(resourceName)) {
+            Collection<String> assignedRoles = null;
+            if (!isUnAuthenticated) {
+                String[] groupIds = getGroupIds(wsCred);
+                if (groupIds != null && groupIds.length > 0) {
+                    String realmName = getRealmName(wsCred);
+                    // Just include the group name and not the id
+                    assignedRoles = AccessIdUtil.getUniqueIds(groupIds, realmName);
+                }
+            }
+
+            if (assignedRoles == null) {
+                return Collections.emptySet();
+            }
+
+            Set<String> roles = new HashSet<>();
+            if (!onlyDeclaredRoles) {
+                roles.addAll(assignedRoles);
+            } else {
+                // Only add roles to the return Set if it is one of the declared roles in the application
+                for (String assignedRole : assignedRoles) {
+                    if (declaredRoles.contains(assignedRole)) {
+                        roles.add(assignedRole);
+                    }
+                }
+            }
             return roles;
         }
 
-        if (useRoleAsGroupName && !isAuthzInfoAvailableForApp(resourceName)) {
-            String[] groupIds = getGroupIds(wsCred);
-            if (groupIds != null && groupIds.length > 0) {
-                String realmName = getRealmName(wsCred);
-                // Just include the group name and not the id
-                Collection<String> assignedRoles = AccessIdUtil.getUniqueIds(groupIds, realmName);
-                if (assignedRoles != null) {
-                    roles.addAll(assignedRoles);
-                }
-            }
-        } else {
+        Set<String> roles = new HashSet<>();
+        if (!isUnAuthenticated) {
             String accessId = getAccessId(wsCred);
             String realmName = getRealmName(wsCred);
             Collection<String> userRoles = getRolesForAccessId(resourceName, accessId, realmName);
             if (userRoles != null) {
-                roles.addAll(userRoles);
+                if (!onlyDeclaredRoles) {
+                    roles.addAll(userRoles);
+                } else {
+                    // Only add roles to the return Set if it is one of the declared roles in the application
+                    for (String assignedRole : userRoles) {
+                        if (declaredRoles.contains(assignedRole)) {
+                            roles.add(assignedRole);
+                        }
+                    }
+                }
             }
             String[] groupIds = getGroupIds(wsCred);
             if (groupIds != null && groupIds.length > 0) {
                 for (int i = 0; i < groupIds.length; i++) {
                     String groupId = groupIds[i];
                     Collection<String> assignedRoles = getRolesForAccessId(resourceName, groupId, realmName);
-                    if (assignedRoles != null) {
+                    if (!onlyDeclaredRoles) {
                         roles.addAll(assignedRoles);
+                    } else {
+                        // Only add roles to the return Set if it is one of the declared roles in the application
+                        for (String assignedRole : assignedRoles) {
+                            if (declaredRoles.contains(assignedRole)) {
+                                roles.add(assignedRole);
+                            }
+                        }
+                    }
+                }
+            }
+            Collection<String> allAuthenticatedUsersRoles = getRolesForSpecialSubject(resourceName, AuthorizationTableService.ALL_AUTHENTICATED_USERS);
+            if (allAuthenticatedUsersRoles != null) {
+                if (!onlyDeclaredRoles) {
+                    roles.addAll(allAuthenticatedUsersRoles);
+                } else {
+                    // Only add roles to the return Set if it is one of the declared roles in the application
+                    for (String assignedRole : allAuthenticatedUsersRoles) {
+                        if (declaredRoles.contains(assignedRole)) {
+                            roles.add(assignedRole);
+                        }
                     }
                 }
             }
         }
-        Collection<String> allAuthenticatedUsersRoles = getRolesForSpecialSubject(resourceName, AuthorizationTableService.ALL_AUTHENTICATED_USERS);
         Collection<String> everyoneRoles = getRolesForSpecialSubject(resourceName, AuthorizationTableService.EVERYONE);
-        if (allAuthenticatedUsersRoles != null) {
-            roles.addAll(allAuthenticatedUsersRoles);
-        }
         if (everyoneRoles != null) {
-            roles.addAll(everyoneRoles);
+            if (!onlyDeclaredRoles) {
+                roles.addAll(everyoneRoles);
+            } else {
+                // Only add roles to the return Set if it is one of the declared roles in the application
+                for (String assignedRole : everyoneRoles) {
+                    if (declaredRoles.contains(assignedRole)) {
+                        roles.add(assignedRole);
+                    }
+                }
+            }
         }
         return roles;
     }

--- a/dev/com.ibm.ws.security.authorization.jacc.testprovider/src/com/ibm/ws/security/authorization/jacc/provider/AuthzPolicy.java
+++ b/dev/com.ibm.ws.security.authorization.jacc.testprovider/src/com/ibm/ws/security/authorization/jacc/provider/AuthzPolicy.java
@@ -1,0 +1,150 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package com.ibm.ws.security.authorization.jacc.provider;
+
+import java.security.Permission;
+import java.security.Principal;
+
+import javax.security.jacc.EJBMethodPermission;
+import javax.security.jacc.EJBRoleRefPermission;
+import javax.security.jacc.PolicyContext;
+import javax.security.jacc.PolicyContextException;
+import javax.security.jacc.WebResourcePermission;
+import javax.security.jacc.WebRoleRefPermission;
+import javax.security.jacc.WebUserDataPermission;
+
+import com.ibm.websphere.ras.Tr;
+import com.ibm.websphere.ras.TraceComponent;
+
+/**
+ *
+ */
+public interface AuthzPolicy {
+
+    static final TraceComponent tc = Tr.register(JaccPolicyProxy.class);
+
+    /**
+     * Return Boolean.TRUE or Boolean.FALSE if the permission check is handled by this method.
+     * A value of "null" is returned when the call of this method needs to do additional checking
+     *
+     * @param principals
+     * @param perm
+     * @return
+     */
+    default Boolean implies(Iterable<Principal> principals, Permission p) {
+        if (p instanceof WebResourcePermission) {
+            WSPolicyConfigurationImpl pc = getPolicyConfiguration();
+            JaccProvider jaccProvider = JaccProvider.getInstance();
+            // If there is no policy configuration, the application doesn't
+            // have any security constraints.  In that case return true.
+            if (pc == null) {
+                return true;
+            }
+            if (principals == null || !principals.iterator().hasNext()) {
+                if (tc.isDebugEnabled())
+                    Tr.debug(tc, "Checking the unchecked list");
+                if (jaccProvider.checkUncheckedPerm(pc, p)) {
+                    return true;
+                } else {
+                    return jaccProvider.isEveryoneGranted(pc, p, PolicyContext.getContextID());
+                }
+            } else {
+                if (tc.isDebugEnabled())
+                    Tr.debug(tc, "Checking the excluded list");
+                if (jaccProvider.checkExcludedPerm(pc, p)) {
+                    return false;
+                } else {
+                    if (tc.isDebugEnabled())
+                        Tr.debug(tc, "Checking the role list");
+                    return jaccProvider.checkRolePerm(pc, p, PolicyContext.getContextID());
+                }
+            }
+        } else if (p instanceof WebUserDataPermission) {
+            WSPolicyConfigurationImpl pc = getPolicyConfiguration();
+            JaccProvider jaccProvider = JaccProvider.getInstance();
+            // If there is no policy configuration, the application doesn't
+            // have any security constraints.  In that case return true.
+            if (pc == null) {
+                return true;
+            }
+            if (tc.isDebugEnabled())
+                Tr.debug(tc, "Checking the excluded list");
+            if (jaccProvider.checkExcludedPerm(pc, p)) {
+                return false;
+            } else {
+                if (tc.isDebugEnabled())
+                    Tr.debug(tc, "Not in the excluded list: Checking for unchecked");
+                return jaccProvider.checkUncheckedPerm(pc, p);
+            }
+        } else if (p instanceof WebRoleRefPermission || p instanceof EJBRoleRefPermission) {
+            WSPolicyConfigurationImpl pc = getPolicyConfiguration();
+            JaccProvider jaccProvider = JaccProvider.getInstance();
+            // If there is no policy configuration, the application doesn't
+            // have any security constraints.  In that case return true.
+            if (pc == null) {
+                return true;
+            }
+            if (tc.isDebugEnabled())
+                Tr.debug(tc, "Checking the role list");
+            return jaccProvider.checkRolePerm(pc, p, PolicyContext.getContextID());
+        } else if (p instanceof EJBMethodPermission) {
+            WSPolicyConfigurationImpl pc = getPolicyConfiguration();
+            JaccProvider jaccProvider = JaccProvider.getInstance();
+            // If there is no policy configuration, the application doesn't
+            // have any security constraints.  In that case return true.
+            if (pc == null) {
+                return true;
+            }
+            if (tc.isDebugEnabled())
+                Tr.debug(tc, "Checking the excluded list");
+            if (jaccProvider.checkExcludedPerm(pc, p)) {
+                return false;
+            } else {
+                if (tc.isDebugEnabled())
+                    Tr.debug(tc, "Checking the unchecked list");
+                if (jaccProvider.checkUncheckedPerm(pc, p)) {
+                    return true;
+                } else {
+                    return jaccProvider.checkRolePerm(pc, p, PolicyContext.getContextID());
+                }
+            }
+        }
+        return null;
+    }
+
+    public static WSPolicyConfigurationImpl getPolicyConfiguration() {
+        //get contextID;
+        String contextID = PolicyContext.getContextID();
+        WSPolicyConfigurationImpl pc = null;
+        pc = AllPolicyConfigs.getInstance().getPolicyConfig(contextID);
+
+        if (pc == null) {
+            if (tc.isDebugEnabled())
+                Tr.debug(tc, "Cannot get the policy configuration object. exit value:false");
+            return null;
+        }
+
+        boolean inService = false;
+        try {
+            inService = pc.inService();
+        } catch (PolicyContextException pce) {
+            if (tc.isDebugEnabled())
+                Tr.debug(tc, "security.jacc.provider.inservice", new Object[] { pce });
+        }
+
+        if (!inService) {
+            if (tc.isDebugEnabled())
+                Tr.debug(tc, "The policy configuration object is not in the commit state. exit value:false");
+            return null;
+        }
+
+        return pc;
+    }
+}

--- a/dev/com.ibm.ws.security.authorization.jacc.testprovider/src/com/ibm/ws/security/authorization/jacc/provider/JaccPolicyProxy.java
+++ b/dev/com.ibm.ws.security.authorization.jacc.testprovider/src/com/ibm/ws/security/authorization/jacc/provider/JaccPolicyProxy.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -19,24 +19,19 @@ import java.security.Permission;
 import java.security.PermissionCollection;
 import java.security.Policy;
 import java.security.ProtectionDomain;
+import java.util.Arrays;
 
 import javax.security.jacc.EJBMethodPermission;
 import javax.security.jacc.EJBRoleRefPermission;
-import javax.security.jacc.PolicyContext;
-import javax.security.jacc.PolicyContextException;
 import javax.security.jacc.WebResourcePermission;
 import javax.security.jacc.WebRoleRefPermission;
 import javax.security.jacc.WebUserDataPermission;
 
-import com.ibm.websphere.ras.Tr;
-import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.websphere.ras.annotation.Trivial;
 
-public class JaccPolicyProxy extends Policy {
+public class JaccPolicyProxy extends Policy implements AuthzPolicy {
     private static Policy policy = null;
     private ProtectionDomain self = null;
-    private JaccProvider jaccProvider = null;
-    private static final TraceComponent tc = Tr.register(JaccPolicyProxy.class);
 
     static {
         /**
@@ -111,114 +106,10 @@ public class JaccPolicyProxy extends Policy {
     public boolean implies(ProtectionDomain pd, Permission p) {
         boolean result = false;
         if ((self == pd) && (self != null)) { // self always true
-            result = true;
-        } else if (p instanceof WebResourcePermission) {
-            WSPolicyConfigurationImpl pc = getPolicyConfiguration();
-            // If there is no policy configuration, the application doesn't
-            // have any security constraints.  In that case return true.
-            if (pc == null) {
-                return true;
-            }
-            if (pd.getPrincipals() == null || pd.getPrincipals().length < 1) {
-                if (tc.isDebugEnabled())
-                    Tr.debug(tc, "Checking the unchecked list");
-                if (jaccProvider.checkUncheckedPerm(pc, p)) {
-                    return true;
-                } else {
-                    return jaccProvider.isEveryoneGranted(pc, p, PolicyContext.getContextID());
-                }
-            } else {
-                if (tc.isDebugEnabled())
-                    Tr.debug(tc, "Checking the excluded list");
-                if (jaccProvider.checkExcludedPerm(pc, p)) {
-                    return false;
-                } else {
-                    if (tc.isDebugEnabled())
-                        Tr.debug(tc, "Checking the role list");
-                    return jaccProvider.checkRolePerm(pc, p, PolicyContext.getContextID());
-                }
-            }
-        } else if (p instanceof WebUserDataPermission) {
-            WSPolicyConfigurationImpl pc = getPolicyConfiguration();
-            // If there is no policy configuration, the application doesn't
-            // have any security constraints.  In that case return true.
-            if (pc == null) {
-                return true;
-            }
-            if (tc.isDebugEnabled())
-                Tr.debug(tc, "Checking the excluded list");
-            if (jaccProvider.checkExcludedPerm(pc, p)) {
-                return false;
-            } else {
-                if (tc.isDebugEnabled())
-                    Tr.debug(tc, "Not in the excluded list: Checking for unchecked");
-                return jaccProvider.checkUncheckedPerm(pc, p);
-            }
-        } else if (p instanceof WebRoleRefPermission || p instanceof EJBRoleRefPermission) {
-            WSPolicyConfigurationImpl pc = getPolicyConfiguration();
-            // If there is no policy configuration, the application doesn't
-            // have any security constraints.  In that case return true.
-            if (pc == null) {
-                return true;
-            }
-            if (tc.isDebugEnabled())
-                Tr.debug(tc, "Checking the role list");
-            return jaccProvider.checkRolePerm(pc, p, PolicyContext.getContextID());
-        } else if (p instanceof EJBMethodPermission) {
-            WSPolicyConfigurationImpl pc = getPolicyConfiguration();
-            // If there is no policy configuration, the application doesn't
-            // have any security constraints.  In that case return true.
-            if (pc == null) {
-                return true;
-            }
-            if (tc.isDebugEnabled())
-                Tr.debug(tc, "Checking the excluded list");
-            if (jaccProvider.checkExcludedPerm(pc, p)) {
-                return false;
-            } else {
-                if (tc.isDebugEnabled())
-                    Tr.debug(tc, "Checking the unchecked list");
-                if (jaccProvider.checkUncheckedPerm(pc, p)) {
-                    return true;
-                } else {
-                    return jaccProvider.checkRolePerm(pc, p, PolicyContext.getContextID());
-                }
-            }
-        } else {
-            result = policy.implies(pd, p);
-        }
-        return result;
-    }
-
-    private WSPolicyConfigurationImpl getPolicyConfiguration() {
-        //get contextID;
-        String contextID = PolicyContext.getContextID();
-        WSPolicyConfigurationImpl pc = null;
-        pc = AllPolicyConfigs.getInstance().getPolicyConfig(contextID);
-
-        if (pc == null) {
-            if (tc.isDebugEnabled())
-                Tr.debug(tc, "Cannot get the policy configuration object. exit value:false");
-            return null;
+            return true;
         }
 
-        boolean inService = false;
-        try {
-            inService = pc.inService();
-        } catch (PolicyContextException pce) {
-            if (tc.isDebugEnabled())
-                Tr.debug(tc, "security.jacc.provider.inservice", new Object[] { pce });
-        }
-
-        if (!inService) {
-            if (tc.isDebugEnabled())
-                Tr.debug(tc, "The policy configuration object is not in the commit state. exit value:false");
-            return null;
-        }
-
-        if (jaccProvider == null) {
-            jaccProvider = JaccProvider.getInstance();
-        }
-        return pc;
+        Boolean defaultChecks = implies(Arrays.asList(pd.getPrincipals()), p);
+        return defaultChecks != null ? defaultChecks : policy.implies(pd, p);
     }
 }

--- a/dev/com.ibm.ws.security.authorization.jacc.testprovider/src/com/ibm/ws/security/authorization/jacc/provider/WSPolicyConfigurationImpl.java
+++ b/dev/com.ibm.ws.security.authorization.jacc.testprovider/src/com/ibm/ws/security/authorization/jacc/provider/WSPolicyConfigurationImpl.java
@@ -22,6 +22,7 @@ import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import javax.security.jacc.PolicyConfiguration;
 import javax.security.jacc.PolicyContextException;
@@ -42,7 +43,7 @@ public class WSPolicyConfigurationImpl implements PolicyConfiguration {
     String contextID = null;
     List<Permission> excludedList = null;
     List<Permission> uncheckedList = null;
-    Map<String, List<Permission>> roleToPermMap = new HashMap<String, List<Permission>>();
+    Map<String, List<Permission>> roleToPermMap = new ConcurrentHashMap<String, List<Permission>>();
     ContextState state = ContextState.STATE_OPEN;
 
     public WSPolicyConfigurationImpl(String s) throws PolicyContextException {
@@ -72,12 +73,13 @@ public class WSPolicyConfigurationImpl implements PolicyConfiguration {
         if (permissioncollection != null) {
             List<Permission> permList = roleToPermMap.get(s);
             if (permList == null) {
-                List<Permission> newPermList = new ArrayList<Permission>();
-                for (Enumeration<Permission> e = permissioncollection.elements(); e.hasMoreElements();) {
-                    newPermList.add(e.nextElement());
+                permList = new ArrayList<Permission>();
+                List<Permission> oldValue = roleToPermMap.putIfAbsent(s, permList);
+                if (oldValue != null) {
+                    permList = oldValue;
                 }
-                roleToPermMap.put(s, newPermList);
-            } else {
+            }
+            synchronized (permList) {
                 for (Enumeration<Permission> e = permissioncollection.elements(); e.hasMoreElements();) {
                     permList.add(e.nextElement());
                 }
@@ -99,10 +101,13 @@ public class WSPolicyConfigurationImpl implements PolicyConfiguration {
         if (permission != null) {
             List<Permission> permList = roleToPermMap.get(s);
             if (permList == null) {
-                List<Permission> newPermList = new ArrayList<Permission>();
-                newPermList.add(permission);
-                roleToPermMap.put(s, newPermList);
-            } else {
+                permList = new ArrayList<Permission>();
+                List<Permission> oldValue = roleToPermMap.putIfAbsent(s, permList);
+                if (oldValue != null) {
+                    permList = oldValue;
+                }
+            }
+            synchronized (permList) {
                 permList.add(permission);
             }
         }

--- a/dev/com.ibm.ws.security.authorization/src/com/ibm/ws/security/authorization/AuthorizationService.java
+++ b/dev/com.ibm.ws.security.authorization/src/com/ibm/ws/security/authorization/AuthorizationService.java
@@ -90,20 +90,20 @@ public interface AuthorizationService {
     default boolean isStarStarRoleMapped(String resourceName) {
         return false;
     }
+
     /**
-     *
-     * Retrieve all declared roles subject is assigned to within the provided resource
+     * Retrieve all declared roles in the application that subject is assigned
      *
      * Any dynamically assigned roles should not be returned.
      *
-     * @param resourceName the name of the resource being accessed, used to
-     *            look up the corresponding authorization table. Must not be {@code null}.
-     * @param subject the Subject which roles we are trying to find in the resource. Must not be {@code null}.
+     * @param resourceName the name of the resource being accessed (i.e. the application), used to
+     *                         look up the corresponding authorization table. Must not be {@code null}.
+     * @param subject      the Subject which roles we are trying to find in the resource. Must not be {@code null}.
      *
      * @return {@code Set<String>} of all the roles assigned to the subject in the resource.
-     *            Returns an empty set if no roles for
+     *         Returns an empty set if no roles for
      */
-    default Set<String> getAllDeclaredRolesForResourceForSubject(String resourceName, Subject subject){
+    default Set<String> getAllDeclaredRolesForResourceForSubject(String resourceName, Subject subject) {
         return new HashSet<String>(Collections.EMPTY_SET);
     }
 

--- a/dev/com.ibm.ws.security.authorization/src/com/ibm/ws/security/authorization/DeclaredRolesService.java
+++ b/dev/com.ibm.ws.security.authorization/src/com/ibm/ws/security/authorization/DeclaredRolesService.java
@@ -1,0 +1,70 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package com.ibm.ws.security.authorization;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Each container implements this method to provide the declared roles that are configured
+ * in the application.
+ */
+public class DeclaredRolesService {
+    private final Map<String, Map<String, Set<String>>> declaredRolesMap = new ConcurrentHashMap<>();
+
+    public Set<String> getDeclaredRoles(String appName) {
+        Map<String, Set<String>> moduleRolesMap = declaredRolesMap.get(appName);
+        if (moduleRolesMap != null && !moduleRolesMap.isEmpty()) {
+            Set<String> declaredRoles = new HashSet<>();
+            for (Set<String> moduleRoles : moduleRolesMap.values()) {
+                declaredRoles.addAll(moduleRoles);
+            }
+            return declaredRoles;
+
+        }
+        return Collections.emptySet();
+    }
+
+    public void addDeclaredRoles(String appName, String moduleName, Collection<String> roles) {
+        if (roles.size() > 0) {
+            Map<String, Set<String>> moduleRolesMap = declaredRolesMap.get(appName);
+            if (moduleRolesMap == null) {
+                moduleRolesMap = new ConcurrentHashMap<>();
+                Map<String, Set<String>> oldValue = declaredRolesMap.putIfAbsent(appName, moduleRolesMap);
+                if (oldValue != null) {
+                    moduleRolesMap = oldValue;
+                }
+            }
+            Set<String> moduleRoles = moduleRolesMap.get(moduleName);
+            if (moduleRoles == null) {
+                moduleRoles = Collections.newSetFromMap(new ConcurrentHashMap<>());
+                Set<String> oldValue = moduleRolesMap.putIfAbsent(moduleName, moduleRoles);
+                if (oldValue != null) {
+                    moduleRoles = oldValue;
+                }
+            }
+            moduleRoles.addAll(roles);
+        }
+    }
+
+    public void removeModule(String appName, String moduleName) {
+        Map<String, Set<String>> moduleRolesMap = declaredRolesMap.get(appName);
+        if (moduleRolesMap != null) {
+            moduleRolesMap.remove(moduleName);
+            if (moduleRolesMap.isEmpty()) {
+                declaredRolesMap.remove(appName);
+            }
+        }
+    }
+}

--- a/dev/com.ibm.ws.webcontainer.security.app/bnd.bnd
+++ b/dev/com.ibm.ws.webcontainer.security.app/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017, 2024 IBM Corporation and others.
+# Copyright (c) 2017, 2026 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -54,12 +54,19 @@ Service-Component: \
     optional:='taiService,interceptorService,webAuthenticator,webJaccService,unprotectedResourceService,webAppSecurityConfigChangeListener,loggedOutCookieCacheService'; \
     dynamic:='ssoAuthFilter,taiService,interceptorService,webAuthenticator,webJaccService,unprotectedResourceService,authenticatorFactory,webAppSecurityConfigChangeListener'; \
     properties:="service.vendor=IBM,loggedOutCookieCacheService.target=(id=unbound)", \
+  com.ibm.ws.webcontainer.security.WebDeclaredRolesService; \
+    implementation:=com.ibm.ws.webcontainer.security.WebDeclaredRolesService; \
+    provide:='com.ibm.ws.security.authorization.DeclaredRolesService,\
+              com.ibm.ws.webcontainer.security.WebDeclaredRolesService'; \
+    configuration-policy:=ignore; \
+    properties:="service.vendor=IBM", \
   com.ibm.ws.webcontainer.security.ServletStartedListener; \
     implementation:=com.ibm.ws.webcontainer.security.ServletStartedListener; \
     provide:='com.ibm.wsspi.webcontainer.collaborator.WebAppInitializationCollaborator'; \
     activate:=activate;\
     deactivate:=deactivate;\
     webJaccService=com.ibm.ws.webcontainer.security.WebJaccService;\
+    declaredRolesService=com.ibm.ws.webcontainer.security.WebDeclaredRolesService;\
     dynamic:='webJaccService';\
     optional:='webJaccService';\
     configuration-policy:=ignore;\
@@ -77,6 +84,7 @@ Service-Component: \
     activate:=activate; \
     deactivate:=deactivate; \
     webJaccService=com.ibm.ws.webcontainer.security.WebJaccService; \
+    declaredRolesService=com.ibm.ws.webcontainer.security.WebDeclaredRolesService;\
     dynamic:='webJaccService'; \
     optional:='webJaccService'; \
     properties:="service.vendor=IBM"

--- a/dev/com.ibm.ws.webcontainer.security/src/com/ibm/ws/webcontainer/security/MetaDataListenerImpl.java
+++ b/dev/com.ibm.ws.webcontainer.security/src/com/ibm/ws/webcontainer/security/MetaDataListenerImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2024 IBM Corporation and others.
+ * Copyright (c) 2015, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -33,6 +33,18 @@ public class MetaDataListenerImpl implements ModuleMetaDataListener {
     protected static final String KEY_WEB_JACC_SERVICE = "webJaccService";
     protected final AtomicServiceReference<WebJaccService> webJaccService = new AtomicServiceReference<WebJaccService>(KEY_WEB_JACC_SERVICE);
 
+    private WebDeclaredRolesService rolesService;
+
+    protected void setDeclaredRolesService(WebDeclaredRolesService rolesService) {
+        this.rolesService = rolesService;
+    }
+
+    protected void unsetDeclaredRolesService(WebDeclaredRolesService rolesService) {
+        if (rolesService == this.rolesService) {
+            this.rolesService = null;
+        }
+    }
+
     protected void setWebJaccService(ServiceReference<WebJaccService> reference) {
         webJaccService.setReference(reference);
     }
@@ -56,16 +68,20 @@ public class MetaDataListenerImpl implements ModuleMetaDataListener {
      */
     @Override
     public void moduleMetaDataCreated(MetaDataEvent<ModuleMetaData> event) throws MetaDataException {
-        WebJaccService js = webJaccService.getService();
-        if (js != null) {
-            MetaData metaData = event.getMetaData();
-            if (metaData instanceof WebModuleMetaData) {
-                WebModuleMetaData wmmd = (WebModuleMetaData) metaData;
-                if (wmmd.getSecurityMetaData() != null && ((SecurityMetadata) (wmmd.getSecurityMetaData())).getSecurityConstraintCollection() != null) {
-                    // propagate the security constraints when it is available.
-                    WebAppConfig webAppConfig = wmmd.getConfiguration();
-                    js.propagateWebConstraints(webAppConfig.getApplicationName(), webAppConfig.getModuleName(), webAppConfig);
+        MetaData metaData = event.getMetaData();
+        if (metaData instanceof WebModuleMetaData) {
+            WebModuleMetaData wmmd = (WebModuleMetaData) metaData;
+            SecurityMetadata securityMetadata = (SecurityMetadata) wmmd.getSecurityMetaData();
+            if (securityMetadata != null) {
+                WebAppConfig webAppConfig = wmmd.getConfiguration();
+                String appName = webAppConfig.getApplicationName();
+                String moduleName = webAppConfig.getModuleName();
+                WebJaccService js = webJaccService.getService();
+                // propagate the security constraints when it is available.
+                if (js != null && securityMetadata.getSecurityConstraintCollection() != null) {
+                    js.propagateWebConstraints(appName, moduleName, webAppConfig);
                 }
+                rolesService.addDeclaredRoles(appName, moduleName, securityMetadata.getRoles());
             }
         }
     }
@@ -77,8 +93,12 @@ public class MetaDataListenerImpl implements ModuleMetaDataListener {
      */
     @Override
     public void moduleMetaDataDestroyed(MetaDataEvent<ModuleMetaData> event) {
-        // TODO Auto-generated method stub
-
+        MetaData metaData = event.getMetaData();
+        if (metaData instanceof WebModuleMetaData) {
+            WebModuleMetaData wmmd = (WebModuleMetaData) metaData;
+            WebAppConfig webAppConfig = wmmd.getConfiguration();
+            rolesService.removeModule(webAppConfig.getApplicationName(), webAppConfig.getModuleName());
+        }
     }
 
 }

--- a/dev/com.ibm.ws.webcontainer.security/src/com/ibm/ws/webcontainer/security/ServletStartedListener.java
+++ b/dev/com.ibm.ws.webcontainer.security/src/com/ibm/ws/webcontainer/security/ServletStartedListener.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2024 IBM Corporation and others.
+ * Copyright (c) 2012, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -61,6 +61,18 @@ public class ServletStartedListener implements WebAppInitializationCollaborator 
     protected static final String KEY_WEB_JACC_SERVICE = "webJaccService";
     private final AtomicServiceReference<WebJaccService> webJaccService = new AtomicServiceReference<WebJaccService>(KEY_WEB_JACC_SERVICE);
 
+    private WebDeclaredRolesService rolesService;
+
+    public void setDeclaredRolesService(WebDeclaredRolesService rolesService) {
+        this.rolesService = rolesService;
+    }
+
+    public void unsetDeclaredRolesService(WebDeclaredRolesService rolesService) {
+        if (rolesService == this.rolesService) {
+            this.rolesService = null;
+        }
+    }
+
     protected void setWebJaccService(ServiceReference<WebJaccService> reference) {
         webJaccService.setReference(reference);
     }
@@ -92,13 +104,18 @@ public class ServletStartedListener implements WebAppInitializationCollaborator 
             SecurityMetadata securityMetadataFromDD = getSecurityMetadata(webAppConfig);
             updateSecurityMetadata(securityMetadataFromDD, webAppConfig);
             setModuleSecurityMetaData(moduleContainer, securityMetadataFromDD);
+
+            String appName = webAppConfig.getApplicationName();
+            String moduleName = webAppConfig.getModuleName();
+            rolesService.addDeclaredRoles(appName, moduleName, securityMetadataFromDD.getRoles());
+
             if (com.ibm.ws.webcontainer.osgi.WebContainer.getServletContainerSpecLevel() >= 31) {
                 notifyDeployOfUncoveredMethods(webAppConfig);
             }
             if (checkDynamicAnnotation(webAppConfig)) {
                 WebJaccService js = webJaccService.getService();
                 if (js != null) {
-                    js.propagateWebConstraints(webAppConfig.getApplicationName(), webAppConfig.getModuleName(), webAppConfig);
+                    js.propagateWebConstraints(appName, moduleName, webAppConfig);
                 }
             }
         } catch (UnableToAdaptException e) {

--- a/dev/com.ibm.ws.webcontainer.security/src/com/ibm/ws/webcontainer/security/WebDeclaredRolesService.java
+++ b/dev/com.ibm.ws.webcontainer.security/src/com/ibm/ws/webcontainer/security/WebDeclaredRolesService.java
@@ -1,0 +1,15 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package com.ibm.ws.webcontainer.security;
+
+import com.ibm.ws.security.authorization.DeclaredRolesService;
+
+public class WebDeclaredRolesService extends DeclaredRolesService {
+}

--- a/dev/com.ibm.ws.webcontainer.security/test/com/ibm/ws/webcontainer/security/MetaDataListenerImplTest.java
+++ b/dev/com.ibm.ws.webcontainer.security/test/com/ibm/ws/webcontainer/security/MetaDataListenerImplTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2024 IBM Corporation and others.
+ * Copyright (c) 2015, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -53,6 +53,7 @@ public class MetaDataListenerImplTest {
     @SuppressWarnings("unchecked")
     private final ServiceReference<WebJaccService> jsr = context.mock(ServiceReference.class, "jaccServiceRef");
     private final WebJaccService js = context.mock(WebJaccService.class);
+    private final WebDeclaredRolesService rolesService = new WebDeclaredRolesService();
     private final ComponentContext cc = context.mock(ComponentContext.class);
     @SuppressWarnings("rawtypes")
     private final MetaDataEvent mde = context.mock(MetaDataEvent.class);
@@ -72,10 +73,8 @@ public class MetaDataListenerImplTest {
             {
                 one(mde).getMetaData();
                 will(returnValue(wmmd));
-                allowing(wmmd).getSecurityMetaData();
+                one(wmmd).getSecurityMetaData();
                 will(returnValue(smd));
-                one(smd).getSecurityConstraintCollection();
-                will(returnValue(scc));
                 one(wmmd).getConfiguration();
                 will(returnValue(wac));
                 one(wac).getApplicationName();
@@ -84,10 +83,22 @@ public class MetaDataListenerImplTest {
                 will(returnValue(MODULE_NAME));
                 one(cc).locateService("webJaccService", jsr);
                 will(returnValue(js));
+                one(smd).getSecurityConstraintCollection();
+                will(returnValue(scc));
                 one(js).propagateWebConstraints(APP_NAME, MODULE_NAME, wac);
+                one(smd).getRoles();
+                one(mde).getMetaData();
+                will(returnValue(wmmd));
+                one(wmmd).getConfiguration();
+                will(returnValue(wac));
+                one(wac).getApplicationName();
+                will(returnValue(APP_NAME));
+                one(wac).getModuleName();
+                will(returnValue(MODULE_NAME));
             }
         });
         MetaDataListenerImpl mdli = new MetaDataListenerImpl();
+        mdli.setDeclaredRolesService(rolesService);
         mdli.setWebJaccService(jsr);
         mdli.activate(cc);
 
@@ -114,12 +125,24 @@ public class MetaDataListenerImplTest {
 
         context.checking(new Expectations() {
             {
+                one(mde).getMetaData();
+                will(returnValue(wmmd));
+                one(wmmd).getSecurityMetaData();
+                will(returnValue(smd));
+                one(wmmd).getConfiguration();
+                will(returnValue(wac));
+                one(wac).getApplicationName();
+                will(returnValue(APP_NAME));
+                one(wac).getModuleName();
+                will(returnValue(MODULE_NAME));
                 one(cc).locateService("webJaccService", jsr);
                 will(returnValue(null));
                 never(js).propagateWebConstraints(APP_NAME, MODULE_NAME, wac);
+                one(smd).getRoles();
             }
         });
         MetaDataListenerImpl mdli = new MetaDataListenerImpl();
+        mdli.setDeclaredRolesService(rolesService);
         mdli.setWebJaccService(jsr);
         mdli.activate(cc);
 
@@ -147,12 +170,11 @@ public class MetaDataListenerImplTest {
             {
                 one(mde).getMetaData();
                 will(returnValue(mmd));
-                one(cc).locateService("webJaccService", jsr);
-                will(returnValue(js));
                 never(js).propagateWebConstraints(APP_NAME, MODULE_NAME, wac);
             }
         });
         MetaDataListenerImpl mdli = new MetaDataListenerImpl();
+        mdli.setDeclaredRolesService(rolesService);
         mdli.setWebJaccService(jsr);
         mdli.activate(cc);
 
@@ -180,14 +202,15 @@ public class MetaDataListenerImplTest {
             {
                 one(mde).getMetaData();
                 will(returnValue(wmmd));
-                allowing(wmmd).getSecurityMetaData();
+                one(wmmd).getSecurityMetaData();
                 will(returnValue(null));
-                one(cc).locateService("webJaccService", jsr);
-                will(returnValue(js));
+                never(cc).locateService("webJaccService", jsr);
                 never(js).propagateWebConstraints(APP_NAME, MODULE_NAME, wac);
+                never(smd).getRoles();
             }
         });
         MetaDataListenerImpl mdli = new MetaDataListenerImpl();
+        mdli.setDeclaredRolesService(rolesService);
         mdli.setWebJaccService(jsr);
         mdli.activate(cc);
 
@@ -215,16 +238,24 @@ public class MetaDataListenerImplTest {
             {
                 one(mde).getMetaData();
                 will(returnValue(wmmd));
-                allowing(wmmd).getSecurityMetaData();
+                one(wmmd).getSecurityMetaData();
                 will(returnValue(smd));
-                one(smd).getSecurityConstraintCollection();
-                will(returnValue(null));
+                one(wmmd).getConfiguration();
+                will(returnValue(wac));
+                one(wac).getApplicationName();
+                will(returnValue(APP_NAME));
+                one(wac).getModuleName();
+                will(returnValue(MODULE_NAME));
                 one(cc).locateService("webJaccService", jsr);
                 will(returnValue(js));
+                one(smd).getSecurityConstraintCollection();
+                will(returnValue(null));
                 never(js).propagateWebConstraints(APP_NAME, MODULE_NAME, wac);
+                one(smd).getRoles();
             }
         });
         MetaDataListenerImpl mdli = new MetaDataListenerImpl();
+        mdli.setDeclaredRolesService(rolesService);
         mdli.setWebJaccService(jsr);
         mdli.activate(cc);
 

--- a/dev/com.ibm.ws.webcontainer.security/test/com/ibm/ws/webcontainer/security/ServletStartedListenerTest.java
+++ b/dev/com.ibm.ws.webcontainer.security/test/com/ibm/ws/webcontainer/security/ServletStartedListenerTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2024 IBM Corporation and others.
+ * Copyright (c) 2015, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -126,6 +126,7 @@ public class ServletStartedListenerTest {
                     one(cc).locateService("webJaccService", jsr);
                     will(returnValue(js));
                     one(js).propagateWebConstraints(APP_NAME, MODULE_NAME, wac);
+                    one(smd).getRoles();
                 }
             });
         } catch (UnableToAdaptException e) {
@@ -135,6 +136,7 @@ public class ServletStartedListenerTest {
             fail("An exception is caught." + e);
         }
         ServletStartedListener ssl = new ServletStartedListener();
+        ssl.setDeclaredRolesService(new WebDeclaredRolesService());
         ssl.setWebJaccService(jsr);
         ssl.activate(cc);
 

--- a/dev/com.ibm.ws.webcontainer.security/test/com/ibm/ws/webcontainer/security/internal/ServletStartedListenerTest.java
+++ b/dev/com.ibm.ws.webcontainer.security/test/com/ibm/ws/webcontainer/security/internal/ServletStartedListenerTest.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2012 IBM Corporation and others.
+ * Copyright (c) 2012, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -38,6 +38,7 @@ import org.junit.Test;
 
 import com.ibm.ws.container.service.app.deploy.WebModuleInfo;
 import com.ibm.ws.webcontainer.security.ServletStartedListener;
+import com.ibm.ws.webcontainer.security.WebDeclaredRolesService;
 import com.ibm.ws.webcontainer.security.metadata.SecurityConstraint;
 import com.ibm.ws.webcontainer.security.metadata.SecurityConstraintCollection;
 import com.ibm.ws.webcontainer.security.metadata.SecurityMetadata;
@@ -93,7 +94,8 @@ public class ServletStartedListenerTest {
      * @throws java.lang.Exception
      */
     @AfterClass
-    public static void tearDownAfterClass() throws Exception {}
+    public static void tearDownAfterClass() throws Exception {
+    }
 
     /**
      * @throws java.lang.Exception
@@ -107,11 +109,12 @@ public class ServletStartedListenerTest {
      * @throws java.lang.Exception
      */
     @After
-    public void tearDown() throws Exception {}
+    public void tearDown() throws Exception {
+    }
 
     /**
      * Test method for {@link com.ibm.ws.webcontainer.security.ServletStartedListener#started(com.ibm.ws.container.service.app.deploy.DeployedMod)}.
-     * 
+     *
      * @throws UnableToAdaptException
      */
     @Test
@@ -127,15 +130,20 @@ public class ServletStartedListenerTest {
                 allowing(moduleContainer).adapt(WebAppConfig.class);
                 will(returnValue(webAppConfig));
 
+                one(webAppConfig).getApplicationName();
+                one(webAppConfig).getModuleName();
+                allowing(webModuleMetaDataMock).getSecurityMetaData();
+                will(returnValue(securityMetadataMock));
+                allowing(securityMetadataMock).getRoles();
+
                 allowing(webAppConfig).getServletInfos();
                 will(returnValue(servletConfigs));
                 allowing(webAppConfig).getMetaData();
                 will(returnValue(webModuleMetaDataMock));
-                allowing(webModuleMetaDataMock).getSecurityMetaData();
-                will(returnValue(securityMetadataMock));
             }
         });
 
+        servletStartedListener.setDeclaredRolesService(new WebDeclaredRolesService());
         servletStartedListener.started(deployedMod.getContainer());
         mock.assertIsSatisfied();
 
@@ -407,7 +415,7 @@ public class ServletStartedListenerTest {
     }
 
     /**
-     * 
+     *
      * @param urlPatterns
      * @param httpMethod
      * @param rolesAllowed

--- a/dev/fattest.simplicity/src/com/ibm/websphere/simplicity/beansxml/BeansAsset.java
+++ b/dev/fattest.simplicity/src/com/ibm/websphere/simplicity/beansxml/BeansAsset.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2022 IBM Corporation and others.
+ * Copyright (c) 2021, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -57,7 +57,7 @@ public class BeansAsset extends ClassLoaderAsset {
      * All the supported CDI versions
      */
     public static enum CDIVersion {
-        CDI10, CDI11, CDI20, CDI30, CDI40
+        CDI10, CDI11, CDI20, CDI30, CDI40, CDI41
     };
 
     //A static array containing cached BeansAsset instances for all combinations of DiscoveryMode and CDIVersion
@@ -123,6 +123,8 @@ public class BeansAsset extends ClassLoaderAsset {
             beans = "beans30_";
         } else if (version == CDIVersion.CDI40) {
             beans = "beans40_";
+        } else if (version == CDIVersion.CDI41) {
+            beans = "beans41_";
         } else {
             throw new IllegalArgumentException("Unknown CDI Version: " + version);
         }

--- a/dev/fattest.simplicity/src/com/ibm/websphere/simplicity/beansxml/beans41_all.xml
+++ b/dev/fattest.simplicity/src/com/ibm/websphere/simplicity/beansxml/beans41_all.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="https://jakarta.ee/xml/ns/jakartaee"
+    xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_4_1.xsd"
+    version="4.1" bean-discovery-mode="all">
+</beans>

--- a/dev/fattest.simplicity/src/com/ibm/websphere/simplicity/beansxml/beans41_annotated.xml
+++ b/dev/fattest.simplicity/src/com/ibm/websphere/simplicity/beansxml/beans41_annotated.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="https://jakarta.ee/xml/ns/jakartaee"
+    xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_4_1.xsd"
+    version="4.1" bean-discovery-mode="annotated">
+</beans>

--- a/dev/fattest.simplicity/src/com/ibm/websphere/simplicity/beansxml/beans41_none.xml
+++ b/dev/fattest.simplicity/src/com/ibm/websphere/simplicity/beansxml/beans41_none.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="https://jakarta.ee/xml/ns/jakartaee"
+    xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_4_1.xsd"
+    version="4.1" bean-discovery-mode="none">
+</beans>

--- a/dev/io.openliberty.security.authorization.internal.3.0_fat/bnd.bnd
+++ b/dev/io.openliberty.security.authorization.internal.3.0_fat/bnd.bnd
@@ -26,4 +26,11 @@ fat.project: true
 	com.ibm.ws.componenttest.2.0;version=latest,\
 	com.ibm.ws.security.authorization.jacc.testprovider;version=latest,\
 	io.openliberty.security.authorization.jacc.testprovider;version=latest,\
-	io.openliberty.security.authorization.internal.jacc.3.0;version=latest
+	io.openliberty.security.authorization.internal.jacc.3.0;version=latest,\
+	io.openliberty.jakarta.annotation.3.0;version=latest,\
+	io.openliberty.jakarta.cdi.4.1;version=latest,\
+	io.openliberty.jakarta.enterpriseBeans.4.0;version=latest,\
+	io.openliberty.jakarta.security.4.0;version=latest,\
+	io.openliberty.jakarta.authorization.3.0;version=latest,\
+	com.ibm.websphere.appserver.api.basics,\
+	io.openliberty.jakarta.restfulWS.4.0

--- a/dev/io.openliberty.security.authorization.internal.3.0_fat/fat/src/io/openliberty/security/authorization/ejb/annotations/AnnotationEJB1.java
+++ b/dev/io.openliberty.security.authorization.internal.3.0_fat/fat/src/io/openliberty/security/authorization/ejb/annotations/AnnotationEJB1.java
@@ -1,0 +1,41 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.security.authorization.ejb.annotations;
+
+import java.io.PrintWriter;
+
+import io.openliberty.security.authorization.fat.EJBContextWrapper;
+import io.openliberty.security.authorization.fat.TestUtil;
+import jakarta.annotation.Resource;
+import jakarta.annotation.security.RolesAllowed;
+import jakarta.ejb.EJBContext;
+import jakarta.ejb.Stateless;
+import jakarta.inject.Inject;
+import jakarta.security.enterprise.SecurityContext;
+
+@Stateless
+public class AnnotationEJB1 {
+
+    @Inject
+    SecurityContext secContext;
+
+    @Resource
+    EJBContext ejbContext;
+
+    @RolesAllowed({ "EJBRole1" })
+    public void doTest(PrintWriter out) {
+        TestUtil.printSecurityData(out, new EJBContextWrapper(ejbContext), secContext);
+    }
+
+    @RolesAllowed({ "EJBRole2" })
+    public void doTest2(PrintWriter out) {
+        TestUtil.printSecurityData(out, new EJBContextWrapper(ejbContext), secContext);
+    }
+}

--- a/dev/io.openliberty.security.authorization.internal.3.0_fat/fat/src/io/openliberty/security/authorization/ejb/annotations/AnnotationEJB2.java
+++ b/dev/io.openliberty.security.authorization.internal.3.0_fat/fat/src/io/openliberty/security/authorization/ejb/annotations/AnnotationEJB2.java
@@ -1,0 +1,41 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.security.authorization.ejb.annotations;
+
+import java.io.PrintWriter;
+
+import io.openliberty.security.authorization.fat.EJBContextWrapper;
+import io.openliberty.security.authorization.fat.TestUtil;
+import jakarta.annotation.Resource;
+import jakarta.annotation.security.RolesAllowed;
+import jakarta.ejb.EJBContext;
+import jakarta.ejb.Stateless;
+import jakarta.inject.Inject;
+import jakarta.security.enterprise.SecurityContext;
+
+@Stateless
+public class AnnotationEJB2 {
+
+    @Inject
+    SecurityContext secContext;
+
+    @Resource
+    EJBContext ejbContext;
+
+    @RolesAllowed({ "EJBRole1" })
+    public void doTest(PrintWriter out) {
+        TestUtil.printSecurityData(out, new EJBContextWrapper(ejbContext), secContext);
+    }
+
+    @RolesAllowed({ "EJBRole3" })
+    public void doTest2(PrintWriter out) {
+        TestUtil.printSecurityData(out, new EJBContextWrapper(ejbContext), secContext);
+    }
+}

--- a/dev/io.openliberty.security.authorization.internal.3.0_fat/fat/src/io/openliberty/security/authorization/ejb/annotations/EJBAnnotationServlet1.java
+++ b/dev/io.openliberty.security.authorization.internal.3.0_fat/fat/src/io/openliberty/security/authorization/ejb/annotations/EJBAnnotationServlet1.java
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.security.authorization.ejb.annotations;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+
+import jakarta.ejb.EJB;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+@WebServlet("/ejbServlet1/*")
+public class EJBAnnotationServlet1 extends HttpServlet {
+
+    private static final long serialVersionUID = 1L;
+
+    @EJB
+    AnnotationEJB1 ejb;
+
+    @Override
+    protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        PrintWriter out = response.getWriter();
+        if (request.getRequestURI().endsWith("allowUnauthenticated")) {
+            ejb.doTest2(out);
+        } else {
+            ejb.doTest(out);
+        }
+    }
+}

--- a/dev/io.openliberty.security.authorization.internal.3.0_fat/fat/src/io/openliberty/security/authorization/ejb/annotations/overrideweb.xml
+++ b/dev/io.openliberty.security.authorization.internal.3.0_fat/fat/src/io/openliberty/security/authorization/ejb/annotations/overrideweb.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<web-app xmlns="https://jakarta.ee/xml/ns/jakartaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee 
+         https://jakarta.ee/xml/ns/jakartaee/web-app_6_1.xsd"
+         version="6.1">
+    
+    <context-param>
+        <param-name>jakarta.security.jacc.PolicyFactory.provider</param-name>
+        <param-value>io.openliberty.security.authorization.fat.OverridePolicyFactory</param-value>
+    </context-param>
+
+    <security-constraint>
+        <web-resource-collection>
+            <url-pattern>/ejbServlet1</url-pattern>
+        </web-resource-collection>
+        <auth-constraint>
+            <role-name>**</role-name>
+        </auth-constraint>
+    </security-constraint>
+    <login-config>
+        <auth-method>BASIC</auth-method>
+        <realm-name>authz</realm-name>
+    </login-config>
+    
+</web-app>

--- a/dev/io.openliberty.security.authorization.internal.3.0_fat/fat/src/io/openliberty/security/authorization/ejb/annotations/web.xml
+++ b/dev/io.openliberty.security.authorization.internal.3.0_fat/fat/src/io/openliberty/security/authorization/ejb/annotations/web.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<web-app xmlns="https://jakarta.ee/xml/ns/jakartaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee 
+         https://jakarta.ee/xml/ns/jakartaee/web-app_6_1.xsd"
+         version="6.1">
+    
+    <security-constraint>
+        <web-resource-collection>
+            <url-pattern>/ejbServlet1</url-pattern>
+        </web-resource-collection>
+        <auth-constraint>
+            <role-name>**</role-name>
+        </auth-constraint>
+    </security-constraint>
+    <login-config>
+        <auth-method>BASIC</auth-method>
+        <realm-name>authz</realm-name>
+    </login-config>
+    
+</web-app>

--- a/dev/io.openliberty.security.authorization.internal.3.0_fat/fat/src/io/openliberty/security/authorization/fat/ComponentContextWrapper.java
+++ b/dev/io.openliberty.security.authorization.internal.3.0_fat/fat/src/io/openliberty/security/authorization/fat/ComponentContextWrapper.java
@@ -1,0 +1,18 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.security.authorization.fat;
+
+import java.security.Principal;
+
+public interface ComponentContextWrapper {
+    public boolean isUserInRole(String role);
+
+    public Principal getUserPrincipal();
+}

--- a/dev/io.openliberty.security.authorization.internal.3.0_fat/fat/src/io/openliberty/security/authorization/fat/EJBContextWrapper.java
+++ b/dev/io.openliberty.security.authorization.internal.3.0_fat/fat/src/io/openliberty/security/authorization/fat/EJBContextWrapper.java
@@ -1,0 +1,33 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.security.authorization.fat;
+
+import java.security.Principal;
+
+import jakarta.ejb.EJBContext;
+
+public class EJBContextWrapper implements ComponentContextWrapper {
+
+    private final EJBContext ejbContext;
+
+    public EJBContextWrapper(EJBContext context) {
+        ejbContext = context;
+    }
+
+    @Override
+    public boolean isUserInRole(String role) {
+        return ejbContext.isCallerInRole(role);
+    }
+
+    @Override
+    public Principal getUserPrincipal() {
+        return ejbContext.getCallerPrincipal();
+    }
+}

--- a/dev/io.openliberty.security.authorization.internal.3.0_fat/fat/src/io/openliberty/security/authorization/fat/OverridePolicy.java
+++ b/dev/io.openliberty.security.authorization.internal.3.0_fat/fat/src/io/openliberty/security/authorization/fat/OverridePolicy.java
@@ -1,0 +1,47 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.security.authorization.fat;
+
+import java.security.Permission;
+import java.security.PermissionCollection;
+
+import javax.security.auth.Subject;
+
+import jakarta.security.jacc.EJBMethodPermission;
+import jakarta.security.jacc.Policy;
+import jakarta.security.jacc.PolicyFactory;
+import jakarta.security.jacc.WebResourcePermission;
+
+public class OverridePolicy implements Policy {
+
+    private final Policy delegate;
+
+    OverridePolicy(PolicyFactory delegateFactory, String contextId) {
+        this.delegate = delegateFactory.getPolicy(contextId);
+    }
+
+    @Override
+    public boolean implies(Permission permissionToBeChecked, Subject subject) {
+        if (permissionToBeChecked instanceof WebResourcePermission &&
+            permissionToBeChecked.getName().endsWith("/allowUnauthenticated")) {
+            return true;
+        }
+        if (permissionToBeChecked instanceof EJBMethodPermission &&
+            permissionToBeChecked.getActions().contains("doTest2")) {
+            return true;
+        }
+        return delegate.implies(permissionToBeChecked, subject);
+    }
+
+    @Override
+    public PermissionCollection getPermissionCollection(Subject arg0) {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/dev/io.openliberty.security.authorization.internal.3.0_fat/fat/src/io/openliberty/security/authorization/fat/OverridePolicyFactory.java
+++ b/dev/io.openliberty.security.authorization.internal.3.0_fat/fat/src/io/openliberty/security/authorization/fat/OverridePolicyFactory.java
@@ -1,0 +1,55 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.security.authorization.fat;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import jakarta.security.jacc.Policy;
+import jakarta.security.jacc.PolicyFactory;
+
+public class OverridePolicyFactory extends PolicyFactory {
+
+    private final Map<String, Policy> policyMap = new ConcurrentHashMap<>();
+
+    private volatile Policy globalPolicy = null;
+
+    private final PolicyFactory delegate;
+
+    public OverridePolicyFactory(PolicyFactory delegate) {
+        this.delegate = delegate;
+        globalPolicy = new OverridePolicy(delegate, null);
+    }
+
+    @Override
+    public Policy getPolicy(String contextId) {
+        if (contextId == null) {
+            return globalPolicy;
+        }
+
+        Policy policy = policyMap.get(contextId);
+        if (policy == null) {
+            // get policy and set it in the map
+            policy = new OverridePolicy(delegate, contextId);
+            policyMap.put(contextId, policy);
+        }
+
+        return policy;
+    }
+
+    @Override
+    public void setPolicy(String contextId, Policy policy) {
+        if (contextId != null) {
+            policyMap.put(contextId, policy);
+        } else {
+            globalPolicy = policy;
+        }
+    }
+}

--- a/dev/io.openliberty.security.authorization.internal.3.0_fat/fat/src/io/openliberty/security/authorization/fat/RestContextWrapper.java
+++ b/dev/io.openliberty.security.authorization.internal.3.0_fat/fat/src/io/openliberty/security/authorization/fat/RestContextWrapper.java
@@ -1,0 +1,37 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.security.authorization.fat;
+
+import java.security.Principal;
+
+import jakarta.ws.rs.core.SecurityContext;
+
+/**
+ *
+ */
+public class RestContextWrapper implements ComponentContextWrapper {
+
+    private final SecurityContext restSecContext;
+
+    public RestContextWrapper(SecurityContext secContext) {
+        this.restSecContext = secContext;
+    }
+
+    @Override
+    public boolean isUserInRole(String role) {
+        return restSecContext.isUserInRole(role);
+    }
+
+    @Override
+    public Principal getUserPrincipal() {
+        return restSecContext.getUserPrincipal();
+    }
+
+}

--- a/dev/io.openliberty.security.authorization.internal.3.0_fat/fat/src/io/openliberty/security/authorization/fat/ServletContextWrapper.java
+++ b/dev/io.openliberty.security.authorization.internal.3.0_fat/fat/src/io/openliberty/security/authorization/fat/ServletContextWrapper.java
@@ -1,0 +1,33 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.security.authorization.fat;
+
+import java.security.Principal;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+public class ServletContextWrapper implements ComponentContextWrapper {
+
+    private final HttpServletRequest request;
+
+    public ServletContextWrapper(HttpServletRequest request) {
+        this.request = request;
+    }
+
+    @Override
+    public boolean isUserInRole(String role) {
+        return request.isUserInRole(role);
+    }
+
+    @Override
+    public Principal getUserPrincipal() {
+        return request.getUserPrincipal();
+    }
+}

--- a/dev/io.openliberty.security.authorization.internal.3.0_fat/fat/src/io/openliberty/security/authorization/fat/TestUtil.java
+++ b/dev/io.openliberty.security.authorization.internal.3.0_fat/fat/src/io/openliberty/security/authorization/fat/TestUtil.java
@@ -1,0 +1,115 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.security.authorization.fat;
+
+import java.io.PrintWriter;
+import java.security.PermissionCollection;
+import java.security.Principal;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import javax.security.auth.Subject;
+
+import jakarta.security.enterprise.SecurityContext;
+import jakarta.security.jacc.PolicyConfiguration;
+import jakarta.security.jacc.PolicyConfigurationFactory;
+import jakarta.security.jacc.PolicyContext;
+import jakarta.security.jacc.PrincipalMapper;
+
+public class TestUtil {
+
+    public static final Set<String> allRoles = Set.of("CDIRole1", "CDIRole2", "CDIRole3", "CDIRole4",
+                                                      "WebRole1", "WebRole2", "WebRole3", "WebRole4",
+                                                      "EJBRole1", "EJBRole2", "EJBRole3", "EJBRole4",
+                                                      "RestRole1", "RestRole2", "RestRole3", "RestRole4",
+                                                      "WebServicesRole1", "WebServicesRole2", "WebServicesRole3", "WebServicesRole4",
+                                                      "AllAuthenticated");
+
+    public static void printSecurityData(PrintWriter out, ComponentContextWrapper componentContext, SecurityContext secContext) {
+
+        // Display user principal
+        Principal userPrincipal = componentContext.getUserPrincipal();
+        String principalName = null;
+        if (userPrincipal == null) {
+            principalName = "Not authenticated";
+        } else {
+            principalName = userPrincipal.getName();
+            // EJB's getUserPrincipal returns a Principal with the name of UNAUTHENTICATED instead of null
+            if ("UNAUTHENTICATED".equals(principalName)) {
+                principalName = "Not authenticated";
+            }
+        }
+        out.println("User Principal: " + principalName);
+
+        if (secContext.getCallerPrincipal() != null) {
+            out.println("Caller Principal: " + secContext.getCallerPrincipal().getName());
+        } else {
+            out.println("Caller Principal: Not authenticated");
+        }
+
+        // Check roles
+        for (String role : allRoles) {
+            checkRole(out, componentContext, role, secContext);
+        }
+        checkRole(out, componentContext, "**", secContext);
+
+        Set<String> declaredRoles = secContext.getAllDeclaredCallerRoles();
+
+        out.println("Declared Roles: " + setToString(declaredRoles));
+
+        try {
+
+            Subject subject = (Subject) PolicyContext.getContext(PolicyContext.SUBJECT);
+            PrincipalMapper roleMapper = (PrincipalMapper) PolicyContext.getContext(PolicyContext.PRINCIPAL_MAPPER);
+            boolean isStarStarMapped = roleMapper.isAnyAuthenticatedUserRoleMapped();
+            Set<String> mappedRoles = roleMapper.getMappedRoles(subject);
+
+            out.println("Is ** mapped: " + isStarStarMapped);
+            out.println("PrincipalMapper Roles for subject: " + setToString(mappedRoles));
+
+            PolicyConfiguration pc = PolicyConfigurationFactory.get().getPolicyConfiguration();
+
+            if (pc == null) {
+                out.println("PolicyConfiguration is null");
+            } else {
+                Map<String, PermissionCollection> rolePerms = pc.getPerRolePermissions();
+                Set<String> calculatedDeclaredCallerRoles = new HashSet<>();
+                for (String role : mappedRoles) {
+                    PermissionCollection perms = rolePerms.get(role);
+                    if (perms != null && perms.elements().hasMoreElements()) {
+                        calculatedDeclaredCallerRoles.add(role);
+                    }
+                }
+                out.println("Calculated declared roles: " + setToString(calculatedDeclaredCallerRoles));
+            }
+        } catch (Throwable e) {
+            // Expected when no policy is defined or appAuthorizatoin feature is not enabled
+        }
+    }
+
+    public static String setToString(Set<String> set) {
+        StringBuilder builder = new StringBuilder();
+        for (String element : set) {
+            if (builder.length() != 0) {
+                builder.append(", ");
+            }
+            builder.append(element);
+        }
+        return builder.toString();
+    }
+
+    private static void checkRole(PrintWriter out, ComponentContextWrapper componentContext, String role, SecurityContext secContext) {
+        boolean inRole = componentContext.isUserInRole(role);
+        out.println("User in role " + role + ": " + inRole);
+        inRole = secContext.isCallerInRole(role);
+        out.println("Caller in role " + role + ": " + inRole);
+    }
+}

--- a/dev/io.openliberty.security.authorization.internal.3.0_fat/fat/src/io/openliberty/security/authorization/internal/tests/AbstractRolesTest.java
+++ b/dev/io.openliberty.security.authorization.internal.3.0_fat/fat/src/io/openliberty/security/authorization/internal/tests/AbstractRolesTest.java
@@ -1,0 +1,190 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.security.authorization.internal.tests;
+
+import java.net.Authenticator;
+import java.net.PasswordAuthentication;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.Set;
+
+import com.ibm.websphere.simplicity.PortType;
+
+import componenttest.custom.junit.runner.RepeatTestFilter;
+import componenttest.topology.impl.LibertyServer;
+import io.openliberty.security.authorization.fat.TestUtil;
+import junit.framework.Assert;
+
+public class AbstractRolesTest {
+
+    enum InRoleOutput {
+        DECLARED_IN_COMPONENT, ALL
+    }
+
+    public static final String WITH_AUTHZ_ID = "withAuthz";
+    public static final String WITH_POLICY_ID = "withPolicy";
+
+    public static HttpResponse<String> sendGetRequest(LibertyServer server, HttpClient client, String uri) throws Exception {
+        URI requestURI = URI.create("http://" + server.getHostname() + ":" + server.getPort(PortType.WC_defaulthost) + uri);
+        HttpRequest request = HttpRequest.newBuilder().uri(requestURI).GET().build();
+        HttpResponse<String> response = client.send(request,
+                                                    HttpResponse.BodyHandlers.ofString());
+
+        return response;
+    }
+
+    public static HttpClient createHttpClient() {
+        HttpClient client = HttpClient.newBuilder().build();
+        return client;
+    }
+
+    public static HttpClient createHttpClient(String user, String password) {
+        HttpClient client = HttpClient.newBuilder().authenticator(new Authenticator() {
+            @Override
+            protected PasswordAuthentication getPasswordAuthentication() {
+                return new PasswordAuthentication(user, password.toCharArray());
+            }
+        }).build();
+        return client;
+    }
+
+    public static void validateResponse(String response, String user, Set<String> declaredRolesExpected, Set<String> allRolesExpected, boolean isStarStarMapped,
+                                        InRoleOutput componentOutput) {
+        StringBuilder errorMessage = new StringBuilder();
+        String userInResponse = getValue(response, "User Principal:", errorMessage, true);
+        if (userInResponse != null && !userInResponse.equals(user)) {
+            errorMessage.append("User Principal in response was ").append(userInResponse).append(", but expected ").append(user).append('\n');
+        }
+        userInResponse = getValue(response, "Caller Principal:", errorMessage, true);
+        if (userInResponse != null && !userInResponse.equals(user)) {
+            errorMessage.append("Caller Principal in response was ").append(userInResponse).append(", but expected ").append(user).append('\n');
+        }
+
+        /**
+         * Presently Component context isUserInRole() returns true for any declared roles, whereas
+         * SecurityContext.isCallerInRole is returning true for all roles that are mapped even if they are not
+         * declared roles in the servlet.
+         */
+
+        Set<String> componentRolesExpected = declaredRolesExpected;
+        if (componentOutput == InRoleOutput.ALL) {
+            componentRolesExpected = allRolesExpected;
+        }
+        for (String role : TestUtil.allRoles) {
+            String inRoleString = getValue(response, "User in role " + role + ":", errorMessage, true);
+            if (inRoleString != null) {
+                Boolean inRoleBoolean = "true".equals(inRoleString) ? Boolean.TRUE : "false".equals(inRoleString) ? Boolean.FALSE : null;
+                boolean expectedUserInRole = componentRolesExpected.contains(role);
+                if (inRoleBoolean == null || expectedUserInRole != inRoleBoolean.booleanValue()) {
+                    errorMessage.append("User in role in response for role ").append(role).append(" was ").append(inRoleString).append(", but expected ").append(expectedUserInRole).append('\n');
+                }
+            }
+            inRoleString = getValue(response, "Caller in role " + role + ":", errorMessage, true);
+            if (inRoleString != null) {
+                Boolean inRoleBoolean = "true".equals(inRoleString) ? Boolean.TRUE : "false".equals(inRoleString) ? Boolean.FALSE : null;
+                boolean expectedCallerInRole = allRolesExpected.contains(role);
+                if (inRoleBoolean == null || expectedCallerInRole != inRoleBoolean.booleanValue()) {
+                    errorMessage.append("Caller in role in response for role ").append(role).append(" was ").append(inRoleString).append(", but expected ").append(expectedCallerInRole).append('\n');
+                }
+            }
+        }
+        String inRoleString = getValue(response, "User in role **:", errorMessage, true);
+        if (inRoleString != null) {
+            Boolean inRoleBoolean = "true".equals(inRoleString) ? Boolean.TRUE : "false".equals(inRoleString) ? Boolean.FALSE : null;
+            boolean expectedUserInRole = !user.equals("Not authenticated");
+            if (inRoleBoolean == null || expectedUserInRole != inRoleBoolean.booleanValue()) {
+                errorMessage.append("User in role in response for role ** was ").append(inRoleString).append(", but expected ").append(expectedUserInRole).append('\n');
+            }
+        }
+        inRoleString = getValue(response, "Caller in role **:", errorMessage, true);
+        if (inRoleString != null) {
+            Boolean inRoleBoolean = "true".equals(inRoleString) ? Boolean.TRUE : "false".equals(inRoleString) ? Boolean.FALSE : null;
+            boolean expectedCallerInRole = !user.equals("Not authenticated");
+            if (inRoleBoolean == null || expectedCallerInRole != inRoleBoolean.booleanValue()) {
+                errorMessage.append("Caller in role in response for role ** was ").append(inRoleString).append(", but expected ").append(expectedCallerInRole).append('\n');
+            }
+        }
+
+        String declaredRolesString = getValue(response, "Declared Roles:", errorMessage, true);
+        if (declaredRolesString != null) {
+            setComparison(declaredRolesString, "Declared roles", declaredRolesExpected, errorMessage);
+        }
+
+        boolean policyEnabled = RepeatTestFilter.isRepeatActionActive(WITH_POLICY_ID);
+
+        String isStarStarMappedString = getValue(response, "Is ** mapped:", errorMessage, policyEnabled);
+        if (isStarStarMappedString != null) {
+            Boolean inMappedBoolean = "true".equals(isStarStarMappedString) ? Boolean.TRUE : "false".equals(isStarStarMappedString) ? Boolean.FALSE : null;
+            if (inMappedBoolean == null || isStarStarMapped != inMappedBoolean.booleanValue()) {
+                errorMessage.append("Is ** mapped in response was ").append(isStarStarMappedString).append(", but expected ").append(isStarStarMapped).append('\n');
+            }
+        }
+
+        String allRolesString = getValue(response, "PrincipalMapper Roles for subject:", errorMessage, policyEnabled);
+        if (allRolesString != null) {
+            setComparison(allRolesString, "PrincipalMapper roles for subject", allRolesExpected, errorMessage);
+        }
+        if (errorMessage.length() > 0) {
+            System.out.println(response);
+            Assert.fail("Response did not contain expected value \n" + errorMessage.toString());
+        }
+    }
+
+    private static void setComparison(String valueFromResponse, String messagePrefix, Set<String> expectedValue, StringBuilder errorMessage) {
+        Set<String> responseSet = valueFromResponse.equals("") ? Set.of() : Set.of(valueFromResponse.split(", "));
+        boolean mismatch = responseSet.size() != expectedValue.size();
+        if (!mismatch) {
+            for (String expectedRole : expectedValue) {
+                if (!responseSet.contains(expectedRole)) {
+                    mismatch = true;
+                    break;
+                }
+            }
+        }
+        if (mismatch) {
+            errorMessage.append(messagePrefix).append(" in response was ").append(valueFromResponse).append(", but expected ").append(TestUtil.setToString(expectedValue)).append('\n');
+        }
+
+    }
+
+    private static String getValue(String response, String prefix, StringBuilder errorMessage, boolean expectedValue) {
+        int index = response.indexOf(prefix);
+        if (index >= 0) {
+            if (!expectedValue) {
+                errorMessage.append(prefix).append(" found in response when it wasn't expected\n");
+            }
+            int startIndex = response.indexOf(':', index);
+            int endIndex = response.indexOf('\n', index);
+            if (startIndex >= 0 && endIndex >= 0) {
+                return response.substring(startIndex + 1, endIndex).trim();
+            }
+        }
+        if (expectedValue) {
+            errorMessage.append(prefix).append(" not found in response\n");
+        }
+        return null;
+    }
+
+    public static void installJaccUserFeature(LibertyServer myServer) throws Exception {
+        myServer.installUserBundle("io.openliberty.security.authorization.jacc.testprovider_3.0");
+        myServer.installUserFeature("jaccTestProvider-3.0");
+        myServer.installUserBundle("io.openliberty.security.authorization.jacc.testprovider.spec_3.0");
+        myServer.installUserFeature("authzTestProvider-3.0");
+    }
+
+    public static void uninstallJaccUserFeature(LibertyServer myServer) throws Exception {
+        myServer.uninstallUserBundle("io.openliberty.security.authorization.jacc.testprovider_3.0");
+        myServer.uninstallUserFeature("jaccTestProvider-3.0");
+        myServer.uninstallUserBundle("io.openliberty.security.authorization.jacc.testprovider.spec_3.0");
+        myServer.uninstallUserFeature("authzTestProvider-3.0");
+    }
+}

--- a/dev/io.openliberty.security.authorization.internal.3.0_fat/fat/src/io/openliberty/security/authorization/internal/tests/AnnotationRoleGroupTest.java
+++ b/dev/io.openliberty.security.authorization.internal.3.0_fat/fat/src/io/openliberty/security/authorization/internal/tests/AnnotationRoleGroupTest.java
@@ -1,0 +1,50 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.security.authorization.internal.tests;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+
+import componenttest.annotation.Server;
+import componenttest.rules.repeater.FeatureReplacementAction;
+import componenttest.rules.repeater.RepeatTests;
+import componenttest.topology.impl.LibertyServer;
+
+public class AnnotationRoleGroupTest extends AnnotationRolesTest {
+
+    private static final String SERVER_NAME = "AnnotationGroupTest";
+
+    @ClassRule
+    public static RepeatTests repeats = RepeatTests.withoutModification() //
+                    .andWith(new FeatureReplacementAction().forServers(SERVER_NAME).addFeature("appAuthorization-3.0").withID(WITH_AUTHZ_ID)) //
+                    .andWith(new FeatureReplacementAction().forServers(SERVER_NAME).addFeature("usr:authzTestProvider-3.0").withID(WITH_POLICY_ID));
+
+    @Server(SERVER_NAME)
+    public static LibertyServer groupServer;
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        installJaccUserFeature(groupServer);
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        if (groupServer.isStarted()) {
+            groupServer.stopServer();
+        }
+        uninstallJaccUserFeature(groupServer);
+    }
+
+    @Override
+    protected LibertyServer getLibertyServer() {
+        return groupServer;
+    }
+}

--- a/dev/io.openliberty.security.authorization.internal.3.0_fat/fat/src/io/openliberty/security/authorization/internal/tests/AnnotationRolesTest.java
+++ b/dev/io.openliberty.security.authorization.internal.3.0_fat/fat/src/io/openliberty/security/authorization/internal/tests/AnnotationRolesTest.java
@@ -1,0 +1,195 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.security.authorization.internal.tests;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.net.http.HttpClient;
+import java.net.http.HttpResponse;
+import java.util.Set;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions;
+import com.ibm.websphere.simplicity.beansxml.BeansAsset;
+import com.ibm.websphere.simplicity.beansxml.BeansAsset.CDIVersion;
+import com.ibm.websphere.simplicity.beansxml.BeansAsset.DiscoveryMode;
+
+import componenttest.annotation.Server;
+import componenttest.annotation.SkipForRepeat;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.custom.junit.runner.RepeatTestFilter;
+import componenttest.rules.repeater.FeatureReplacementAction;
+import componenttest.rules.repeater.RepeatTests;
+import componenttest.topology.impl.LibertyServer;
+import io.openliberty.security.authorization.ejb.annotations.EJBAnnotationServlet1;
+import io.openliberty.security.authorization.fat.TestUtil;
+import io.openliberty.security.authorization.rest.annotations.RestApplication;
+import io.openliberty.security.authorization.web.annotations.WebAnnotationServlet1;
+
+@RunWith(FATRunner.class)
+public class AnnotationRolesTest extends AbstractRolesTest {
+
+    private static final String SERVER_NAME = "AnnotationTest";
+
+    @ClassRule
+    public static RepeatTests repeats = RepeatTests.withoutModification() //
+                    .andWith(new FeatureReplacementAction().forServers(SERVER_NAME).addFeature("appAuthorization-3.0").withID(WITH_AUTHZ_ID)) //
+                    .andWith(new FeatureReplacementAction().forServers(SERVER_NAME).addFeature("usr:authzTestProvider-3.0").withID(WITH_POLICY_ID));
+
+    @Server(SERVER_NAME)
+    public static LibertyServer staticServer;
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        installJaccUserFeature(staticServer);
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        if (staticServer.isStarted()) {
+            staticServer.stopServer();
+        }
+        uninstallJaccUserFeature(staticServer);
+    }
+
+    protected LibertyServer getLibertyServer() {
+        return staticServer;
+    }
+
+    @Test
+    public void validateServlet() throws Exception {
+        WebArchive war = ShrinkWrap.create(WebArchive.class, "annotationTest.war") //
+                        .addPackages(false, TestUtil.class.getPackageName(), WebAnnotationServlet1.class.getPackageName()) //
+                        .addAsWebInfResource(BeansAsset.getBeansAsset(DiscoveryMode.ALL, CDIVersion.CDI41), "beans.xml");
+        if (RepeatTestFilter.isRepeatActionActive(WITH_POLICY_ID)) {
+            war.addAsWebInfResource(WebAnnotationServlet1.class.getPackage(), "web.xml", "web.xml");
+        }
+        LibertyServer server = getLibertyServer();
+        if (!server.isStarted()) {
+            ShrinkHelper.exportAppToServer(server, war, DeployOptions.SERVER_ONLY);
+            server.startServer();
+        } else {
+            server.setMarkToEndOfLog();
+            ShrinkHelper.exportAppToServer(server, war, DeployOptions.SERVER_ONLY, DeployOptions.DISABLE_VALIDATION);
+            assertNotNull("The application annotationTest did not appear to have been updated.",
+                          server.waitForStringInLog("CWWKZ0003I.* annotationTest"));
+        }
+
+        HttpClient client = createHttpClient("user1", "user1pwd");
+        HttpResponse<String> response = sendGetRequest(server, client, "/annotationTest/servlet1");
+        assertEquals(200, response.statusCode());
+        validateResponse(response.body(), "user1", Set.of("WebRole1", "WebRole3"), Set.of("CDIRole2", "CDIRole3", "CDIRole4",
+                                                                                          "WebRole1", "WebRole3", "WebRole4",
+                                                                                          "EJBRole1", "EJBRole2", "EJBRole4",
+                                                                                          "RestRole1", "RestRole2", "RestRole3",
+                                                                                          "WebServicesRole2", "WebServicesRole3", "WebServicesRole4",
+                                                                                          "AllAuthenticated"),
+                         false, InRoleOutput.DECLARED_IN_COMPONENT);
+        client = createHttpClient();
+        response = sendGetRequest(server, client, "/annotationTest/servlet1");
+        assertEquals(401, response.statusCode());
+
+        if (RepeatTestFilter.isRepeatActionActive(WITH_POLICY_ID)) {
+            response = sendGetRequest(server, client, "/annotationTest/servlet1/allowUnauthenticated");
+            assertEquals(200, response.statusCode());
+            validateResponse(response.body(), "Not authenticated", Set.of(), Set.of(),
+                             false, InRoleOutput.DECLARED_IN_COMPONENT);
+        }
+    }
+
+    @Test
+    public void validateEJB() throws Exception {
+        WebArchive war = ShrinkWrap.create(WebArchive.class, "annotationTest.war") //
+                        .addPackages(false, TestUtil.class.getPackageName(), EJBAnnotationServlet1.class.getPackageName()) //
+                        .addAsWebInfResource(BeansAsset.getBeansAsset(DiscoveryMode.ALL, CDIVersion.CDI41), "beans.xml");
+        if (RepeatTestFilter.isRepeatActionActive(WITH_POLICY_ID)) {
+            war.addAsWebInfResource(EJBAnnotationServlet1.class.getPackage(), "overrideweb.xml", "web.xml");
+        } else {
+            war.addAsWebInfResource(EJBAnnotationServlet1.class.getPackage(), "web.xml", "web.xml");
+        }
+        LibertyServer server = getLibertyServer();
+        if (!server.isStarted()) {
+            ShrinkHelper.exportAppToServer(server, war, DeployOptions.SERVER_ONLY);
+            server.startServer();
+        } else {
+            server.setMarkToEndOfLog();
+            ShrinkHelper.exportAppToServer(server, war, DeployOptions.SERVER_ONLY, DeployOptions.DISABLE_VALIDATION);
+            assertNotNull("The application annotationTest did not appear to have been updated.",
+                          server.waitForStringInLog("CWWKZ0003I.* annotationTest"));
+        }
+
+        HttpClient client = createHttpClient("user1", "user1pwd");
+        HttpResponse<String> response = sendGetRequest(server, client, "/annotationTest/ejbServlet1");
+        assertEquals(200, response.statusCode());
+        validateResponse(response.body(), "user1", Set.of("EJBRole1", "EJBRole2"), Set.of("CDIRole2", "CDIRole3", "CDIRole4",
+                                                                                          "WebRole1", "WebRole3", "WebRole4",
+                                                                                          "EJBRole1", "EJBRole2", "EJBRole4",
+                                                                                          "RestRole1", "RestRole2", "RestRole3",
+                                                                                          "WebServicesRole2", "WebServicesRole3", "WebServicesRole4",
+                                                                                          "AllAuthenticated"),
+                         // When using not using a policy, all roles are returned instead of only the ones declared in the EJBs.
+                         // When there is a policy, then it only returns the ones that are declared.
+                         false, RepeatTestFilter.isRepeatActionActive(WITH_POLICY_ID) ? InRoleOutput.DECLARED_IN_COMPONENT : InRoleOutput.ALL);
+
+        client = createHttpClient();
+        response = sendGetRequest(server, client, "/annotationTest/ejbServlet1");
+        assertEquals(401, response.statusCode());
+
+        if (RepeatTestFilter.isRepeatActionActive(WITH_POLICY_ID)) {
+            response = sendGetRequest(server, client, "/annotationTest/ejbServlet1/allowUnauthenticated");
+            assertEquals(200, response.statusCode());
+            validateResponse(response.body(), "Not authenticated", Set.of(), Set.of(),
+                             false, InRoleOutput.DECLARED_IN_COMPONENT);
+        }
+    }
+
+    @Test
+    @SkipForRepeat(WITH_POLICY_ID) // Rest Permissions are not put into the Jakarta Authorization policy, so will not get expected behavior
+    public void validateRest() throws Exception {
+        WebArchive war = ShrinkWrap.create(WebArchive.class, "annotationTest.war") //
+                        .addPackages(false, TestUtil.class.getPackageName(), RestApplication.class.getPackageName()) //
+                        .addAsWebInfResource(BeansAsset.getBeansAsset(DiscoveryMode.ALL, CDIVersion.CDI41), "beans.xml");
+        //.addAsWebInfResource(RestApplication.class.getPackage(), "web.xml", "web.xml");
+        LibertyServer server = getLibertyServer();
+        if (!server.isStarted()) {
+            ShrinkHelper.exportAppToServer(server, war, DeployOptions.SERVER_ONLY);
+            server.startServer();
+        } else {
+            server.setMarkToEndOfLog();
+            ShrinkHelper.exportAppToServer(server, war, DeployOptions.SERVER_ONLY, DeployOptions.DISABLE_VALIDATION);
+            assertNotNull("The application annotationTest did not appear to have been updated.",
+                          server.waitForStringInLog("CWWKZ0003I.* annotationTest"));
+        }
+
+        HttpClient client = createHttpClient("user1", "user1pwd");
+        HttpResponse<String> response = sendGetRequest(server, client, "/annotationTest/rest/resource1/doTest");
+        assertEquals(200, response.statusCode());
+        validateResponse(response.body(), "user1", Set.of("RestRole1", "RestRole2"), Set.of("CDIRole2", "CDIRole3", "CDIRole4",
+                                                                                            "WebRole1", "WebRole3", "WebRole4",
+                                                                                            "EJBRole1", "EJBRole2", "EJBRole4",
+                                                                                            "RestRole1", "RestRole2", "RestRole3",
+                                                                                            "WebServicesRole2", "WebServicesRole3", "WebServicesRole4",
+                                                                                            "AllAuthenticated"),
+                         false, InRoleOutput.DECLARED_IN_COMPONENT);
+
+        client = createHttpClient();
+        response = sendGetRequest(server, client, "/annotationTest/rest/resource1/doTest");
+        assertEquals(401, response.statusCode());
+    }
+}

--- a/dev/io.openliberty.security.authorization.internal.3.0_fat/fat/src/io/openliberty/security/authorization/internal/tests/FATSuite.java
+++ b/dev/io.openliberty.security.authorization.internal.3.0_fat/fat/src/io/openliberty/security/authorization/internal/tests/FATSuite.java
@@ -17,7 +17,9 @@ import org.junit.runners.Suite.SuiteClasses;
 @RunWith(Suite.class)
 @SuiteClasses({
                 FactoryMessagesTests.class,
-                ProviderServiceRemovalTest.class
+                ProviderServiceRemovalTest.class,
+                AnnotationRolesTest.class,
+                AnnotationRoleGroupTest.class
 })
 public class FATSuite {
 }

--- a/dev/io.openliberty.security.authorization.internal.3.0_fat/fat/src/io/openliberty/security/authorization/rest/annotations/RestApplication.java
+++ b/dev/io.openliberty.security.authorization.internal.3.0_fat/fat/src/io/openliberty/security/authorization/rest/annotations/RestApplication.java
@@ -1,0 +1,18 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.security.authorization.rest.annotations;
+
+import jakarta.ws.rs.ApplicationPath;
+import jakarta.ws.rs.core.Application;
+
+@ApplicationPath("/rest")
+public class RestApplication extends Application {
+
+}

--- a/dev/io.openliberty.security.authorization.internal.3.0_fat/fat/src/io/openliberty/security/authorization/rest/annotations/RestResource1.java
+++ b/dev/io.openliberty.security.authorization.internal.3.0_fat/fat/src/io/openliberty/security/authorization/rest/annotations/RestResource1.java
@@ -1,0 +1,59 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.security.authorization.rest.annotations;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+
+import io.openliberty.security.authorization.fat.RestContextWrapper;
+import io.openliberty.security.authorization.fat.TestUtil;
+import jakarta.annotation.security.RolesAllowed;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.MediaType;
+
+@Path("/resource1")
+public class RestResource1 {
+
+    @Inject
+    private jakarta.security.enterprise.SecurityContext securityContext;
+
+    @Context
+    private jakarta.ws.rs.core.SecurityContext restSecContext;
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    @RolesAllowed({ "RestRole1" })
+    @Path("/doTest")
+    public String doTest() {
+        StringWriter sw = new StringWriter();
+        PrintWriter out = new PrintWriter(sw);
+        TestUtil.printSecurityData(out, new RestContextWrapper(restSecContext), securityContext);
+        out.flush();
+        return sw.toString();
+
+    }
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    @RolesAllowed({ "RestRole2" })
+    @Path("/doTest2")
+    public String doTest2() {
+        StringWriter sw = new StringWriter();
+        PrintWriter out = new PrintWriter(sw);
+        TestUtil.printSecurityData(out, new RestContextWrapper(restSecContext), securityContext);
+        out.flush();
+        return sw.toString();
+
+    }
+}

--- a/dev/io.openliberty.security.authorization.internal.3.0_fat/fat/src/io/openliberty/security/authorization/rest/annotations/RestResource2.java
+++ b/dev/io.openliberty.security.authorization.internal.3.0_fat/fat/src/io/openliberty/security/authorization/rest/annotations/RestResource2.java
@@ -1,0 +1,59 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.security.authorization.rest.annotations;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+
+import io.openliberty.security.authorization.fat.RestContextWrapper;
+import io.openliberty.security.authorization.fat.TestUtil;
+import jakarta.annotation.security.RolesAllowed;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.MediaType;
+
+@Path("/resource2")
+public class RestResource2 {
+
+    @Inject
+    private jakarta.security.enterprise.SecurityContext securityContext;
+
+    @Context
+    private jakarta.ws.rs.core.SecurityContext restSecContext;
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    @RolesAllowed({ "RestRole2" })
+    @Path("/doTest")
+    public String doTest() {
+        StringWriter sw = new StringWriter();
+        PrintWriter out = new PrintWriter(sw);
+        TestUtil.printSecurityData(out, new RestContextWrapper(restSecContext), securityContext);
+        out.flush();
+        return sw.toString();
+
+    }
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    @RolesAllowed({ "RestRole4" })
+    @Path("/doTest2")
+    public String doTest2() {
+        StringWriter sw = new StringWriter();
+        PrintWriter out = new PrintWriter(sw);
+        TestUtil.printSecurityData(out, new RestContextWrapper(restSecContext), securityContext);
+        out.flush();
+        return sw.toString();
+
+    }
+}

--- a/dev/io.openliberty.security.authorization.internal.3.0_fat/fat/src/io/openliberty/security/authorization/rest/annotations/web.xml
+++ b/dev/io.openliberty.security.authorization.internal.3.0_fat/fat/src/io/openliberty/security/authorization/rest/annotations/web.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<web-app xmlns="https://jakarta.ee/xml/ns/jakartaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee 
+         https://jakarta.ee/xml/ns/jakartaee/web-app_6_1.xsd"
+         version="6.1">
+    
+    <security-constraint>
+        <web-resource-collection>
+            <url-pattern>/rest/*</url-pattern>
+        </web-resource-collection>
+        <auth-constraint>
+            <role-name>**</role-name>
+        </auth-constraint>
+    </security-constraint>
+    <login-config>
+        <auth-method>BASIC</auth-method>
+        <realm-name>authz</realm-name>
+    </login-config>
+    
+</web-app>

--- a/dev/io.openliberty.security.authorization.internal.3.0_fat/fat/src/io/openliberty/security/authorization/web/annotations/AbstractRoleTestServlet.java
+++ b/dev/io.openliberty.security.authorization.internal.3.0_fat/fat/src/io/openliberty/security/authorization/web/annotations/AbstractRoleTestServlet.java
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.security.authorization.web.annotations;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+
+import io.openliberty.security.authorization.fat.ServletContextWrapper;
+import io.openliberty.security.authorization.fat.TestUtil;
+import jakarta.inject.Inject;
+import jakarta.security.enterprise.SecurityContext;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+public class AbstractRoleTestServlet extends HttpServlet {
+
+    @Inject
+    SecurityContext secContext;
+
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        PrintWriter out = response.getWriter();
+        TestUtil.printSecurityData(out, new ServletContextWrapper(request), secContext);
+    }
+}

--- a/dev/io.openliberty.security.authorization.internal.3.0_fat/fat/src/io/openliberty/security/authorization/web/annotations/WebAnnotationServlet1.java
+++ b/dev/io.openliberty.security.authorization.internal.3.0_fat/fat/src/io/openliberty/security/authorization/web/annotations/WebAnnotationServlet1.java
@@ -1,0 +1,23 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.security.authorization.web.annotations;
+
+import jakarta.annotation.security.DeclareRoles;
+import jakarta.servlet.annotation.HttpConstraint;
+import jakarta.servlet.annotation.ServletSecurity;
+import jakarta.servlet.annotation.WebServlet;
+
+@WebServlet("/servlet1/*")
+@DeclareRoles({ "WebRole1", "WebRole2" })
+@ServletSecurity(@HttpConstraint(rolesAllowed = { "WebRole1" }))
+public class WebAnnotationServlet1 extends AbstractRoleTestServlet {
+
+    private static final long serialVersionUID = 1L;
+}

--- a/dev/io.openliberty.security.authorization.internal.3.0_fat/fat/src/io/openliberty/security/authorization/web/annotations/WebAnnotationServlet2.java
+++ b/dev/io.openliberty.security.authorization.internal.3.0_fat/fat/src/io/openliberty/security/authorization/web/annotations/WebAnnotationServlet2.java
@@ -1,0 +1,23 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.security.authorization.web.annotations;
+
+import jakarta.annotation.security.DeclareRoles;
+import jakarta.servlet.annotation.HttpConstraint;
+import jakarta.servlet.annotation.ServletSecurity;
+import jakarta.servlet.annotation.WebServlet;
+
+@WebServlet("/servlet2/*")
+@DeclareRoles({ "WebRole2", "WebRole3" })
+@ServletSecurity(@HttpConstraint(rolesAllowed = { "WebRole2" }))
+public class WebAnnotationServlet2 extends AbstractRoleTestServlet {
+
+    private static final long serialVersionUID = 1L;
+}

--- a/dev/io.openliberty.security.authorization.internal.3.0_fat/fat/src/io/openliberty/security/authorization/web/annotations/web.xml
+++ b/dev/io.openliberty.security.authorization.internal.3.0_fat/fat/src/io/openliberty/security/authorization/web/annotations/web.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<web-app xmlns="https://jakarta.ee/xml/ns/jakartaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee 
+         https://jakarta.ee/xml/ns/jakartaee/web-app_6_1.xsd"
+         version="6.1">
+    
+  <context-param>
+    <param-name>jakarta.security.jacc.PolicyFactory.provider</param-name>
+    <param-value>io.openliberty.security.authorization.fat.OverridePolicyFactory</param-value>
+  </context-param>
+    
+</web-app>

--- a/dev/io.openliberty.security.authorization.internal.3.0_fat/publish/servers/AnnotationGroupTest/bootstrap.properties
+++ b/dev/io.openliberty.security.authorization.internal.3.0_fat/publish/servers/AnnotationGroupTest/bootstrap.properties
@@ -1,0 +1,11 @@
+###############################################################################
+# Copyright (c) 2026 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+###############################################################################
+bootstrap.include=../testports.properties
+com.ibm.ws.logging.trace.specification=*=info

--- a/dev/io.openliberty.security.authorization.internal.3.0_fat/publish/servers/AnnotationGroupTest/server.xml
+++ b/dev/io.openliberty.security.authorization.internal.3.0_fat/publish/servers/AnnotationGroupTest/server.xml
@@ -1,0 +1,107 @@
+<!--
+  ~ Copyright (c) 2026 IBM Corporation and others.
+  ~ All rights reserved. This program and the accompanying materials
+  ~ are made available under the terms of the Eclipse Public License 2.0
+  ~ which accompanies this distribution, and is available at
+  ~ http://www.eclipse.org/legal/epl-2.0/
+  ~
+  ~ SPDX-License-Identifier: EPL-2.0
+  -->
+
+<server>
+    <featureManager>
+        <feature>webProfile-11.0</feature>
+    </featureManager>
+
+    <include location="../fatTestPorts.xml"/>
+
+    <webContainer deferServletLoad="false"/>
+
+	<basicRegistry id="basic" realm="authz">
+        <user name="user0" password="user0pwd" />
+        <user name="user1" password="user1pwd" />
+        <user name="user2" password="user2pwd" />
+        <group name="CDIRole1">
+            <member name="user2"/>
+        </group>
+        <group name="CDIRole2">
+            <member name="user1"/>
+        </group>
+        <group name="CDIRole3">
+            <member name="user1"/>
+            <member name="user2"/>
+        </group>
+        <group name="CDIRole4">
+            <member name="user0"/>
+            <member name="user1"/>
+        </group>
+        <group name="WebRole1">
+            <member name="user1"/>
+        </group>
+        <group name="WebRole2">
+            <member name="user2"/>
+        </group>
+        <group name="WebRole3">
+            <member name="user0"/>
+            <member name="user1"/>
+        </group>
+        <group name="WebRole4">
+            <member name="user0"/>
+            <member name="user1"/>
+            <member name="user2"/>
+        </group>
+        <group name="EJBRole1">
+            <member name="user0"/>
+            <member name="user1"/>
+            <member name="user2"/>
+        </group>
+        <group name="EJBRole2">
+            <member name="user0"/>
+            <member name="user1"/>
+        </group>
+        <group name="EJBRole3">
+            <member name="user2"/>
+        </group>
+        <group name="EJBRole4">
+            <member name="user1"/>
+        </group>
+        <group name="RestRole1">
+            <member name="user0"/>
+            <member name="user1"/>
+        </group>
+        <group name="RestRole2">
+            <member name="user0"/>
+            <member name="user1"/>
+            <member name="user2"/>
+        </group>
+        <group name="RestRole3">
+            <member name="user1"/>
+        </group>
+        <group name="RestRole4">
+            <member name="user2"/>
+        </group>
+        <group name="WebServicesRole1">
+            <member name="user2"/>
+        </group>
+        <group name="WebServicesRole2">
+            <member name="user1"/>
+        </group>
+        <group name="WebServicesRole3">
+            <member name="user0"/>
+            <member name="user1"/>
+            <member name="user2"/>
+        </group>
+        <group name="WebServicesRole4">
+            <member name="user0"/>
+            <member name="user1"/>
+        </group>
+        <group name="AllAuthenticated">
+            <member name="user0"/>
+            <member name="user1"/>
+            <member name="user2"/>
+        </group>
+	</basicRegistry>
+
+	<application type="war" id="annotationTest" name="annotationTest" location="${server.config.dir}/apps/annotationTest.war"/>
+
+</server>

--- a/dev/io.openliberty.security.authorization.internal.3.0_fat/publish/servers/AnnotationTest/bootstrap.properties
+++ b/dev/io.openliberty.security.authorization.internal.3.0_fat/publish/servers/AnnotationTest/bootstrap.properties
@@ -1,0 +1,11 @@
+###############################################################################
+# Copyright (c) 2026 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+###############################################################################
+bootstrap.include=../testports.properties
+com.ibm.ws.logging.trace.specification=*=info

--- a/dev/io.openliberty.security.authorization.internal.3.0_fat/publish/servers/AnnotationTest/server.xml
+++ b/dev/io.openliberty.security.authorization.internal.3.0_fat/publish/servers/AnnotationTest/server.xml
@@ -1,0 +1,119 @@
+<!--
+  ~ Copyright (c) 2026 IBM Corporation and others.
+  ~ All rights reserved. This program and the accompanying materials
+  ~ are made available under the terms of the Eclipse Public License 2.0
+  ~ which accompanies this distribution, and is available at
+  ~ http://www.eclipse.org/legal/epl-2.0/
+  ~
+  ~ SPDX-License-Identifier: EPL-2.0
+  -->
+
+<server>
+    <featureManager>
+        <feature>webProfile-11.0</feature>
+    </featureManager>
+
+    <include location="../fatTestPorts.xml"/>
+
+    <webContainer deferServletLoad="false"/>
+
+	<basicRegistry id="basic" realm="authz">
+		<user name="user0" password="user0pwd" />
+		<user name="user1" password="user1pwd" />
+		<group name="group1">
+			<member name="user0" />
+			<member name="user1" />
+		</group>
+		<user name="user2" password="user2pwd" />
+		<group name="group2">
+			<member name="user1" />
+			<member name="user2" />
+		</group>
+		<user name="user3" password="user3pwd" />
+		<group name="group3">
+			<member name="user3" />
+		</group>
+		<user name="user4" password="user4 pwd" />
+		<group name="group4">
+			<member name="user4" />
+		</group>
+		<user name="user5" password="user5pwd " />
+		<group name="group5">
+			<member name="user5" />
+		</group>
+		<user name="user6" password="user6pwd" />
+	</basicRegistry>
+
+	<application type="war" id="annotationTest" name="annotationTest" location="${server.config.dir}/apps/annotationTest.war">
+        <application-bnd>
+            <security-role name="CDIRole1">
+                <user name="user2"/>
+            </security-role>
+            <security-role name="CDIRole2">
+                <user name="user1"/>
+            </security-role>
+            <security-role name="CDIRole3">
+                <group name="group2"/>
+            </security-role>
+            <security-role name="CDIRole4">
+                <group name="group1"/>
+            </security-role>
+            <security-role name="WebRole1">
+                <user name="user1"/>
+            </security-role>
+            <security-role name="WebRole2">
+                <user name="user2"/>
+            </security-role>
+            <security-role name="WebRole3">
+                <group name="group1"/>
+            </security-role>
+            <security-role name="WebRole4">
+                <group name="group1"/>
+                <group name="group2"/>
+            </security-role>
+            <security-role name="EJBRole1">
+                <group name="group1"/>
+                <group name="group2"/>
+            </security-role>
+            <security-role name="EJBRole2">
+                <group name="group1"/>
+            </security-role>
+            <security-role name="EJBRole3">
+                <user name="user2"/>
+            </security-role>
+            <security-role name="EJBRole4">
+                <user name="user1"/>
+            </security-role>
+            <security-role name="RestRole1">
+                <group name="group1"/>
+            </security-role>
+            <security-role name="RestRole2">
+                <group name="group1"/>
+                <group name="group2"/>
+            </security-role>
+            <security-role name="RestRole3">
+                <user name="user1"/>
+            </security-role>
+            <security-role name="RestRole4">
+                <user name="user2"/>
+            </security-role>
+            <security-role name="WebServicesRole1">
+                <user name="user2"/>
+            </security-role>
+            <security-role name="WebServicesRole2">
+                <user name="user1"/>
+            </security-role>
+            <security-role name="WebServicesRole3">
+                <group name="group1"/>
+                <group name="group2"/>
+            </security-role>
+            <security-role name="WebServicesRole4">
+                <group name="group1"/>
+            </security-role>
+            <security-role name="AllAuthenticated">
+                <special-subject type="ALL_AUTHENTICATED_USERS"/>
+            </security-role>
+        </application-bnd>
+	</application>
+
+</server>

--- a/dev/io.openliberty.security.authorization.internal.jacc.3.0/src/io/openliberty/security/authorization/jacc/internal/proxy/JakartaPolicyFactoryProxyImpl.java
+++ b/dev/io.openliberty.security.authorization.internal.jacc.3.0/src/io/openliberty/security/authorization/jacc/internal/proxy/JakartaPolicyFactoryProxyImpl.java
@@ -10,7 +10,6 @@
 package io.openliberty.security.authorization.jacc.internal.proxy;
 
 import java.security.Permission;
-import java.util.Set;
 
 import javax.security.auth.Subject;
 

--- a/dev/io.openliberty.security.authorization.internal.jacc.3.0/src/io/openliberty/security/authorization/jacc/internal/web/AuthorizationServletInitializer.java
+++ b/dev/io.openliberty.security.authorization.internal.jacc.3.0/src/io/openliberty/security/authorization/jacc/internal/web/AuthorizationServletInitializer.java
@@ -82,11 +82,9 @@ public class AuthorizationServletInitializer implements ServletContainerInitiali
                 if (configFactory != null) {
                     PolicyConfigurationFactory.setPolicyConfigurationFactory(configFactory);
                     configFactoryAdded = true;
-                    Tr.info(tc, "JACC_AUTHORIZATION_MODULE_CONFIGURED", "PolicyConfigurationFactory", configFactoryName, servletContext.getServletContextName());
                     JakartaPolicyConfigFactoryProxy configFactoryProxy = JakartaPolicyConfigFactoryProxy.getInstance();
-                    if (configFactoryProxy != null) {
-                        configFactoryProxy.ensurePolicyConfigInitialized();
-                    }
+                    configFactoryProxy.ensurePolicyConfigInitialized();
+                    Tr.info(tc, "JACC_AUTHORIZATION_MODULE_CONFIGURED", "PolicyConfigurationFactory", configFactoryName, servletContext.getServletContextName());
                 }
             }
 

--- a/dev/io.openliberty.security.authorization.jacc.testprovider/src/com/ibm/ws/security/authorization/jacc/provider/JaccPolicyProxy.java
+++ b/dev/io.openliberty.security.authorization.jacc.testprovider/src/com/ibm/ws/security/authorization/jacc/provider/JaccPolicyProxy.java
@@ -25,29 +25,21 @@ import com.ibm.websphere.ras.annotation.Trivial;
 import jakarta.security.jacc.EJBMethodPermission;
 import jakarta.security.jacc.EJBRoleRefPermission;
 import jakarta.security.jacc.Policy;
-import jakarta.security.jacc.PolicyContextException;
+import jakarta.security.jacc.PolicyContext;
 import jakarta.security.jacc.WebResourcePermission;
 import jakarta.security.jacc.WebRoleRefPermission;
 import jakarta.security.jacc.WebUserDataPermission;
 
-public class JaccPolicyProxy implements Policy {
-    private JaccProvider jaccProvider = null;
+public class JaccPolicyProxy implements Policy, AuthzPolicy {
     private static final TraceComponent tc = Tr.register(JaccPolicyProxy.class);
-    private final String contextID;
 
-    public JaccPolicyProxy(String contextId) {
-        this.contextID = contextId;
+    public JaccPolicyProxy() {
     }
 
     @Override
     public boolean implies(Permission p, Subject subject) {
-        // If there is no policy configuration, the application doesn't
-        // have any security constraints.  In that case return true.
-        WSPolicyConfigurationImpl pc = getPolicyConfiguration();
-        if (pc == null) {
-            return true;
-        }
-        return Policy.super.implies(p, subject);
+        Boolean defaultChecks = implies(subject.getPrincipals(), p);
+        return defaultChecks == null ? false : defaultChecks;
     }
 
     @Override
@@ -55,19 +47,21 @@ public class JaccPolicyProxy implements Policy {
         if (p instanceof WebResourcePermission) {
             Set<Principal> principals = subject == null ? null : subject.getPrincipals();
             if (principals != null && principals.size() > 0) {
-                WSPolicyConfigurationImpl pc = getPolicyConfiguration();
+                WSPolicyConfigurationImpl pc = AuthzPolicy.getPolicyConfiguration();
                 if (pc != null) {
+                    JaccProvider jaccProvider = JaccProvider.getInstance();
                     if (tc.isDebugEnabled())
                         Tr.debug(tc, "Checking the role list");
-                    return jaccProvider.checkRolePerm(pc, p, contextID);
+                    return jaccProvider.checkRolePerm(pc, p, PolicyContext.getContextID());
                 }
             }
         } else if (p instanceof WebRoleRefPermission || p instanceof EJBRoleRefPermission || p instanceof EJBMethodPermission) {
-            WSPolicyConfigurationImpl pc = getPolicyConfiguration();
+            WSPolicyConfigurationImpl pc = AuthzPolicy.getPolicyConfiguration();
             if (pc != null) {
+                JaccProvider jaccProvider = JaccProvider.getInstance();
                 if (tc.isDebugEnabled())
                     Tr.debug(tc, "Checking the role list");
-                return jaccProvider.checkRolePerm(pc, p, contextID);
+                return jaccProvider.checkRolePerm(pc, p, PolicyContext.getContextID());
             }
         }
         return false;
@@ -76,8 +70,9 @@ public class JaccPolicyProxy implements Policy {
     @Override
     public boolean isExcluded(Permission p) {
         if (p instanceof WebResourcePermission || p instanceof WebUserDataPermission || p instanceof EJBMethodPermission) {
-            WSPolicyConfigurationImpl pc = getPolicyConfiguration();
+            WSPolicyConfigurationImpl pc = AuthzPolicy.getPolicyConfiguration();
             if (pc != null) {
+                JaccProvider jaccProvider = JaccProvider.getInstance();
                 if (tc.isDebugEnabled())
                     Tr.debug(tc, "Checking the excluded list");
 
@@ -90,15 +85,16 @@ public class JaccPolicyProxy implements Policy {
     @Override
     public boolean isUnchecked(Permission p) {
         if (p instanceof WebResourcePermission || p instanceof WebUserDataPermission || p instanceof EJBMethodPermission) {
-            WSPolicyConfigurationImpl pc = getPolicyConfiguration();
+            WSPolicyConfigurationImpl pc = AuthzPolicy.getPolicyConfiguration();
             if (pc != null) {
+                JaccProvider jaccProvider = JaccProvider.getInstance();
                 if (tc.isDebugEnabled())
                     Tr.debug(tc, "Checking the unchecked list");
                 if (jaccProvider.checkUncheckedPerm(pc, p)) {
                     return true;
                 }
                 if (p instanceof WebResourcePermission) {
-                    return jaccProvider.isEveryoneGranted(pc, p, contextID);
+                    return jaccProvider.isEveryoneGranted(pc, p, PolicyContext.getContextID());
                 }
             }
         }
@@ -107,37 +103,6 @@ public class JaccPolicyProxy implements Policy {
 
     @Override
     public void refresh() {
-    }
-
-    private WSPolicyConfigurationImpl getPolicyConfiguration() {
-        //get contextID;
-        WSPolicyConfigurationImpl pc = null;
-        pc = AllPolicyConfigs.getInstance().getPolicyConfig(contextID);
-
-        if (pc == null) {
-            if (tc.isDebugEnabled())
-                Tr.debug(tc, "Cannot get the policy configuration object. exit value:false");
-            return null;
-        }
-
-        boolean inService = false;
-        try {
-            inService = pc.inService();
-        } catch (PolicyContextException pce) {
-            if (tc.isDebugEnabled())
-                Tr.debug(tc, "security.jacc.provider.inservice", new Object[] { pce });
-        }
-
-        if (!inService) {
-            if (tc.isDebugEnabled())
-                Tr.debug(tc, "The policy configuration object is not in the commit state. exit value:false");
-            return null;
-        }
-
-        if (jaccProvider == null) {
-            jaccProvider = JaccProvider.getInstance();
-        }
-        return pc;
     }
 
     @Override
@@ -166,74 +131,7 @@ public class JaccPolicyProxy implements Policy {
         @Trivial
         @Override
         public boolean implies(Permission p) {
-            boolean result = false;
-            Set<Principal> principals = subject == null ? null : subject.getPrincipals();
-            if (p instanceof WebResourcePermission) {
-                WSPolicyConfigurationImpl pc = getPolicyConfiguration();
-                if (pc == null) {
-                    return false;
-                }
-                if (principals == null || principals.size() < 1) {
-                    if (tc.isDebugEnabled())
-                        Tr.debug(tc, "Checking the unchecked list");
-                    if (jaccProvider.checkUncheckedPerm(pc, p)) {
-                        return true;
-                    } else {
-                        return jaccProvider.isEveryoneGranted(pc, p, contextID);
-                    }
-                } else {
-                    if (tc.isDebugEnabled())
-                        Tr.debug(tc, "Checking the excluded list");
-                    if (jaccProvider.checkExcludedPerm(pc, p)) {
-                        return false;
-                    } else {
-                        if (tc.isDebugEnabled())
-                            Tr.debug(tc, "Checking the role list");
-                        return jaccProvider.checkRolePerm(pc, p, contextID);
-                    }
-                }
-            } else if (p instanceof WebUserDataPermission) {
-                WSPolicyConfigurationImpl pc = getPolicyConfiguration();
-                if (pc == null) {
-                    return false;
-                }
-                if (tc.isDebugEnabled())
-                    Tr.debug(tc, "Checking the excluded list");
-                if (jaccProvider.checkExcludedPerm(pc, p)) {
-                    return false;
-                } else {
-                    if (tc.isDebugEnabled())
-                        Tr.debug(tc, "Not in the excluded list: Checking for unchecked");
-                    return jaccProvider.checkUncheckedPerm(pc, p);
-                }
-            } else if (p instanceof WebRoleRefPermission || p instanceof EJBRoleRefPermission) {
-                WSPolicyConfigurationImpl pc = getPolicyConfiguration();
-                if (pc == null) {
-                    return false;
-                }
-                if (tc.isDebugEnabled())
-                    Tr.debug(tc, "Checking the role list");
-                return jaccProvider.checkRolePerm(pc, p, contextID);
-            } else if (p instanceof EJBMethodPermission) {
-                WSPolicyConfigurationImpl pc = getPolicyConfiguration();
-                if (pc == null) {
-                    return false;
-                }
-                if (tc.isDebugEnabled())
-                    Tr.debug(tc, "Checking the excluded list");
-                if (jaccProvider.checkExcludedPerm(pc, p)) {
-                    return false;
-                } else {
-                    if (tc.isDebugEnabled())
-                        Tr.debug(tc, "Checking the unchecked list");
-                    if (jaccProvider.checkUncheckedPerm(pc, p)) {
-                        return true;
-                    } else {
-                        return jaccProvider.checkRolePerm(pc, p, contextID);
-                    }
-                }
-            }
-            return result;
+            return JaccPolicyProxy.this.implies(p, subject);
         }
 
         @Override

--- a/dev/io.openliberty.security.authorization.jacc.testprovider/src/com/ibm/ws/security/authorization/jacc/provider/JaccPolicyProxyFactory.java
+++ b/dev/io.openliberty.security.authorization.jacc.testprovider/src/com/ibm/ws/security/authorization/jacc/provider/JaccPolicyProxyFactory.java
@@ -19,26 +19,24 @@ public class JaccPolicyProxyFactory extends PolicyFactory {
 
     private final Map<String, Policy> policyMap = new ConcurrentHashMap<>();
 
+    private volatile Policy globalPolicy = new JaccPolicyProxy();
+
     @Override
     public Policy getPolicy(String contextId) {
         if (contextId == null) {
-            return null;
+            return globalPolicy;
         }
 
         Policy policy = policyMap.get(contextId);
-        if (policy == null) {
-            // get policy and set it in the map
-            policy = new JaccPolicyProxy(contextId);
-            policyMap.put(contextId, policy);
-        }
-
-        return policy;
+        return policy == null ? globalPolicy : policy;
     }
 
     @Override
     public void setPolicy(String contextId, Policy policy) {
         if (contextId != null) {
             policyMap.put(contextId, policy);
+        } else {
+            globalPolicy = policy;
         }
     }
 

--- a/dev/io.openliberty.security.authorization.jacc.testprovider/src/com/ibm/ws/security/authorization/jacc/provider/PolicyFactoryImpl.java
+++ b/dev/io.openliberty.security.authorization.jacc.testprovider/src/com/ibm/ws/security/authorization/jacc/provider/PolicyFactoryImpl.java
@@ -19,10 +19,12 @@ public class PolicyFactoryImpl extends PolicyFactory {
 
     private final Map<String, Policy> policyMap = new ConcurrentHashMap<>();
 
+    private volatile Policy globalPolicy = new PolicyImpl(null);
+
     @Override
     public Policy getPolicy(String contextId) {
         if (contextId == null) {
-            return null;
+            return globalPolicy;
         }
 
         Policy policy = policyMap.get(contextId);
@@ -39,6 +41,8 @@ public class PolicyFactoryImpl extends PolicyFactory {
     public void setPolicy(String contextId, Policy policy) {
         if (contextId != null) {
             policyMap.put(contextId, policy);
+        } else {
+            globalPolicy = policy;
         }
     }
 

--- a/dev/io.openliberty.security.authorization.jacc.testprovider/src/com/ibm/ws/security/authorization/jacc/provider/PolicyImpl.java
+++ b/dev/io.openliberty.security.authorization.jacc.testprovider/src/com/ibm/ws/security/authorization/jacc/provider/PolicyImpl.java
@@ -28,6 +28,7 @@ import jakarta.security.jacc.Policy;
 import jakarta.security.jacc.PolicyConfiguration;
 import jakarta.security.jacc.PolicyConfigurationFactory;
 import jakarta.security.jacc.PolicyContext;
+import jakarta.security.jacc.PolicyContextException;
 import jakarta.security.jacc.PrincipalMapper;
 
 public class PolicyImpl implements Policy {
@@ -42,7 +43,7 @@ public class PolicyImpl implements Policy {
     public boolean implies(Permission p, Subject subject) {
         // If there is no policy configuration, the application doesn't
         // have any security constraints.  In that case return true.
-        PolicyConfiguration pc = PolicyConfigurationFactory.get().getPolicyConfiguration(contextID);
+        PolicyConfiguration pc = getPolicyConfiguration();
         if (pc == null) {
             return true;
         }
@@ -51,7 +52,7 @@ public class PolicyImpl implements Policy {
 
     @Override
     public boolean impliesByRole(Permission p, Subject subject) {
-        Map<String, PermissionCollection> perRolePermissions = PolicyConfigurationFactory.get().getPolicyConfiguration(contextID).getPerRolePermissions();
+        Map<String, PermissionCollection> perRolePermissions = getPolicyConfiguration().getPerRolePermissions();
         if (p instanceof EJBMethodPermission) {
             List<String> requiredRoleList = getRequiredRoleList(perRolePermissions, p);
             if (requiredRoleList == null || requiredRoleList.size() == 0) {
@@ -94,12 +95,12 @@ public class PolicyImpl implements Policy {
 
     @Override
     public boolean isExcluded(Permission p) {
-        return PolicyConfigurationFactory.get().getPolicyConfiguration(contextID).getExcludedPermissions().implies(p);
+        return getPolicyConfiguration().getExcludedPermissions().implies(p);
     }
 
     @Override
     public boolean isUnchecked(Permission p) {
-        return PolicyConfigurationFactory.get().getPolicyConfiguration(contextID).getUncheckedPermissions().implies(p);
+        return getPolicyConfiguration().getUncheckedPermissions().implies(p);
     }
 
     @Override
@@ -109,5 +110,11 @@ public class PolicyImpl implements Policy {
     @Override
     public PermissionCollection getPermissionCollection(Subject subject) {
         throw new UnsupportedOperationException();
+    }
+
+    private PolicyConfiguration getPolicyConfiguration() {
+        PolicyConfigurationFactory factory = PolicyConfigurationFactory.get();
+        
+        return contextID == null ? factory.getPolicyConfiguration() : factory.getPolicyConfiguration(contextID);
     }
 }

--- a/dev/io.openliberty.security.authorization.jacc.testprovider/src/com/ibm/ws/security/authorization/jacc/provider/PolicyImpl.java
+++ b/dev/io.openliberty.security.authorization.jacc.testprovider/src/com/ibm/ws/security/authorization/jacc/provider/PolicyImpl.java
@@ -12,8 +12,6 @@ package com.ibm.ws.security.authorization.jacc.provider;
 
 import java.security.Permission;
 import java.security.PermissionCollection;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
@@ -22,13 +20,13 @@ import javax.security.auth.Subject;
 
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.websphere.security.cred.WSCredential;
 
 import jakarta.security.jacc.EJBMethodPermission;
 import jakarta.security.jacc.Policy;
 import jakarta.security.jacc.PolicyConfiguration;
 import jakarta.security.jacc.PolicyConfigurationFactory;
 import jakarta.security.jacc.PolicyContext;
-import jakarta.security.jacc.PolicyContextException;
 import jakarta.security.jacc.PrincipalMapper;
 
 public class PolicyImpl implements Policy {
@@ -54,13 +52,13 @@ public class PolicyImpl implements Policy {
     public boolean impliesByRole(Permission p, Subject subject) {
         Map<String, PermissionCollection> perRolePermissions = getPolicyConfiguration().getPerRolePermissions();
         if (p instanceof EJBMethodPermission) {
-            List<String> requiredRoleList = getRequiredRoleList(perRolePermissions, p);
-            if (requiredRoleList == null || requiredRoleList.size() == 0) {
+            if (!hasRequiredRolePermission(perRolePermissions, p)) {
                 return true;
             }
         }
+
         PrincipalMapper principalMapper = PolicyContext.get(PolicyContext.PRINCIPAL_MAPPER);
-        if (!principalMapper.isAnyAuthenticatedUserRoleMapped() && !subject.getPrincipals().isEmpty()) {
+        if (!principalMapper.isAnyAuthenticatedUserRoleMapped() && !isUnAuthenticatedSubject(subject)) {
             PermissionCollection rolePermissions = perRolePermissions.get("**");
             if (rolePermissions != null && rolePermissions.implies(p)) {
                 return true;
@@ -76,21 +74,33 @@ public class PolicyImpl implements Policy {
         return false;
     }
 
-    private List<String> getRequiredRoleList(Map<String, PermissionCollection> perRolePermissions, Permission p) {
-        List<String> requiredRoleList = null;
+    private boolean isUnAuthenticatedSubject(Subject subject) {
+        if (subject.getPrincipals().size() == 0) {
+            return true;
+        }
+        Set<WSCredential> credentials = subject.getPublicCredentials(WSCredential.class);
+        for (WSCredential wscred : credentials) {
+            if (wscred.isUnauthenticated()) {
+                return true;
+            }
+        }
+        return false;
+
+    }
+
+    private boolean hasRequiredRolePermission(Map<String, PermissionCollection> perRolePermissions, Permission p) {
         if (!perRolePermissions.isEmpty()) {
-            requiredRoleList = new ArrayList<String>();
             for (Entry<String, PermissionCollection> e : perRolePermissions.entrySet()) {
                 PermissionCollection perm = e.getValue();
                 if (perm.implies(p)) {
                     String role = e.getKey();
-                    requiredRoleList.add(role);
                     if (tc.isDebugEnabled())
-                        Tr.debug(tc, "Added role: " + role + " to the requiredRoleList for Permission: " + p + " granted by : " + perm);
+                        Tr.debug(tc, "Found a required role: " + role + " for Permission: " + p + " granted by : " + perm);
+                    return true;
                 }
             }
         }
-        return requiredRoleList;
+        return false;
     }
 
     @Override
@@ -114,7 +124,7 @@ public class PolicyImpl implements Policy {
 
     private PolicyConfiguration getPolicyConfiguration() {
         PolicyConfigurationFactory factory = PolicyConfigurationFactory.get();
-        
+
         return contextID == null ? factory.getPolicyConfiguration() : factory.getPolicyConfiguration(contextID);
     }
 }


### PR DESCRIPTION
- Update to have the SecurityContext.getAllDeclaredCallerRoles method implementation only return application declared roles by having webcontainer and ejbcontainer both implement a new DeclaredRolesService
- Convert from using Service-Component in bnd to using annotations for projects I was adding new function to
- Add new tests that valid the roles returned from SecurityContext and PrincipalMapper
- Add new tests for validating the values returned from SecurityContext user principal and is user in role methods as well as the same method from the component specific methods
- Add new CDI 4.1 BeansAsset to fattest.simplicity
- Update test Policy implementations to support global policy when passed null instead of throwing an exception

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [ ] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
