### PR TITLE
Convert com.ibm.ws.rest.handler.validator_fat from Derby to H2

### DIFF
--- a/dev/com.ibm.ws.rest.handler.validator_fat/build.gradle
+++ b/dev/com.ibm.ws.rest.handler.validator_fat/build.gradle
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017,2024 IBM Corporation and others.
+ * Copyright (c) 2017,2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -18,7 +18,7 @@ configurations {
   }
 }
 
-addRequiredLibraries.dependsOn addDerby
+addRequiredLibraries.dependsOn addH2Java8
 
 dependencies {
   requiredLibs project(':com.ibm.ws.microprofile.openapi')

--- a/dev/com.ibm.ws.rest.handler.validator_fat/fat/src/com/ibm/ws/rest/handler/validator/fat/ValidateDSCustomLoginModuleTest.java
+++ b/dev/com.ibm.ws.rest.handler.validator_fat/fat/src/com/ibm/ws/rest/handler/validator/fat/ValidateDSCustomLoginModuleTest.java
@@ -10,6 +10,8 @@
 package com.ibm.ws.rest.handler.validator.fat;
 
 import static com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions.SERVER_ONLY;
+import static componenttest.annotation.SkipForRepeat.EE7_FEATURES;
+import static componenttest.annotation.SkipForRepeat.EE8_FEATURES;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -37,9 +39,9 @@ import com.ibm.websphere.simplicity.ShrinkHelper;
 import com.ibm.websphere.simplicity.log.Log;
 import com.ibm.ws.rest.handler.validator.loginmodule.TestLoginModule;
 
-
 import componenttest.annotation.AllowedFFDC;
 import componenttest.annotation.Server;
+import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.rules.repeater.EERepeatActions;
 import componenttest.rules.repeater.FeatureReplacementAction;
@@ -101,17 +103,11 @@ public class ValidateDSCustomLoginModuleTest extends FATServletClient {
         messages.add("J2CA7001I: .* TestValidationJMSAdapter"); // J2CA7001I: Resource adapter TestValidationJMSAdapter installed in # seconds.
         server.waitForStringsInLogUsingMark(messages);
 
-        Log.info(c, "setUp", "initialize users for defaultdb (customLoginDS) and recoverydb (transaction dataSource)");
+        Log.info(c, "setUp", "initialize users for defaultdb (customLoginDS)");
 
-        JsonObject response;
-        response = FATSuite.createHttpsRequestWithAdminUser(server, "/ibm/api/validation/dataSource/customLoginDS?auth=container")
-                           .run(JsonObject.class);
-        Log.info(c, "setUp", "customLoginDS response: " + response);
-
-        response = FATSuite.createHttpsRequestWithAdminUser(server, "/ibm/api/validation/DATASOURCE/transaction%2FDATASOURCE%5Bdefault-0%5D")//?auth=container&authAlias=auth1")
-                           .run(JsonObject.class);
-        Log.info(c, "setUp", "transaction dataSource response: " + response);
-    }
+        JsonObject response = FATSuite.createHttpsRequestWithAdminUser(server, "/ibm/api/validation/dataSource/customLoginDS?auth=container")
+                                      .run(JsonObject.class);
+        Log.info(c, "setUp", "customLoginDS response: " + response);    }
 
     @AfterClass
     public static void tearDown() throws Exception {
@@ -369,6 +365,7 @@ public class ValidateDSCustomLoginModuleTest extends FATServletClient {
      * when the type matches the case specified in server.xml. In this test the specific
      * instance's uid is specified.
      */
+    @SkipForRepeat({ EE7_FEATURES, EE8_FEATURES }) // container auth not yet used for recovery data source
     @Test
     public void testValidateNestedDifferentCase() throws Exception {
         JsonObject json = FATSuite.createHttpsRequestWithAdminUser(server, "/ibm/api/validation/DATASOURCE/transaction%2FDATASOURCE%5Bdefault-0%5D?auth=container&authAlias=auth1")
@@ -395,6 +392,7 @@ public class ValidateDSCustomLoginModuleTest extends FATServletClient {
      * when the type matches the case specified in server.xml. In this test no
      * UID is provided.
      */
+    @SkipForRepeat({ EE7_FEATURES, EE8_FEATURES }) // container auth not yet used for recovery data source
     @Test
     public void testValidateNestedDifferentCaseMulitple() throws Exception {
         JsonArray json = FATSuite.createHttpsRequestWithAdminUser(server, "/ibm/api/validation/DATASOURCE?auth=container&authAlias=auth1")

--- a/dev/com.ibm.ws.rest.handler.validator_fat/fat/src/com/ibm/ws/rest/handler/validator/fat/ValidateDSCustomLoginModuleTest.java
+++ b/dev/com.ibm.ws.rest.handler.validator_fat/fat/src/com/ibm/ws/rest/handler/validator/fat/ValidateDSCustomLoginModuleTest.java
@@ -37,7 +37,8 @@ import com.ibm.websphere.simplicity.ShrinkHelper;
 import com.ibm.websphere.simplicity.log.Log;
 import com.ibm.ws.rest.handler.validator.loginmodule.TestLoginModule;
 
-import componenttest.annotation.ExpectedFFDC;
+
+import componenttest.annotation.AllowedFFDC;
 import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.rules.repeater.EERepeatActions;
@@ -100,12 +101,16 @@ public class ValidateDSCustomLoginModuleTest extends FATServletClient {
         messages.add("J2CA7001I: .* TestValidationJMSAdapter"); // J2CA7001I: Resource adapter TestValidationJMSAdapter installed in # seconds.
         server.waitForStringsInLogUsingMark(messages);
 
-        // TODO remove once transactions code is fixed to use container auth for the recovery log dataSource
-        // Lacking this fix, transaction manager will experience an auth failure and log FFDC for it.
-        // The following line causes an XA-capable data source to be used for the first time outside of a test method execution,
-        // so that the FFDC is not considered a test failure.
-        JsonObject response = FATSuite.createHttpsRequestWithAdminUser(server, "/ibm/api/validation/dataSource/customLoginDS").run(JsonObject.class);
-        Log.info(c, "setUp", "DefaultDataSource response: " + response);
+        Log.info(c, "setUp", "initialize users for defaultdb (customLoginDS) and recoverydb (transaction dataSource)");
+
+        JsonObject response;
+        response = FATSuite.createHttpsRequestWithAdminUser(server, "/ibm/api/validation/dataSource/customLoginDS?auth=container")
+                           .run(JsonObject.class);
+        Log.info(c, "setUp", "customLoginDS response: " + response);
+
+        response = FATSuite.createHttpsRequestWithAdminUser(server, "/ibm/api/validation/DATASOURCE/transaction%2FDATASOURCE%5Bdefault-0%5D")//?auth=container&authAlias=auth1")
+                           .run(JsonObject.class);
+        Log.info(c, "setUp", "transaction dataSource response: " + response);
     }
 
     @AfterClass
@@ -121,10 +126,12 @@ public class ValidateDSCustomLoginModuleTest extends FATServletClient {
      * This default endpoint invocation is equivalent to an application direct lookup, which does
      * not get container managed authentication applied and therefore should not succeed.
      */
+    @AllowedFFDC({ "com.ibm.ws.rsadapter.exceptions.DataStoreAdapterException",
+                   "java.sql.SQLInvalidAuthorizationSpecException",
+                   "javax.resource.spi.ResourceAllocationException",
+                   "javax.resource.spi.SecurityException",
+                   "org.h2.jdbc.JdbcSQLInvalidAuthorizationSpecException" })
     @Test
-    @ExpectedFFDC({ "java.sql.SQLNonTransientException",
-                    "javax.resource.spi.SecurityException",
-                    "javax.resource.spi.ResourceAllocationException" })
     public void testCustomLoginModuleDirectLookupInvalid() throws Exception {
         JsonObject json = FATSuite.createHttpsRequestWithAdminUser(server, "/ibm/api/validation/dataSource/customLoginDS")
                         .run(JsonObject.class);
@@ -145,10 +152,10 @@ public class ValidateDSCustomLoginModuleTest extends FATServletClient {
         assertNull(err, json.get("successful"));
         assertNull(err, json.get("failure"));
         assertNull(err, json.get("info"));
-        assertEquals(err, "08004", getString(json, "sqlState"));
-        assertEquals(err, "40000", json.getString("errorCode"));
-        assertEquals(err, "java.sql.SQLNonTransientException", getString(json, "class"));
-        assertTrue(err, getString(json, "message").contains("Invalid authentication"));
+        assertEquals(err, "28000", getString(json, "sqlState"));
+        assertEquals(err, "28000", json.getString("errorCode"));
+        assertEquals(err, "java.sql.SQLInvalidAuthorizationSpecException", getString(json, "class"));
+        assertTrue(err, getString(json, "message").contains("Wrong user name or password"));
     }
 
     /**
@@ -203,10 +210,10 @@ public class ValidateDSCustomLoginModuleTest extends FATServletClient {
     /**
      * Test specifyig a non-existant customLoginConfig
      */
+    @AllowedFFDC({ "java.sql.SQLException",
+                   "javax.resource.ResourceException",
+                   "javax.security.auth.login.LoginException" })
     @Test
-    @ExpectedFFDC({ "javax.security.auth.login.LoginException",
-                    "javax.resource.ResourceException",
-                    "java.sql.SQLException" })
     public void testCustomLoginIBMWebBndWrongName() throws Exception {
         JsonObject json = FATSuite.createHttpsRequestWithAdminUser(server, "/ibm/api/validation/dataSource/customLoginDSWebBnd?auth=container&loginConfig=bogus")
                         .run(JsonObject.class);
@@ -374,13 +381,13 @@ public class ValidateDSCustomLoginModuleTest extends FATServletClient {
         assertTrue(err, json.getBoolean("successful"));
         assertNull(err, json.get("failure"));
         assertNotNull(err, json = json.getJsonObject("info"));
-        assertEquals(err, "Apache Derby", json.getString("databaseProductName"));
+        assertEquals(err, "H2", json.getString("databaseProductName"));
         assertTrue(err, json.getString("databaseProductVersion").matches(VERSION_REGEX));
-        assertEquals(err, "Apache Derby Embedded JDBC Driver", json.getString("jdbcDriverName"));
+        assertEquals(err, "H2 JDBC Driver", json.getString("jdbcDriverName"));
         assertTrue(err, json.getString("jdbcDriverVersion").matches(VERSION_REGEX));
-        assertNull(err, json.get("catalog")); // currently not supported by Derby
-        assertEquals(err, "DBUSER", json.getString("schema"));
-        assertEquals(err, "dbuser", json.getString("user"));
+        assertEquals(err, "RECOVERYDB", json.getString("catalog")); // H2 returns database name as catalog
+        assertEquals(err, "PUBLIC", json.getString("schema"));
+        assertEquals(err, "DBUSER", json.getString("user"));
     }
 
     /*
@@ -403,13 +410,13 @@ public class ValidateDSCustomLoginModuleTest extends FATServletClient {
         assertTrue(err, j.getBoolean("successful"));
         assertNull(err, j.get("failure"));
         assertNotNull(err, j = j.getJsonObject("info"));
-        assertEquals(err, "Apache Derby", j.getString("databaseProductName"));
+        assertEquals(err, "H2", j.getString("databaseProductName"));
         assertTrue(err, j.getString("databaseProductVersion").matches(VERSION_REGEX));
-        assertEquals(err, "Apache Derby Embedded JDBC Driver", j.getString("jdbcDriverName"));
+        assertEquals(err, "H2 JDBC Driver", j.getString("jdbcDriverName"));
         assertTrue(err, j.getString("jdbcDriverVersion").matches(VERSION_REGEX));
-        assertNull(err, j.get("catalog")); // currently not supported by Derby
-        assertEquals(err, "DBUSER", j.getString("schema"));
-        assertEquals(err, "dbuser", j.getString("user"));
+        assertEquals(err, "RECOVERYDB", j.getString("catalog")); // H2 returns database name as catalog
+        assertEquals(err, "PUBLIC", j.getString("schema"));
+        assertEquals(err, "DBUSER", j.getString("user"));
     }
 
     private static void assertSuccessResponse(JsonObject json, String expectedUID, String expectedID, String expectedJndiName) {
@@ -421,9 +428,9 @@ public class ValidateDSCustomLoginModuleTest extends FATServletClient {
         assertNull(err, json.get("failure"));
         JsonObject info = json.getJsonObject("info");
         assertNotNull(err, info);
-        assertEquals(err, "Apache Derby", info.getString("databaseProductName"));
+        assertEquals(err, "H2", info.getString("databaseProductName"));
         assertTrue(err, info.getString("databaseProductVersion").matches(VERSION_REGEX));
-        assertEquals(err, "Apache Derby Embedded JDBC Driver", info.getString("jdbcDriverName"));
+        assertEquals(err, "H2 JDBC Driver", info.getString("jdbcDriverName"));
         assertTrue(err, info.getString("jdbcDriverVersion").matches(VERSION_REGEX));
     }
 

--- a/dev/com.ibm.ws.rest.handler.validator_fat/fat/src/com/ibm/ws/rest/handler/validator/fat/ValidateDataSourceTest.java
+++ b/dev/com.ibm.ws.rest.handler.validator_fat/fat/src/com/ibm/ws/rest/handler/validator/fat/ValidateDataSourceTest.java
@@ -30,7 +30,7 @@ import org.junit.runner.RunWith;
 
 import com.ibm.websphere.simplicity.log.Log;
 
-import componenttest.annotation.ExpectedFFDC;
+import componenttest.annotation.AllowedFFDC;
 import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.rules.repeater.MicroProfileActions;
@@ -104,9 +104,9 @@ public class ValidateDataSourceTest extends FATServletClient {
         assertTrue(err, json.getBoolean("successful"));
         assertNull(err, json.get("failure"));
         assertNotNull(err, json = json.getJsonObject("info"));
-        assertEquals(err, "Apache Derby", json.getString("databaseProductName"));
+        assertEquals(err, "H2", json.getString("databaseProductName"));
         assertTrue(err, json.getString("databaseProductVersion").matches(VERSION_REGEX));
-        assertEquals(err, "Apache Derby Embedded JDBC Driver", json.getString("jdbcDriverName"));
+        assertEquals(err, "H2 JDBC Driver", json.getString("jdbcDriverName"));
         assertTrue(err, json.getString("jdbcDriverVersion").matches(VERSION_REGEX));
     }
 
@@ -132,10 +132,12 @@ public class ValidateDataSourceTest extends FATServletClient {
         assertSuccessResponse(json, "DefaultDataSource", "DefaultDataSource");
     }
 
+    @AllowedFFDC({ "com.ibm.ws.rsadapter.exceptions.DataStoreAdapterException",
+                   "java.sql.SQLInvalidAuthorizationSpecException",
+                   "javax.resource.spi.SecurityException",
+                   "javax.resource.spi.ResourceAllocationException",
+                   "org.h2.jdbc.JdbcSQLInvalidAuthorizationSpecException" })
     @Test
-    @ExpectedFFDC({ "java.sql.SQLNonTransientException",
-                    "javax.resource.spi.SecurityException",
-                    "javax.resource.spi.ResourceAllocationException" })
     public void testAppAuthFails() throws Exception {
         JsonObject json = FATSuite.createHttpsRequestWithAdminUser(server, "/ibm/api/validation/dataSource/DefaultDataSource")
                         .requestProp("X-Validation-User", "bogus")
@@ -156,10 +158,10 @@ public class ValidateDataSourceTest extends FATServletClient {
         assertNull(err, json.get("jndiName"));
         assertNull(err, json.get("failure"));
         assertNull(err, json.get("info"));
-        assertEquals(err, "08004", json.getString("sqlState"));
-        assertEquals(err, "40000", json.getString("errorCode"));
-        assertEquals(err, "java.sql.SQLNonTransientException", json.getString("class"));
-        assertTrue(err, json.getString("message").contains("Invalid authentication"));
+        assertEquals(err, "28000", json.getString("sqlState"));
+        assertEquals(err, "28000", json.getString("errorCode"));
+        assertEquals(err, "java.sql.SQLInvalidAuthorizationSpecException", json.getString("class"));
+        assertTrue(err, json.getString("message").contains("Wrong user name or password"));
     }
 
     @Test
@@ -187,9 +189,9 @@ public class ValidateDataSourceTest extends FATServletClient {
         assertTrue(err, json.getBoolean("successful"));
         assertNull(err, json.get("failure"));
         assertNotNull(err, json = json.getJsonObject("info"));
-        assertEquals(err, "Apache Derby", json.getString("databaseProductName"));
+        assertEquals(err, "H2", json.getString("databaseProductName"));
         assertTrue(err, json.getString("databaseProductVersion").matches(VERSION_REGEX));
-        assertEquals(err, "Apache Derby Embedded JDBC Driver", json.getString("jdbcDriverName"));
+        assertEquals(err, "H2 JDBC Driver", json.getString("jdbcDriverName"));
         assertTrue(err, json.getString("jdbcDriverVersion").matches(VERSION_REGEX));
     }
 
@@ -227,10 +229,11 @@ public class ValidateDataSourceTest extends FATServletClient {
                         .run(String.class);
     }
 
+    @AllowedFFDC({ "java.sql.SQLNonTransientException",
+                   "javax.resource.spi.ResourceAllocationException",
+                   "com.ibm.ws.rsadapter.exceptions.DataStoreAdapterException",
+                   "org.h2.jdbc.JdbcSQLNonTransientConnectionException" })
     @Test
-    @ExpectedFFDC(value = { "java.sql.SQLException",
-                            "javax.resource.spi.ResourceAllocationException",
-                            "com.ibm.ws.rsadapter.exceptions.DataStoreAdapterException" })
     public void testMultiple() throws Exception {
         JsonArray json = FATSuite.createHttpsRequestWithAdminUser(server, "/ibm/api/validation/dataSource?auth=application")
                         .requestProp("X-Validation-User", "dbuser")
@@ -260,11 +263,11 @@ public class ValidateDataSourceTest extends FATServletClient {
         assertTrue(err, j.getBoolean("successful"));
         assertNull(err, j.get("failure"));
         assertNotNull(err, j = j.getJsonObject("info"));
-        assertEquals(err, "Apache Derby", j.getString("databaseProductName"));
+        assertEquals(err, "H2", j.getString("databaseProductName"));
         assertTrue(err, j.getString("databaseProductVersion").matches(VERSION_REGEX));
-        assertNull(err, j.get("catalog")); // currently not supported by Derby
-        assertEquals(err, "DBUSER", j.getString("schema"));
-        assertEquals(err, "dbuser", j.getString("user"));
+        assertEquals(err, "DEFAULTDB", j.getString("catalog")); // H2 returns database name as catalog
+        assertEquals(err, "PUBLIC", j.getString("schema"));
+        assertEquals(err, "DBUSER", j.getString("user"));
 
         // [2]: config.displayId=dataSource[WrongDefaultAuth]
         j = json.getJsonObject(2);
@@ -274,7 +277,7 @@ public class ValidateDataSourceTest extends FATServletClient {
         assertTrue(err, j.getBoolean("successful"));
         assertNull(err, j.get("failure"));
         assertNotNull(err, j = j.getJsonObject("info"));
-        assertEquals(err, "Apache Derby Embedded JDBC Driver", j.getString("jdbcDriverName"));
+        assertEquals(err, "H2 JDBC Driver", j.getString("jdbcDriverName"));
         assertTrue(err, j.getString("jdbcDriverVersion").matches(VERSION_REGEX));
 
         // [3]: config.displayId=dataSource[default-0]
@@ -294,25 +297,17 @@ public class ValidateDataSourceTest extends FATServletClient {
         assertFalse(err, j.getBoolean("successful"));
         assertNull(err, j.get("info"));
         assertNotNull(err, j = j.getJsonObject("failure"));
-        assertEquals(err, "XJ004", j.getString("sqlState"));
-        assertEquals(err, "40000", j.getString("errorCode"));
-        assertEquals(err, "java.sql.SQLException", j.getString("class"));
-        assertTrue(err, j.getString("message").contains("memory:doesNotExist"));
+        assertEquals(err, "90146", j.getString("sqlState"));
+        assertEquals(err, "90146", j.getString("errorCode"));
+        assertEquals(err, "java.sql.SQLNonTransientException", j.getString("class"));
+        assertTrue(err, j.getString("message").contains("doesNotExist"));
         JsonArray stack = j.getJsonArray("stack");
         assertNotNull(err, stack);
         assertTrue(err, stack.size() > 10); // stack is actually much longer, but size could vary
-        assertTrue(err, stack.getString(0).startsWith("org.apache.derby."));
-        assertTrue(err, stack.getString(1).startsWith("org.apache.derby."));
-        assertTrue(err, stack.getString(2).startsWith("org.apache.derby."));
-        assertNotNull(err, j = j.getJsonObject("cause"));
-        assertEquals(err, "org.apache.derby.iapi.error.StandardException", j.getString("class"));
-        assertTrue(err, j.getString("message").contains("memory:doesNotExist"));
-        stack = j.getJsonArray("stack");
-        assertNotNull(err, stack);
-        assertTrue(err, stack.size() > 10); // stack is actually much longer, but size could vary
-        assertTrue(err, stack.getString(0).startsWith("org.apache.derby."));
-        assertTrue(err, stack.getString(1).startsWith("org.apache.derby."));
-        assertTrue(err, stack.getString(2).startsWith("org.apache.derby."));
+        assertTrue(err, stack.getString(0).startsWith("org.h2."));
+        assertTrue(err, stack.getString(1).startsWith("org.h2."));
+        assertTrue(err, stack.getString(2).startsWith("org.h2."));
+        assertNull(err, j.getJsonObject("cause"));
 
         // [5]: config.displayId=transaction/dataSource[default-0]
         j = json.getJsonObject(5);
@@ -322,13 +317,13 @@ public class ValidateDataSourceTest extends FATServletClient {
         assertTrue(err, j.getBoolean("successful"));
         assertNull(err, j.get("failure"));
         assertNotNull(err, j = j.getJsonObject("info"));
-        assertEquals(err, "Apache Derby", j.getString("databaseProductName"));
+        assertEquals(err, "H2", j.getString("databaseProductName"));
         assertTrue(err, j.getString("databaseProductVersion").matches(VERSION_REGEX));
-        assertEquals(err, "Apache Derby Embedded JDBC Driver", j.getString("jdbcDriverName"));
+        assertEquals(err, "H2 JDBC Driver", j.getString("jdbcDriverName"));
         assertTrue(err, j.getString("jdbcDriverVersion").matches(VERSION_REGEX));
-        assertNull(err, j.get("catalog")); // currently not supported by Derby
-        assertEquals(err, "DBUSER", j.getString("schema"));
-        assertEquals(err, "dbuser", j.getString("user"));
+        assertEquals(err, "RECOVERYDB", j.getString("catalog")); // H2 returns database name as catalog
+        assertEquals(err, "PUBLIC", j.getString("schema"));
+        assertEquals(err, "DBUSER", j.getString("user"));
     }
 
     @Test
@@ -351,9 +346,9 @@ public class ValidateDataSourceTest extends FATServletClient {
         assertTrue(err, json.getBoolean("successful"));
         assertNull(err, json.get("failure"));
         assertNotNull(err, json = json.getJsonObject("info"));
-        assertEquals(err, "Apache Derby", json.getString("databaseProductName"));
+        assertEquals(err, "H2", json.getString("databaseProductName"));
         assertTrue(err, json.getString("databaseProductVersion").matches(VERSION_REGEX));
-        assertEquals(err, "Apache Derby Embedded JDBC Driver", json.getString("jdbcDriverName"));
+        assertEquals(err, "H2 JDBC Driver", json.getString("jdbcDriverName"));
         assertTrue(err, json.getString("jdbcDriverVersion").matches(VERSION_REGEX));
     }
 
@@ -368,11 +363,11 @@ public class ValidateDataSourceTest extends FATServletClient {
 
     @Test
     public void testNotValidatable() throws Exception {
-        JsonObject json = FATSuite.createHttpsRequestWithAdminUser(server, "/ibm/api/validation/library/Derby")
+        JsonObject json = FATSuite.createHttpsRequestWithAdminUser(server, "/ibm/api/validation/library/H2")
                         .run(JsonObject.class);
         String err = "unexpected response: " + json;
-        assertEquals(err, "Derby", json.getString("uid"));
-        assertEquals(err, "Derby", json.getString("id"));
+        assertEquals(err, "H2", json.getString("uid"));
+        assertEquals(err, "H2", json.getString("id"));
         assertFalse(err, json.getBoolean("successful"));
         assertNull(err, json.get("info"));
         assertNotNull(err, json = json.getJsonObject("failure"));
@@ -390,9 +385,9 @@ public class ValidateDataSourceTest extends FATServletClient {
         assertTrue(err, json.getBoolean("successful"));
         assertNull(err, json.get("failure"));
         assertNotNull(err, json = json.getJsonObject("info"));
-        assertEquals(err, "Apache Derby", json.getString("databaseProductName"));
+        assertEquals(err, "H2", json.getString("databaseProductName"));
         assertTrue(err, json.getString("databaseProductVersion").matches(VERSION_REGEX));
-        assertEquals(err, "Apache Derby Embedded JDBC Driver", json.getString("jdbcDriverName"));
+        assertEquals(err, "H2 JDBC Driver", json.getString("jdbcDriverName"));
         assertTrue(err, json.getString("jdbcDriverVersion").matches(VERSION_REGEX));
     }
 
@@ -407,13 +402,15 @@ public class ValidateDataSourceTest extends FATServletClient {
         assertTrue(err, json.getBoolean("successful"));
         assertNull(err, json.get("failure"));
         assertNotNull(err, json = json.getJsonObject("info"));
-        assertEquals(err, "Apache Derby", json.getString("databaseProductName"));
+        assertEquals(err, "H2", json.getString("databaseProductName"));
         assertTrue(err, json.getString("databaseProductVersion").matches(VERSION_REGEX));
-        assertEquals(err, "Apache Derby Embedded JDBC Driver", json.getString("jdbcDriverName"));
+        assertEquals(err, "H2 JDBC Driver", json.getString("jdbcDriverName"));
         assertTrue(err, json.getString("jdbcDriverVersion").matches(VERSION_REGEX));
     }
 
-    @ExpectedFFDC(value = { "javax.security.auth.login.LoginException", "javax.resource.ResourceException", "java.sql.SQLException" })
+    @AllowedFFDC({ "java.sql.SQLException",
+                   "javax.resource.ResourceException",
+                   "javax.security.auth.login.LoginException" })
     @Test
     public void testProvidedAuthDoesNotExist() throws Exception {
         JsonObject json = FATSuite.createHttpsRequestWithAdminUser(server, "/ibm/api/validation/dataSource/DefaultDataSource?auth=container&authAlias=authDoesntExist")
@@ -452,9 +449,9 @@ public class ValidateDataSourceTest extends FATServletClient {
         assertTrue(err, json.getBoolean("successful"));
         assertNull(err, json.get("failure"));
         assertNotNull(err, json = json.getJsonObject("info"));
-        assertEquals(err, "Apache Derby", json.getString("databaseProductName"));
+        assertEquals(err, "H2", json.getString("databaseProductName"));
         assertTrue(err, json.getString("databaseProductVersion").matches(VERSION_REGEX));
-        assertEquals(err, "Apache Derby Embedded JDBC Driver", json.getString("jdbcDriverName"));
+        assertEquals(err, "H2 JDBC Driver", json.getString("jdbcDriverName"));
         assertTrue(err, json.getString("jdbcDriverVersion").matches(VERSION_REGEX));
     }
 
@@ -469,19 +466,20 @@ public class ValidateDataSourceTest extends FATServletClient {
         assertTrue(err, json.getBoolean("successful"));
         assertNull(err, json.get("failure"));
         assertNotNull(err, json = json.getJsonObject("info"));
-        assertEquals(err, "Apache Derby", json.getString("databaseProductName"));
+        assertEquals(err, "H2", json.getString("databaseProductName"));
         assertTrue(err, json.getString("databaseProductVersion").matches(VERSION_REGEX));
-        assertEquals(err, "Apache Derby Embedded JDBC Driver", json.getString("jdbcDriverName"));
+        assertEquals(err, "H2 JDBC Driver", json.getString("jdbcDriverName"));
         assertTrue(err, json.getString("jdbcDriverVersion").matches(VERSION_REGEX));
-        assertNull(err, json.get("catalog")); // currently not supported by Derby
-        assertEquals(err, "DBUSER", json.getString("schema"));
-        assertEquals(err, "dbuser", json.getString("user"));
+        assertEquals(err, "DEFAULTDB", json.getString("catalog")); // H2 returns database name as catalog
+        assertEquals(err, "PUBLIC", json.getString("schema"));
+        assertEquals(err, "DBUSER", json.getString("user"));
     }
 
+    @AllowedFFDC({ "com.ibm.ws.rsadapter.exceptions.DataStoreAdapterException",
+                   "java.sql.SQLNonTransientException",
+                   "javax.resource.spi.ResourceAllocationException",
+                   "org.h2.jdbc.JdbcSQLNonTransientConnectionException" })
     @Test
-    @ExpectedFFDC(value = { "java.sql.SQLException",
-                            "javax.resource.spi.ResourceAllocationException",
-                            "com.ibm.ws.rsadapter.exceptions.DataStoreAdapterException" })
     public void testTopLevelIDSQLException() throws Exception {
         JsonObject json = FATSuite.createHttpsRequestWithAdminUser(server, "/ibm/api/validation/dataSource/jdbc%2Fnonexistentdb")
                         .run(JsonObject.class);
@@ -498,36 +496,24 @@ public class ValidateDataSourceTest extends FATServletClient {
         assertNull(err, json.get("jndiName"));
         assertNull(err, json.get("failure"));
         assertNull(err, json.get("info"));
-        assertEquals(err, "XJ004", json.getString("sqlState"));
-        assertEquals(err, "40000", json.getString("errorCode"));
-        assertEquals(err, "java.sql.SQLException", json.getString("class"));
-        assertTrue(err, json.getString("message").contains("memory:doesNotExist"));
+        assertEquals(err, "90146", json.getString("sqlState"));
+        assertEquals(err, "90146", json.getString("errorCode"));
+        assertEquals(err, "java.sql.SQLNonTransientException", json.getString("class"));
+        assertTrue(err, json.getString("message").contains("doesNotExist"));
         JsonArray stack = json.getJsonArray("stack");
         assertNotNull(err, stack);
         assertTrue(err, stack.size() > 10); // stack is actually much longer, but size could vary
-        assertTrue(err, stack.getString(0).startsWith("org.apache.derby."));
-        assertTrue(err, stack.getString(1).startsWith("org.apache.derby."));
-        assertTrue(err, stack.getString(2).startsWith("org.apache.derby."));
-        assertNotNull(err, json = json.getJsonObject("cause"));
-        assertNull(err, json.get("uid"));
-        assertNull(err, json.get("id"));
-        assertNull(err, json.get("jndiName"));
-        assertNull(err, json.get("failure"));
-        assertNull(err, json.get("info"));
-        assertEquals(err, "org.apache.derby.iapi.error.StandardException", json.getString("class"));
-        assertTrue(err, json.getString("message").contains("memory:doesNotExist"));
-        stack = json.getJsonArray("stack");
-        assertNotNull(err, stack);
-        assertTrue(err, stack.size() > 10); // stack is actually much longer, but size could vary
-        assertTrue(err, stack.getString(0).startsWith("org.apache.derby."));
-        assertTrue(err, stack.getString(1).startsWith("org.apache.derby."));
-        assertTrue(err, stack.getString(2).startsWith("org.apache.derby."));
+        assertTrue(err, stack.getString(0).startsWith("org.h2."));
+        assertTrue(err, stack.getString(1).startsWith("org.h2."));
+        assertTrue(err, stack.getString(2).startsWith("org.h2."));
+        assertNull(err, json.getJsonObject("cause"));
     }
 
-    @ExpectedFFDC(value = { "javax.resource.spi.SecurityException",
-                            "java.sql.SQLNonTransientException",
-                            "javax.resource.spi.ResourceAllocationException"
-    })
+    @AllowedFFDC({ "com.ibm.ws.rsadapter.exceptions.DataStoreAdapterException",
+                   "java.sql.SQLInvalidAuthorizationSpecException",
+                   "javax.resource.spi.SecurityException",
+                   "javax.resource.spi.ResourceAllocationException",
+                   "org.h2.jdbc.JdbcSQLInvalidAuthorizationSpecException" })
     @Test
     public void testWrongDefaultAuth() throws Exception {
         JsonObject json = FATSuite.createHttpsRequestWithAdminUser(server, "/ibm/api/validation/dataSource/WrongDefaultAuth?auth=container")
@@ -548,15 +534,17 @@ public class ValidateDataSourceTest extends FATServletClient {
         assertNull(err, json.get("successful"));
         assertNull(err, json.get("failure"));
         assertNull(err, json.get("info"));
-        assertEquals(err, "08004", json.getString("sqlState"));
-        assertEquals(err, "40000", json.getString("errorCode"));
-        assertEquals(err, "java.sql.SQLNonTransientException", json.getString("class"));
-        assertTrue(err, json.getString("message").contains("Invalid authentication"));
+        assertEquals(err, "28000", json.getString("sqlState"));
+        assertEquals(err, "28000", json.getString("errorCode"));
+        assertEquals(err, "java.sql.SQLInvalidAuthorizationSpecException", json.getString("class"));
+        assertTrue(err, json.getString("message").contains("Wrong user name or password"));
     }
 
-    @ExpectedFFDC(value = { "javax.resource.spi.SecurityException",
-                            "java.sql.SQLNonTransientException",
-                            "javax.resource.spi.ResourceAllocationException" })
+    @AllowedFFDC({ "com.ibm.ws.rsadapter.exceptions.DataStoreAdapterException",
+                   "java.sql.SQLInvalidAuthorizationSpecException",
+                   "javax.resource.spi.SecurityException",
+                   "javax.resource.spi.ResourceAllocationException",
+                   "org.h2.jdbc.JdbcSQLInvalidAuthorizationSpecException" })
     @Test
     public void testWrongProvidedAuth() throws Exception {
         JsonObject json = FATSuite.createHttpsRequestWithAdminUser(server, "/ibm/api/validation/dataSource/DefaultDataSource?auth=container&authAlias=auth2")
@@ -577,10 +565,10 @@ public class ValidateDataSourceTest extends FATServletClient {
         assertNull(err, json.get("successful"));
         assertNull(err, json.get("failure"));
         assertNull(err, json.get("info"));
-        assertEquals(err, "08004", json.getString("sqlState"));
-        assertEquals(err, "40000", json.getString("errorCode"));
-        assertEquals(err, "java.sql.SQLNonTransientException", json.getString("class"));
-        assertTrue(err, json.getString("message").contains("Invalid authentication"));
+        assertEquals(err, "28000", json.getString("sqlState"));
+        assertEquals(err, "28000", json.getString("errorCode"));
+        assertEquals(err, "java.sql.SQLInvalidAuthorizationSpecException", json.getString("class"));
+        assertTrue(err, json.getString("message").contains("Wrong user name or password"));
     }
 
     /*
@@ -657,9 +645,9 @@ public class ValidateDataSourceTest extends FATServletClient {
         assertNull(err, json.get("failure"));
         JsonObject info = json.getJsonObject("info");
         assertNotNull(err, info);
-        assertEquals(err, "Apache Derby", info.getString("databaseProductName"));
+        assertEquals(err, "H2", info.getString("databaseProductName"));
         assertTrue(err, info.getString("databaseProductVersion").matches(VERSION_REGEX));
-        assertEquals(err, "Apache Derby Embedded JDBC Driver", info.getString("jdbcDriverName"));
+        assertEquals(err, "H2 JDBC Driver", info.getString("jdbcDriverName"));
         assertTrue(err, info.getString("jdbcDriverVersion").matches(VERSION_REGEX));
     }
 }

--- a/dev/com.ibm.ws.rest.handler.validator_fat/fat/src/com/ibm/ws/rest/handler/validator/fat/ValidateOpenApiSchemaTest.java
+++ b/dev/com.ibm.ws.rest.handler.validator_fat/fat/src/com/ibm/ws/rest/handler/validator/fat/ValidateOpenApiSchemaTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2025 IBM Corporation and others.
+ * Copyright (c) 2019, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -212,12 +212,12 @@ public class ValidateOpenApiSchemaTest extends FATServletClient {
         assertTrue(err, json.getBoolean("successful"));
         assertNull(err, json.get("failure"));
         assertNotNull(err, json = json.getJsonObject("info"));
-        assertEquals(err, "Apache Derby", json.getString("databaseProductName"));
+        assertEquals(err, "H2", json.getString("databaseProductName"));
         assertTrue(err, json.getString("databaseProductVersion").matches(VERSION_REGEX));
-        assertEquals(err, "Apache Derby Embedded JDBC Driver", json.getString("jdbcDriverName"));
+        assertEquals(err, "H2 JDBC Driver", json.getString("jdbcDriverName"));
         assertTrue(err, json.getString("jdbcDriverVersion").matches(VERSION_REGEX));
-        assertEquals(err, "DBUSER1", json.getString("schema"));
-        assertEquals(err, "dbuser1", json.getString("user"));
+        assertEquals(err, "PUBLIC", json.getString("schema"));
+        assertEquals(err, "DBUSER1", json.getString("user"));
     }
 
     /**

--- a/dev/com.ibm.ws.rest.handler.validator_fat/publish/files/validatorCustomLoginModuleServer.xml
+++ b/dev/com.ibm.ws.rest.handler.validator_fat/publish/files/validatorCustomLoginModuleServer.xml
@@ -69,10 +69,10 @@
   </dataSource>
   
   <transaction enableHADBPeerLocking="false">
-    <DATASOURCE transactional="false">
+    <DATASOURCE transactional="false" containerAuthDataRef="auth1">
       <connectionManager maxPoolSize="5" connectionTimeout="0s"/>
       <jdbcDriver libraryRef="H2"/>
-   	  <properties.h2 URL="jdbc:h2:mem:recoverydb;DB_CLOSE_DELAY=-1;INIT=CREATE USER IF NOT EXISTS dbuser PASSWORD 'dbpass' ADMIN"/>
+   	  <properties.h2 URL="jdbc:h2:mem:recoverydb;DB_CLOSE_DELAY=-1"/>
     </DATASOURCE>
   </transaction>
   

--- a/dev/com.ibm.ws.rest.handler.validator_fat/publish/files/validatorCustomLoginModuleServer.xml
+++ b/dev/com.ibm.ws.rest.handler.validator_fat/publish/files/validatorCustomLoginModuleServer.xml
@@ -1,3 +1,12 @@
+<!--
+    Copyright (c) 2017, 2026 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License 2.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-2.0/
+    
+    SPDX-License-Identifier: EPL-2.0
+ -->
 <server>
   <include location="../fatTestPorts.xml" />
 
@@ -15,8 +24,8 @@
   <keyStore id="defaultKeyStore" password="Liberty"/>
   <quickStartSecurity userName="adminuser" userPassword="adminpwd"/>
   
-  <library id="Derby">
-    <file name="${shared.resource.dir}/derby/derby.jar"/>
+  <library id="H2">
+    <file name="${shared.resource.dir}/h2Java8/h2.jar"/>
   </library>
   
   <authData id="auth1" user="dbuser" password="dbpass"/>
@@ -42,9 +51,9 @@
   </jmsTopicConnectionFactory>
   
   <dataSource id="customLoginDS" jndiName="jdbc/customLoginDS" jaasLoginContextEntry="customLoginEntry">
-    <jdbcDriver libraryRef="Derby"/>
+    <jdbcDriver libraryRef="H2"/>
     <!-- user/password settings propagated by custom login module -->
-    <properties.derby.embedded databaseName="memory:defaultdb" createDatabase="create"/>
+    <properties.h2 URL="jdbc:h2:mem:defaultdb;DB_CLOSE_DELAY=-1"/>
   </dataSource>
   
   <!-- This datasource intentionally has no auth data associated in server.xml, to simulate a <custom-login-configuration>
@@ -54,20 +63,20 @@
        </resource-ref>
   -->
   <dataSource id="customLoginDSWebBnd" jndiName="jdbc/customLoginDSWebBnd">
-    <jdbcDriver libraryRef="Derby"/>
+    <jdbcDriver libraryRef="H2"/>
     <!-- user/password settings propagated by custom login module -->
-    <properties.derby.embedded databaseName="memory:defaultdb" createDatabase="create"/>
+    <properties.h2 URL="jdbc:h2:mem:defaultdb;DB_CLOSE_DELAY=-1"/>
   </dataSource>
   
   <transaction enableHADBPeerLocking="false">
     <DATASOURCE transactional="false">
       <connectionManager maxPoolSize="5" connectionTimeout="0s"/>
-      <jdbcDriver libraryRef="Derby"/>
-   	  <properties.derby.embedded databaseName="memory:recoverydb" createDatabase="create"/>
+      <jdbcDriver libraryRef="H2"/>
+   	  <properties.h2 URL="jdbc:h2:mem:recoverydb;DB_CLOSE_DELAY=-1;INIT=CREATE USER IF NOT EXISTS dbuser PASSWORD 'dbpass' ADMIN"/>
     </DATASOURCE>
   </transaction>
   
-  <javaPermission codebase="${shared.resource.dir}/derby/derby.jar" className="java.security.AllPermission"/>
+  <javaPermission codebase="${shared.resource.dir}/h2Java8/h2.jar" className="java.security.AllPermission"/>
   <javaPermission codebase="${server.config.dir}/customLoginModule.jar" className="java.security.AllPermission"/>
 
   <javaPermission codebase="${server.config.dir}/dropins/TestValidationJMSAdapter.rar"

--- a/dev/com.ibm.ws.rest.handler.validator_fat/publish/servers/com.ibm.ws.rest.handler.validator.jdbc.fat/bootstrap.properties
+++ b/dev/com.ibm.ws.rest.handler.validator_fat/publish/servers/com.ibm.ws.rest.handler.validator.jdbc.fat/bootstrap.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017,2019 IBM Corporation and others.
+# Copyright (c) 2017,2026 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -14,5 +14,3 @@ bootstrap.include=../testports.properties
 com.ibm.ws.logging.trace.specification=*=info:rest.configbased=all:rest.validation=all:com.ibm.ws.jdbc=all:com.ibm.ejs.j2c.ConnectionManagerServiceImpl=all
 com.ibm.ws.logging.max.file.size=0
 ds.loglevel=debug
-derby.connection.requireAuthentication=true
-derby.user.dbuser=dbpass

--- a/dev/com.ibm.ws.rest.handler.validator_fat/publish/servers/com.ibm.ws.rest.handler.validator.jdbc.fat/server.xml
+++ b/dev/com.ibm.ws.rest.handler.validator_fat/publish/servers/com.ibm.ws.rest.handler.validator.jdbc.fat/server.xml
@@ -39,8 +39,8 @@
     <user>reader</user>
   </reader-role>
   
-  <library id="Derby">
-    <file name="${shared.resource.dir}/derby/derby.jar"/>
+  <library id="H2">
+    <file name="${shared.resource.dir}/h2Java8/h2.jar"/>
   </library>
   
   <variable name="DB_USER" value="dbuser"/>
@@ -48,40 +48,39 @@
 
   <dataSource id="DataSourceWithoutJDBCDriver" jndiName="jdbc/withoutJDBCDriver" connectionSharing="MatchCurrentState" transactional="false">
     <containerAuthData id="dbuser-auth" user="dbuser" password="{xor}Oz0vPiws"/>
-   	<properties.derby.embedded databaseName="memory:withoutJDBCDriver"/>
+   	<properties.h2 URL="jdbc:h2:mem:withoutJDBCDriver;DB_CLOSE_DELAY=-1"/>
   </dataSource>
 
   <dataSource id="DefaultDataSource" isolationLevel="TRANSACTION_READ_COMMITTED">
-    <jdbcDriver libraryRef="Derby"/>
-    <!-- user/password settings defined in bootstrap.properties -->
-   	<properties.derby.embedded databaseName="memory:defaultdb" createDatabase="create" 
-   	                           user="${DB_USER}" password="${DB_PASS}"/>
+    <jdbcDriver libraryRef="H2"/>
+   	<properties.h2 URL="jdbc:h2:mem:defaultdb;DB_CLOSE_DELAY=-1"
+   	               user="${DB_USER}" password="${DB_PASS}"/>
   </dataSource>
 
   <dataSource id="jdbc/nonexistentdb" jndiName="${id}">
     <connectionManager id="NestedConPool" agedTimeout="1h2m3s" connectionTimeout="0s" maxIdleTime="40m" reapTime="2m30s"/>
-    <jdbcDriver libraryRef="Derby"/>
-   	<properties.derby.embedded databaseName="memory:doesNotExist"/>
+    <jdbcDriver libraryRef="H2"/>
+   	<properties.h2 URL="jdbc:h2:file:./doesNotExist;IFEXISTS=TRUE;DB_CLOSE_DELAY=-1"/>
   </dataSource>
 
   <transaction enableHADBPeerLocking="false">
     <dataSource transactional="false" containerAuthDataRef="auth1">
       <connectionManager maxPoolSize="5" connectionTimeout="0s"/>
-      <jdbcDriver libraryRef="Derby"/>
-   	  <properties.derby.embedded databaseName="memory:recoverydb" createDatabase="create"/>
+      <jdbcDriver libraryRef="H2"/>
+   	  <properties.h2 URL="jdbc:h2:mem:recoverydb;DB_CLOSE_DELAY=-1"/>
     </dataSource>
   </transaction>
 
   <!-- ejbLite and batch features are intentionally disabled -->
   <databaseStore id="unavailableDBStore">
     <dataSource id="unavailableDS">
-      <jdbcDriver libraryRef="Derby"/>
-      <properties.derby.embedded databaseName="memory:unavailabledb"/>
+      <jdbcDriver libraryRef="H2"/>
+      <properties.h2 URL="jdbc:h2:file:./unavailabledb;IFEXISTS=TRUE;DB_CLOSE_DELAY=-1"/>
     </dataSource>
   </databaseStore>
 
   <!-- mongo feature intentionally disabled, so it doesn't matter that we are using an incorrect library -->
-  <mongo id="mongo" libraryRef="DerbyLib"/>
+  <mongo id="mongo" libraryRef="H2Lib"/>
   <mongoDB id="MongoDBNotEnabled" jndiName="mongo/db" mongoRef="mongo" databaseName="db-test" />
   
   <authData id="auth1" user="dbuser" password="dbpass"/>
@@ -89,26 +88,26 @@
   <authData id="auth2" user="dbuser" password="wrong_password"/>
   
   <dataSource jndiName="jdbc/defaultauth" containerAuthDataRef="auth1"> <!-- id omitted for testing -->
-    <connectionManager enableSharingForDirectLookups="false"/>  
-    <jdbcDriver id="NestedDerbyDriver" libraryRef="Derby"
-     javax.sql.DataSource="org.apache.derby.jdbc.EmbeddedDataSource"
-     javax.sql.ConnectionPoolDataSource="org.apache.derby.jdbc.EmbeddedConnectionPoolDataSource"
-     javax.sql.XADataSource="org.apache.derby.jdbc.EmbeddedXADataSource"/>
-    <onConnect>SET CURRENT SCHEMA = APP</onConnect>
-    <onConnect>SET CURRENT SQLID = APP</onConnect>
-    <properties.derby.embedded databaseName="memory:defaultdb" createDatabase="create"/>
+    <connectionManager enableSharingForDirectLookups="false"/>
+    <jdbcDriver id="NestedH2Driver" libraryRef="H2"
+     javax.sql.DataSource="org.h2.jdbcx.JdbcDataSource"
+     javax.sql.ConnectionPoolDataSource="org.h2.jdbcx.JdbcDataSource"
+     javax.sql.XADataSource="org.h2.jdbcx.JdbcDataSource"/>
+    <onConnect>CREATE SCHEMA IF NOT EXISTS DBUSER</onConnect>
+    <onConnect>DROP TABLE IF EXISTS NON_EXISTENT_TABLE</onConnect>
+    <properties.h2 URL="jdbc:h2:mem:defaultdb;DB_CLOSE_DELAY=-1"/>
   </dataSource>
 
   <dataSource id="WrongDefaultAuth" jndiName="jdbc/wrongdefaultauth"
     connectionManagerRef="pool1" containerAuthDataRef="auth2" commitOrRollbackOnCleanup="rollback"
-    invalidProperty="The property's value." jdbcDriverRef="DerbyDriver" queryTimeout="2m10s"
+    invalidProperty="The property's value." jdbcDriverRef="H2Driver" queryTimeout="2m10s"
     recoveryAuthDataRef="auth2" statementCacheSize="15" validationTimeout="20s">
-    <properties databaseName="memory:defaultdb" createDatabase="create"/>
+    <properties URL="jdbc:h2:mem:defaultdb;DB_CLOSE_DELAY=-1"/>
   </dataSource>
 
   <connectionManager id="pool1" maxPoolSize="10" purgePolicy="ValidateAllConnections"/>
 
-  <jdbcDriver id="DerbyDriver" libraryRef="Derby"/>
+  <jdbcDriver id="H2Driver" libraryRef="H2"/>
   
-  <javaPermission codebase="${shared.resource.dir}/derby/derby.jar" className="java.security.AllPermission"/>
+  <javaPermission codebase="${shared.resource.dir}/h2Java8/h2.jar" className="java.security.AllPermission"/>
 </server>

--- a/dev/com.ibm.ws.rest.handler.validator_fat/publish/servers/com.ibm.ws.rest.handler.validator.openapi.fat/server.xml
+++ b/dev/com.ibm.ws.rest.handler.validator_fat/publish/servers/com.ibm.ws.rest.handler.validator.openapi.fat/server.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2019, 2025 IBM Corporation and others.
+    Copyright (c) 2019, 2026 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -44,8 +44,8 @@
     <user>reader</user>
   </reader-role>
 
-  <!-- configuration error: this points at Derby jars, not Cloudant -->
-  <cloudant id="cloudant" libraryRef="Derby" url="http://myhost.rchland.ibm.com:5984"/>
+  <!-- configuration error: this points at H2 jars, not Cloudant -->
+  <cloudant id="cloudant" libraryRef="H2" url="http://myhost.rchland.ibm.com:5984"/>
   <cloudantDatabase id="cldb" jndiName="cloudant/testdb" cloudantRef="cloudant" databaseName="exampledb" create="true"/>
 
   <connectionFactory id="cf1" jndiName="eis/cf1">
@@ -54,13 +54,13 @@
   </connectionFactory>
 
   <dataSource id="DefaultDataSource">
-    <jdbcDriver libraryRef="Derby"/>
-   	<properties.derby.embedded databaseName="memory:derbydb" createDatabase="create"/>
-   	<containerAuthData user="derbyuser1" password="derbypwd1"/>
+    <jdbcDriver libraryRef="H2"/>
+   	<properties.h2 URL="jdbc:h2:mem:h2db;DB_CLOSE_DELAY=-1"/>
+   	<containerAuthData user="h2user1" password="h2pwd1"/>
   </dataSource>
 
-  <library id="Derby">
-    <file name="${shared.resource.dir}/derby/derby.jar"/>
+  <library id="H2">
+    <file name="${shared.resource.dir}/h2Java8/h2.jar"/>
   </library>
 
   <messagingEngine id="defaultME"/>
@@ -76,5 +76,5 @@
     <properties.wasJms temporaryTopicNamePrefix="TMPTOP3"/>
   </jmsTopicConnectionFactory>
 
-  <javaPermission codebase="${shared.resource.dir}/derby/derby.jar" className="java.security.AllPermission"/>
+  <javaPermission codebase="${shared.resource.dir}/h2Java8/h2.jar" className="java.security.AllPermission"/>
 </server>

--- a/dev/com.ibm.ws.rest.handler.validator_fat/publish/servers/validator-customLoginModule-Server/bootstrap.properties
+++ b/dev/com.ibm.ws.rest.handler.validator_fat/publish/servers/validator-customLoginModule-Server/bootstrap.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017,2019 IBM Corporation and others.
+# Copyright (c) 2017,2026 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -14,5 +14,3 @@ bootstrap.include=../testports.properties
 com.ibm.ws.logging.trace.specification=*=info:rest.configbased=all:rest.validation=all:com.ibm.ws.jdbc=all
 com.ibm.ws.logging.max.file.size=0
 ds.loglevel=debug
-derby.connection.requireAuthentication=true
-derby.user.dbuser=dbpass

--- a/dev/com.ibm.ws.rest.handler.validator_fat/publish/servers/validator-customLoginModule-Server/server.xml
+++ b/dev/com.ibm.ws.rest.handler.validator_fat/publish/servers/validator-customLoginModule-Server/server.xml
@@ -1,3 +1,12 @@
+<!--
+    Copyright (c) 2017, 2026 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License 2.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-2.0/
+    
+    SPDX-License-Identifier: EPL-2.0
+ -->
 <server>
   <include location="../fatTestPorts.xml" />
 
@@ -15,8 +24,8 @@
   <keyStore id="defaultKeyStore" password="Liberty"/>
   <quickStartSecurity userName="adminuser" userPassword="adminpwd"/>
   
-  <library id="Derby">
-    <file name="${shared.resource.dir}/derby/derby.jar"/>
+  <library id="H2">
+    <file name="${shared.resource.dir}/h2Java8/h2.jar"/>
   </library>
   
   <authData id="auth1" user="dbuser" password="dbpass"/>
@@ -42,9 +51,9 @@
   </jmsTopicConnectionFactory>
   
   <dataSource id="customLoginDS" jndiName="jdbc/customLoginDS" jaasLoginContextEntry="customLoginEntry">
-    <jdbcDriver libraryRef="Derby"/>
+    <jdbcDriver libraryRef="H2"/>
     <!-- user/password settings propagated by custom login module -->
-    <properties.derby.embedded databaseName="memory:defaultdb" createDatabase="create"/>
+    <properties.h2 URL="jdbc:h2:mem:defaultdb;DB_CLOSE_DELAY=-1"/>
   </dataSource>
   
   <!-- This datasource intentionally has no auth data associated in server.xml, to simulate a <custom-login-configuration>
@@ -54,20 +63,20 @@
        </resource-ref>
   -->
   <dataSource id="customLoginDSWebBnd" jndiName="jdbc/customLoginDSWebBnd">
-    <jdbcDriver libraryRef="Derby"/>
+    <jdbcDriver libraryRef="H2"/>
     <!-- user/password settings propagated by custom login module -->
-    <properties.derby.embedded databaseName="memory:defaultdb" createDatabase="create"/>
+    <properties.h2 URL="jdbc:h2:mem:defaultdb;DB_CLOSE_DELAY=-1"/>
   </dataSource>
 
   <transaction enableHADBPeerLocking="false">
     <DATASOURCE transactional="false">
       <connectionManager maxPoolSize="5" connectionTimeout="0s"/>
-      <jdbcDriver libraryRef="Derby"/>
-   	  <properties.derby.embedded databaseName="memory:recoverydb" createDatabase="create"/>
+      <jdbcDriver libraryRef="H2"/>
+   	  <properties.h2 URL="jdbc:h2:mem:recoverydb;DB_CLOSE_DELAY=-1"/>
     </DATASOURCE>
   </transaction>
   
-  <javaPermission codebase="${shared.resource.dir}/derby/derby.jar" className="java.security.AllPermission"/>
+  <javaPermission codebase="${shared.resource.dir}/h2Java8/h2.jar" className="java.security.AllPermission"/>
   <javaPermission codebase="${server.config.dir}/customLoginModule.jar" className="java.security.AllPermission"/>
 
   <javaPermission codebase="${server.config.dir}/dropins/TestValidationJMSAdapter.rar"

--- a/dev/com.ibm.ws.rest.handler.validator_fat/semeruFips140_3CustomProfile.properties
+++ b/dev/com.ibm.ws.rest.handler.validator_fat/semeruFips140_3CustomProfile.properties
@@ -3,5 +3,5 @@ RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.desc.name = Custom OpenJCEPl
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.extends = RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Liberty
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Custom.jce.provider.2 = sun.security.provider.Sun [+ \
     {KeyStore, JKS, *, ModuleAndFullClassName:java.base/java.security.KeyStore}, \
-    {MessageDigest, SHA-1, *, FullClassName:org.apache.derby.iapi.services.monitor.Monitor}, \
+    {MessageDigest, SHA-256, *, FullClassName:org.h2.security.SHA256}, \
     {MessageDigest, SHA-1, *, ModuleAndFullClassName:java.base/java.security.KeyStore}]

--- a/dev/com.ibm.ws.rest.handler.validator_fat/test-applications/testOpenAPIApp/resources/META-INF/openapi.yaml
+++ b/dev/com.ibm.ws.rest.handler.validator_fat/test-applications/testOpenAPIApp/resources/META-INF/openapi.yaml
@@ -1,5 +1,5 @@
 # *******************************************************************************
-# Copyright (c) 2019 IBM Corporation and others.
+# Copyright (c) 2019,2026 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -596,26 +596,25 @@ components:
           configElementName: "containerAuthData"
           uid: "dataSource[DefaultDataSource]/containerAuthData[default-0]"
           password: "******"
-          user: "derbyuser1"
+          user: "h2user1"
         enableConnectionCasting: false
         jdbcDriverRef:
           configElementName: "jdbcDriver"
           uid: "dataSource[DefaultDataSource]/jdbcDriver[default-0]"
           libraryRef:
             configElementName: "library"
-            uid: "Derby"
-            id: "Derby"
+            uid: "H2"
+            id: "H2"
             apiTypeVisibility: "spec,ibm-api,api,stable"
             fileRef:
               - configElementName: "file"
-                uid: "library[Derby]/file[default-0]"
-                name: "/Users/myself/drivers/derby/derby.jar"
+                uid: "library[H2]/file[default-0]"
+                name: "/Users/myself/drivers/h2/h2.jar"
         statementCacheSize: 10,
         syncQueryTimeoutWithTransactionTimeout: false,
         transactional: true,
-        properties.derby.embedded:
-          createDatabase: "create"
-          databaseName: "memory:derbydb"
+        properties.h2:
+          URL: "jdbc:h2:mem:h2db;DB_CLOSE_DELAY=-1"
         api:
           - "/ibm/api/validation/dataSource/DefaultDataSource"
     validation.cloudantDatabase.result:


### PR DESCRIPTION
Converts the com.ibm.ws.rest.handler.validator_fat test bucket from Derby to H2

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
