### PR TITLE
Convert data errorpaths and concurrent buckets to H2

### DIFF
--- a/dev/com.ibm.ws.concurrent_fat_db/build.gradle
+++ b/dev/com.ibm.ws.concurrent_fat_db/build.gradle
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2020 IBM Corporation and others.
+ * Copyright (c) 2017, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -11,4 +11,4 @@
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 
-addRequiredLibraries.dependsOn addDerby
+addRequiredLibraries.dependsOn addH2Java8

--- a/dev/com.ibm.ws.concurrent_fat_db/publish/servers/concurrent_fat_db/server.xml
+++ b/dev/com.ibm.ws.concurrent_fat_db/publish/servers/concurrent_fat_db/server.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2017,2020 IBM Corporation and others.
+    Copyright (c) 2017,2026 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -23,20 +23,20 @@
 
     <dataSource id="CPDataSource" jndiName="jdbc/CPDataSource" type="javax.sql.ConnectionPoolDataSource">
         <connectionManager autoCloseConnections="false"/>
-        <jdbcDriver libraryRef="DerbyLib"/>
-        <properties.derby.embedded createDatabase="create" databaseName="memory:concurrent_fat_db"/>
+        <jdbcDriver libraryRef="H2Lib"/>
+        <properties.h2 URL="jdbc:h2:mem:concurrent_fat_db;DB_CLOSE_DELAY=-1"/>
     </dataSource>
 
     <dataSource id="DefaultDataSource"> <!-- an XADataSource -->
         <connectionManager autoCloseConnections="true"/>
-        <jdbcDriver libraryRef="DerbyLib"/>
-        <properties.derby.embedded createDatabase="create" databaseName="memory:concurrent_fat_db"/>
+        <jdbcDriver libraryRef="H2Lib"/>
+        <properties.h2 URL="jdbc:h2:mem:concurrent_fat_db;DB_CLOSE_DELAY=-1"/>
     </dataSource>
 
-    <library id="DerbyLib">
-        <fileset dir="${shared.resource.dir}/derby" includes="derby.jar"/>
+    <library id="H2Lib">
+        <fileset dir="${shared.resource.dir}/h2Java8" includes="h2.jar"/>
     </library>
 
-    <!-- permissions for Derby -->
-    <javaPermission codebase="${shared.resource.dir}/derby/derby.jar" className="java.security.AllPermission"/>
+    <!-- permissions for H2 -->
+    <javaPermission codebase="${shared.resource.dir}/h2Java8/h2.jar" className="java.security.AllPermission"/>
 </server>

--- a/dev/com.ibm.ws.concurrent_fat_demo/build.gradle
+++ b/dev/com.ibm.ws.concurrent_fat_demo/build.gradle
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 IBM Corporation and others.
+ * Copyright (c) 2017,2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -11,5 +11,5 @@
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 
-addRequiredLibraries.dependsOn addDerby
+addRequiredLibraries.dependsOn addH2Java8
 

--- a/dev/com.ibm.ws.concurrent_fat_demo/publish/servers/com.ibm.ws.concurrent.fat.demo/server.xml
+++ b/dev/com.ibm.ws.concurrent_fat_demo/publish/servers/com.ibm.ws.concurrent.fat.demo/server.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2017 IBM Corporation and others.
+    Copyright (c) 2017,2026 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -19,15 +19,15 @@
   </featureManager>
 
   <dataSource jndiName="jdbc/testdb">
-    <jdbcDriver libraryRef="Derby"/>
-    <properties.derby.embedded createDatabase="create" databaseName="memory:testdb"/>
+    <jdbcDriver libraryRef="H2"/>
+    <properties.h2 URL="jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1"/>
   </dataSource>
 
-  <library id="Derby">
-    <fileset dir="${shared.resource.dir}/derby" includes="derby.jar"/>
+  <library id="H2">
+    <fileset dir="${shared.resource.dir}/h2Java8" includes="h2.jar"/>
   </library>
 
-  <javaPermission codebase="${shared.resource.dir}/derby/derby.jar" className="java.security.AllPermission"/>
+  <javaPermission codebase="${shared.resource.dir}/h2Java8/h2.jar" className="java.security.AllPermission"/>
 
   <include location="../fatTestPorts.xml"/>
 </server>

--- a/dev/io.openliberty.data.internal_fat_errorpaths/build.gradle
+++ b/dev/io.openliberty.data.internal_fat_errorpaths/build.gradle
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 IBM Corporation and others.
+ * Copyright (c) 2024,2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -11,4 +11,4 @@
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 
-addRequiredLibraries.dependsOn addDerby
+addRequiredLibraries.dependsOn addH2

--- a/dev/io.openliberty.data.internal_fat_errorpaths/fat/src/test/jakarta/data/errpaths/DataIntrospectorTest.java
+++ b/dev/io.openliberty.data.internal_fat_errorpaths/fat/src/test/jakarta/data/errpaths/DataIntrospectorTest.java
@@ -116,7 +116,7 @@ public class DataIntrospectorTest extends FATServletClient {
     @Test
     public void testOutputContainsDatabaseStore() {
         assertLineFound("    for databaseStore application[DataErrPathsTestApp]" +
-                        "/databaseStore[java:app/jdbc/DerbyDataSource]");
+                        "/databaseStore[java:app/jdbc/H2DataSource]");
 
         assertLineFound("    for databaseStore application[DataErrPathsTestApp]" +
                         "/module[DataErrPathsTestApp.war]" +
@@ -131,7 +131,7 @@ public class DataIntrospectorTest extends FATServletClient {
     public void testOutputContainsDataStore() {
         assertLineFound("        dataStore: AbsentFromConfig");
         assertLineFound("        dataStore: java:app/env/WrongPersistenceUnitRef");
-        assertLineFound("        dataStore: java:app/jdbc/DerbyDataSource");
+        assertLineFound("        dataStore: java:app/jdbc/H2DataSource");
         assertLineFound("        dataStore: java:comp/DefaultDataSource");
         assertLineFound("        dataStore: java:comp/jdbc/InvalidDatabase");
         assertLineFound("        dataStore: java:module/env/DoesNotExist");
@@ -240,7 +240,7 @@ public class DataIntrospectorTest extends FATServletClient {
     public void testOutputContainsRepositoryAnnotation() {
         // fields of the annotation could be printed in any order
         assertLineContains("      @Repository(");
-        assertLineContains("dataStore=\"java:app/jdbc/DerbyDataSource\"");
+        assertLineContains("dataStore=\"java:app/jdbc/H2DataSource\"");
     }
 
     /**

--- a/dev/io.openliberty.data.internal_fat_errorpaths/publish/servers/io.openliberty.data.internal.fat.errpaths/server.xml
+++ b/dev/io.openliberty.data.internal_fat_errorpaths/publish/servers/io.openliberty.data.internal.fat.errpaths/server.xml
@@ -27,13 +27,11 @@
   </data>
 
   <application location="DataErrPathsTestApp.war">
-    <classloader commonLibraryRef="DerbyLib"/>
+    <classloader commonLibraryRef="H2Lib"/>
   </application>
 
-  <library id="DerbyLib">
-    <file name="${shared.resource.dir}/derby/derby.jar"/>
+  <library id="H2Lib">
+    <file name="${shared.resource.dir}/h2/h2.jar"/>
   </library>
-
-  <javaPermission codeBase="${shared.resource.dir}/derby/derby.jar" className="java.security.AllPermission"/>
 
 </server>

--- a/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/resources/WEB-INF/classes/META-INF/persistence.xml
+++ b/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/resources/WEB-INF/classes/META-INF/persistence.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- 
 /*******************************************************************************
- * Copyright (c) 2024 IBM Corporation and others.
+ * Copyright (c) 2024,2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -21,7 +21,7 @@
 
     <!-- A valid persistence unit -->
     <persistence-unit name="VoterPersistenceUnit">
-        <jta-data-source>java:app/jdbc/DerbyDataSource</jta-data-source>
+        <jta-data-source>java:app/jdbc/H2DataSource</jta-data-source>
         <class>test.jakarta.data.errpaths.web.Voter</class>
         <exclude-unlisted-classes>true</exclude-unlisted-classes>
         <properties>

--- a/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/DataErrPathsTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/DataErrPathsTestServlet.java
@@ -63,21 +63,19 @@ import org.junit.Test;
 import componenttest.app.FATServlet;
 import test.jakarta.data.errpaths.web.Voters.NameAndZipCode;
 
-@DataSourceDefinition(name = "java:app/jdbc/DerbyDataSource",
-                      className = "org.apache.derby.jdbc.EmbeddedXADataSource",
-                      databaseName = "memory:testdb",
+@DataSourceDefinition(name = "java:app/jdbc/H2DataSource",
+                      className = "org.h2.jdbcx.JdbcDataSource",
+                      url = "jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1",
                       user = "dbuser1",
-                      password = "dbpwd1",
-                      properties = "createDatabase=create")
+                      password = "dbpwd1")
 @DataSourceDefinition(name = "java:module/jdbc/DataSourceForInvalidEntity",
-                      className = "org.apache.derby.jdbc.EmbeddedXADataSource",
-                      databaseName = "memory:testdb",
+                      className = "org.h2.jdbcx.JdbcDataSource",
+                      url = "jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1",
                       user = "dbuser1",
-                      password = "dbpwd1",
-                      properties = "createDatabase=create")
+                      password = "dbpwd1")
 @DataSourceDefinition(name = "java:comp/jdbc/InvalidDatabase",
-                      className = "org.apache.derby.jdbc.EmbeddedXADataSource",
-                      databaseName = "notfounddb",
+                      className = "org.h2.jdbcx.JdbcDataSource",
+                      url = "jdbc:h2:mem:notfounddb;IFEXISTS=TRUE;DB_CLOSE_DELAY=-1",
                       user = "dbuser1",
                       password = "dbpwd1")
 @PersistenceUnit(name = "java:app/env/VoterPersistenceUnitRef",

--- a/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/Voters.java
+++ b/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/Voters.java
@@ -43,7 +43,7 @@ import jakarta.data.repository.Update;
  * Some methods are valid.
  * Others have errors, as indicated.
  */
-@Repository(dataStore = "java:app/jdbc/DerbyDataSource")
+@Repository(dataStore = "java:app/jdbc/H2DataSource")
 public interface Voters extends BasicRepository<Voter, Integer> {
     static record NameAndZipCode(String name, int zipCode) {
     }


### PR DESCRIPTION
Converts the following test buckets from Derby to H2:

io.openliberty.data.internal_fat_errorpaths
com.ibm.ws.concurrent_fat_db
com.ibm.ws.concurrent_fat_demo

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
