### PR TITLE
Skip All EBJ Module Unprotected Tests on Windows Repeats

### DIFF
--- a/dev/com.ibm.ws.security.javaeesec_fat.2/fat/src/com/ibm/ws/security/javaeesec/fat/EJBModuleRealmTest.java
+++ b/dev/com.ibm.ws.security.javaeesec_fat.2/fat/src/com/ibm/ws/security/javaeesec/fat/EJBModuleRealmTest.java
@@ -142,6 +142,8 @@ public class EJBModuleRealmTest extends JavaEESecTestBase {
         Log.info(logClass, getCurrentTestName(), "-----Entering " + getCurrentTestName());
         Log.info(logClass, getCurrentTestName(), "-----Creating EAR app.");
 
+        assumeNotWindowsEe9Plus();
+
         // create ejbinwarservlet.war,
         WCApplicationHelper.createWar(myServer, TEMP_DIR, EJB_REALM1_WAR_NAME, true, EJB_BEAN_JAR_NAME, true, "web.jar.base", "web.ejb.jar.bean",
                                       "web.war.ejb.annotated.servlet.realm1", "web.war.identitystores.ldap.ldap1", "web.war.identitystores.ldap");

--- a/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/EJBModuleTestUnprotectedServlet.java
+++ b/dev/com.ibm.ws.security.javaeesec_fat/fat/src/com/ibm/ws/security/javaeesec/fat/EJBModuleTestUnprotectedServlet.java
@@ -77,6 +77,8 @@ public class EJBModuleTestUnprotectedServlet extends JavaEESecTestBase {
     @BeforeClass
     public static void setUp() throws Exception {
         Log.info(logClass, "setUp()", "-----setting up test");
+        assumeNotWindowsEe9Plus();
+
         ldapServer = new LocalLdapServer();
         ldapServer.start();
 


### PR DESCRIPTION
The EJB tests are now showing the File could not be processed issue on windows when the applications are transformed. the tests will still run on <EE9, but need to find a replacement to the current transformation process given this is stopping us running a significant amount of the Java EE Sec tests on Windows with EE9+

Fixes [#309779](https://wasrtc.hursley.ibm.com:9443/jazz/web/projects/WS-CD#action=com.ibm.team.workitem.viewWorkItem&id=309779)

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [ ] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
