### PR TITLE
Fix EOL for generated soruce in data FAT

### DIFF
--- a/dev/io.openliberty.data.internal_fat_jpa_hibernate/build.gradle
+++ b/dev/io.openliberty.data.internal_fat_jpa_hibernate/build.gradle
@@ -122,8 +122,9 @@ task addHibernatePermissions() {
         // Ignore all lines inside the tagged section
       }
 
-      // overwrite the file with the updated lines
-      java.nio.file.Files.write(path, updated)
+      // overwrite the file with the updated lines, preserving Unix line endings
+      String content = updated.join('\n') + '\n'
+      java.nio.file.Files.write(path, content.getBytes(java.nio.charset.StandardCharsets.UTF_8))
     }
   }
 }
@@ -149,7 +150,8 @@ task addGeneratedSources() {
         from 'build/libs/generated/sources/annotationProcessor/java/main'
         into generated_src
       }
-      println "Copied generated sources to source folder for version control"
+      ant.fixcrlf(srcdir: generated_src, eol: 'lf', includes: '**/*.java')
+      println "Copied generated sources to source folder for version control and updated line endings to Unix format (LF)"
     }
 }
 


### PR DESCRIPTION
- fixed EOL for generated source in data FAT
- fixed EOL for updated server.xml in data FAT
Co-authored-by-AI: IBM Bob 1.0.1


- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".