### PR TITLE
convert data_fat_global and data_fat_config buckets to H2 database

### DIFF
--- a/dev/fattest.simplicity/src/com/ibm/websphere/simplicity/config/DataSource.java
+++ b/dev/fattest.simplicity/src/com/ibm/websphere/simplicity/config/DataSource.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2021 IBM Corporation and others.
+ * Copyright (c) 2017, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -26,6 +26,7 @@ import com.ibm.websphere.simplicity.config.dsprops.Properties_db2_i_toolbox;
 import com.ibm.websphere.simplicity.config.dsprops.Properties_db2_jcc;
 import com.ibm.websphere.simplicity.config.dsprops.Properties_derby_client;
 import com.ibm.websphere.simplicity.config.dsprops.Properties_derby_embedded;
+import com.ibm.websphere.simplicity.config.dsprops.Properties_h2;
 import com.ibm.websphere.simplicity.config.dsprops.Properties_informix;
 import com.ibm.websphere.simplicity.config.dsprops.Properties_informix_jcc;
 import com.ibm.websphere.simplicity.config.dsprops.Properties_microsoft_sqlserver;
@@ -112,6 +113,9 @@ public class DataSource extends ConfigElement {
 
     @XmlElement(name = DataSourceProperties.GENERIC)
     private ConfigElementList<Properties> genericProps;
+
+    @XmlElement(name = DataSourceProperties.H2)
+    private ConfigElementList<Properties_h2> h2Props;
 
     @XmlElement(name = DataSourceProperties.INFORMIX_JCC)
     private ConfigElementList<Properties_informix_jcc> informixJccProps;
@@ -210,6 +214,8 @@ public class DataSource extends ConfigElement {
             return DataSourceProperties.GENERIC;
         else if (informixJccProps != null)
             return DataSourceProperties.INFORMIX_JCC;
+        else if (h2Props != null)
+            return DataSourceProperties.H2;
         else if (informixJdbcProps != null)
             return DataSourceProperties.INFORMIX_JDBC;
         else if (oracleProps != null)
@@ -242,6 +248,8 @@ public class DataSource extends ConfigElement {
             nestedPropElements.addAll(this.derbyNetClientProps);
         if (this.genericProps != null)
             nestedPropElements.addAll(this.genericProps);
+        if (this.h2Props != null)
+            nestedPropElements.addAll(this.h2Props);
         if (this.informixJccProps != null)
             nestedPropElements.addAll(this.informixJccProps);
         if (this.informixJdbcProps != null)
@@ -274,6 +282,8 @@ public class DataSource extends ConfigElement {
             this.derbyNetClientProps.clear();
         if (this.genericProps != null)
             this.genericProps.clear();
+        if (this.h2Props != null)
+            this.h2Props.clear();
         if (this.informixJccProps != null)
             this.informixJccProps.clear();
         if (this.informixJdbcProps != null)
@@ -323,6 +333,12 @@ public class DataSource extends ConfigElement {
 
     public ConfigElementList<Properties_derby_embedded> getProperties_derby_embedded() {
         return this.derbyEmbeddedProps == null ? (derbyEmbeddedProps = new ConfigElementList<Properties_derby_embedded>()) : derbyEmbeddedProps;
+    }
+
+    public ConfigElementList<Properties_h2> getProperties_h2() {
+        if (h2Props == null)
+            h2Props = new ConfigElementList<Properties_h2>();
+        return h2Props;
     }
 
     public ConfigElementList<Properties_informix_jcc> getProperties_informix_jcc() {
@@ -748,6 +764,16 @@ public class DataSource extends ConfigElement {
             // TODO finish setting the properties
             db2JccProps = new ConfigElementList<Properties_db2_jcc>();
             db2JccProps.add(properties);
+            throw new Exception("Database or driver not yet supported");
+        } else if (database_vendorname.equalsIgnoreCase(BootstrapProperty.DB_H2.getPropertyName()) &&
+                   database_drivername.equalsIgnoreCase(BootstrapProperty.DB_H2_DRIVER.getPropertyName())) {
+            // TODO H2 is not yet supported as a specified database
+            Properties_h2 properties = new Properties_h2();
+            properties.setPassword(database_password1);
+            properties.setURL("jdbc:h2:" + database_name);
+            properties.setUser(database_user1);
+            h2Props = new ConfigElementList<Properties_h2>();
+            h2Props.add(properties);
             throw new Exception("Database or driver not yet supported");
         } else if (database_vendorname.equalsIgnoreCase(BootstrapProperty.DB_INFORMIX.getPropertyName())
                    && database_drivername.equalsIgnoreCase(BootstrapProperty.DB_DB2_JCC_DRIVER.getPropertyName())) {

--- a/dev/fattest.simplicity/src/com/ibm/websphere/simplicity/config/DataSourceProperties.java
+++ b/dev/fattest.simplicity/src/com/ibm/websphere/simplicity/config/DataSourceProperties.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2020 IBM Corporation and others.
+ * Copyright (c) 2017, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -22,6 +22,7 @@ public class DataSourceProperties extends ConfigElement {
     public static final String DERBY_EMBEDDED = "properties.derby.embedded";
     public static final String DERBY_CLIENT = "properties.derby.client";
     public static final String GENERIC = "properties";
+    public static final String H2 = "properties.h2";
     public static final String INFORMIX_JCC = "properties.informix.jcc";
     public static final String INFORMIX_JDBC = "properties.informix";
     public static final String ORACLE_JDBC = "properties.oracle";

--- a/dev/fattest.simplicity/src/com/ibm/websphere/simplicity/config/dsprops/Properties_h2.java
+++ b/dev/fattest.simplicity/src/com/ibm/websphere/simplicity/config/dsprops/Properties_h2.java
@@ -1,0 +1,54 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.websphere.simplicity.config.dsprops;
+
+import javax.xml.bind.annotation.XmlAttribute;
+
+import com.ibm.websphere.simplicity.config.DataSourceProperties;
+
+/**
+ * Lists data source properties specific to this driver.
+ */
+public class Properties_h2 extends DataSourceProperties {
+    private String URL;
+
+    @Override
+    public String getElementName() {
+        return H2;
+    }
+
+    public String getURL() {
+        return this.URL;
+    }
+
+    @XmlAttribute(name = "URL")
+    public void setURL(String URL) {
+        this.URL = URL;
+    }
+
+    /**
+     * Returns a String listing the properties and their values.
+     */
+    @Override
+    public String toString() {
+        StringBuilder buf = new StringBuilder("{");
+        if (getPassword() != null)
+            buf.append("password=\"" + getPassword() + "\" ");
+        if (getUser() != null)
+            buf.append("user=\"" + getUser() + "\" ");
+        if (URL != null)
+            buf.append("URL=\"" + URL + "\" ");
+        buf.append("}");
+        return buf.toString();
+    }
+}

--- a/dev/fattest.simplicity/src/componenttest/common/apiservices/BootstrapProperty.java
+++ b/dev/fattest.simplicity/src/componenttest/common/apiservices/BootstrapProperty.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -116,7 +116,7 @@ public enum BootstrapProperty {
     PROPERTY_SEP("."),
 
     // Database properties
-    // Values needed for each type of database can be found in prereq.dbtest 
+    // Values needed for each type of database can be found in prereq.dbtest
     // properties files for databases and jdbc drivers
     LIBERTY_DBJARS("liberty.db_jars"),
     // location of the jdbc jars.  this is set by run-fat-bucket.xml
@@ -171,6 +171,7 @@ public enum BootstrapProperty {
     DB_DB2("DB2"),
     DB_DB2_ISERIES("DB2iSeries"),
     DB_DB2_ZOS("DB2zOS"),
+    DB_H2("H2"),
     DB_INFORMIX("Informix"),
     DB_ORACLE("Oracle"),
     DB_SQLSERVER("SQLServer"),
@@ -186,6 +187,7 @@ public enum BootstrapProperty {
     DB_DB2_JCC_DRIVER("DB2"),
     DB_DB2_INATIVE_DRIVER("DB2_iNative"),
     DB_DB2_ITOOLBOX_DRIVER("DB2_iToolbox"),
+    DB_H2_DRIVER("H2"),
     DB_INFORMIX_DRIVER("Informix"),
     DB_ORACLE_DRIVER("Oracle"),
     DB_SQLSERVER_DRIVER("Microsoft_SQL_Server_JDBC_Driver"),
@@ -210,7 +212,7 @@ public enum BootstrapProperty {
     /**
      * Get the String value of the property that is read from and written to the bootstrapping
      * properties file.
-     * 
+     *
      * @return The String value of the property
      */
     public String getPropertyName() {

--- a/dev/io.openliberty.data.internal_fat_config/build.gradle
+++ b/dev/io.openliberty.data.internal_fat_config/build.gradle
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 IBM Corporation and others.
+ * Copyright (c) 2023,2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -11,4 +11,4 @@
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 
-addRequiredLibraries.dependsOn addDerby
+addRequiredLibraries.dependsOn addH2

--- a/dev/io.openliberty.data.internal_fat_config/fat/src/test/jakarta/data/config/DataConfigTest.java
+++ b/dev/io.openliberty.data.internal_fat_config/fat/src/test/jakarta/data/config/DataConfigTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023,2025 IBM Corporation and others.
+ * Copyright (c) 2023,2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -177,6 +177,8 @@ public class DataConfigTest extends FATServletClient {
         config.getDatabaseStores().removeById("MyDataStore");
         DataSource MyDataStore = (DataSource) config.getDataSources().getById("DefaultDataSource").clone();
         MyDataStore.setId("MyDataStore");
+        // H2 must use same user on in-memory database
+        MyDataStore.setContainerAuthDataRef("auth1");
         config.getDataSources().add(MyDataStore);
         Data data;
         ConfigElementList<Data> datas = config.getData();

--- a/dev/io.openliberty.data.internal_fat_config/publish/servers/io.openliberty.data.internal.fat.config/server.xml
+++ b/dev/io.openliberty.data.internal_fat_config/publish/servers/io.openliberty.data.internal.fat.config/server.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2023.2024 IBM Corporation and others.
+    Copyright (c) 2023.2026 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -31,14 +31,12 @@
   <databaseStore id="MyDataStore" authDataRef="auth1" createTables="true" dropTables="false" tablePrefix="TEST"/>
 
   <dataSource id="DefaultDataSource">
-    <jdbcDriver libraryRef="DerbyLib"/>
-    <properties.derby.embedded createDatabase="create" databaseName="memory:testdb"/>
+    <jdbcDriver libraryRef="H2Lib"/>
+    <properties.h2 URL="jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1"/>
   </dataSource>
 
-  <library id="DerbyLib">
-    <file name="${shared.resource.dir}/derby/derby.jar"/>
+  <library id="H2Lib">
+    <file name="${shared.resource.dir}/h2/h2.jar"/>
   </library>
-
-  <javaPermission codeBase="${shared.resource.dir}/derby/derby.jar" className="java.security.AllPermission"/>
 
 </server>

--- a/dev/io.openliberty.data.internal_fat_global/build.gradle
+++ b/dev/io.openliberty.data.internal_fat_global/build.gradle
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2025 IBM Corporation and others.
+ * Copyright (c) 2025,2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -11,4 +11,4 @@
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 
-addRequiredLibraries.dependsOn addDerby
+addRequiredLibraries.dependsOn addH2

--- a/dev/io.openliberty.data.internal_fat_global/fat/src/test/jakarta/data/global/DataJavaGlobalTest.java
+++ b/dev/io.openliberty.data.internal_fat_global/fat/src/test/jakarta/data/global/DataJavaGlobalTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2025 IBM Corporation and others.
+ * Copyright (c) 2025,2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -249,16 +249,16 @@ public class DataJavaGlobalTest extends FATServletClient {
         found = "found: " + json;
 
         assertEquals(found,
-                     "Apache Derby",
+                     "H2",
                      json.getString("DatabaseProductName"));
 
         assertEquals(found,
-                     "Apache Derby Embedded JDBC Driver",
+                     "H2 JDBC Driver",
                      json.getString("DriverName"));
 
         assertEquals(found,
-                     "dbuser2",
-                     json.getString("UserName"));
+                     "DBUSER2",
+                     json.getString("UserName").toUpperCase());
     }
 
     /**

--- a/dev/io.openliberty.data.internal_fat_global/publish/servers/io.openliberty.data.internal.fat.global/server.xml
+++ b/dev/io.openliberty.data.internal_fat_global/publish/servers/io.openliberty.data.internal.fat.global/server.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2025 IBM Corporation and others.
+    Copyright (c) 2025,2026 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -27,17 +27,15 @@
   </data>
 
   <application location="DataGlobalRestApp.war">
-    <classloader commonLibraryRef="DerbyLib"/>
+    <classloader commonLibraryRef="H2Lib"/>
   </application>
 
   <application location="DataGlobalWebApp.war">
-    <classloader commonLibraryRef="DerbyLib"/>
+    <classloader commonLibraryRef="H2Lib"/>
   </application>
 
-  <library id="DerbyLib">
-    <file name="${shared.resource.dir}/derby/derby.jar"/>
+  <library id="H2Lib">
+    <file name="${shared.resource.dir}/h2/h2.jar"/>
   </library>
-
-  <javaPermission codeBase="${shared.resource.dir}/derby/derby.jar" className="java.security.AllPermission"/>
 
 </server>

--- a/dev/io.openliberty.data.internal_fat_global/test-applications/DataGlobalRestApp/src/test/jakarta/data/global/rest/Reminder.java
+++ b/dev/io.openliberty.data.internal_fat_global/test-applications/DataGlobalRestApp/src/test/jakarta/data/global/rest/Reminder.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2025 IBM Corporation and others.
+ * Copyright (c) 2025,2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -54,6 +54,7 @@ public class Reminder {
     public MonthDay monthDayCreated;
 
     @Column(nullable = false)
+    @Convert(converter = YearConverter.class)
     @JsonbTypeAdapter(YearAdapter.class)
     public Year yearCreated;
 
@@ -92,7 +93,7 @@ public class Reminder {
 
         @Override
         public LocalDate convertToDatabaseColumn(MonthDay md) {
-            return md.atYear(0);
+            return md.atYear(2000);
         }
 
         @Override
@@ -116,6 +117,26 @@ public class Reminder {
         @Override
         public Integer adaptToJson(Year year) {
             return year.getValue();
+        }
+    }
+
+    // TODO remove once EclipseLink issue #TODO is fixed
+    static class YearConverter implements AttributeConverter<Year, Integer> {
+
+        @Override
+        public Integer convertToDatabaseColumn(Year year) {
+            if (year == null)
+                return null;
+
+            return year.getValue();
+        }
+
+        @Override
+        public Year convertToEntityAttribute(Integer i) {
+            if (i == null)
+                return null;
+
+            return Year.of(i);
         }
     }
 

--- a/dev/io.openliberty.data.internal_fat_global/test-applications/DataGlobalRestApp/src/test/jakarta/data/global/rest/Reminders.java
+++ b/dev/io.openliberty.data.internal_fat_global/test-applications/DataGlobalRestApp/src/test/jakarta/data/global/rest/Reminders.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2025 IBM Corporation and others.
+ * Copyright (c) 2025,2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -25,11 +25,10 @@ import jakarta.data.repository.Repository;
  * that is defined in this application.
  */
 @DataSourceDefinition(name = "java:global/jdbc/RestResourceDataSource",
-                      className = "org.apache.derby.jdbc.EmbeddedXADataSource",
-                      databaseName = "memory:testdb",
+                      className = "org.h2.jdbcx.JdbcDataSource",
+                      url = "jdbc:h2:mem:testrestdb;DB_CLOSE_DELAY=-1",
                       user = "dbuser1",
-                      password = "dbpwd1",
-                      properties = "createDatabase=create")
+                      password = "dbpwd1")
 @Repository(dataStore = "java:global/jdbc/RestResourceDataSource")
 public interface Reminders extends CrudRepository<Reminder, Long> {
 

--- a/dev/io.openliberty.data.internal_fat_global/test-applications/DataGlobalRestApp/src/test/jakarta/data/global/webapp/Alphabet.java
+++ b/dev/io.openliberty.data.internal_fat_global/test-applications/DataGlobalRestApp/src/test/jakarta/data/global/webapp/Alphabet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2025 IBM Corporation and others.
+ * Copyright (c) 2025,2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -27,11 +27,10 @@ import jakarta.data.repository.Repository;
  * resource reference that that is defined by this application.
  */
 @DataSourceDefinition(name = "java:global/jdbc/WebAppDataSource",
-                      className = "org.apache.derby.jdbc.EmbeddedXADataSource",
-                      databaseName = "memory:testdb",
+                      className = "org.h2.jdbcx.JdbcDataSource",
+                      url = "jdbc:h2:mem:testwebdb;DB_CLOSE_DELAY=-1",
                       user = "dbuser2",
-                      password = "dbpwd2",
-                      properties = "createDatabase=create")
+                      password = "dbpwd2")
 @Resource(name = "java:global/env/jdbc/WebAppDataSourceRef",
           lookup = "java:global/jdbc/WebAppDataSource")
 @Repository(dataStore = "java:global/env/jdbc/WebAppDataSourceRef")


### PR DESCRIPTION
Convert data_fat_global bucket to H2 database
Convert data_fat_config bucket to H2 database
Add properties.h2 to simplicity.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
