### PR TITLE
Update multi release classloading processing to be more efficient

### DIFF
--- a/dev/com.ibm.ws.artifact.zip/src/com/ibm/ws/artifact/zip/cache/internal/ZipFileHandleImpl.java
+++ b/dev/com.ibm.ws.artifact.zip/src/com/ibm/ws/artifact/zip/cache/internal/ZipFileHandleImpl.java
@@ -1,14 +1,11 @@
 /*******************************************************************************
- * Copyright (c) 2012,2024 IBM Corporation and others.
+ * Copyright (c) 2012,2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package com.ibm.ws.artifact.zip.cache.internal;
 
@@ -275,7 +272,7 @@ public class ZipFileHandleImpl implements ZipFileHandle {
     public InputStream getInputStream(ZipFile useZipFile, String zipEntryName) throws IOException {
         ZipEntry zipEntry = useZipFile.getEntry(zipEntryName);
         if ( zipEntry == null ) {
-            throw new FileNotFoundException("Zip file [ " + getPath() + " ] does not container entry [ " + zipEntryName + " ]");
+            throw new FileNotFoundException("Zip file [ " + getPath() + " ] does not contain entry [ " + zipEntryName + " ]");
         }
 
         return getInputStream(useZipFile, zipEntry);

--- a/dev/com.ibm.ws.artifact.zip/src/com/ibm/ws/artifact/zip/internal/ZipFileArtifactNotifier.java
+++ b/dev/com.ibm.ws.artifact.zip/src/com/ibm/ws/artifact/zip/internal/ZipFileArtifactNotifier.java
@@ -917,7 +917,11 @@ public class ZipFileArtifactNotifier implements ArtifactNotifier, com.ibm.ws.ker
 
         if ( a_path.isEmpty() || ((a_path.length() == 1) && (a_path.charAt(0) == '/')) ) {
             for ( ZipEntryData entry : allEntryData ) {
-                // Do not include phantom entry data
+                // Do not include phantom entry data.
+                // Consumers of the entry paths are not expecting a nonexistent entry in the zip
+                // file that cannot be consumed.  Only real entries should be returned to external
+                // consumers of the notifier for that reason.  This change maintains 
+                // the previous behavior so as not to cause a consumer to cause an error.
                 if (entry.isPhantom()) {
                     continue;
                 }

--- a/dev/com.ibm.ws.artifact.zip/src/com/ibm/ws/artifact/zip/internal/ZipFileArtifactNotifier.java
+++ b/dev/com.ibm.ws.artifact.zip/src/com/ibm/ws/artifact/zip/internal/ZipFileArtifactNotifier.java
@@ -1,14 +1,11 @@
 /*******************************************************************************
- * Copyright (c) 2012,2018 IBM Corporation and others.
+ * Copyright (c) 2012,2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
- * SPDX-License-Identifier: EPL-2.0
  *
- * Contributors:
- *     IBM Corporation - initial API and implementation
+ * SPDX-License-Identifier: EPL-2.0
  *******************************************************************************/
 package com.ibm.ws.artifact.zip.internal;
 
@@ -920,6 +917,10 @@ public class ZipFileArtifactNotifier implements ArtifactNotifier, com.ibm.ws.ker
 
         if ( a_path.isEmpty() || ((a_path.length() == 1) && (a_path.charAt(0) == '/')) ) {
             for ( ZipEntryData entry : allEntryData ) {
+                // Do not include phantom entry data
+                if (entry.isPhantom()) {
+                    continue;
+                }
                 a_paths.add( "/" + entry.r_getPath() );
             }
             a_paths.add("/");

--- a/dev/com.ibm.ws.artifact.zip/src/com/ibm/ws/artifact/zip/internal/ZipFileContainer.java
+++ b/dev/com.ibm.ws.artifact.zip/src/com/ibm/ws/artifact/zip/internal/ZipFileContainer.java
@@ -842,12 +842,10 @@ public class ZipFileContainer implements com.ibm.wsspi.artifact.ArtifactContaine
 
     private static class ZipFileDetails {
         final ZipEntryData[] zipEntryData;
-        final boolean isMultiRelease;
         final Map<String, ZipEntryData> zipEntryDataMap;
 
-        ZipFileDetails(ZipEntryData[] zipEntryData, boolean isMultiRelease, Map<String, ZipEntryData> zipEntryDataMap) {
+        ZipFileDetails(ZipEntryData[] zipEntryData, Map<String, ZipEntryData> zipEntryDataMap) {
             this.zipEntryData = zipEntryData;
-            this.isMultiRelease = isMultiRelease;
             this.zipEntryDataMap = zipEntryDataMap;
         }
     }
@@ -913,7 +911,7 @@ public class ZipFileContainer implements com.ibm.wsspi.artifact.ArtifactContaine
                         zipEntryDataMap = new HashMap<>(zipEntryDataMap);
                     }
 
-                    zipFileDetails = new ZipFileDetails(useZipEntryData, isMultiRelease, zipEntryDataMap);
+                    zipFileDetails = new ZipFileDetails(useZipEntryData, zipEntryDataMap);
                 }
             }
         }
@@ -942,13 +940,12 @@ public class ZipFileContainer implements com.ibm.wsspi.artifact.ArtifactContaine
         setZipFileDetails();
         ZipEntryData entryData = zipFileDetails.zipEntryDataMap.get(r_path);
         if ( entryData != null ) {
-            if (zipFileDetails.isMultiRelease && entryData instanceof MultiReleaseFileZipEntryData) {
-                // If this is an MRJAR, check the entry for /META-INF/versions/n/<r_path> location reference
-                MultiReleaseFileZipEntryData multiReleaseData = (MultiReleaseFileZipEntryData) entryData;
+            ZipEntryData multiReleaseData = entryData.getMultiReleaseEntry();
+            if (multiReleaseData != entryData) {
                 if ( TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled() ) {
-                    Tr.debug(tc, "Found MR path: META-INF/versions/" + multiReleaseData.multiReleaseJavaVersion + "/" + r_path);
+                    Tr.debug(tc, "Found MR path: META-INF/versions/" + ((MultiReleaseFileZipEntryData) entryData).multiReleaseJavaVersion + "/" + r_path);
                 }
-                return multiReleaseData.multiReleaseEntry;
+                entryData = multiReleaseData;
             }
         }
         return entryData;
@@ -1001,14 +998,14 @@ public class ZipFileContainer implements com.ibm.wsspi.artifact.ArtifactContaine
         int location = ZipFileContainerUtils.locatePath( getZipEntryData(), r_path );
 
         // If this is an MRJAR, check the entry for /META-INF/versions/n/<r_path> location reference
-        if (zipFileDetails.isMultiRelease && location >= 0) {
+        if (location >= 0) {
             ZipEntryData entryData = zipFileDetails.zipEntryData[location];
-            if (entryData instanceof MultiReleaseFileZipEntryData) {
-                MultiReleaseFileZipEntryData multiReleaseData = (MultiReleaseFileZipEntryData) entryData;
+            ZipEntryData multiReleaseData = entryData.getMultiReleaseEntry();
+            if (multiReleaseData != entryData) {
                 if ( TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled() ) {
-                    Tr.debug(tc, "Found MR path: META-INF/versions/" + multiReleaseData.multiReleaseJavaVersion + "/" + r_path);
+                    Tr.debug(tc, "Found MR path: META-INF/versions/" + ((MultiReleaseFileZipEntryData) entryData).multiReleaseJavaVersion + "/" + r_path);
                 }
-                location = multiReleaseData.multiReleaseEntry.getOffset();
+                location = multiReleaseData.getOffset();
             }
         }
         if ( COLLECT_TIMINGS ) {

--- a/dev/com.ibm.ws.artifact.zip/src/com/ibm/ws/artifact/zip/internal/ZipFileContainer.java
+++ b/dev/com.ibm.ws.artifact.zip/src/com/ibm/ws/artifact/zip/internal/ZipFileContainer.java
@@ -1,14 +1,11 @@
 /*******************************************************************************
- * Copyright (c) 2011,2025 IBM Corporation and others.
+ * Copyright (c) 2011,2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package com.ibm.ws.artifact.zip.internal;
 
@@ -29,10 +26,12 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.jar.Manifest;
+import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 
 import com.ibm.websphere.ras.Tr;
@@ -40,6 +39,7 @@ import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.websphere.ras.annotation.Trivial;
 import com.ibm.ws.artifact.zip.cache.ZipCachingProperties;
 import com.ibm.ws.artifact.zip.cache.ZipFileHandle;
+import com.ibm.ws.artifact.zip.internal.ZipFileContainerUtils.MultiReleaseFileZipEntryData;
 import com.ibm.ws.artifact.zip.internal.ZipFileContainerUtils.ZipEntryData;
 import com.ibm.ws.ffdc.annotation.FFDCIgnore;
 import com.ibm.ws.kernel.service.util.JavaInfo;
@@ -181,7 +181,6 @@ public class ZipFileContainer implements com.ibm.wsspi.artifact.ArtifactContaine
 
     private static enum Timings {
         ARRAY_CREATE_TIME,
-        MAP_CREATE_TIME,
         ARRAY_LOOKUP_TIME,
         MAP_LOOKUP_TIME,
         EXTRACT_TIME;
@@ -199,7 +198,6 @@ public class ZipFileContainer implements com.ibm.wsspi.artifact.ArtifactContaine
         if ( COLLECT_TIMINGS ) {
             System.out.println("ZFC Timings Key");
             System.out.println("ZFC [ " + Timings.ARRAY_CREATE_TIME + " ] [ Time creating the zip entry data array ]");
-            System.out.println("ZFC [ " + Timings.MAP_CREATE_TIME + " ] [ Time creating zip entry data map ]");
             System.out.println("ZFC [ " + Timings.ARRAY_LOOKUP_TIME + " ] [ Time doing array lookups ]");
             System.out.println("ZFC [ " + Timings.MAP_LOOKUP_TIME + " ] [ Time doing map lookups ]");
             System.out.println("ZFC [ " + Timings.EXTRACT_TIME + " ] [ Time extracting nested containers ]");
@@ -242,11 +240,11 @@ public class ZipFileContainer implements com.ibm.wsspi.artifact.ArtifactContaine
         }
     }
 
-    private final String archiveName;
+    final String archiveName;
 
     // Multi-release support ...
 
-    private static final int CURRENT_JAVA_VERSION = JavaInfo.majorVersion();
+    static final int CURRENT_JAVA_VERSION = JavaInfo.majorVersion();
 
     // JDK-defined system property for controlling MR. Possible values: true (default), force, false
 
@@ -264,13 +262,6 @@ public class ZipFileContainer implements com.ibm.wsspi.artifact.ArtifactContaine
 
         JDK_DISABLE_MULTI_RELEASE = "false".equalsIgnoreCase(mrProp);
     }
-
-    // Assign 'isMultiRelease' using double locking ...
-    private static class MultiReleaseLock {
-        // EMPTY
-    }
-    private final MultiReleaseLock multiReleaseLock = new MultiReleaseLock();
-    private volatile Boolean isMultiRelease = null;
 
     /**
      * Create a root zip file type container which is not an enclosed container.
@@ -849,14 +840,25 @@ public class ZipFileContainer implements com.ibm.wsspi.artifact.ArtifactContaine
         }
     }
 
+    private static class ZipFileDetails {
+        final ZipEntryData[] zipEntryData;
+        final boolean isMultiRelease;
+        final Map<String, ZipEntryData> zipEntryDataMap;
+
+        ZipFileDetails(ZipEntryData[] zipEntryData, boolean isMultiRelease, Map<String, ZipEntryData> zipEntryDataMap) {
+            this.zipEntryData = zipEntryData;
+            this.isMultiRelease = isMultiRelease;
+            this.zipEntryDataMap = zipEntryDataMap;
+        }
+    }
+
     //
 
-    private static class ZipEntryDataLock {
+    private static class ZipFileDetailsLock {
         // EMPTY
     }
-    private final ZipEntryDataLock zipEntryDataLock = new ZipEntryDataLock();
-    private volatile ZipEntryData[] zipEntryData;
-    private Map<String, ZipEntryData> zipEntryDataMap;
+    private final ZipFileDetailsLock zipFileDetailsLock = new ZipFileDetailsLock();
+    private volatile ZipFileDetails zipFileDetails;
 
     private String getTimingName() {
         if ( archiveFileLock == null ) {
@@ -867,27 +869,51 @@ public class ZipFileContainer implements com.ibm.wsspi.artifact.ArtifactContaine
     }
 
     @Trivial
-    private void setZipEntryData() {
-        if ( zipEntryData == null ) {
-            synchronized( zipEntryDataLock ) {
-                if ( zipEntryData == null ) {
+    private void setZipFileDetails() {
+        if ( zipFileDetails == null ) {
+            synchronized( zipFileDetailsLock ) {
+                if ( zipFileDetails == null ) {
                     String timingName = (COLLECT_TIMINGS ? getTimingName() : null);
 
                     long dataStart = (COLLECT_TIMINGS ? System.nanoTime() : -1L);
-                    ZipEntryData[] useZipEntryData = createZipEntryData();
+                    boolean isMultiRelease;
+                    ZipEntryData[] useZipEntryData;
+                    Map<String, ZipEntryData> zipEntryDataMap;
+
+                    ZipFile useZipFile = openZipFileHandle();
+                    if ( useZipFile == null ) {
+                        isMultiRelease = false;
+                        zipEntryDataMap = null;
+                        useZipEntryData = new ZipEntryData[0];
+                    } else {
+                        try {
+                            isMultiRelease = isMultiRelease(useZipFile);
+                            // Using a LinkedHashMap to have it be in insert order to give the same
+                            // sort characteristics as putting entries into a list.
+                            zipEntryDataMap = new LinkedHashMap<String, ZipEntryData>();
+                            useZipEntryData = ZipFileContainerUtils.collectZipEntries(useZipFile, zipEntryDataMap, isMultiRelease);
+                        } finally {
+                            closeZipFileHandle(); // throws IOException
+                        }
+                    }
+
                     if ( COLLECT_TIMINGS ) {
                         record(Timings.ARRAY_CREATE_TIME, dataStart, System.nanoTime(), timingName, 1);
                     }
 
-                    if ( USE_EXTRA_PATH_CACHE ) {
-                        long mapStart = (COLLECT_TIMINGS ? System.nanoTime() : -1L);
-                        zipEntryDataMap = ZipFileContainerUtils.setLocations(useZipEntryData);
-                        if ( COLLECT_TIMINGS ) {
-                            record(Timings.MAP_CREATE_TIME, mapStart, System.nanoTime(), timingName, 1);
-                        }
+                    // Need to set the location always since the locatePath uses the location
+                    // integer instead of a ZipEntryData return value
+                    ZipFileContainerUtils.setLocations(useZipEntryData);
+
+                    if ( !USE_EXTRA_PATH_CACHE ) {
+                        zipEntryDataMap = null;
+                    } else {
+                        // convert from a LinkedHashMap to a normal HashMap to 
+                        // not have the extra memory overhead
+                        zipEntryDataMap = new HashMap<>(zipEntryDataMap);
                     }
 
-                    zipEntryData = useZipEntryData; 
+                    zipFileDetails = new ZipFileDetails(useZipEntryData, isMultiRelease, zipEntryDataMap);
                 }
             }
         }
@@ -900,8 +926,8 @@ public class ZipFileContainer implements com.ibm.wsspi.artifact.ArtifactContaine
     // And several times from within ZipFileContainer itself.
     @Trivial
     protected ZipEntryData[] getZipEntryData() {
-        setZipEntryData();
-        return zipEntryData;
+        setZipFileDetails();
+        return zipFileDetails.zipEntryData;
     }
 
     /**
@@ -913,8 +939,19 @@ public class ZipFileContainer implements com.ibm.wsspi.artifact.ArtifactContaine
      */
     @Trivial
     private ZipEntryData fastGetZipEntryData(String r_path) {
-        setZipEntryData();
-        return zipEntryDataMap.get(r_path);
+        setZipFileDetails();
+        ZipEntryData entryData = zipFileDetails.zipEntryDataMap.get(r_path);
+        if ( entryData != null ) {
+            if (zipFileDetails.isMultiRelease && entryData instanceof MultiReleaseFileZipEntryData) {
+                // If this is an MRJAR, check the entry for /META-INF/versions/n/<r_path> location reference
+                MultiReleaseFileZipEntryData multiReleaseData = (MultiReleaseFileZipEntryData) entryData;
+                if ( TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled() ) {
+                    Tr.debug(tc, "Found MR path: META-INF/versions/" + multiReleaseData.multiReleaseJavaVersion + "/" + r_path);
+                }
+                return multiReleaseData.multiReleaseEntry;
+            }
+        }
+        return entryData;
     }
 
     // 'locatePath' is modal, depending on whether 'isMultiRelease' has
@@ -947,24 +984,6 @@ public class ZipFileContainer implements com.ibm.wsspi.artifact.ArtifactContaine
 
     @Trivial
     public int locatePath(String r_path) {
-        // If this is an MRJAR, check under /META-INF/versions/n/<r_path>
-        if ( (isMultiRelease != null) && isMultiRelease.booleanValue() ) {
-            int mrLocation = locateMultiReleasePath(r_path);
-            if ( mrLocation >= 0 ) {
-                return mrLocation;
-            }
-        }
-
-        // The direct lookup is not an 'else' case: The multi-release
-        // location is an alternate to the direct location.  If the
-        // multi-release location is not present, fall back to the direct
-        // location.
-
-        return locateDirectPath(r_path);
-    }
-
-    @Trivial
-    private int locateDirectPath(String r_path) { 
         if ( USE_EXTRA_PATH_CACHE ) {
             long mapLookupStart = (COLLECT_TIMINGS ? System.nanoTime() : -1L);
             ZipEntryData entryData = fastGetZipEntryData(r_path);
@@ -980,30 +999,23 @@ public class ZipFileContainer implements com.ibm.wsspi.artifact.ArtifactContaine
         // directory entry which is the parent of an entry.
         long lookupStart = (COLLECT_TIMINGS ? System.nanoTime() : -1L);        
         int location = ZipFileContainerUtils.locatePath( getZipEntryData(), r_path );
+
+        // If this is an MRJAR, check the entry for /META-INF/versions/n/<r_path> location reference
+        if (zipFileDetails.isMultiRelease && location >= 0) {
+            ZipEntryData entryData = zipFileDetails.zipEntryData[location];
+            if (entryData instanceof MultiReleaseFileZipEntryData) {
+                MultiReleaseFileZipEntryData multiReleaseData = (MultiReleaseFileZipEntryData) entryData;
+                if ( TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled() ) {
+                    Tr.debug(tc, "Found MR path: META-INF/versions/" + multiReleaseData.multiReleaseJavaVersion + "/" + r_path);
+                }
+                location = multiReleaseData.multiReleaseEntry.getOffset();
+            }
+        }
         if ( COLLECT_TIMINGS ) {
             record(Timings.ARRAY_LOOKUP_TIME, lookupStart, System.nanoTime(), null, ARRAY_LOOKUP_FREQUENCY);
         }
+
         return location;
-    }
-
-    @Trivial
-    private int locateMultiReleasePath(String path) {
-        // Multi-release files may be at /com/foo/A.class and /META-INF/versions/9/com/foo/A.class
-        // Since we commonly blindly try-load META-INF and java.* entries, optimize those out
-        if ( (path == null) || path.startsWith("META-INF") || path.startsWith("java/") ) {
-            return -1;
-        }
-
-        for ( int currentVersion = CURRENT_JAVA_VERSION; currentVersion >= 9; currentVersion-- ) {
-            int versionPath = locateDirectPath("META-INF/versions/" + currentVersion + "/" + path);
-            if ( versionPath >= 0 ) {
-                if ( TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled() ) {
-                    Tr.debug(tc, "Found MR path: META-INF/versions/" + currentVersion + "/" + path);
-                }
-                return versionPath;
-            }
-        } 
-        return -1;
     }
 
     @Trivial
@@ -1022,29 +1034,10 @@ public class ZipFileContainer implements com.ibm.wsspi.artifact.ArtifactContaine
         }
     }
 
-    @Trivial
-    private ZipEntryData[] createZipEntryData() {
-        ZipFile useZipFile = openZipFileHandle();
-        if ( useZipFile == null ) {
-            return new ZipEntryData[0];
-        }
-
-        try {
-            return ZipFileContainerUtils.collectZipEntries(useZipFile);
-        } finally {
-            closeZipFileHandle(); // throws IOException
-        }
-    }
-
-    private boolean initializeMultiRelease() {
-        if ( isMultiRelease != null ) {
-            return isMultiRelease;
-        }
-
+    private boolean isMultiRelease(ZipFile zipFile) {
         // Multi-Release jars only apply to JDK 9+
         if ( CURRENT_JAVA_VERSION < 9 ) {
-            isMultiRelease = Boolean.FALSE;
-            return isMultiRelease;
+            return false;
         }
 
         // Multi-Release jars can be disabled with JDK system properties
@@ -1052,63 +1045,46 @@ public class ZipFileContainer implements com.ibm.wsspi.artifact.ArtifactContaine
             if ( TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled() ) {
                 Tr.debug(tc, "JDK system property set to globally disable multi-release jars");
             }
-           isMultiRelease = Boolean.FALSE;
-           return isMultiRelease;
+           return false;
         }
 
         // Only .jar files can be multi-release (not .war or .ear)
         if ( !archiveName.endsWith(".jar") ) {
-            isMultiRelease = Boolean.FALSE;
-            return isMultiRelease;
+            return false;
         }
 
-        // Only synchronize the expensive check against the manifest file.
-        //
         // The earlier checks are simple and quick and always produce the same
         // assignment.  There is no harm if they are performed multiple times.
         //
         // On the other hand, the manifest check is quite expensive, and must
-        // not be performed more than once.
+        // not be performed more than once.  The locking for setZipFileDetails
+        // guards this method call to avoid doing this logic multiple times.
 
-        synchronized ( multiReleaseLock ) {
-            if ( isMultiRelease != null ) { // Use double-locking.
-                return isMultiRelease;
+        // Multi-release is disabled for this JAR unless
+        // a main attribute 'Multi-Release' is present and is "true".
+
+        ZipEntry mfEntry = zipFile.getEntry("META-INF/MANIFEST.MF");
+        if (mfEntry == null) {
+            if ( TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled() ) {
+                Tr.debug(tc, "No MANIFEST.MF found in container. Assuming not multi-release");
             }
+            return false;
+        }
 
-            // Multi-release is disabled for this JAR unless
-            // a main attribute 'Multi-Release' is present and is "true".
-
-            ZipFileEntry mfEntry = getEntry("META-INF/MANIFEST.MF");
-            if ( mfEntry == null ) {
-                if ( TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled() ) {
-                    Tr.debug(tc, "No MANIFEST.MF found in container. Assuming not multi-release");
-                }
-                isMultiRelease = Boolean.FALSE;
-                return isMultiRelease;
-
+        try ( InputStream mfStream = zipFile.getInputStream(mfEntry) ) {
+            Manifest mf = new Manifest(mfStream);
+            String isMultiReleaseAttr = mf.getMainAttributes().getValue("Multi-Release");
+            if ( TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled() ) {
+                Tr.debug(tc, "Raw value for 'Multi-Release' attribute: " + isMultiReleaseAttr);
+            }
+            if ( isMultiReleaseAttr != null ) {
+                return Boolean.parseBoolean( isMultiReleaseAttr.trim() );
             } else {
-                Boolean isMR;
-
-                try ( InputStream mfStream = mfEntry.getInputStream() ) {
-                    Manifest mf = new Manifest(mfStream);
-                    String isMultiReleaseAttr = mf.getMainAttributes().getValue("Multi-Release");
-                    if ( TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled() ) {
-                        Tr.debug(tc, "Raw value for 'Multi-Release' attribute: " + isMultiReleaseAttr);
-                    }
-                    if ( isMultiReleaseAttr != null ) {
-                        isMR = Boolean.valueOf( isMultiReleaseAttr.trim() );
-                    } else {
-                        isMR = Boolean.FALSE;
-                    }
-                } catch ( IOException e ) {
-                    // FFDC
-                    isMR = Boolean.FALSE;
-                }
-
-                isMultiRelease = isMR;
+                return false;
             }
-
-            return isMultiRelease;
+        } catch ( IOException e ) {
+            // FFDC
+            return false;
         }
     }
 
@@ -1262,10 +1238,6 @@ public class ZipFileContainer implements com.ibm.wsspi.artifact.ArtifactContaine
         // 'getEntry' is invoked from 'initializeMultiRelease'!
         // The guard on the path is absolutely necessary to avoid
         // infinite recursion.
-
-        if ( (isMultiRelease == null) && !entryPath.startsWith("META-INF") ) {
-            initializeMultiRelease();
-        }
 
         int location = locatePath(r_entryPath);
 

--- a/dev/com.ibm.ws.artifact.zip/src/com/ibm/ws/artifact/zip/internal/ZipFileContainerUtils.java
+++ b/dev/com.ibm.ws.artifact.zip/src/com/ibm/ws/artifact/zip/internal/ZipFileContainerUtils.java
@@ -304,7 +304,11 @@ public class ZipFileContainerUtils {
         List<List<Integer>> offsetsStack = new ArrayList<List<Integer>>(32);
 
         for ( int nextOffset = 0; nextOffset < zipEntryData.length; nextOffset++ ) {
-            // Do not include phantom entry data in the iterator data
+            // Do not include phantom entry data in the iterator data.
+            // Consumers of the iterator are not expecting a nonexistent entry in the zip
+            // file that cannot be consumed.  Only real entries should be returned to external
+            // consumers of the Container iterator for that reason.  This change maintains 
+            // the previous behavior so as not to cause a consumer to cause an error.
             if (zipEntryData[nextOffset].isPhantom()) {
                 continue;
             }
@@ -451,6 +455,10 @@ public class ZipFileContainerUtils {
             return false;
         }
 
+        ZipEntryData getMultiReleaseEntry() {
+            return this;
+        }
+
         abstract String getPath();
 
         abstract boolean isDirectory();
@@ -559,13 +567,10 @@ public class ZipFileContainerUtils {
             // it just points to the multi-release version of the entry
             return size == -1;
         }
-        
+
+        @Override
         ZipEntryData getMultiReleaseEntry() {
             return multiReleaseEntry;
-        }
-
-        int getMultiReleaseJavaVersion() {
-            return multiReleaseJavaVersion;
         }
     }
 

--- a/dev/com.ibm.ws.artifact.zip/src/com/ibm/ws/artifact/zip/internal/ZipFileContainerUtils.java
+++ b/dev/com.ibm.ws.artifact.zip/src/com/ibm/ws/artifact/zip/internal/ZipFileContainerUtils.java
@@ -1,14 +1,11 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2024 IBM Corporation and others.
+ * Copyright (c) 2018, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package com.ibm.ws.artifact.zip.internal;
 
@@ -212,6 +209,10 @@ public class ZipFileContainerUtils {
         }
     }
 
+    private static final String MULTI_RELEASE_PREFIX = "META-INF/versions/";
+
+    private static final int MULTI_RELEASE_PREFIX_LENGTH = MULTI_RELEASE_PREFIX.length();
+
     private static final List<Integer> EMPTY_OFFSETS = null;
 
     private static final int[] EMPTY_OFFSETS_ARRAY = new int[0];
@@ -250,7 +251,7 @@ public class ZipFileContainerUtils {
         int numValues = offsets.size();
         
         int[] extractedValues;
-        
+
         if ( numValues == 0 ) {
             extractedValues = EMPTY_OFFSETS_ARRAY;
         } else {
@@ -303,6 +304,10 @@ public class ZipFileContainerUtils {
         List<List<Integer>> offsetsStack = new ArrayList<List<Integer>>(32);
 
         for ( int nextOffset = 0; nextOffset < zipEntryData.length; nextOffset++ ) {
+            // Do not include phantom entry data in the iterator data
+            if (zipEntryData[nextOffset].isPhantom()) {
+                continue;
+            }
             String r_nextPath = zipEntryData[nextOffset].r_getPath();
             int r_nextPathLen = r_nextPath.length();
 
@@ -420,7 +425,7 @@ public class ZipFileContainerUtils {
         }
 
         final String r_path;
-        private final long time;
+        final long time;
         private int offset = -1;
 
         final void setOffset(int offset) {
@@ -441,6 +446,11 @@ public class ZipFileContainerUtils {
             return time;
         }
 
+        @Trivial
+        boolean isPhantom()  {
+            return false;
+        }
+
         abstract String getPath();
 
         abstract boolean isDirectory();
@@ -450,9 +460,9 @@ public class ZipFileContainerUtils {
 
     @Trivial
     private static class FileZipEntryData extends ZipEntryData {
-        FileZipEntryData(ZipEntry zipEntry) {
-            super(stripPath(zipEntry.getName()), zipEntry.getTime());
-            this.path = zipEntry.getName();
+        FileZipEntryData(String entryPath, ZipEntry zipEntry) {
+            super(stripPath(entryPath), zipEntry.getTime());
+            this.path = entryPath;
             this.size = (int) zipEntry.getSize();
         }
 
@@ -476,10 +486,93 @@ public class ZipFileContainerUtils {
         }
     }
 
+    /**
+     * This ZipEntryData implementation represents an entry that may or may not actually exist.
+     * If it doesn't exist it is a "phantom" entry pointing to the entry that exists in the mutli 
+     * release space. The phantom entry is needed when doing a lookup to avoid looking up an entry
+     * multiple times for each of multi release versions it could be located in.
+     */
+    @Trivial
+    static class MultiReleaseFileZipEntryData extends ZipEntryData {
+        /**
+         * This constructor is used when the entry actually exists in the zip file and there is a multi release
+         * version of the file as well.
+         */
+        MultiReleaseFileZipEntryData(String entryPath, String relativePath, ZipEntry zipEntry, ZipEntryData multiReleaseEntry, int multiReleaseJavaVersion) {
+            super(relativePath, zipEntry.getTime());
+            this.path = entryPath;
+            this.size = (int) zipEntry.getSize();
+            this.multiReleaseEntry = multiReleaseEntry;
+            this.multiReleaseJavaVersion = multiReleaseJavaVersion;
+        }
+
+        /**
+         * This constructor is used when replacing an entry with a new one due to a newer Java version identified
+         * or finding a multi release entry for an existing ZipEntryData
+         */
+        MultiReleaseFileZipEntryData(ZipEntryData entryData, ZipEntryData multiReleaseEntry, int multiReleaseJavaVersion) {
+            super(entryData.r_path, entryData.time);
+            this.path = entryData.getPath();
+            this.size = entryData.getSize();
+            this.multiReleaseEntry = multiReleaseEntry;
+            this.multiReleaseJavaVersion = multiReleaseJavaVersion;
+        }
+
+        /**
+         * This constructor is used when the entry doesn't exists in the zip file and there is a multi release
+         * version of the entry that this entry points to for fast lookup.
+         */
+        MultiReleaseFileZipEntryData(String phantomPath, String relativePhantomPath, ZipEntryData multiReleaseEntry, int multiReleaseJavaVersion) {
+            super(relativePhantomPath, -1);
+            this.path = phantomPath;
+            this.size = -1;
+            this.multiReleaseEntry = multiReleaseEntry;
+            this.multiReleaseJavaVersion = multiReleaseJavaVersion;
+        }
+
+        final String path;
+
+        final ZipEntryData multiReleaseEntry;
+
+        final int multiReleaseJavaVersion;
+
+        @Override
+        String getPath() {
+            return path;
+        }            
+
+        @Override
+        boolean isDirectory() {
+            return false; 
+        }
+        
+        final int size;
+
+        @Override
+        int getSize() {
+            return size;
+        }
+
+        @Override
+        boolean isPhantom() {
+            // if size == -1, then it is not a real entry in the zip file
+            // it just points to the multi-release version of the entry
+            return size == -1;
+        }
+        
+        ZipEntryData getMultiReleaseEntry() {
+            return multiReleaseEntry;
+        }
+
+        int getMultiReleaseJavaVersion() {
+            return multiReleaseJavaVersion;
+        }
+    }
+
     @Trivial
     private static class DirZipEntryData extends ZipEntryData {
-        DirZipEntryData(ZipEntry zipEntry) {
-            super(stripPath(zipEntry.getName()), zipEntry.getTime());
+        DirZipEntryData(String entryPath, ZipEntry zipEntry) {
+            super(stripPath(entryPath), zipEntry.getTime());
         }
 
         @Override
@@ -496,15 +589,6 @@ public class ZipFileContainerUtils {
         int getSize() {
             return 0;
         }
-    }
-
-    @Trivial
-    private static final ZipEntryData createZipEntryData(ZipEntry entry) {
-        String path = entry.getName();
-        if (path.charAt( path.length() - 1 ) == '/' ) {
-            return new DirZipEntryData(entry);
-        }
-        return new FileZipEntryData(entry);
     }
 
     private static class SearchZipEntryData extends ZipEntryData {
@@ -542,7 +626,7 @@ public class ZipFileContainerUtils {
     public static class ZipEntryDataComparator implements Comparator<ZipEntryData> {
         @Trivial
         public int compare(ZipEntryData data1, ZipEntryData data2) {
-            return PathUtils.PATH_COMPARATOR.compare( data1.r_getPath(), data2.r_getPath() );
+            return PathUtils.PATH_COMPARATOR.compare( data1.r_path, data2.r_path );
         }
     }
 
@@ -552,6 +636,10 @@ public class ZipFileContainerUtils {
      * Collect data for the entries of a zip file.
      *
      * Intermediate / implied paths are not added to the result.
+     * 
+     * Multi-release entries are interpreted and the non multi release 
+     * entry is updated or a phantom entry is created to point to the 
+     * multi-release entry.
      *
      * Answer the zip entries sorted using the path comparator.
      * See {@link PathUtils#PATH_COMPARATOR}.
@@ -561,15 +649,74 @@ public class ZipFileContainerUtils {
      * @return Sorted data for entries of the zip file.
      */
     @Trivial
-    public static ZipEntryData[] collectZipEntries(ZipFile zipFile) {
-        final List<ZipEntryData> entriesList = new ArrayList<ZipEntryData>();
+    public static ZipEntryData[] collectZipEntries(ZipFile zipFile, Map<String, ZipEntryData> entryDataMap, boolean isMultiRelease) {
 
         final Enumeration<? extends ZipEntry> zipEntries = zipFile.entries();
         while ( zipEntries.hasMoreElements() ) {
-            entriesList.add( createZipEntryData( zipEntries.nextElement() ) );
+            ZipEntry zipEntry = zipEntries.nextElement();
+            String entryPath = zipEntry.getName();
+            boolean isDirectory = (entryPath.charAt( entryPath.length() - 1 ) == '/' );
+            ZipEntryData entryData = isDirectory ? new DirZipEntryData(entryPath, zipEntry) : new FileZipEntryData(entryPath, zipEntry);
+
+            String entryRelativePath = entryData.r_path;
+            ZipEntryData oldValue = entryDataMap.put(entryRelativePath, entryData);
+            if (isMultiRelease && !isDirectory) {
+                // check to see if we just removed a previous value that we need to account for
+                if (oldValue != null) {
+                    if (oldValue instanceof MultiReleaseFileZipEntryData) {
+                        MultiReleaseFileZipEntryData multiReleaseData = (MultiReleaseFileZipEntryData) oldValue;
+                        // If the existing entry was a phantom entry, it had the multi release data in it, but not the
+                        // non multi release data.  As such convert the phantom MultiReleaseFileZipEntryData to a
+                        // non phantom version.
+                        //
+                        // Otherwise, put the multi release value back instead of a non multi release value.  This should
+                        // never happen, but possibly it could if there are duplicates of the same entry in the zip.  If we
+                        // do we have duplicates, have the last one win.
+                        entryDataMap.put(entryRelativePath, new MultiReleaseFileZipEntryData(entryPath, entryRelativePath, zipEntry, multiReleaseData.multiReleaseEntry, multiReleaseData.multiReleaseJavaVersion));
+                    }
+                }
+
+                // Check to see if the current entryData is from a multi release location and if
+                // the version number is valid for the current java version either
+                // a) update to have a phantom entry created for it to point to the multi release 
+                //    location if a non multi release entry doesn't exist
+                // b) convert a non multi release entry to a multi release entry to point to this one
+                // c) check the version number to see if it is higher than the current referenced
+                //    multi release entry and replace it if it is
+                // d) do nothing because the current non multi release entry has the right information 
+                else if (entryRelativePath.startsWith(MULTI_RELEASE_PREFIX)) {
+                    int nextSlashIndex = entryRelativePath.indexOf('/', MULTI_RELEASE_PREFIX_LENGTH);
+                    if (nextSlashIndex > 0) {
+                        String javaVersionString = entryRelativePath.substring(MULTI_RELEASE_PREFIX_LENGTH, nextSlashIndex);
+                        int javaVersionInt;
+                        try {
+                            javaVersionInt = Integer.parseInt(javaVersionString);
+                        } catch (NumberFormatException e) {
+                            javaVersionInt = -1;
+                        }
+
+                        // precondition
+                        if (javaVersionInt >= 9 && javaVersionInt <= ZipFileContainer.CURRENT_JAVA_VERSION) {
+                            String relativeUnversionedPath = entryRelativePath.substring(nextSlashIndex + 1);
+                            ZipEntryData unVersionedEntry = entryDataMap.get(relativeUnversionedPath);
+
+                            // scenario a
+                            if (unVersionedEntry == null) {
+                                String unversionedPath = entryRelativePath.substring(nextSlashIndex);
+                                entryDataMap.put(relativeUnversionedPath, new MultiReleaseFileZipEntryData(unversionedPath, relativeUnversionedPath, entryData, javaVersionInt));
+
+                            // scenario b and c
+                            } else if (!(unVersionedEntry instanceof MultiReleaseFileZipEntryData) ||
+                                            javaVersionInt > ((MultiReleaseFileZipEntryData) unVersionedEntry).multiReleaseJavaVersion) {
+                                entryDataMap.put(relativeUnversionedPath, new MultiReleaseFileZipEntryData(unVersionedEntry, entryData, javaVersionInt));
+                            }
+                        }
+                    }
+                }
+            }
         }
         
-        ZipEntryData[] entryData = entriesList.toArray( new ZipEntryData[ entriesList.size() ] );
+        ZipEntryData[] entryData = entryDataMap.values().toArray( new ZipEntryData[ entryDataMap.size() ] );
 
         Arrays.sort(entryData, ZIP_ENTRY_DATA_COMPARATOR);
 
@@ -577,25 +724,18 @@ public class ZipFileContainerUtils {
     }
 
     /**
-     * Create a table of entry data using the relative paths of the entries as
-     * keys.  As a side effect, set the offset of each entry data to its location
-     * int he entry data array.
+     * Set the offset of each entry data to its location
+     * in the entry data array.
      * 
      * @param entryData The array of entry data to place in a table.
-     * 
-     * @return The table of entry data.
      */
     @Trivial
-    public static Map<String, ZipEntryData> setLocations(ZipEntryData[] entryData) {
-    	Map<String, ZipEntryData> entryDataMap = new HashMap<String, ZipEntryData>(entryData.length);
+    public static void setLocations(ZipEntryData[] entryData) {
     	
     	for ( int entryNo = 0; entryNo < entryData.length; entryNo++ ) {
     		ZipEntryData entry = entryData[entryNo];
     		entry.setOffset(entryNo);
-    		entryDataMap.put(entry.r_path, entry);
     	}
-    	
-    	return entryDataMap;
     }
 
     /**
@@ -644,7 +784,7 @@ public class ZipFileContainerUtils {
      * @return The path with leading and trailing slashes removed.
      */
     @Trivial
-    private static String stripPath(String path) {
+    static String stripPath(String path) {
         int pathLen = path.length();
 
         if ( pathLen == 0 ) {

--- a/dev/com.ibm.ws.artifact.zip/src/com/ibm/ws/artifact/zip/internal/ZipFileEntry.java
+++ b/dev/com.ibm.ws.artifact.zip/src/com/ibm/ws/artifact/zip/internal/ZipFileEntry.java
@@ -1,14 +1,11 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2025 IBM Corporation and others.
+ * Copyright (c) 2011, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package com.ibm.ws.artifact.zip.internal;
 
@@ -180,6 +177,12 @@ public class ZipFileEntry implements ExtractableArtifactEntry {
     public InputStream getInputStream() throws IOException {
         if ( (zipEntryData == null) || zipEntryData.isDirectory() ) {
             return null;
+        }
+
+        // This should never happen, but safeguard against it if it does.  Do the same as what is done
+        // when ZipHandle.getInputStream() gets a non existent entry
+        if (zipEntryData.isPhantom()) {
+            throw new FileNotFoundException("Zip file [ " + rootContainer.archiveName + " ] does not contain entry [ " + zipEntryData.getPath() + " ]");
         }
 
         final ZipFileHandle zipFileHandle = rootContainer.getZipFileHandle(); // throws IOException


### PR DESCRIPTION
- Before this change for multi release jars, each entry lookup with do N number of lookups where N was the Java version - 7.  So for Java 21 for instance it will end up doing 14 entry lookup potentially if it the class is not in META-INF/versions/XX directory
- After this change, the META-INF/versions processing is done during the first populating of the data for a ZipContainer instance so that there is a link to the META-INF/versions directory that is correct for the current running Java version.  Now we are back do only 1 lookup.
- As part of this if a zip entry is only in META-INF/versions/XX directory like module-info.class, then we create a phantom ZipEntryData in order to keep a reference to the one in META-INF/versions.


- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [ ] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
