### PR TITLE
Convert MicroProfile context propagation tests from Derby to H2

### DIFF
--- a/dev/com.ibm.ws.concurrent.mp_fat/build.gradle
+++ b/dev/com.ibm.ws.concurrent.mp_fat/build.gradle
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017,2024 IBM Corporation and others.
+ * Copyright (c) 2017,2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -11,7 +11,7 @@
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 
-addRequiredLibraries.dependsOn addDerby
+addRequiredLibraries.dependsOn addH2Java8
 
 configurations {
   requiredLibs {

--- a/dev/com.ibm.ws.concurrent.mp_fat/publish/servers/MPConcurrentTxTestServer/server.xml
+++ b/dev/com.ibm.ws.concurrent.mp_fat/publish/servers/MPConcurrentTxTestServer/server.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2019,2020 IBM Corporation and others.
+    Copyright (c) 2019,2026 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -25,24 +25,24 @@
     
     <application location="MPConcurrentTxApp.war"/>
 
-    <dataSource id="DefaultDataSource">
+    <dataSource id="DefaultDataSource" type="javax.sql.XADataSource">
         <connectionManager autoCloseConnections="true"/>
-        <jdbcDriver libraryRef="DerbyLib"/>
-        <properties.derby.embedded createDatabase="create" databaseName="memory:txdb"/>
+        <jdbcDriver libraryRef="H2Lib"/>
+        <properties.h2 URL="jdbc:h2:mem:txdb"/>
     </dataSource>
 
     <dataSource id="OnePhaseDataSource" jndiName="jdbc/ds1phase" type="javax.sql.ConnectionPoolDataSource">
         <connectionManager autoCloseConnections="false"/>
-        <jdbcDriver libraryRef="DerbyLib"/>
-        <properties.derby.embedded createDatabase="create" databaseName="memory:txdb"/>
+        <jdbcDriver libraryRef="H2Lib"/>
+        <properties.h2 URL="jdbc:h2:mem:txdb"/>
     </dataSource>
 
-    <library id="DerbyLib">
-        <fileset dir="${shared.resource.dir}/derby" includes="derby.jar"/>
+    <library id="H2Lib">
+        <fileset dir="${shared.resource.dir}/h2Java8" includes="h2.jar"/>
     </library>
 
-    <!-- permissions for Derby -->
-    <javaPermission codebase="${shared.resource.dir}/derby/derby.jar" className="java.security.AllPermission"/>
+    <!-- permissions for H2 -->
+    <javaPermission codebase="${shared.resource.dir}/h2Java8/h2.jar" className="java.security.AllPermission"/>
 
     <!-- Needed for application to use a ForkJoinPool, access the thread context class loader, and shut down an unmanaged ExecutorService that the test application creates -->
     <javaPermission codebase="${server.config.dir}/apps/MPConcurrentTxApp.war" className="java.lang.RuntimePermission" name="getClassLoader"/>

--- a/dev/com.ibm.ws.concurrent.mp_fat_jakarta/build.gradle
+++ b/dev/com.ibm.ws.concurrent.mp_fat_jakarta/build.gradle
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2024 IBM Corporation and others.
+ * Copyright (c) 2021, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -7,8 +7,6 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  *******************************************************************************/
-
-addRequiredLibraries.dependsOn addDerby
 
 configurations {
   requiredLibs {

--- a/dev/com.ibm.ws.rest.handler.config_fat/bnd.bnd
+++ b/dev/com.ibm.ws.rest.handler.config_fat/bnd.bnd
@@ -35,7 +35,6 @@ fat.project: true
     com.ibm.websphere.org.osgi.core;version=latest,\
     com.ibm.wsspi.org.osgi.service.component.annotations;version=latest,\
     com.ibm.ws.org.osgi.annotation.versioning;version=latest,\
-    org.apache.derby:derby;strategy=exact;version=10.11.1.1,\
     com.ibm.ws.security.jaas.common;version=latest,\
     com.ibm.ws.microprofile.openapi;version=latest,\
     com.ibm.websphere.org.eclipse.microprofile.openapi.1.0;version=latest

--- a/dev/com.ibm.ws.rest.handler.config_fat/build.gradle
+++ b/dev/com.ibm.ws.rest.handler.config_fat/build.gradle
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017,2024 IBM Corporation and others.
+ * Copyright (c) 2017,2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -17,7 +17,7 @@ configurations {
   }
 }
 
-addRequiredLibraries.dependsOn addDerby
+addRequiredLibraries.dependsOn addH2Java8
 
 dependencies {
   requiredLibs project(':com.ibm.ws.microprofile.openapi')

--- a/dev/com.ibm.ws.rest.handler.config_fat/fat/src/com/ibm/ws/rest/handler/config/fat/ConfigRESTHandlerAppDefinedResourcesTest.java
+++ b/dev/com.ibm.ws.rest.handler.config_fat/fat/src/com/ibm/ws/rest/handler/config/fat/ConfigRESTHandlerAppDefinedResourcesTest.java
@@ -52,7 +52,7 @@ import componenttest.topology.utils.FATServletClient;
 @RunWith(FATRunner.class)
 public class ConfigRESTHandlerAppDefinedResourcesTest extends FATServletClient {
     private static final String APP_NAME = "AppDefResourcesApp";
-    private static final String DerbyVersion = "10.11.1.1";
+    private static final String H2Version = "2.1.214 (2022-06-13)";
 
     @ClassRule
     public static RepeatTests r = RepeatTests.withoutModificationInFullMode() // servlet-3.1
@@ -392,8 +392,8 @@ public class ConfigRESTHandlerAppDefinedResourcesTest extends FATServletClient {
         JsonObject authData;
         assertNotNull(err, authData = ds.getJsonObject("containerAuthDataRef"));
         assertEquals(err, "authData", authData.getString("configElementName"));
-        assertEquals(err, "derbyAuth1", authData.getString("uid"));
-        assertEquals(err, "derbyAuth1", authData.getString("id"));
+        assertEquals(err, "h2Auth1", authData.getString("uid"));
+        assertEquals(err, "h2Auth1", authData.getString("id"));
         assertEquals(err, "dbuser1", authData.getString("user"));
         assertEquals(err, "******", authData.getString("password"));
 
@@ -405,13 +405,13 @@ public class ConfigRESTHandlerAppDefinedResourcesTest extends FATServletClient {
         assertEquals(err, "jdbcDriver", driver.getString("configElementName"));
         assertEquals(err, "application[AppDefResourcesApp]/module[AppDefResourcesApp.war]/dataSource[java:module/env/jdbc/ds2]/jdbcDriver", driver.getString("uid"));
         assertEquals(err, "application[AppDefResourcesApp]/module[AppDefResourcesApp.war]/dataSource[java:module/env/jdbc/ds2]/jdbcDriver", driver.getString("id"));
-        assertEquals(err, "org.apache.derby.jdbc.EmbeddedXADataSource", driver.getString("javax.sql.XADataSource"));
+        assertEquals(err, "org.h2.jdbcx.JdbcDataSource", driver.getString("javax.sql.XADataSource"));
 
         JsonObject library;
         assertNotNull(err, library = driver.getJsonObject("libraryRef"));
         assertEquals(err, "library", library.getString("configElementName"));
-        assertEquals(err, "Derby", library.getString("uid"));
-        assertEquals(err, "Derby", library.getString("id"));
+        assertEquals(err, "H2", library.getString("uid"));
+        assertEquals(err, "H2", library.getString("id"));
         assertEquals(err, "spec,ibm-api,api,stable", library.getString("apiTypeVisibility"));
 
         JsonArray files;
@@ -419,31 +419,27 @@ public class ConfigRESTHandlerAppDefinedResourcesTest extends FATServletClient {
         assertNotNull(err, files = library.getJsonArray("fileRef"));
         assertNotNull(err, file = files.getJsonObject(0));
         assertEquals(err, "file", file.getString("configElementName"));
-        assertEquals(err, "library[Derby]/file[default-0]", file.getString("uid"));
+        assertEquals(err, "library[H2]/file[default-0]", file.getString("uid"));
         assertNull(err, file.get("id"));
-        assertTrue(err, file.getString("name").endsWith("derby.jar"));
+        assertTrue(err, file.getString("name").endsWith("h2.jar"));
 
         JsonArray onConnect;
         assertNotNull(err, onConnect = ds.getJsonArray("onConnect"));
         assertEquals(err, 1, onConnect.size());
-        assertEquals(err, "DECLARE GLOBAL TEMPORARY TABLE TEMP2 (COL1 VARCHAR(80)) ON COMMIT PRESERVE ROWS NOT LOGGED", onConnect.getString(0));
+        assertEquals(err, "CREATE TABLE IF NOT EXISTS TEMP2 (COL1 VARCHAR(80))", onConnect.getString(0));
 
         JsonObject props;
         assertNotNull(err, props = ds.getJsonObject("properties"));
-        assertEquals(err, 3, props.size());
-        assertEquals(err, "create", props.getString("createDatabase"));
-        String databaseName;
-        assertNotNull(err, databaseName = props.getString("databaseName"));
-        assertTrue(err, databaseName.endsWith("configRHTestDB"));
-        assertTrue(err, databaseName.contains("resources")); // must expand ${shared.resource.dir}
+        assertEquals(err, 2, props.size());
+        assertEquals(err, "******", props.getString("URL"));
         assertEquals(err, 220, props.getInt("loginTimeout"));
 
         assertEquals(err, 82, ds.getInt("queryTimeout"));
 
         assertNotNull(err, authData = ds.getJsonObject("recoveryAuthDataRef"));
         assertEquals(err, "authData", authData.getString("configElementName"));
-        assertEquals(err, "derbyAuth2", authData.getString("uid"));
-        assertEquals(err, "derbyAuth2", authData.getString("id"));
+        assertEquals(err, "h2Auth2", authData.getString("uid"));
+        assertEquals(err, "h2Auth2", authData.getString("id"));
         assertEquals(err, "dbuser2", authData.getString("user"));
         assertEquals(err, "******", authData.getString("password"));
 
@@ -505,13 +501,13 @@ public class ConfigRESTHandlerAppDefinedResourcesTest extends FATServletClient {
         assertEquals(err, "jdbcDriver", driver.getString("configElementName"));
         assertEquals(err, "dataSource[java:global/env/jdbc/ds4]/jdbcDriver", driver.getString("uid"));
         assertEquals(err, "dataSource[java:global/env/jdbc/ds4]/jdbcDriver", driver.getString("id"));
-        assertTrue(err, driver.getString("javax.sql.XADataSource").startsWith("org.apache.derby.jdbc."));
+        assertTrue(err, driver.getString("java.sql.Driver").equals("org.h2.Driver"));
 
         JsonObject library;
         assertNotNull(err, library = driver.getJsonObject("libraryRef"));
         assertEquals(err, "library", library.getString("configElementName"));
-        assertEquals(err, "Derby", library.getString("uid"));
-        assertEquals(err, "Derby", library.getString("id"));
+        assertEquals(err, "H2", library.getString("uid"));
+        assertEquals(err, "H2", library.getString("id"));
         assertEquals(err, "spec,ibm-api,api,stable", library.getString("apiTypeVisibility"));
 
         JsonArray files;
@@ -519,22 +515,21 @@ public class ConfigRESTHandlerAppDefinedResourcesTest extends FATServletClient {
         assertNotNull(err, files = library.getJsonArray("fileRef"));
         assertNotNull(err, file = files.getJsonObject(0));
         assertEquals(err, "file", file.getString("configElementName"));
-        assertEquals(err, "library[Derby]/file[default-0]", file.getString("uid"));
+        assertEquals(err, "library[H2]/file[default-0]", file.getString("uid"));
         assertNull(err, file.get("id"));
-        assertTrue(err, file.getString("name").endsWith("derby.jar"));
+        assertTrue(err, file.getString("name").endsWith("h2.jar"));
 
         JsonObject props;
         assertNotNull(err, props = ds.getJsonObject("properties"));
-        assertEquals(err, 4, props.size());
-        assertEquals(err, "create", props.getString("createDatabase"));
-        assertEquals(err, "memory:fourthdb", props.getString("databaseName"));
+        assertEquals(err, 3, props.size());
+        assertEquals(err, "******", props.getString("URL"));
         assertEquals(err, "dbuser4", props.getString("user"));
         assertEquals(err, "******", props.getString("password"));
 
         assertEquals(err, 10, ds.getInt("statementCacheSize"));
         assertFalse(err, ds.getBoolean("syncQueryTimeoutWithTransactionTimeout"));
         assertTrue(err, ds.getBoolean("transactional"));
-        assertEquals(err, "javax.sql.XADataSource", ds.getString("type"));
+        assertEquals(err, "java.sql.Driver", ds.getString("type"));
 
         JsonArray api;
         assertNotNull(err, api = ds.getJsonArray("api"));
@@ -553,12 +548,12 @@ public class ConfigRESTHandlerAppDefinedResourcesTest extends FATServletClient {
         assertTrue(err, json.getBoolean("successful"));
         assertNull(err, json.get("failure"));
         assertNotNull(err, json = json.getJsonObject("info"));
-        assertEquals(err, "Apache Derby", json.getString("databaseProductName"));
+        assertEquals(err, "H2", json.getString("databaseProductName"));
         assertNotNull(err, json.getString("databaseProductVersion"));
-        assertEquals(err, "Apache Derby Embedded JDBC Driver", json.getString("jdbcDriverName"));
+        assertEquals(err, "H2 JDBC Driver", json.getString("jdbcDriverName"));
         assertNotNull(err, json.getString("jdbcDriverVersion"));
-        assertEquals(err, "DBUSER4", json.getString("schema"));
-        assertEquals(err, "dbuser4", json.getString("user"));
+        assertEquals(err, "PUBLIC", json.getString("schema"));
+        assertEquals(err, "DBUSER4", json.getString("user"));
     }
 
     /**
@@ -639,9 +634,9 @@ public class ConfigRESTHandlerAppDefinedResourcesTest extends FATServletClient {
                      ejb_ds_driver.getString("id"));
 
         assertNull(err, web_ds_driver.get("javax.sql.ConnectionPoolDataSource"));
-        assertEquals(err, "org.apache.derby.jdbc.EmbeddedConnectionPoolDataSource", ejb_ds_driver.getString("javax.sql.ConnectionPoolDataSource"));
+        assertEquals(err, "org.h2.jdbcx.JdbcDataSource", ejb_ds_driver.getString("javax.sql.XADataSource"));
 
-        assertEquals(err, "org.apache.derby.jdbc.EmbeddedDataSource", web_ds_driver.getString("javax.sql.DataSource"));
+        assertEquals(err, "org.h2.jdbcx.JdbcDataSource", web_ds_driver.getString("javax.sql.XADataSource"));
         assertNull(err, ejb_ds_driver.get("javax.sql.DataSource"));
 
         assertNotNull(err, web_ds_driver.getJsonObject("libraryRef"));
@@ -652,13 +647,10 @@ public class ConfigRESTHandlerAppDefinedResourcesTest extends FATServletClient {
         assertNotNull(err, ejb_ds_props = ejb_ds.getJsonObject("properties"));
 
         assertEquals(err, 1, web_ds_props.size());
-        assertEquals(err, 2, ejb_ds_props.size());
+        assertEquals(err, 1, ejb_ds_props.size());
 
-        assertNull(err, web_ds_props.get("createDatabase"));
-        assertEquals(err, "create", ejb_ds_props.getString("createDatabase"));
-
-        assertEquals(err, "memory:thirddb;create=true", web_ds_props.getString("databaseName"));
-        assertEquals(err, "memory:ejbdb", ejb_ds_props.getString("databaseName"));
+        assertEquals(err, "******", web_ds_props.getString("URL"));
+        assertEquals(err, "******", ejb_ds_props.getString("URL"));
 
         assertEquals(err, 10, web_ds.getInt("statementCacheSize"));
         assertEquals(err, 10, ejb_ds.getInt("statementCacheSize"));
@@ -669,8 +661,8 @@ public class ConfigRESTHandlerAppDefinedResourcesTest extends FATServletClient {
         assertTrue(err, web_ds.getBoolean("transactional"));
         assertTrue(err, ejb_ds.getBoolean("transactional"));
 
-        assertEquals(err, "javax.sql.DataSource", web_ds.getString("type"));
-        assertEquals(err, "javax.sql.ConnectionPoolDataSource", ejb_ds.getString("type"));
+        assertEquals(err, "javax.sql.XADataSource", web_ds.getString("type"));
+        assertEquals(err, "javax.sql.XADataSource", ejb_ds.getString("type"));
 
         JsonArray web_ds_api, ejb_ds_api;
         assertNotNull(err, web_ds_api = web_ds.getJsonArray("api"));
@@ -728,13 +720,13 @@ public class ConfigRESTHandlerAppDefinedResourcesTest extends FATServletClient {
         assertEquals(err, "application[AppDefResourcesApp]/module[AppDefResourcesApp.war]/dataSource[java:comp/env/jdbc/ds3]/jdbcDriver",
                      driver.getString("id"));
         assertNull(err, driver.get("jndiName"));
-        assertEquals(err, "org.apache.derby.jdbc.EmbeddedDataSource", driver.getString("javax.sql.DataSource"));
+        assertEquals(err, "org.h2.jdbcx.JdbcDataSource", driver.getString("javax.sql.XADataSource"));
 
         JsonObject library;
         assertNotNull(err, library = driver.getJsonObject("libraryRef"));
         assertEquals(err, "library", library.getString("configElementName"));
-        assertEquals(err, "Derby", library.getString("uid"));
-        assertEquals(err, "Derby", library.getString("id"));
+        assertEquals(err, "H2", library.getString("uid"));
+        assertEquals(err, "H2", library.getString("id"));
         assertEquals(err, "spec,ibm-api,api,stable", library.getString("apiTypeVisibility"));
 
         JsonArray files;
@@ -742,9 +734,9 @@ public class ConfigRESTHandlerAppDefinedResourcesTest extends FATServletClient {
         assertNotNull(err, files = library.getJsonArray("fileRef"));
         assertNotNull(err, file = files.getJsonObject(0));
         assertEquals(err, "file", file.getString("configElementName"));
-        assertEquals(err, "library[Derby]/file[default-0]", file.getString("uid"));
+        assertEquals(err, "library[H2]/file[default-0]", file.getString("uid"));
         assertNull(err, file.get("id"));
-        assertTrue(err, file.getString("name").endsWith("derby.jar"));
+        assertTrue(err, file.getString("name").endsWith("h2.jar"));
     }
 
     /**
@@ -1090,20 +1082,20 @@ public class ConfigRESTHandlerAppDefinedResourcesTest extends FATServletClient {
         assertNull(err, jj.get("id"));
         assertNotNull(err, jj = jj.getJsonObject("libraryRef"));
         assertEquals(err, "library", jj.getString("configElementName"));
-        assertEquals(err, "Derby", jj.getString("uid"));
-        assertEquals(err, "Derby", jj.getString("id"));
+        assertEquals(err, "H2", jj.getString("uid"));
+        assertEquals(err, "H2", jj.getString("id"));
         assertEquals(err, "spec,ibm-api,api,stable", jj.getString("apiTypeVisibility"));
         assertNotNull(err, json = jj.getJsonArray("fileRef"));
         assertEquals(err, 1, json.size());
         assertNotNull(err, jj = json.getJsonObject(0));
         assertEquals(err, "file", jj.getString("configElementName"));
-        assertEquals(err, "library[Derby]/file[default-0]", jj.getString("uid"));
-        assertTrue(err, jj.getString("name").endsWith("derby.jar"));
+        assertEquals(err, "library[H2]/file[default-0]", jj.getString("uid"));
+        assertTrue(err, jj.getString("name").endsWith("h2.jar"));
         assertEquals(err, 10, j.getInt("statementCacheSize"));
         assertEquals(err, false, j.getBoolean("syncQueryTimeoutWithTransactionTimeout"));
         assertEquals(err, false, j.getBoolean("transactional"));
-        assertNotNull(err, j = j.getJsonObject("properties.derby.embedded"));
-        assertEquals(err, "memory:recoverydb", j.getString("databaseName"));
+        assertNotNull(err, j = j.getJsonObject("properties.h2"));
+        assertEquals(err, "jdbc:h2:mem:recoverydb;DB_CLOSE_DELAY=-1", j.getString("URL"));
     }
 
     /**
@@ -1206,7 +1198,7 @@ public class ConfigRESTHandlerAppDefinedResourcesTest extends FATServletClient {
     @Test
     @SkipIfSysProp(SkipIfSysProp.OS_IBMI) //Skip on IBM i due to additional Db2 JDBC driver in JDK
     public void testValidateAppDefinedDataSources() throws Exception {
-        JsonArray array = FATSuite.createHttpsRequestWithAdminUser(server, "/ibm/api/validation/dataSource?auth=container&authAlias=derbyAuth3")
+        JsonArray array = FATSuite.createHttpsRequestWithAdminUser(server, "/ibm/api/validation/dataSource?auth=container&authAlias=h2Auth3")
                         .run(JsonArray.class);
         String err = array.toString();
         assertEquals(err, 6, array.size());
@@ -1262,12 +1254,12 @@ public class ConfigRESTHandlerAppDefinedResourcesTest extends FATServletClient {
         assertTrue(err, v.getBoolean("successful"));
         assertNull(err, v.get("failure"));
         assertNotNull(err, info = v.getJsonObject("info"));
-        assertEquals(err, "Apache Derby", info.getString("databaseProductName"));
-        assertTrue(err, info.getString("databaseProductVersion").contains(DerbyVersion));
-        assertEquals(err, "Apache Derby Embedded JDBC Driver", info.getString("jdbcDriverName"));
-        assertTrue(err, info.getString("jdbcDriverVersion").contains(DerbyVersion));
-        assertEquals(err, "DBUSER3", info.getString("schema"));
-        assertEquals(err, "dbuser3", info.getString("user"));
+        assertEquals(err, "H2", info.getString("databaseProductName"));
+        assertTrue(err, info.getString("databaseProductVersion").contains(H2Version));
+        assertEquals(err, "H2 JDBC Driver", info.getString("jdbcDriverName"));
+        assertTrue(err, info.getString("jdbcDriverVersion").contains(H2Version));
+        assertEquals(err, "PUBLIC", info.getString("schema"));
+        assertEquals(err, "DBUSER3", info.getString("user"));
 
         assertNotNull(err, v = array.getJsonObject(2));
         assertEquals(err, "application[AppDefResourcesApp]/module[AppDefResourcesApp.war]/dataSource[java:module/env/jdbc/ds2]", v.getString("uid"));
@@ -1279,12 +1271,12 @@ public class ConfigRESTHandlerAppDefinedResourcesTest extends FATServletClient {
         assertTrue(err, v.getBoolean("successful"));
         assertNull(err, v.get("failure"));
         assertNotNull(err, info = v.getJsonObject("info"));
-        assertEquals(err, "Apache Derby", info.getString("databaseProductName"));
-        assertTrue(err, info.getString("databaseProductVersion").contains(DerbyVersion));
-        assertEquals(err, "Apache Derby Embedded JDBC Driver", info.getString("jdbcDriverName"));
-        assertTrue(err, info.getString("jdbcDriverVersion").contains(DerbyVersion));
-        assertEquals(err, "DBUSER3", info.getString("schema"));
-        assertEquals(err, "dbuser3", info.getString("user"));
+        assertEquals(err, "H2", info.getString("databaseProductName"));
+        assertTrue(err, info.getString("databaseProductVersion").contains(H2Version));
+        assertEquals(err, "H2 JDBC Driver", info.getString("jdbcDriverName"));
+        assertTrue(err, info.getString("jdbcDriverVersion").contains(H2Version));
+        assertEquals(err, "PUBLIC", info.getString("schema"));
+        assertEquals(err, "DBUSER3", info.getString("user"));
 
         assertNotNull(err, v = array.getJsonObject(3));
         assertEquals(err, "application[AppDefResourcesApp]/module[AppDefResourcesEJB.jar]/component[AppDefinedResourcesBean]/dataSource[java:comp/env/jdbc/ds3]",
@@ -1298,12 +1290,12 @@ public class ConfigRESTHandlerAppDefinedResourcesTest extends FATServletClient {
         assertTrue(err, v.getBoolean("successful"));
         assertNull(err, v.get("failure"));
         assertNotNull(err, info = v.getJsonObject("info"));
-        assertEquals(err, "Apache Derby", info.getString("databaseProductName"));
-        assertTrue(err, info.getString("databaseProductVersion").contains(DerbyVersion));
-        assertEquals(err, "Apache Derby Embedded JDBC Driver", info.getString("jdbcDriverName"));
-        assertTrue(err, info.getString("jdbcDriverVersion").contains(DerbyVersion));
-        assertEquals(err, "DBUSER3", info.getString("schema"));
-        assertEquals(err, "dbuser3", info.getString("user"));
+        assertEquals(err, "H2", info.getString("databaseProductName"));
+        assertTrue(err, info.getString("databaseProductVersion").contains(H2Version));
+        assertEquals(err, "H2 JDBC Driver", info.getString("jdbcDriverName"));
+        assertTrue(err, info.getString("jdbcDriverVersion").contains(H2Version));
+        assertEquals(err, "PUBLIC", info.getString("schema"));
+        assertEquals(err, "DBUSER3", info.getString("user"));
 
         assertNotNull(err, v = array.getJsonObject(4));
         assertEquals(err, "DefaultDataSource", v.getString("uid"));
@@ -1327,12 +1319,12 @@ public class ConfigRESTHandlerAppDefinedResourcesTest extends FATServletClient {
         assertTrue(err, v.getBoolean("successful"));
         assertNull(err, v.get("failure"));
         assertNotNull(err, info = v.getJsonObject("info"));
-        assertEquals(err, "Apache Derby", info.getString("databaseProductName"));
-        assertTrue(err, info.getString("databaseProductVersion").contains(DerbyVersion));
-        assertEquals(err, "Apache Derby Embedded JDBC Driver", info.getString("jdbcDriverName"));
-        assertTrue(err, info.getString("jdbcDriverVersion").contains(DerbyVersion));
-        assertEquals(err, "DBUSER3", info.getString("schema"));
-        assertEquals(err, "dbuser3", info.getString("user"));
+        assertEquals(err, "H2", info.getString("databaseProductName"));
+        assertTrue(err, info.getString("databaseProductVersion").contains(H2Version));
+        assertEquals(err, "H2 JDBC Driver", info.getString("jdbcDriverName"));
+        assertTrue(err, info.getString("jdbcDriverVersion").contains(H2Version));
+        assertEquals(err, "PUBLIC", info.getString("schema"));
+        assertEquals(err, "DBUSER3", info.getString("user"));
     }
 
     /**

--- a/dev/com.ibm.ws.rest.handler.config_fat/fat/src/com/ibm/ws/rest/handler/config/fat/ConfigRESTHandlerTest.java
+++ b/dev/com.ibm.ws.rest.handler.config_fat/fat/src/com/ibm/ws/rest/handler/config/fat/ConfigRESTHandlerTest.java
@@ -201,7 +201,7 @@ public class ConfigRESTHandlerTest extends FATServletClient {
         String error;
         error = j.getString("error");
         assertTrue(err, error.startsWith("CWWKO1531E") && error.contains("mongo"));
-        assertEquals(err, "DerbyLib", j.getString("libraryRef"));
+        assertEquals(err, "H2Lib", j.getString("libraryRef"));
         assertEquals(err, "pwd1", j.getString("password")); //TODO Don't reveal password here
         assertEquals(err, "u1", j.getString("user"));
 
@@ -263,8 +263,8 @@ public class ConfigRESTHandlerTest extends FATServletClient {
                 else
                     found = true;
         assertTrue(err, found);
-        assertNotNull(err, j = j.getJsonObject("properties.derby.embedded"));
-        assertEquals(err, "memory:withoutJDBCDriver", j.getString("databaseName"));
+        assertNotNull(err, j = j.getJsonObject("properties.h2"));
+        assertEquals(err, "jdbc:h2:mem:withoutJDBCDriver;DB_CLOSE_DELAY=-1", j.getString("URL"));
 
         j = json.getJsonObject(1);
         assertEquals(err, "dataSource", j.getString("configElementName"));
@@ -284,15 +284,15 @@ public class ConfigRESTHandlerTest extends FATServletClient {
         assertNull(err, jj.get("id"));
         assertNotNull(err, jj = jj.getJsonObject("libraryRef"));
         assertEquals(err, "library", jj.getString("configElementName"));
-        assertEquals(err, "Derby", jj.getString("uid"));
-        assertEquals(err, "Derby", jj.getString("id"));
+        assertEquals(err, "H2", jj.getString("uid"));
+        assertEquals(err, "H2", jj.getString("id"));
         assertEquals(err, "spec,ibm-api,api,stable", jj.getString("apiTypeVisibility"));
         assertNotNull(err, ja = jj.getJsonArray("fileRef"));
         assertEquals(err, 1, ja.size());
         assertNotNull(err, jj = ja.getJsonObject(0));
         assertEquals(err, "file", jj.getString("configElementName"));
-        assertEquals(err, "library[Derby]/file[default-0]", jj.getString("uid"));
-        assertTrue(err, jj.getString("name").endsWith("derby.jar"));
+        assertEquals(err, "library[H2]/file[default-0]", jj.getString("uid"));
+        assertTrue(err, jj.getString("name").endsWith("h2.jar"));
         assertEquals(err, 10, j.getInt("statementCacheSize"));
         assertEquals(err, false, j.getBoolean("syncQueryTimeoutWithTransactionTimeout"));
         assertEquals(err, true, j.getBoolean("transactional"));
@@ -306,9 +306,8 @@ public class ConfigRESTHandlerTest extends FATServletClient {
                 else
                     found = true;
         assertTrue(err, found);
-        assertNotNull(err, j = j.getJsonObject("properties.derby.embedded"));
-        assertEquals(err, "create", j.getString("createDatabase"));
-        assertEquals(err, "memory:defaultdb", j.getString("databaseName"));
+        assertNotNull(err, j = j.getJsonObject("properties.h2"));
+        assertEquals(err, "jdbc:h2:mem:defaultdb;DB_CLOSE_DELAY=-1", j.getString("URL"));
         assertEquals(err, "dbuser", j.getString("user"));
         assertEquals(err, "******", j.getString("password"));
 
@@ -325,18 +324,18 @@ public class ConfigRESTHandlerTest extends FATServletClient {
         assertEquals(err, "JdBcDrIvEr", jj.getString("configElementName"));
         assertEquals(err, "dataSource[NestedElementCase]/JdBcDrIvEr[default-0]", jj.getString("uid"));
         assertNull(err, jj.get("id"));
-        assertEquals(err, "org.apache.derby.jdbc.EmbeddedDataSource", jj.getString("javax.sql.DataSource"));
+        assertEquals(err, "org.h2.jdbcx.JdbcDataSource", jj.getString("javax.sql.DataSource"));
         assertNotNull(err, jj = jj.getJsonObject("libraryRef"));
         assertEquals(err, "library", jj.getString("configElementName"));
-        assertEquals(err, "Derby", jj.getString("uid"));
-        assertEquals(err, "Derby", jj.getString("id"));
+        assertEquals(err, "H2", jj.getString("uid"));
+        assertEquals(err, "H2", jj.getString("id"));
         assertEquals(err, "spec,ibm-api,api,stable", jj.getString("apiTypeVisibility"));
         assertNotNull(err, ja = jj.getJsonArray("fileRef"));
         assertEquals(err, 1, ja.size());
         assertNotNull(err, jj = ja.getJsonObject(0));
         assertEquals(err, "file", jj.getString("configElementName"));
-        assertEquals(err, "library[Derby]/file[default-0]", jj.getString("uid"));
-        assertTrue(err, jj.getString("name").endsWith("derby.jar"));
+        assertEquals(err, "library[H2]/file[default-0]", jj.getString("uid"));
+        assertTrue(err, jj.getString("name").endsWith("h2.jar"));
 
         j = json.getJsonObject(3);
         assertEquals(err, "dataSource", j.getString("configElementName"));
@@ -368,19 +367,19 @@ public class ConfigRESTHandlerTest extends FATServletClient {
         assertEquals(err, "The property's value.", j.getString("invalidProperty"));
         assertNotNull(err, jj = j.getJsonObject("jdbcDriverRef"));
         assertEquals(err, "jdbcDriver", jj.getString("configElementName"));
-        assertEquals(err, "DerbyDriver", jj.getString("uid"));
-        assertEquals(err, "DerbyDriver", jj.getString("id"));
+        assertEquals(err, "H2Driver", jj.getString("uid"));
+        assertEquals(err, "H2Driver", jj.getString("id"));
         assertNotNull(err, jj = jj.getJsonObject("libraryRef"));
         assertEquals(err, "library", jj.getString("configElementName"));
-        assertEquals(err, "Derby", jj.getString("uid"));
-        assertEquals(err, "Derby", jj.getString("id"));
+        assertEquals(err, "H2", jj.getString("uid"));
+        assertEquals(err, "H2", jj.getString("id"));
         assertEquals(err, "spec,ibm-api,api,stable", jj.getString("apiTypeVisibility"));
         assertNotNull(err, ja = jj.getJsonArray("fileRef"));
         assertEquals(err, 1, ja.size());
         assertNotNull(err, jj = ja.getJsonObject(0));
         assertEquals(err, "file", jj.getString("configElementName"));
-        assertEquals(err, "library[Derby]/file[default-0]", jj.getString("uid"));
-        assertTrue(err, jj.getString("name").endsWith("derby.jar"));
+        assertEquals(err, "library[H2]/file[default-0]", jj.getString("uid"));
+        assertTrue(err, jj.getString("name").endsWith("h2.jar"));
         assertEquals(err, 130, j.getInt("queryTimeout"));
         assertNotNull(err, jj = j.getJsonObject("recoveryAuthDataRef"));
         assertEquals(err, "authData", jj.getString("configElementName"));
@@ -402,8 +401,7 @@ public class ConfigRESTHandlerTest extends FATServletClient {
                     found = true;
         assertTrue(err, found);
         assertNotNull(err, j = j.getJsonObject("properties"));
-        assertEquals(err, "create", j.getString("createDatabase"));
-        assertEquals(err, "memory:defaultdb", j.getString("databaseName"));
+        assertEquals(err, "******", j.getString("URL"));
 
         j = json.getJsonObject(4);
         assertEquals(err, "dataSource", j.getString("configElementName"));
@@ -442,32 +440,31 @@ public class ConfigRESTHandlerTest extends FATServletClient {
         assertTrue(err, found);
         assertNotNull(err, jj = j.getJsonObject("jdbcDriverRef"));
         assertEquals(err, "jdbcDriver", jj.getString("configElementName"));
-        assertEquals(err, "dataSource[default-0]/jdbcDriver[NestedDerbyDriver]", jj.getString("uid"));
-        assertEquals(err, "NestedDerbyDriver", jj.getString("id"));
-        assertEquals(err, "org.apache.derby.jdbc.EmbeddedDataSource", jj.getString("javax.sql.DataSource"));
-        assertEquals(err, "org.apache.derby.jdbc.EmbeddedConnectionPoolDataSource", jj.getString("javax.sql.ConnectionPoolDataSource"));
-        assertEquals(err, "org.apache.derby.jdbc.EmbeddedXADataSource", jj.getString("javax.sql.XADataSource"));
+        assertEquals(err, "dataSource[default-0]/jdbcDriver[NestedH2Driver]", jj.getString("uid"));
+        assertEquals(err, "NestedH2Driver", jj.getString("id"));
+        assertEquals(err, "org.h2.jdbcx.JdbcDataSource", jj.getString("javax.sql.DataSource"));
+        assertEquals(err, "org.h2.jdbcx.JdbcDataSource", jj.getString("javax.sql.ConnectionPoolDataSource"));
+        assertEquals(err, "org.h2.jdbcx.JdbcDataSource", jj.getString("javax.sql.XADataSource"));
         assertNotNull(err, jj = jj.getJsonObject("libraryRef"));
         assertEquals(err, "library", jj.getString("configElementName"));
-        assertEquals(err, "Derby", jj.getString("uid"));
-        assertEquals(err, "Derby", jj.getString("id"));
+        assertEquals(err, "H2", jj.getString("uid"));
+        assertEquals(err, "H2", jj.getString("id"));
         assertEquals(err, "spec,ibm-api,api,stable", jj.getString("apiTypeVisibility"));
         assertNotNull(err, ja = jj.getJsonArray("fileRef"));
         assertEquals(err, 1, ja.size());
         assertNotNull(err, jj = ja.getJsonObject(0));
         assertEquals(err, "file", jj.getString("configElementName"));
-        assertEquals(err, "library[Derby]/file[default-0]", jj.getString("uid"));
-        assertTrue(err, jj.getString("name").endsWith("derby.jar"));
+        assertEquals(err, "library[H2]/file[default-0]", jj.getString("uid"));
+        assertTrue(err, jj.getString("name").endsWith("h2.jar"));
         assertNotNull(err, ja = j.getJsonArray("onConnect"));
         assertEquals(err, 2, ja.size());
-        assertEquals(err, "SET CURRENT SCHEMA = APP", ja.getString(0));
-        assertEquals(err, "SET CURRENT SQLID = APP", ja.getString(1));
+        assertEquals(err, "SET SCHEMA DBUSER", ja.getString(0));
+        assertEquals(err, "DROP TABLE IF EXISTS NON_EXISTENT_TABLE", ja.getString(1));
         assertEquals(err, 10, j.getInt("statementCacheSize"));
         assertEquals(err, false, j.getBoolean("syncQueryTimeoutWithTransactionTimeout"));
         assertEquals(err, true, j.getBoolean("transactional"));
-        assertNotNull(err, j = j.getJsonObject("properties.derby.embedded"));
-        assertEquals(err, "create", j.getString("createDatabase"));
-        assertEquals(err, "memory:defaultdb", j.getString("databaseName"));
+        assertNotNull(err, j = j.getJsonObject("properties.h2"));
+        assertEquals(err, "jdbc:h2:mem:defaultdb;DB_CLOSE_DELAY=-1", j.getString("URL"));
 
         j = json.getJsonObject(5);
         assertEquals(err, "dataSource", j.getString("configElementName"));
@@ -505,20 +502,20 @@ public class ConfigRESTHandlerTest extends FATServletClient {
         assertNull(err, jj.get("id"));
         assertNotNull(err, jj = jj.getJsonObject("libraryRef"));
         assertEquals(err, "library", jj.getString("configElementName"));
-        assertEquals(err, "Derby", jj.getString("uid"));
-        assertEquals(err, "Derby", jj.getString("id"));
+        assertEquals(err, "H2", jj.getString("uid"));
+        assertEquals(err, "H2", jj.getString("id"));
         assertEquals(err, "spec,ibm-api,api,stable", jj.getString("apiTypeVisibility"));
         assertNotNull(err, ja = jj.getJsonArray("fileRef"));
         assertEquals(err, 1, ja.size());
         assertNotNull(err, jj = ja.getJsonObject(0));
         assertEquals(err, "file", jj.getString("configElementName"));
-        assertEquals(err, "library[Derby]/file[default-0]", jj.getString("uid"));
-        assertTrue(err, jj.getString("name").endsWith("derby.jar"));
+        assertEquals(err, "library[H2]/file[default-0]", jj.getString("uid"));
+        assertTrue(err, jj.getString("name").endsWith("h2.jar"));
         assertEquals(err, 10, j.getInt("statementCacheSize"));
         assertEquals(err, false, j.getBoolean("syncQueryTimeoutWithTransactionTimeout"));
         assertEquals(err, true, j.getBoolean("transactional"));
-        assertNotNull(err, j = j.getJsonObject("properties.derby.embedded"));
-        assertEquals(err, "memory:doesNotExist", j.getString("databaseName"));
+        assertNotNull(err, j = j.getJsonObject("properties.h2"));
+        assertEquals(err, "jdbc:h2:file:doesNotExist;IF_EXISTS=TRUE;DB_CLOSE_DELAY=-1", j.getString("URL"));
 
         j = json.getJsonObject(6);
         assertEquals(err, "dataSource", j.getString("configElementName"));
@@ -561,20 +558,20 @@ public class ConfigRESTHandlerTest extends FATServletClient {
         assertNull(err, jj.get("id"));
         assertNotNull(err, jj = jj.getJsonObject("libraryRef"));
         assertEquals(err, "library", jj.getString("configElementName"));
-        assertEquals(err, "Derby", jj.getString("uid"));
-        assertEquals(err, "Derby", jj.getString("id"));
+        assertEquals(err, "H2", jj.getString("uid"));
+        assertEquals(err, "H2", jj.getString("id"));
         assertEquals(err, "spec,ibm-api,api,stable", jj.getString("apiTypeVisibility"));
         assertNotNull(err, ja = jj.getJsonArray("fileRef"));
         assertEquals(err, 1, ja.size());
         assertNotNull(err, jj = ja.getJsonObject(0));
         assertEquals(err, "file", jj.getString("configElementName"));
-        assertEquals(err, "library[Derby]/file[default-0]", jj.getString("uid"));
-        assertTrue(err, jj.getString("name").endsWith("derby.jar"));
+        assertEquals(err, "library[H2]/file[default-0]", jj.getString("uid"));
+        assertTrue(err, jj.getString("name").endsWith("h2.jar"));
         assertEquals(err, 10, j.getInt("statementCacheSize"));
         assertEquals(err, false, j.getBoolean("syncQueryTimeoutWithTransactionTimeout"));
         assertEquals(err, false, j.getBoolean("transactional"));
-        assertNotNull(err, j = j.getJsonObject("properties.derby.embedded"));
-        assertEquals(err, "memory:recoverydb", j.getString("databaseName"));
+        assertNotNull(err, j = j.getJsonObject("properties.h2"));
+        assertEquals(err, "jdbc:h2:mem:recoverydb;DB_CLOSE_DELAY=-1", j.getString("URL"));
     }
 
     // Invoke /ibm/api/config/dataSource with jndiName to filter for a specific dataSource instance.
@@ -600,8 +597,8 @@ public class ConfigRESTHandlerTest extends FATServletClient {
                 else
                     found = true;
         assertTrue(err, found);
-        assertNotNull(err, j = j.getJsonObject("properties.derby.embedded"));
-        assertEquals(err, "memory:withoutJDBCDriver", j.getString("databaseName"));
+        assertNotNull(err, j = j.getJsonObject("properties.h2"));
+        assertEquals(err, "jdbc:h2:mem:withoutJDBCDriver;DB_CLOSE_DELAY=-1", j.getString("URL"));
     }
 
     // Invoke /ibm/api/config/dataSource with jndiName query parameter specified with 2 different values on same request
@@ -631,8 +628,9 @@ public class ConfigRESTHandlerTest extends FATServletClient {
         JsonArray ja;
         assertNotNull(err, ja = j.getJsonArray("onConnect"));
         assertEquals(err, 2, ja.size());
-        assertEquals(err, "SET CURRENT SCHEMA = APP", ja.getString(0));
-        assertEquals(err, "SET CURRENT SQLID = APP", ja.getString(1));
+
+        assertEquals(err, "SET SCHEMA DBUSER", ja.getString(0));
+        assertEquals(err, "DROP TABLE IF EXISTS NON_EXISTENT_TABLE", ja.getString(1));
         assertEquals(err, false, j.getBoolean("syncQueryTimeoutWithTransactionTimeout"));
     }
 
@@ -976,11 +974,11 @@ public class ConfigRESTHandlerTest extends FATServletClient {
         assertEquals(err, "JdBcDrIvEr", j.getString("configElementName"));
         assertEquals(err, "dataSource[NestedElementCase]/JdBcDrIvEr[default-0]", j.getString("uid"));
         assertNull(err, j.get("id"));
-        assertEquals(err, "org.apache.derby.jdbc.EmbeddedDataSource", j.getString("javax.sql.DataSource"));
+        assertEquals(err, "org.h2.jdbcx.JdbcDataSource", j.getString("javax.sql.DataSource"));
         assertNotNull(err, j = j.getJsonObject("libraryRef"));
         //Given library is already tested elsewhere, no need to check all attributes
         assertEquals(err, "library", j.getString("configElementName"));
-        assertEquals(err, "Derby", j.getString("uid"));
+        assertEquals(err, "H2", j.getString("uid"));
     }
 
     /*
@@ -1005,11 +1003,11 @@ public class ConfigRESTHandlerTest extends FATServletClient {
         assertEquals(err, "JdBcDrIvEr", json.getString("configElementName"));
         assertEquals(err, "dataSource[NestedElementCase]/JdBcDrIvEr[default-0]", json.getString("uid"));
         assertNull(err, json.get("id"));
-        assertEquals(err, "org.apache.derby.jdbc.EmbeddedDataSource", json.getString("javax.sql.DataSource"));
+        assertEquals(err, "org.h2.jdbcx.JdbcDataSource", json.getString("javax.sql.DataSource"));
         assertNotNull(err, json = json.getJsonObject("libraryRef"));
         //Given library is already tested elsewhere, no need to check all attributes
         assertEquals(err, "library", json.getString("configElementName"));
-        assertEquals(err, "Derby", json.getString("uid"));
+        assertEquals(err, "H2", json.getString("uid"));
     }
 
     /*

--- a/dev/com.ibm.ws.rest.handler.config_fat/fat/src/com/ibm/ws/rest/handler/config/fat/ConfigRESTHandlerTest.java
+++ b/dev/com.ibm.ws.rest.handler.config_fat/fat/src/com/ibm/ws/rest/handler/config/fat/ConfigRESTHandlerTest.java
@@ -515,7 +515,7 @@ public class ConfigRESTHandlerTest extends FATServletClient {
         assertEquals(err, false, j.getBoolean("syncQueryTimeoutWithTransactionTimeout"));
         assertEquals(err, true, j.getBoolean("transactional"));
         assertNotNull(err, j = j.getJsonObject("properties.h2"));
-        assertEquals(err, "jdbc:h2:file:doesNotExist;IF_EXISTS=TRUE;DB_CLOSE_DELAY=-1", j.getString("URL"));
+        assertEquals(err, "jdbc:h2:file:doesNotExist;IFEXISTS=TRUE;DB_CLOSE_DELAY=-1", j.getString("URL"));
 
         j = json.getJsonObject(6);
         assertEquals(err, "dataSource", j.getString("configElementName"));

--- a/dev/com.ibm.ws.rest.handler.config_fat/publish/servers/com.ibm.ws.rest.handler.config.appdef.fat/bootstrap.properties
+++ b/dev/com.ibm.ws.rest.handler.config_fat/publish/servers/com.ibm.ws.rest.handler.config.appdef.fat/bootstrap.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2019 IBM Corporation and others.
+# Copyright (c) 2019,2026 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -14,8 +14,3 @@ bootstrap.include=../testports.properties
 com.ibm.ws.logging.trace.specification=*=info:rest.configbased=all:rest.config=all:rest.validation=all:com.ibm.ws.jdbc=all:com.ibm.ejs.j2c.ConnectionManagerServiceImpl=all:com.ibm.ws.jca17.processor.service=all:com.ibm.ws.jca.processor.jms.*=all:rarInstall=all
 com.ibm.ws.logging.max.file.size=0
 ds.loglevel=debug
-derby.connection.requireAuthentication=true
-derby.user.dbuser1=dbpwd1
-derby.user.dbuser2=dbpwd2
-derby.user.dbuser3=dbpwd3
-derby.user.dbuser4=dbpwd4

--- a/dev/com.ibm.ws.rest.handler.config_fat/publish/servers/com.ibm.ws.rest.handler.config.appdef.fat/server.xml
+++ b/dev/com.ibm.ws.rest.handler.config_fat/publish/servers/com.ibm.ws.rest.handler.config.appdef.fat/server.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2019 IBM Corporation and others.
+    Copyright (c) 2019,2026 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -30,7 +30,7 @@
   <quickStartSecurity userName="adminuser" userPassword="adminpwd"/>
 
   <application location="AppDefResourcesApp.ear">
-    <classloader commonLibraryRef="Derby"/>
+    <classloader commonLibraryRef="H2"/>
   </application>
 
   <connectionFactory jndiName="eis/cf3" containerAuthDataRef="cfauth1">
@@ -45,22 +45,25 @@
   <transaction>
     <DATASOURCE transactional="false">
       <connectionManager maxPoolSize="5" connectionTimeout="0s"/>
-      <jdbcDriver libraryRef="Derby"/>
-   	  <properties.derby.embedded databaseName="memory:recoverydb" createDatabase="create" user="dbuser1" password="dbpwd1"/>
+      <jdbcDriver libraryRef="H2"/>
+      <properties.h2 URL="jdbc:h2:mem:recoverydb;DB_CLOSE_DELAY=-1" user="dbuser1" password="dbpwd1"/>
     </DATASOURCE>
   </transaction>
 
+  <variable name="create.table.temp2"
+            value="CREATE TABLE IF NOT EXISTS TEMP2 (COL1 VARCHAR(80))"/>
+
   <authData id="cfauth1" user="cfuser1" password="1cfuser"/>
 
-  <authData id="derbyAuth1" user="dbuser1" password="dbpwd1"/>
-  <authData id="derbyAuth2" user="dbuser2" password="dbpwd2"/>
-  <authData id="derbyAuth3" user="dbuser3" password="dbpwd3"/>
+  <authData id="h2Auth1" user="dbuser1" password="dbpwd1"/>
+  <authData id="h2Auth2" user="dbuser2" password="dbpwd2"/>
+  <authData id="h2Auth3" user="dbuser3" password="dbpwd3"/>
 
-  <library id="Derby">
-    <file name="${shared.resource.dir}/derby/derby.jar"/>
+  <library id="H2">
+    <file name="${shared.resource.dir}/h2Java8/h2.jar"/>
   </library>
   
-  <javaPermission codebase="${shared.resource.dir}/derby/derby.jar" className="java.security.AllPermission"/>
+  <javaPermission codebase="${shared.resource.dir}/h2Java8/h2.jar" className="java.security.AllPermission"/>
 
   <javaPermission codebase="${server.config.dir}/apps/AppDefResourcesApp.ear"
                   className="java.lang.RuntimePermission" name="getClassLoader"/>  <!-- for the embedded RAR -->

--- a/dev/com.ibm.ws.rest.handler.config_fat/publish/servers/com.ibm.ws.rest.handler.config.audit.fat/bootstrap.properties
+++ b/dev/com.ibm.ws.rest.handler.config_fat/publish/servers/com.ibm.ws.rest.handler.config.audit.fat/bootstrap.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2024 IBM Corporation and others.
+# Copyright (c) 2024,2026 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -14,5 +14,3 @@ bootstrap.include=../testports.properties
 com.ibm.ws.logging.trace.specification=*=info:rest.configbased=all:rest.config=all:rest.validation=all:com.ibm.ws.jdbc=all:com.ibm.ejs.j2c.ConnectionManagerServiceImpl=all
 com.ibm.ws.logging.max.file.size=0
 ds.loglevel=debug
-derby.connection.requireAuthentication=true
-derby.user.dbuser=dbpass

--- a/dev/com.ibm.ws.rest.handler.config_fat/publish/servers/com.ibm.ws.rest.handler.config.audit.fat/server.xml
+++ b/dev/com.ibm.ws.rest.handler.config_fat/publish/servers/com.ibm.ws.rest.handler.config.audit.fat/server.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2024 IBM Corporation and others.
+    Copyright (c) 2024,2026 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -37,46 +37,45 @@
     <user>reader</user>
   </reader-role>
   
-  <library id="Derby">
-    <file name="${shared.resource.dir}/derby/derby.jar"/>
+  <library id="H2">
+    <file name="${shared.resource.dir}/h2Java8/h2.jar"/>
   </library>
 
   <dataSource id="DataSourceWithoutJDBCDriver" jndiName="jdbc/withoutJDBCDriver" connectionSharing="MatchCurrentState" transactional="false">
     <containerAuthData id="dbuser-auth" user="dbuser" password="{xor}Oz0vPiws"/>
-   	<properties.derby.embedded databaseName="memory:withoutJDBCDriver"/>
+    <properties.h2 URL="jdbc:h2:mem:withoutJDBCDriver;DB_CLOSE_DELAY=-1"/>
   </dataSource>
 
   <dataSource id="DefaultDataSource" isolationLevel="TRANSACTION_READ_COMMITTED">
-    <jdbcDriver libraryRef="Derby"/>
+    <jdbcDriver libraryRef="H2"/>
     <!-- user/password settings defined in bootstrap.properties -->
-   	<properties.derby.embedded databaseName="memory:defaultdb" createDatabase="create" 
-   	                           user="dbuser" password="dbpass"/>
+    <properties.h2 URL="jdbc:h2:mem:defaultdb;DB_CLOSE_DELAY=-1" user="dbuser" password="dbpass"/>
   </dataSource>
 
   <dataSource id="jdbc/nonexistentdb" jndiName="${id}">
     <CONNECTIONMANAGER id="NestedConPool" agedTimeout="1h2m3s" connectionTimeout="0s" maxIdleTime="40m" reapTime="2m30s"/>
-    <jdbcDriver libraryRef="Derby"/>
-   	<properties.derby.embedded databaseName="memory:doesNotExist"/>
+    <jdbcDriver libraryRef="H2"/>
+    <properties.h2 URL="jdbc:h2:file:doesNotExist;IF_EXISTS=TRUE;DB_CLOSE_DELAY=-1"/>
   </dataSource>
 
   <transaction>
     <dataSource transactional="false" containerAuthDataRef="auth1">
       <connectionManager maxPoolSize="5" connectionTimeout="0s"/>
-      <jdbcDriver libraryRef="Derby"/>
-   	  <properties.derby.embedded databaseName="memory:recoverydb" createDatabase="create"/>
+      <jdbcDriver libraryRef="H2"/>
+      <properties.h2 URL="jdbc:h2:mem:recoverydb;DB_CLOSE_DELAY=-1"/>
     </dataSource>
   </transaction>
 
   <!-- ejbLite and batch features are intentionally disabled -->
   <databaseStore id="unavailableDBStore">
     <dataSource id="unavailableDS">
-      <jdbcDriver libraryRef="Derby"/>
-      <properties.derby.embedded databaseName="memory:unavailabledb"/>
+      <jdbcDriver libraryRef="H2"/>
+      <properties.h2 URL="jdbc:h2:file:unavailabledb;IF_EXISTS=TRUE;DB_CLOSE_DELAY=-1"/>
     </dataSource>
   </databaseStore>
 
   <!-- mongo feature intentionally disabled, so it doesn't matter that we are using an incorrect library -->
-  <mongo id="builder" libraryRef="DerbyLib" password="pwd1" user="u1"/>
+  <mongo id="builder" libraryRef="H2Lib" password="pwd1" user="u1"/>
   <mongoDB id="MongoDBNotEnabled" jndiName="mongo/db" mongoRef="builder" databaseName="testdb" />
   
   <authData id="auth1" user="dbuser" password="dbpass"/>
@@ -84,30 +83,30 @@
   <authData id="auth2" user="dbuser" password="wrong_password"/>
   
   <dataSource jndiName="jdbc/defaultauth" containerAuthDataRef="auth1"> <!-- id omitted for testing -->
-    <connectionManager enableSharingForDirectLookups="false"/>  
-    <jdbcDriver id="NestedDerbyDriver" libraryRef="Derby"
-     javax.sql.DataSource="org.apache.derby.jdbc.EmbeddedDataSource"
-     javax.sql.ConnectionPoolDataSource="org.apache.derby.jdbc.EmbeddedConnectionPoolDataSource"
-     javax.sql.XADataSource="org.apache.derby.jdbc.EmbeddedXADataSource"/>
-    <onConnect>SET CURRENT SCHEMA = APP</onConnect>
-    <onConnect>SET CURRENT SQLID = APP</onConnect>
-    <properties.derby.embedded databaseName="memory:defaultdb" createDatabase="create"/>
+    <connectionManager enableSharingForDirectLookups="false"/>
+    <jdbcDriver id="NestedH2Driver" libraryRef="H2"
+     javax.sql.DataSource="org.h2.jdbcx.JdbcDataSource"
+     javax.sql.ConnectionPoolDataSource="org.h2.jdbcx.JdbcDataSource"
+     javax.sql.XADataSource="org.h2.jdbcx.JdbcDataSource"/>
+    <onConnect>SET SCHEMA DBUSER</onConnect>
+    <onConnect>DROP TABLE IF EXISTS NON_EXISTENT_TABLE</onConnect>
+    <properties.h2 URL="jdbc:h2:mem:defaultdb;DB_CLOSE_DELAY=-1"/>
   </dataSource>
 
   <dataSource id="WrongDefaultAuth" jndiName="jdbc/wrongdefaultauth"
     connectionManagerRef="pool1" containerAuthDataRef="auth2" commitOrRollbackOnCleanup="rollback"
-    invalidProperty="The property's value." jdbcDriverRef="DerbyDriver" queryTimeout="2m10s"
+    invalidProperty="The property's value." jdbcDriverRef="H2Driver" queryTimeout="2m10s"
     recoveryAuthDataRef="auth2" statementCacheSize="15" validationTimeout="20s">
-    <properties databaseName="memory:defaultdb" createDatabase="create"/>
+    <properties URL="jdbc:h2:mem:defaultdb;DB_CLOSE_DELAY=-1"/>
   </dataSource>
-  
+
   <dataSource id="NestedElementCase" jndiName="jdbc/nestedElementCase">
-  	<JdBcDrIvEr libraryRef="Derby" javax.sql.DataSource="org.apache.derby.jdbc.EmbeddedDataSource" />
+    <JdBcDrIvEr libraryRef="H2" javax.sql.DataSource="org.h2.jdbcx.JdbcDataSource" />
   </dataSource>
 
   <connectionManager id="pool1" maxPoolSize="10" purgePolicy="ValidateAllConnections"/>
 
-  <jdbcDriver id="DerbyDriver" libraryRef="Derby"/>
+  <jdbcDriver id="H2Driver" libraryRef="H2"/>
 
   <!-- This app doesn't actually exist.  The config is just here to test child-first config -->
   <application id="bogus" location="bogus.war" autoStart="false">
@@ -148,5 +147,5 @@
   	</usr_child>
   </usr_parent>
   
-  <javaPermission codebase="${shared.resource.dir}/derby/derby.jar" className="java.security.AllPermission"/>
+  <javaPermission codebase="${shared.resource.dir}/h2Java8/h2.jar" className="java.security.AllPermission"/>
 </server>

--- a/dev/com.ibm.ws.rest.handler.config_fat/publish/servers/com.ibm.ws.rest.handler.config.audit.fat/server.xml
+++ b/dev/com.ibm.ws.rest.handler.config_fat/publish/servers/com.ibm.ws.rest.handler.config.audit.fat/server.xml
@@ -70,7 +70,7 @@
   <databaseStore id="unavailableDBStore">
     <dataSource id="unavailableDS">
       <jdbcDriver libraryRef="H2"/>
-      <properties.h2 URL="jdbc:h2:file:unavailabledb;IF_EXISTS=TRUE;DB_CLOSE_DELAY=-1"/>
+      <properties.h2 URL="jdbc:h2:file:unavailabledb;IFEXISTS=TRUE;DB_CLOSE_DELAY=-1"/>
     </dataSource>
   </databaseStore>
 

--- a/dev/com.ibm.ws.rest.handler.config_fat/publish/servers/com.ibm.ws.rest.handler.config.audit.fat/server.xml
+++ b/dev/com.ibm.ws.rest.handler.config_fat/publish/servers/com.ibm.ws.rest.handler.config.audit.fat/server.xml
@@ -55,7 +55,7 @@
   <dataSource id="jdbc/nonexistentdb" jndiName="${id}">
     <CONNECTIONMANAGER id="NestedConPool" agedTimeout="1h2m3s" connectionTimeout="0s" maxIdleTime="40m" reapTime="2m30s"/>
     <jdbcDriver libraryRef="H2"/>
-    <properties.h2 URL="jdbc:h2:file:doesNotExist;IF_EXISTS=TRUE;DB_CLOSE_DELAY=-1"/>
+    <properties.h2 URL="jdbc:h2:file:doesNotExist;IFEXISTS=TRUE;DB_CLOSE_DELAY=-1"/>
   </dataSource>
 
   <transaction>

--- a/dev/com.ibm.ws.rest.handler.config_fat/publish/servers/com.ibm.ws.rest.handler.config.audit.feature.fat/bootstrap.properties
+++ b/dev/com.ibm.ws.rest.handler.config_fat/publish/servers/com.ibm.ws.rest.handler.config.audit.feature.fat/bootstrap.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2024 IBM Corporation and others.
+# Copyright (c) 2024,2026 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -14,5 +14,3 @@ bootstrap.include=../testports.properties
 com.ibm.ws.logging.trace.specification=*=info:rest.configbased=all:rest.config=all:rest.validation=all:com.ibm.ws.jdbc=all:com.ibm.ejs.j2c.ConnectionManagerServiceImpl=all
 com.ibm.ws.logging.max.file.size=0
 ds.loglevel=debug
-derby.connection.requireAuthentication=true
-derby.user.dbuser=dbpass

--- a/dev/com.ibm.ws.rest.handler.config_fat/publish/servers/com.ibm.ws.rest.handler.config.audit.feature.fat/server.xml
+++ b/dev/com.ibm.ws.rest.handler.config_fat/publish/servers/com.ibm.ws.rest.handler.config.audit.feature.fat/server.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2024 IBM Corporation and others.
+    Copyright (c) 2024,2026 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -36,46 +36,45 @@
     <user>reader</user>
   </reader-role>
   
-  <library id="Derby">
-    <file name="${shared.resource.dir}/derby/derby.jar"/>
+  <library id="H2">
+    <file name="${shared.resource.dir}/h2Java8/h2.jar"/>
   </library>
 
   <dataSource id="DataSourceWithoutJDBCDriver" jndiName="jdbc/withoutJDBCDriver" connectionSharing="MatchCurrentState" transactional="false">
     <containerAuthData id="dbuser-auth" user="dbuser" password="{xor}Oz0vPiws"/>
-   	<properties.derby.embedded databaseName="memory:withoutJDBCDriver"/>
+    <properties.h2 URL="jdbc:h2:mem:withoutJDBCDriver;DB_CLOSE_DELAY=-1"/>
   </dataSource>
 
   <dataSource id="DefaultDataSource" isolationLevel="TRANSACTION_READ_COMMITTED">
-    <jdbcDriver libraryRef="Derby"/>
+    <jdbcDriver libraryRef="H2"/>
     <!-- user/password settings defined in bootstrap.properties -->
-   	<properties.derby.embedded databaseName="memory:defaultdb" createDatabase="create" 
-   	                           user="dbuser" password="dbpass"/>
+    <properties.h2 URL="jdbc:h2:mem:defaultdb;DB_CLOSE_DELAY=-1" user="dbuser" password="dbpass"/>
   </dataSource>
 
   <dataSource id="jdbc/nonexistentdb" jndiName="${id}">
     <CONNECTIONMANAGER id="NestedConPool" agedTimeout="1h2m3s" connectionTimeout="0s" maxIdleTime="40m" reapTime="2m30s"/>
-    <jdbcDriver libraryRef="Derby"/>
-   	<properties.derby.embedded databaseName="memory:doesNotExist"/>
+    <jdbcDriver libraryRef="H2"/>
+    <properties.h2 URL="jdbc:h2:file:doesNotExist;IF_EXISTS=TRUE;DB_CLOSE_DELAY=-1"/>
   </dataSource>
 
   <transaction>
     <dataSource transactional="false" containerAuthDataRef="auth1">
       <connectionManager maxPoolSize="5" connectionTimeout="0s"/>
-      <jdbcDriver libraryRef="Derby"/>
-   	  <properties.derby.embedded databaseName="memory:recoverydb" createDatabase="create"/>
+      <jdbcDriver libraryRef="H2"/>
+      <properties.h2 URL="jdbc:h2:mem:recoverydb;DB_CLOSE_DELAY=-1"/>
     </dataSource>
   </transaction>
 
   <!-- ejbLite and batch features are intentionally disabled -->
   <databaseStore id="unavailableDBStore">
     <dataSource id="unavailableDS">
-      <jdbcDriver libraryRef="Derby"/>
-      <properties.derby.embedded databaseName="memory:unavailabledb"/>
+      <jdbcDriver libraryRef="H2"/>
+      <properties.h2 URL="jdbc:h2:file:unavailabledb;IF_EXISTS=TRUE;DB_CLOSE_DELAY=-1"/>
     </dataSource>
   </databaseStore>
 
   <!-- mongo feature intentionally disabled, so it doesn't matter that we are using an incorrect library -->
-  <mongo id="builder" libraryRef="DerbyLib" password="pwd1" user="u1"/>
+  <mongo id="builder" libraryRef="H2Lib" password="pwd1" user="u1"/>
   <mongoDB id="MongoDBNotEnabled" jndiName="mongo/db" mongoRef="builder" databaseName="testdb" />
   
   <authData id="auth1" user="dbuser" password="dbpass"/>
@@ -83,30 +82,30 @@
   <authData id="auth2" user="dbuser" password="wrong_password"/>
   
   <dataSource jndiName="jdbc/defaultauth" containerAuthDataRef="auth1"> <!-- id omitted for testing -->
-    <connectionManager enableSharingForDirectLookups="false"/>  
-    <jdbcDriver id="NestedDerbyDriver" libraryRef="Derby"
-     javax.sql.DataSource="org.apache.derby.jdbc.EmbeddedDataSource"
-     javax.sql.ConnectionPoolDataSource="org.apache.derby.jdbc.EmbeddedConnectionPoolDataSource"
-     javax.sql.XADataSource="org.apache.derby.jdbc.EmbeddedXADataSource"/>
-    <onConnect>SET CURRENT SCHEMA = APP</onConnect>
-    <onConnect>SET CURRENT SQLID = APP</onConnect>
-    <properties.derby.embedded databaseName="memory:defaultdb" createDatabase="create"/>
+    <connectionManager enableSharingForDirectLookups="false"/>
+    <jdbcDriver id="NestedH2Driver" libraryRef="H2"
+     javax.sql.DataSource="org.h2.jdbcx.JdbcDataSource"
+     javax.sql.ConnectionPoolDataSource="org.h2.jdbcx.JdbcDataSource"
+     javax.sql.XADataSource="org.h2.jdbcx.JdbcDataSource"/>
+    <onConnect>SET SCHEMA DBUSER</onConnect>
+    <onConnect>DROP TABLE IF EXISTS NON_EXISTENT_TABLE</onConnect>
+    <properties.h2 URL="jdbc:h2:mem:defaultdb;DB_CLOSE_DELAY=-1"/>
   </dataSource>
 
   <dataSource id="WrongDefaultAuth" jndiName="jdbc/wrongdefaultauth"
     connectionManagerRef="pool1" containerAuthDataRef="auth2" commitOrRollbackOnCleanup="rollback"
-    invalidProperty="The property's value." jdbcDriverRef="DerbyDriver" queryTimeout="2m10s"
+    invalidProperty="The property's value." jdbcDriverRef="H2Driver" queryTimeout="2m10s"
     recoveryAuthDataRef="auth2" statementCacheSize="15" validationTimeout="20s">
-    <properties databaseName="memory:defaultdb" createDatabase="create"/>
+    <properties URL="jdbc:h2:mem:defaultdb;DB_CLOSE_DELAY=-1"/>
   </dataSource>
-  
+
   <dataSource id="NestedElementCase" jndiName="jdbc/nestedElementCase">
-  	<JdBcDrIvEr libraryRef="Derby" javax.sql.DataSource="org.apache.derby.jdbc.EmbeddedDataSource" />
+    <JdBcDrIvEr libraryRef="H2" javax.sql.DataSource="org.h2.jdbcx.JdbcDataSource" />
   </dataSource>
 
   <connectionManager id="pool1" maxPoolSize="10" purgePolicy="ValidateAllConnections"/>
 
-  <jdbcDriver id="DerbyDriver" libraryRef="Derby"/>
+  <jdbcDriver id="H2Driver" libraryRef="H2"/>
 
   <!-- This app doesn't actually exist.  The config is just here to test child-first config -->
   <application id="bogus" location="bogus.war" autoStart="false">
@@ -147,5 +146,5 @@
   	</usr_child>
   </usr_parent>
   
-  <javaPermission codebase="${shared.resource.dir}/derby/derby.jar" className="java.security.AllPermission"/>
+  <javaPermission codebase="${shared.resource.dir}/h2Java8/h2.jar" className="java.security.AllPermission"/>
 </server>

--- a/dev/com.ibm.ws.rest.handler.config_fat/publish/servers/com.ibm.ws.rest.handler.config.audit.feature.fat/server.xml
+++ b/dev/com.ibm.ws.rest.handler.config_fat/publish/servers/com.ibm.ws.rest.handler.config.audit.feature.fat/server.xml
@@ -54,7 +54,7 @@
   <dataSource id="jdbc/nonexistentdb" jndiName="${id}">
     <CONNECTIONMANAGER id="NestedConPool" agedTimeout="1h2m3s" connectionTimeout="0s" maxIdleTime="40m" reapTime="2m30s"/>
     <jdbcDriver libraryRef="H2"/>
-    <properties.h2 URL="jdbc:h2:file:doesNotExist;IF_EXISTS=TRUE;DB_CLOSE_DELAY=-1"/>
+    <properties.h2 URL="jdbc:h2:file:doesNotExist;IFEXISTS=TRUE;DB_CLOSE_DELAY=-1"/>
   </dataSource>
 
   <transaction>
@@ -69,7 +69,7 @@
   <databaseStore id="unavailableDBStore">
     <dataSource id="unavailableDS">
       <jdbcDriver libraryRef="H2"/>
-      <properties.h2 URL="jdbc:h2:file:unavailabledb;IF_EXISTS=TRUE;DB_CLOSE_DELAY=-1"/>
+      <properties.h2 URL="jdbc:h2:file:unavailabledb;IFEXISTS=TRUE;DB_CLOSE_DELAY=-1"/>
     </dataSource>
   </databaseStore>
 

--- a/dev/com.ibm.ws.rest.handler.config_fat/publish/servers/com.ibm.ws.rest.handler.config.fat/bootstrap.properties
+++ b/dev/com.ibm.ws.rest.handler.config_fat/publish/servers/com.ibm.ws.rest.handler.config.fat/bootstrap.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017,2019 IBM Corporation and others.
+# Copyright (c) 2017,2026 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -14,5 +14,3 @@ bootstrap.include=../testports.properties
 com.ibm.ws.logging.trace.specification=*=info:rest.configbased=all:rest.config=all:rest.validation=all:com.ibm.ws.jdbc=all:com.ibm.ejs.j2c.ConnectionManagerServiceImpl=all
 com.ibm.ws.logging.max.file.size=0
 ds.loglevel=debug
-derby.connection.requireAuthentication=true
-derby.user.dbuser=dbpass

--- a/dev/com.ibm.ws.rest.handler.config_fat/publish/servers/com.ibm.ws.rest.handler.config.fat/server.xml
+++ b/dev/com.ibm.ws.rest.handler.config_fat/publish/servers/com.ibm.ws.rest.handler.config.fat/server.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2017,2019 IBM Corporation and others.
+    Copyright (c) 2017,2026 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -36,46 +36,45 @@
     <user>reader</user>
   </reader-role>
   
-  <library id="Derby">
-    <file name="${shared.resource.dir}/derby/derby.jar"/>
+  <library id="H2">
+    <file name="${shared.resource.dir}/h2Java8/h2.jar"/>
   </library>
 
   <dataSource id="DataSourceWithoutJDBCDriver" jndiName="jdbc/withoutJDBCDriver" connectionSharing="MatchCurrentState" transactional="false">
     <containerAuthData id="dbuser-auth" user="dbuser" password="{xor}Oz0vPiws"/>
-   	<properties.derby.embedded databaseName="memory:withoutJDBCDriver"/>
+   	<properties.h2 URL="jdbc:h2:mem:withoutJDBCDriver;DB_CLOSE_DELAY=-1"/>
   </dataSource>
 
   <dataSource id="DefaultDataSource" isolationLevel="TRANSACTION_READ_COMMITTED">
-    <jdbcDriver libraryRef="Derby"/>
+    <jdbcDriver libraryRef="H2"/>
     <!-- user/password settings defined in bootstrap.properties -->
-   	<properties.derby.embedded databaseName="memory:defaultdb" createDatabase="create" 
-   	                           user="dbuser" password="dbpass"/>
+   	<properties.h2 URL="jdbc:h2:mem:defaultdb;DB_CLOSE_DELAY=-1" user="dbuser" password="dbpass"/>
   </dataSource>
 
   <dataSource id="jdbc/nonexistentdb" jndiName="${id}">
     <CONNECTIONMANAGER id="NestedConPool" agedTimeout="1h2m3s" connectionTimeout="0s" maxIdleTime="40m" reapTime="2m30s"/>
-    <jdbcDriver libraryRef="Derby"/>
-   	<properties.derby.embedded databaseName="memory:doesNotExist"/>
+    <jdbcDriver libraryRef="H2"/>
+   	<properties.h2 URL="jdbc:h2:file:doesNotExist;IF_EXISTS=TRUE;DB_CLOSE_DELAY=-1"/>
   </dataSource>
 
   <transaction>
     <dataSource transactional="false" containerAuthDataRef="auth1">
       <connectionManager maxPoolSize="5" connectionTimeout="0s"/>
-      <jdbcDriver libraryRef="Derby"/>
-   	  <properties.derby.embedded databaseName="memory:recoverydb" createDatabase="create"/>
+      <jdbcDriver libraryRef="H2"/>
+   	  <properties.h2 URL="jdbc:h2:mem:recoverydb;DB_CLOSE_DELAY=-1"/>
     </dataSource>
   </transaction>
 
   <!-- ejbLite and batch features are intentionally disabled -->
   <databaseStore id="unavailableDBStore">
     <dataSource id="unavailableDS">
-      <jdbcDriver libraryRef="Derby"/>
-      <properties.derby.embedded databaseName="memory:unavailabledb"/>
+      <jdbcDriver libraryRef="H2"/>
+      <properties.h2 URL="jdbc:h2:file:unavailabledb;IF_EXISTS=TRUE;DB_CLOSE_DELAY=-1"/>
     </dataSource>
   </databaseStore>
 
   <!-- mongo feature intentionally disabled, so it doesn't matter that we are using an incorrect library -->
-  <mongo id="builder" libraryRef="DerbyLib" password="pwd1" user="u1"/>
+  <mongo id="builder" libraryRef="H2Lib" password="pwd1" user="u1"/>
   <mongoDB id="MongoDBNotEnabled" jndiName="mongo/db" mongoRef="builder" databaseName="testdb" />
   
   <authData id="auth1" user="dbuser" password="dbpass"/>
@@ -83,30 +82,30 @@
   <authData id="auth2" user="dbuser" password="wrong_password"/>
   
   <dataSource jndiName="jdbc/defaultauth" containerAuthDataRef="auth1"> <!-- id omitted for testing -->
-    <connectionManager enableSharingForDirectLookups="false"/>  
-    <jdbcDriver id="NestedDerbyDriver" libraryRef="Derby"
-     javax.sql.DataSource="org.apache.derby.jdbc.EmbeddedDataSource"
-     javax.sql.ConnectionPoolDataSource="org.apache.derby.jdbc.EmbeddedConnectionPoolDataSource"
-     javax.sql.XADataSource="org.apache.derby.jdbc.EmbeddedXADataSource"/>
-    <onConnect>SET CURRENT SCHEMA = APP</onConnect>
-    <onConnect>SET CURRENT SQLID = APP</onConnect>
-    <properties.derby.embedded databaseName="memory:defaultdb" createDatabase="create"/>
+    <connectionManager enableSharingForDirectLookups="false"/>
+    <jdbcDriver id="NestedH2Driver" libraryRef="H2"
+     javax.sql.DataSource="org.h2.jdbcx.JdbcDataSource"
+     javax.sql.ConnectionPoolDataSource="org.h2.jdbcx.JdbcDataSource"
+     javax.sql.XADataSource="org.h2.jdbcx.JdbcDataSource"/>
+    <onConnect>SET SCHEMA DBUSER</onConnect>
+    <onConnect>DROP TABLE IF EXISTS NON_EXISTENT_TABLE</onConnect>
+    <properties.h2 URL="jdbc:h2:mem:defaultdb;DB_CLOSE_DELAY=-1"/>
   </dataSource>
 
   <dataSource id="WrongDefaultAuth" jndiName="jdbc/wrongdefaultauth"
     connectionManagerRef="pool1" containerAuthDataRef="auth2" commitOrRollbackOnCleanup="rollback"
-    invalidProperty="The property's value." jdbcDriverRef="DerbyDriver" queryTimeout="2m10s"
+    invalidProperty="The property's value." jdbcDriverRef="H2Driver" queryTimeout="2m10s"
     recoveryAuthDataRef="auth2" statementCacheSize="15" validationTimeout="20s">
-    <properties databaseName="memory:defaultdb" createDatabase="create"/>
+    <properties URL="jdbc:h2:mem:defaultdb;DB_CLOSE_DELAY=-1"/>
   </dataSource>
   
   <dataSource id="NestedElementCase" jndiName="jdbc/nestedElementCase">
-  	<JdBcDrIvEr libraryRef="Derby" javax.sql.DataSource="org.apache.derby.jdbc.EmbeddedDataSource" />
+  	<JdBcDrIvEr libraryRef="H2" javax.sql.DataSource="org.h2.jdbcx.JdbcDataSource" />
   </dataSource>
 
   <connectionManager id="pool1" maxPoolSize="10" purgePolicy="ValidateAllConnections"/>
 
-  <jdbcDriver id="DerbyDriver" libraryRef="Derby"/>
+  <jdbcDriver id="H2Driver" libraryRef="H2"/>
 
   <!-- This app doesn't actually exist.  The config is just here to test child-first config -->
   <application id="bogus" location="bogus.war" autoStart="false">
@@ -147,5 +146,5 @@
   	</usr_child>
   </usr_parent>
   
-  <javaPermission codebase="${shared.resource.dir}/derby/derby.jar" className="java.security.AllPermission"/>
+  <javaPermission codebase="${shared.resource.dir}/h2Java8/h2.jar" className="java.security.AllPermission"/>
 </server>

--- a/dev/com.ibm.ws.rest.handler.config_fat/publish/servers/com.ibm.ws.rest.handler.config.fat/server.xml
+++ b/dev/com.ibm.ws.rest.handler.config_fat/publish/servers/com.ibm.ws.rest.handler.config.fat/server.xml
@@ -54,7 +54,7 @@
   <dataSource id="jdbc/nonexistentdb" jndiName="${id}">
     <CONNECTIONMANAGER id="NestedConPool" agedTimeout="1h2m3s" connectionTimeout="0s" maxIdleTime="40m" reapTime="2m30s"/>
     <jdbcDriver libraryRef="H2"/>
-   	<properties.h2 URL="jdbc:h2:file:doesNotExist;IF_EXISTS=TRUE;DB_CLOSE_DELAY=-1"/>
+   	<properties.h2 URL="jdbc:h2:file:doesNotExist;IFEXISTS=TRUE;DB_CLOSE_DELAY=-1"/>
   </dataSource>
 
   <transaction>
@@ -69,7 +69,7 @@
   <databaseStore id="unavailableDBStore">
     <dataSource id="unavailableDS">
       <jdbcDriver libraryRef="H2"/>
-      <properties.h2 URL="jdbc:h2:file:unavailabledb;IF_EXISTS=TRUE;DB_CLOSE_DELAY=-1"/>
+      <properties.h2 URL="jdbc:h2:file:unavailabledb;IFEXISTS=TRUE;DB_CLOSE_DELAY=-1"/>
     </dataSource>
   </databaseStore>
 

--- a/dev/com.ibm.ws.rest.handler.config_fat/semeruFips140_3CustomProfile.properties
+++ b/dev/com.ibm.ws.rest.handler.config_fat/semeruFips140_3CustomProfile.properties
@@ -1,8 +1,8 @@
-# Allowing for open-source org.apache.derby.iapi.services.monitor.Monitor
+# Allowing for open-source org.h2.security.SHA256
 # But To Do: Investigation on the open source with component owner
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.desc.name = Custom OpenJCEPlusFIPS Cryptographic Module FIPS 140-3
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.extends = RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Liberty
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.2 = sun.security.provider.Sun [+ \
     {KeyStore, JKS, *, ModuleAndFullClassName:java.base/java.security.KeyStore}, \
-    {MessageDigest, SHA-1, *, FullClassName:org.apache.derby.iapi.services.monitor.Monitor}, \
+    {MessageDigest, SHA-256, *, FullClassName:org.h2.security.SHA256}, \
     {MessageDigest, SHA-1, *, ModuleAndFullClassName:java.base/java.security.KeyStore}]

--- a/dev/com.ibm.ws.rest.handler.config_fat/test-applications/AppDefResourcesApp/src/test/resthandler/config/appdef/ejb/AppDefinedResourcesBean.java
+++ b/dev/com.ibm.ws.rest.handler.config_fat/test-applications/AppDefResourcesApp/src/test/resthandler/config/appdef/ejb/AppDefinedResourcesBean.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019,2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -46,10 +46,9 @@ import javax.resource.ConnectionFactoryDefinitions;
 })
 
 @DataSourceDefinition(name = "java:comp/env/jdbc/ds3", // same JNDI name is used in WAR module, but okay because different scope
-                      className = "org.apache.derby.jdbc.EmbeddedConnectionPoolDataSource",
-                      databaseName = "memory:ejbdb",
+                      className = "org.h2.jdbcx.JdbcDataSource",
+                      url = "jdbc:h2:mem:ejbdb;DB_CLOSE_DELAY=-1",
                       properties = {
-                                     "createDatabase=create"
                       })
 
 @JMSConnectionFactoryDefinition(name = "java:app/env/jms/tcf",

--- a/dev/com.ibm.ws.rest.handler.config_fat/test-applications/AppDefResourcesApp/src/test/resthandler/config/appdef/web/AppDefinedResourcesServlet.java
+++ b/dev/com.ibm.ws.rest.handler.config_fat/test-applications/AppDefResourcesApp/src/test/resthandler/config/appdef/web/AppDefinedResourcesServlet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019,2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -13,8 +13,12 @@
 package test.resthandler.config.appdef.web;
 
 import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
 import java.util.concurrent.Executor;
 
+import javax.annotation.PostConstruct;
+import javax.annotation.Resource;
 import javax.annotation.sql.DataSourceDefinition;
 import javax.annotation.sql.DataSourceDefinitions;
 import javax.ejb.EJB;
@@ -25,6 +29,7 @@ import javax.resource.AdministeredObjectDefinition;
 import javax.resource.ConnectionFactoryDefinition;
 import javax.resource.spi.TransactionSupport.TransactionSupportLevel;
 import javax.servlet.annotation.WebServlet;
+import javax.sql.DataSource;
 
 import componenttest.app.FATServlet;
 
@@ -52,37 +57,34 @@ import componenttest.app.FATServlet;
 
 @DataSourceDefinitions({
                          @DataSourceDefinition(name = "java:app/env/jdbc/ds1",
-                                               className = "org.apache.derby.jdbc.EmbeddedConnectionPoolDataSource",
-                                               databaseName = "memory:firstdb",
+                                               className = "org.h2.jdbcx.JdbcDataSource",
+                                               url = "jdbc:h2:mem:firstdb;DB_CLOSE_DELAY=-1",
                                                properties = {
                                                               "agedTimeout=1:05:30",
-                                                              "connectionSharing=MatchCurrentState",
-                                                              "createDatabase=create"
+                                                              "connectionSharing=MatchCurrentState"
                                                }),
                          @DataSourceDefinition(name = "java:module/env/jdbc/ds2",
-                                               className = "org.apache.derby.jdbc.EmbeddedXADataSource",
-                                               databaseName = "${shared.resource.dir}/data/configRHTestDB",
+                                               className = "org.h2.jdbcx.JdbcDataSource",
+                                               url = "jdbc:h2:${shared.resource.dir}/data/configRHTestDB;DB_CLOSE_DELAY=-1",
                                                isolationLevel = Connection.TRANSACTION_READ_COMMITTED,
                                                loginTimeout = 220,
                                                maxPoolSize = 2,
                                                maxStatements = 45,
                                                properties = {
                                                               "connectionTimeout=0",
-                                                              "containerAuthDataRef=derbyAuth1",
-                                                              "createDatabase=create",
-                                                              "onConnect=DECLARE GLOBAL TEMPORARY TABLE TEMP2 (COL1 VARCHAR(80)) ON COMMIT PRESERVE ROWS NOT LOGGED",
+                                                              "containerAuthDataRef=h2Auth1",
+                                                              "onConnect=${create.table.temp2}",
                                                               "queryTimeout=1m22s",
                                                               "reapTime=2200s",
-                                                              "recoveryAuthDataRef=derbyAuth2",
+                                                              "recoveryAuthDataRef=h2Auth2",
                                                               "syncQueryTimeoutWithTransactionTimeout=true"
                                                }),
                          @DataSourceDefinition(name = "java:comp/env/jdbc/ds3",
-                                               className = "org.apache.derby.jdbc.EmbeddedDataSource",
-                                               databaseName = "memory:thirddb;create=true"),
+                                               className = "org.h2.jdbcx.JdbcDataSource",
+                                               url = "jdbc:h2:mem:thirddb;DB_CLOSE_DELAY=-1"),
                          @DataSourceDefinition(name = "java:global/env/jdbc/ds4",
                                                className = "", // infer class name
-                                               databaseName = "memory:fourthdb",
-                                               properties = "createDatabase=create",
+                                               url = "jdbc:h2:mem:fourthdb;DB_CLOSE_DELAY=-1",
                                                user = "dbuser4",
                                                password = "dbpwd4")
 })
@@ -129,6 +131,27 @@ import componenttest.app.FATServlet;
 public class AppDefinedResourcesServlet extends FATServlet {
     @EJB
     Executor bean;
+
+    @Resource(lookup = "java:global/env/jdbc/ds4")
+    private DataSource ds4;
+
+    /**
+     * Initialize H2 database users on servlet startup.
+     * H2 in-memory databases require users to be created programmatically.
+     */
+    @PostConstruct
+    public void init() {
+        try (Connection conn = ds4.getConnection();
+             Statement stmt = conn.createStatement()) {
+            // Create dbuser3 with ADMIN privileges for test validation
+            stmt.execute("CREATE USER IF NOT EXISTS dbuser3 PASSWORD 'dbpwd3' ADMIN");
+            System.out.println("H2 user dbuser3 created successfully");
+        } catch (SQLException e) {
+            System.err.println("Failed to create H2 user: " + e.getMessage());
+            e.printStackTrace();
+            throw new RuntimeException(e);
+        }
+    }
 
     /**
      * No-op servlet method that the test case uses to ensure the web module is loaded.


### PR DESCRIPTION
Converts the test buckets for MicroProfile context propagation
and also the test bucket for the Liberty config REST endpoint com.ibm.ws.rest.handler.config_fat

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
