### PR TITLE
Updates to work around bnd repo index race condition

### DIFF
--- a/dev/wlp-gradle/bndSettings.gradle
+++ b/dev/wlp-gradle/bndSettings.gradle
@@ -71,6 +71,7 @@ buildscript {
 import aQute.bnd.build.Workspace
 import aQute.bnd.osgi.Constants
 import aQute.bnd.gradle.BndPlugin
+import aQute.bnd.repository.maven.provider.MavenBndRepository
 
 Workspace.setDriver(Constants.BNDDRIVER_GRADLE)
 Workspace.addGestalt(Constants.GESTALT_BATCH, null)
@@ -185,4 +186,57 @@ gradle.projectsLoaded { gradle ->
     gradle.rootProject.ext.gradleBndProjects = allBndProjects
     gradle.rootProject.ext.projectNames = projectNames
     gradle.rootProject.ext.parseBoolean = { value -> parseBoolean(value) }
+
+    // Pre-initialize indexed Maven repositories to prevent race conditions
+    // that exists in the bnd Index code that causes failures during parallel builds.
+    // Doing pre-initialization here before doing parallel processing avoids the race condition.
+    // When the race condition is encountered, you get an error with the following message:
+    // error : null, for cmd: repo, arguments; [repo, group:artifact, version]
+    println '[Bnd] Pre-initializing indexed Maven repositories...'
+    def startTime = System.currentTimeMillis()
+
+    try {
+        // Find repositories with index files (MavenBndRepository with index parameter)
+        def indexedRepos = workspace.getRepositories().findAll { repo ->
+            repo instanceof MavenBndRepository && repo.getIndexFile() != null
+        }
+
+        if (indexedRepos.isEmpty()) {
+            println '[Bnd] No indexed repositories found'
+            return
+        }
+
+        println "[Bnd] Found ${indexedRepos.size()} indexed repositories to initialize"
+
+        def initialized = []
+        def failed = []
+
+        // Initialize each repository by triggering IndexFile.getBridge()
+        indexedRepos.each { repo ->
+            try {
+                def repoName = repo.getName()
+
+                // Calling list() triggers IndexFile.getBridge() initialization
+                // This ensures the bridge is populated before parallel builds start
+                def artifacts = repo.list('*')
+
+                initialized << repoName
+                println "[Bnd]   [OK] ${repoName} (${artifacts?.size() ?: 0} artifacts)"
+
+            } catch (Exception e) {
+                failed << repo.getName()
+                logger.warn("[Bnd]   [FAILED] ${repo.getName()}: ${e.message}")
+            }
+        }
+
+        def elapsed = System.currentTimeMillis() - startTime
+        println "[Bnd] Initialized ${initialized.size()}/${indexedRepos.size()} repositories in ${elapsed}ms"
+
+        if (!failed.isEmpty()) {
+            logger.warn("[Bnd] Failed to initialize: ${failed.join(', ')}")
+        }
+
+    } catch (Exception e) {
+        logger.error('[Bnd] Repository initialization failed', e)
+    }
 }


### PR DESCRIPTION
- When doing gradle parallel building, there is a race condition when creating a repository index if more than one thread tries to access it while it is being created / populated.  One thread can get a partially initialized index and get an error that looks like `error : null, for cmd: repo, arguments; [repo, group:artifact, version]` and `Exception: java.util.regex.PatternSyntaxException: Unclosed group near index 9`
- With the implementation provided in this PR, the repository indices are initialized before we start parallel building which prevents us from getting into the race condition.

Co-authored-by-AI: IBM Bob 1.0.1

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [ ] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
