### PR TITLE
Remove unused methods

### DIFF
--- a/dev/com.ibm.ws.webcontainer.security/src/com/ibm/ws/webcontainer/security/WebProviderAuthenticatorProxy.java
+++ b/dev/com.ibm.ws.webcontainer.security/src/com/ibm/ws/webcontainer/security/WebProviderAuthenticatorProxy.java
@@ -611,7 +611,6 @@ public class WebProviderAuthenticatorProxy implements WebAuthenticator {
         }
 
         setThreadOidcClientId(oidcClientId);
-        setThreadOidcProvider(oidcClientId);
 
         if (oidcResult.getStatus() == AuthResult.REDIRECT_TO_PROVIDER) {
             return new AuthenticationResult(AuthResult.REDIRECT, oidcResult.getRedirectUrl());
@@ -840,13 +839,5 @@ public class WebProviderAuthenticatorProxy implements WebAuthenticator {
 
     public static void clearThreadOidcClientId() {
         threadOidcClientId.remove();
-    }
-
-    private void setThreadOidcProvider(String oidcProvider) {
-        threadOidcClientId.set(oidcProvider);
-    }
-
-    public static String getThreadOidcProvider() {
-        return threadOidcClientId.get();
     }
 }


### PR DESCRIPTION
We are no longer using setThreadOidcProvider and getThreadOidcProvider. These were replaced by setThreadOidcClientId and getThreadOidcClientId in https://github.com/OpenLiberty/open-liberty/pull/34045


- [X] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [ ] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [X] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".