### PR TITLE
Reduce the disk size of the com.ibm.ws.com.graphql.java bundle

### DIFF
--- a/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
+++ b/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
@@ -2082,11 +2082,6 @@
       <version>1.15.1</version>
     </dependency>
     <dependency>
-      <groupId>org.antlr</groupId>
-      <artifactId>antlr4-runtime</artifactId>
-      <version>4.8</version>
-    </dependency>
-    <dependency>
       <groupId>org.apache.ant</groupId>
       <artifactId>ant-junit</artifactId>
       <version>1.10.10</version>

--- a/dev/cnf/oss_dependencies.maven
+++ b/dev/cnf/oss_dependencies.maven
@@ -412,7 +412,6 @@ net.sourceforge.htmlunit:neko-htmlunit:2.28
 net.sourceforge.htmlunit:neko-htmlunit:2.44.0
 net.sourceforge.htmlunit:webdriver:2.6
 net.sourceforge.serp:serp:1.15.1
-org.antlr:antlr4-runtime:4.8
 org.apache.ant:ant-junit:1.10.10
 org.apache.ant:ant:1.10.10
 org.apache.bcel:bcel:6.6.1

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpGraphQL-1.0/com.ibm.websphere.appserver.mpGraphQL-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpGraphQL-1.0/com.ibm.websphere.appserver.mpGraphQL-1.0.feature
@@ -20,6 +20,7 @@ Subsystem-Name: MicroProfile GraphQL 1.0
   io.openliberty.jandex.internal-2.0
 -bundles= \
  com.ibm.ws.com.graphql.java, \
+ com.ibm.ws.com.graphql.java.javaee, \
  com.ibm.ws.io.smallrye.graphql, \
  com.ibm.ws.org.jboss.logging
 #already provided by kernel...

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mpGraphQL-2.0/io.openliberty.mpGraphQL-2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mpGraphQL-2.0/io.openliberty.mpGraphQL-2.0.feature
@@ -20,6 +20,7 @@ Subsystem-Name: MicroProfile GraphQL 2.0
   io.openliberty.org.eclipse.microprofile.graphql-2.0, \
   io.openliberty.jandex.internal-2.0
 -bundles= \
+ com.ibm.ws.com.graphql.java, \
  com.ibm.ws.com.graphql.java.jakarta, \
  com.ibm.ws.io.smallrye.graphql.jakarta, \
  com.ibm.ws.org.jboss.logging

--- a/dev/com.ibm.ws.com.graphql.java/bnd.bnd
+++ b/dev/com.ibm.ws.com.graphql.java/bnd.bnd
@@ -1,14 +1,11 @@
 #*******************************************************************************
-# Copyright (c) 2020, 2025 IBM Corporation and others.
+# Copyright (c) 2020, 2026 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-2.0/
 #
 # SPDX-License-Identifier: EPL-2.0
-#
-# Contributors:
-#     IBM Corporation - initial API and implementation
 #*******************************************************************************
 
 -include= ~../cnf/resources/bnd/bundle.props
@@ -16,21 +13,3 @@
 -sub: *.bnd
 
 bVersion=1.0
-
--includeresource: \
-  @\${repo;com.graphql-java:graphql-java;20.9},\
-  @\${repo;com.graphql-java:java-dataloader;3.2.0},\
-  @\${repo;org.antlr:antlr4-runtime;4.8}
-
-Export-Package: \
-  graphql.*;version=20.9,\
-  org.dataloader.*;version=3.2.0
-
-Import-Package: \
-  !com.google.errorprone.*,\
-  !org.checkerframework.checker.nullness.qual.*,\
-  !javax.annotation.meta,\
-  !sun.misc,\
-  !com.google.common.util.concurrent,\
-  *
-

--- a/dev/com.ibm.ws.com.graphql.java/main.bnd
+++ b/dev/com.ibm.ws.com.graphql.java/main.bnd
@@ -7,21 +7,22 @@
 #
 # SPDX-License-Identifier: EPL-2.0
 #*******************************************************************************
--include= ~../cnf/resources/bnd/transform.props
 
-Bundle-Name: GraphQL-Java Jakarta
-Bundle-SymbolicName: com.ibm.ws.com.graphql.java.jakarta
-Bundle-Description: Provides GraphQL google common code as a bundle; Jakarta Enabled
+Bundle-Name: GraphQL-Java Base
+Bundle-SymbolicName: com.ibm.ws.com.graphql.java
+Bundle-Description: Provides GraphQL base code as a bundle
 
 -includeresource: \
-  @\${repo;com.graphql-java:graphql-java;20.9}!/(graphql/com/google/common/**)
+  @\${repo;com.graphql-java:graphql-java;20.9}!/!(graphql/com/google/common/**),\
+  @\${repo;com.graphql-java:java-dataloader;3.2.0}
 
 Export-Package: \
-  graphql.com.google.common.*;version=20.9
+  !graphql.com.google.common.*,\
+  graphql.*;version=20.9,\
+  org.dataloader.*;version=3.2.0
 
 Import-Package: \
-  !com.google.errorprone.*,\
-  !org.checkerframework.checker.nullness.qual.*,\
-  !javax.annotation.meta,\
+  !sun.misc,\
   !com.google.common.util.concurrent,\
+  graphql.com.google.common.collect;version="[20.9, 21)",\
   *

--- a/dev/com.ibm.ws.com.graphql.java/original.bnd
+++ b/dev/com.ibm.ws.com.graphql.java/original.bnd
@@ -1,17 +1,26 @@
 #*******************************************************************************
-# Copyright (c) 2022 IBM Corporation and others.
+# Copyright (c) 2022, 2026 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-2.0/
-# 
-# SPDX-License-Identifier: EPL-2.0
 #
-# Contributors:
-#     IBM Corporation - initial API and implementation
+# SPDX-License-Identifier: EPL-2.0
 #*******************************************************************************
 
-Bundle-Name: GraphQL-Java
-Bundle-SymbolicName: com.ibm.ws.com.graphql.java
-Bundle-Description: Provides GraphQL as a bundle
+Bundle-Name: GraphQL-Java JavaEE
+Bundle-SymbolicName: com.ibm.ws.com.graphql.java.javaee
+Bundle-Description: Provides GraphQL google common code as a bundle; Java EE Enabled
 
+-includeresource: \
+  @\${repo;com.graphql-java:graphql-java;20.9}!/(graphql/com/google/common/**)
+
+Export-Package: \
+  graphql.com.google.common.*;version=20.9
+
+Import-Package: \
+  !com.google.errorprone.*,\
+  !org.checkerframework.checker.nullness.qual.*,\
+  !javax.annotation.meta,\
+  !com.google.common.util.concurrent,\
+  *


### PR DESCRIPTION
- Presently the com.ibm.ws.com.graphql.java bundle is 3.86MB and is transformed to make an additional bundle that is 3.86MBs.
- Now instead of two jars, the bundles are restructured to have 3 jars
- The first jar has the content that does not have any dependencies on Java EE APIs.  That jar now is only 2.23 MB.  It also no longer has the org.antlr:antlr4-runtime:4.8 class in it since graphql-java already shades those classes
- The second jar contains the graphql.com.google.common.* classes in it that depend on Java EE and the third jar is the transform of that.  Each jar is 1.3MB
- The feature files are now updated to reference the first jar and the second or third jar depending on mpGraphQL version
- Instead of using 7.72MB now, the code only uses 4.83MB which is about a 2.9MB reduction


- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [ ] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
