### PR TITLE
New Ant targets that do not use LibertyGitClone zip from libertyfs

### DIFF
--- a/.ci-orchestrator/steps/compileFATs.yml
+++ b/.ci-orchestrator/steps/compileFATs.yml
@@ -9,7 +9,7 @@
     - stepName: Launcher SHA
       awaitOutputProperties: true
   properties:
-    build.stub.target: build.CachedWSCD.CompileFATs
+    build.stub.target: build.CompileFATs
     # Do not create IM buckets in this step because some require an image to compile,
     # so they are built in the Compile Liberty Images step.
     create.im.repo: false

--- a/.ci-orchestrator/steps/compileLibertyImages.yml
+++ b/.ci-orchestrator/steps/compileLibertyImages.yml
@@ -12,7 +12,7 @@
     - stepName: Compile FATs
       awaitOutputProperties: true
   properties:
-    build.stub.target: build.CachedWSCD.CompileImageOnly
+    build.stub.target: build.CompileImageOnly
     git.clone.checkout.commit: ${WL SHA:commitSHA}
     git.laos.clone.checkout.commit: ${OL SHA:commitSHA}
     git.launcher.clone.checkout.commit: ${Launcher SHA:commitSHA}

--- a/.ci-orchestrator/steps/unittestOpenLiberty.yml
+++ b/.ci-orchestrator/steps/unittestOpenLiberty.yml
@@ -9,7 +9,7 @@
       awaitOutputProperties: true
   timeoutInMinutes: 1440
   properties:
-    build.stub.target: build.CachedWSCD.OLTest
+    build.stub.target: build.OLTest
     git.clone.checkout.commit: ${WL SHA:commitSHA}
     git.laos.clone.checkout.commit: ${OL SHA:commitSHA}
     git.launcher.clone.checkout.commit: ${Launcher SHA:commitSHA}


### PR DESCRIPTION
Investigate not running targets that result in flow through acquireLibertyfsClone.Liberty, which has been resulting in frequent failures like this:

```
BUILD FAILED
/home/jazz_build/Build/jbe/build.launch/BuildLauncher/checkout-liberty-laos-ghe.xml:49: The following error occurred while executing this line:
/home/jazz_build/Build/jbe/build.launch/BuildLauncher/checkout-common.xml:113: Error while expanding /home/jazz_build/Build/jbe/repoCache/LibertyGitClone_20240605.zip
java.util.zip.ZipException: archive is not a ZIP archive
```

Associated build break defect: https://wasrtc.hursley.ibm.com:9443/jazz/web/projects/WS-CD#action=com.ibm.team.workitem.viewWorkItem&id=309122