### PR TITLE
Add missing Java2 Security permissions

### DIFF
--- a/dev/io.openliberty.security.auth.data_fat/publish/servers/io.openliberty.security.auth.data.fat.dpm.java2/server.xml
+++ b/dev/io.openliberty.security.auth.data_fat/publish/servers/io.openliberty.security.auth.data.fat.dpm.java2/server.xml
@@ -26,4 +26,7 @@
 
     <include location="../fatTestPorts.xml"/>
 
+    <javaPermission className="java.lang.RuntimePermission" name="setFactory" action="*"/>
+    <javaPermission className="java.security.SecurityPermission" name="putProviderProperty" action="*"/>
+
 </server>


### PR DESCRIPTION
Add permissions missing for non-standard linux/windows platforms. 

- [ ] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [ ] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

Fixes [#308951](https://wasrtc.hursley.ibm.com:9443/jazz/web/projects/WS-CD#action=com.ibm.team.workitem.viewWorkItem&id=308951)