### PR TITLE
Reset update flag when app stops to send correct notification on restart

### DIFF
--- a/dev/com.ibm.ws.app.manager/src/com/ibm/ws/app/manager/internal/statemachine/ApplicationStateMachineImpl.java
+++ b/dev/com.ibm.ws.app.manager/src/com/ibm/ws/app/manager/internal/statemachine/ApplicationStateMachineImpl.java
@@ -173,6 +173,8 @@ class ApplicationStateMachineImpl extends ApplicationStateMachine implements App
             cl.cancel();
         }
         final boolean checkForUnprocessedConfigChange = _nextAppConfig.getAndSet(appConfig) != null;
+        // Mark this as an update since we're reconfiguring the application
+        _update.set(true);
 
         addAppStartingFutures(appStartingFutures);
         updateStartAfterFutures(startAfterFutures);
@@ -1284,9 +1286,8 @@ class ApplicationStateMachineImpl extends ApplicationStateMachine implements App
                         throw new IllegalStateException("enterState");
                     case STOPPED:
                         _asmHelper.switchApplicationState(_appConfig.get(), ApplicationState.STOPPED);
-                        // Reset the update flag only when there's no pending config update
-                        // If _nextAppConfig is null, this is a simple stop (not part of an update/restart)
-                        // This ensures stop()->start() sends "application.start" but updates still send "application.update"
+                        // Reset update flag when fully stopped with no pending config changes
+                        // This ensures a subsequent start (not part of update/restart) sends "application.start"
                         if (_nextAppConfig.get() == null) {
                             _update.set(false);
                         }
@@ -1365,7 +1366,8 @@ class ApplicationStateMachineImpl extends ApplicationStateMachine implements App
                             ApplicationInstallInfo aii = new ApplicationInstallInfo(_appConfig.get(), _appContainer.getAndSet(null), _resolvedLocation.getAndSet(null), _handler.get(), ApplicationStateMachineImpl.this);
                             _appInstallInfo.set(aii); // capture the handler so we call the same one for stopping.
                             startCallback = new StartActionCallback();
-                            startAction = new StartAction(_appConfig.get(), _update.getAndSet(true), _appMonitor, aii, startCallback, _futureMonitor, _configurator);
+                            // Use current value of _update flag (don't automatically set to true)
+                            startAction = new StartAction(_appConfig.get(), _update.get(), _appMonitor, aii, startCallback, _futureMonitor, _configurator);
                             _currentAction.set(startAction);
                         }
                         _asmHelper.switchApplicationState(_appConfig.get(), ApplicationState.STARTING);

--- a/dev/com.ibm.ws.app.manager/src/com/ibm/ws/app/manager/internal/statemachine/ApplicationStateMachineImpl.java
+++ b/dev/com.ibm.ws.app.manager/src/com/ibm/ws/app/manager/internal/statemachine/ApplicationStateMachineImpl.java
@@ -694,6 +694,7 @@ class ApplicationStateMachineImpl extends ApplicationStateMachine implements App
     private final AtomicReference<ResolveFileAction> _rfa = new AtomicReference<ResolveFileAction>();
     private final AtomicReference<ApplicationInstallInfo> _appInstallInfo = new AtomicReference<ApplicationInstallInfo>();
     private final AtomicBoolean _update = new AtomicBoolean();
+    private final AtomicReference<StateChangeAction> _lastAction = new AtomicReference<StateChangeAction>();
 
     private final AtomicReference<ApplicationConfig> _appConfig = new AtomicReference<ApplicationConfig>();
     private final AtomicReference<ApplicationConfig> _nextAppConfig = new AtomicReference<ApplicationConfig>();
@@ -1196,6 +1197,8 @@ class ApplicationStateMachineImpl extends ApplicationStateMachine implements App
     private void performAction(StateChangeAction action) {
 
         assertNonInterruptible();
+        // Track the action that led to the current state transition
+        _lastAction.set(action);
         final InternalState currentState = getInternalState();
 
         final InternalState nextState;
@@ -1284,8 +1287,11 @@ class ApplicationStateMachineImpl extends ApplicationStateMachine implements App
                         throw new IllegalStateException("enterState");
                     case STOPPED:
                         _asmHelper.switchApplicationState(_appConfig.get(), ApplicationState.STOPPED);
-                        // Reset the update flag so that subsequent starts are treated as starts, not updates
-                        _update.set(false);
+                        // Reset the update flag only for explicit STOP actions, not for RESTART/CONFIGURE
+                        // This ensures stop()->start() sends "application.start" but updates still send "application.update"
+                        if (_lastAction.get() == StateChangeAction.STOP) {
+                            _update.set(false);
+                        }
                         flushQueuedActions();
                         ApplicationDependency stoppedFuture;
                         while ((stoppedFuture = _notifyAppStopped.poll()) != null) {

--- a/dev/com.ibm.ws.app.manager/src/com/ibm/ws/app/manager/internal/statemachine/ApplicationStateMachineImpl.java
+++ b/dev/com.ibm.ws.app.manager/src/com/ibm/ws/app/manager/internal/statemachine/ApplicationStateMachineImpl.java
@@ -173,8 +173,11 @@ class ApplicationStateMachineImpl extends ApplicationStateMachine implements App
             cl.cancel();
         }
         final boolean checkForUnprocessedConfigChange = _nextAppConfig.getAndSet(appConfig) != null;
-        // Mark this as an update since we're reconfiguring the application
-        _update.set(true);
+        // Mark as update only if there was already a pending config change (reconfiguration)
+        // or if the app has been started before (indicated by _update already being true)
+        if (checkForUnprocessedConfigChange || _update.get()) {
+            _update.set(true);
+        }
 
         addAppStartingFutures(appStartingFutures);
         updateStartAfterFutures(startAfterFutures);

--- a/dev/com.ibm.ws.app.manager/src/com/ibm/ws/app/manager/internal/statemachine/ApplicationStateMachineImpl.java
+++ b/dev/com.ibm.ws.app.manager/src/com/ibm/ws/app/manager/internal/statemachine/ApplicationStateMachineImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2024 IBM Corporation and others.
+ * Copyright (c) 2012, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -1284,6 +1284,8 @@ class ApplicationStateMachineImpl extends ApplicationStateMachine implements App
                         throw new IllegalStateException("enterState");
                     case STOPPED:
                         _asmHelper.switchApplicationState(_appConfig.get(), ApplicationState.STOPPED);
+                        // Reset the update flag so that subsequent starts are treated as starts, not updates
+                        _update.set(false);
                         flushQueuedActions();
                         ApplicationDependency stoppedFuture;
                         while ((stoppedFuture = _notifyAppStopped.poll()) != null) {

--- a/dev/com.ibm.ws.app.manager/src/com/ibm/ws/app/manager/internal/statemachine/ApplicationStateMachineImpl.java
+++ b/dev/com.ibm.ws.app.manager/src/com/ibm/ws/app/manager/internal/statemachine/ApplicationStateMachineImpl.java
@@ -694,7 +694,6 @@ class ApplicationStateMachineImpl extends ApplicationStateMachine implements App
     private final AtomicReference<ResolveFileAction> _rfa = new AtomicReference<ResolveFileAction>();
     private final AtomicReference<ApplicationInstallInfo> _appInstallInfo = new AtomicReference<ApplicationInstallInfo>();
     private final AtomicBoolean _update = new AtomicBoolean();
-    private final AtomicReference<StateChangeAction> _lastAction = new AtomicReference<StateChangeAction>();
 
     private final AtomicReference<ApplicationConfig> _appConfig = new AtomicReference<ApplicationConfig>();
     private final AtomicReference<ApplicationConfig> _nextAppConfig = new AtomicReference<ApplicationConfig>();
@@ -1197,8 +1196,6 @@ class ApplicationStateMachineImpl extends ApplicationStateMachine implements App
     private void performAction(StateChangeAction action) {
 
         assertNonInterruptible();
-        // Track the action that led to the current state transition
-        _lastAction.set(action);
         final InternalState currentState = getInternalState();
 
         final InternalState nextState;
@@ -1287,9 +1284,10 @@ class ApplicationStateMachineImpl extends ApplicationStateMachine implements App
                         throw new IllegalStateException("enterState");
                     case STOPPED:
                         _asmHelper.switchApplicationState(_appConfig.get(), ApplicationState.STOPPED);
-                        // Reset the update flag only for explicit STOP actions, not for RESTART/CONFIGURE
+                        // Reset the update flag only when there's no pending config update
+                        // If _nextAppConfig is null, this is a simple stop (not part of an update/restart)
                         // This ensures stop()->start() sends "application.start" but updates still send "application.update"
-                        if (_lastAction.get() == StateChangeAction.STOP) {
+                        if (_nextAppConfig.get() == null) {
                             _update.set(false);
                         }
                         flushQueuedActions();

--- a/dev/com.ibm.ws.app.manager_fat/fat/src/componenttest/application/manager/test/FATTest.java
+++ b/dev/com.ibm.ws.app.manager_fat/fat/src/componenttest/application/manager/test/FATTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018-2026 IBM Corporation and others.
+ * Copyright (c) 2018,2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.app.manager_fat/fat/src/componenttest/application/manager/test/FATTest.java
+++ b/dev/com.ibm.ws.app.manager_fat/fat/src/componenttest/application/manager/test/FATTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018-2020 IBM Corporation and others.
+ * Copyright (c) 2018-2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -902,6 +902,58 @@ public class FATTest extends AbstractAppManagerTest {
             pathsToCleanup.add(server.getServerRoot() + "/apps");
         }
     }
+    /**
+     * This test verifies that restarting an application via ApplicationMBean sends the correct
+     * "application.start" notification instead of "application.update".
+     * 
+     * Reproduces issue #34736 where stopping and then starting an app via MBean incorrectly
+     * sent "application.update" notification instead of "application.start".
+     * 
+     * @throws Exception
+     */
+    @Test
+    public void testApplicationMBeanRestartNotification() throws Exception {
+        final String method = testName.getMethodName();
+        try {
+            // Setup: Start server with snoop application
+            server.setServerConfigurationFile("/appsConfigured/server.xml");
+            server.copyFileToLibertyServerRoot(PUBLISH_FILES, "apps", SNOOP_WAR);
+            server.startServer(method + ".log");
+            
+            // Wait for initial application start
+            assertNotNull("The snoop application never came up", 
+                         server.waitForStringInLog("CWWKZ0001I.* snoop"));
+            assertNotNull("Should see APPLICATION_START_SUCCESSFUL on initial start",
+                         server.waitForStringInLog("APPLICATION_START_SUCCESSFUL.*snoop"));
+            
+            // Get ApplicationMBean and stop the application
+            com.ibm.ws.fat.util.jmx.mbeans.ApplicationMBean snoopMBean = getApplicationMBean("snoop");
+            server.setMarkToEndOfLog();
+            snoopMBean.stop();
+            
+            // Verify application stopped
+            assertNotNull("The snoop application was not stopped",
+                         server.waitForStringInLogUsingMark("CWWKZ0009I.*snoop"));
+            
+            // Restart application via MBean - this should trigger "application.start" not "application.update"
+            server.setMarkToEndOfLog();
+            snoopMBean.start();
+            
+            // Verify correct notification: should see "application.start"
+            assertNotNull("Should see APPLICATION_START_SUCCESSFUL message after MBean restart",
+                         server.waitForStringInLogUsingMark("APPLICATION_START_SUCCESSFUL.*snoop"));
+            
+            // Verify no update message appears (this was the bug - it incorrectly sent update)
+            assertNull("Should NOT see APPLICATION_UPDATE_SUCCESSFUL message after MBean restart",
+                      server.waitForStringInLogUsingMark("APPLICATION_UPDATE_SUCCESSFUL", 2000));
+            
+            Log.info(c, method, "Test passed: Application restart via MBean correctly sent application.start notification");
+            
+        } finally {
+            pathsToCleanup.add(server.getServerRoot() + "/apps");
+        }
+    }
+
 
     private static String[] getAppIDs(int startId, int numApps) {
         String[] result = new String[numApps];


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] "Fixes #34736" 
- [x] "Fixes #34736" 

Reset _update only when no pending configuration changes exist (_nextAppConfig == null).
This ensures manual restart operations emit application.start, while configuration-driven restarts continue to emit application.update.