### PR TITLE
Performance updates identified from profile data

### DIFF
--- a/dev/com.ibm.ws.app.manager/src/com/ibm/ws/app/manager/ApplicationStateCoordinator.java
+++ b/dev/com.ibm.ws.app.manager/src/com/ibm/ws/app/manager/ApplicationStateCoordinator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2020 IBM Corporation and others.
+ * Copyright (c) 2012, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -121,7 +121,6 @@ public final class ApplicationStateCoordinator {
     }
 
     public static String[] getSlowlyStartingApps() {
-        TimeUnit unit = TimeUnit.SECONDS;
         try {
             while (true) {
                 if (waitForStartingAppPidsLatch.await(1, TimeUnit.SECONDS)) {
@@ -136,27 +135,15 @@ public final class ApplicationStateCoordinator {
             //autoFFDC
         }
         if (appConfigurator != null) {
-            long endTime = System.nanoTime() + unit.toNanos(getApplicationStartTimeout());
             try {
-                do {
-                    if (unconfiguredApps.await(1, TimeUnit.SECONDS)) {
-                        break;
-                    }
-                } while (System.nanoTime() < endTime);
-
+                unconfiguredApps.await(getApplicationStartTimeout(), TimeUnit.SECONDS);
             } catch (InterruptedException e) {
                 // Auto FFDC
             }
 
             appConfigurator.readyForAppsToStart();
-            endTime = System.nanoTime() + unit.toNanos(getApplicationStartTimeout());
             try {
-                do {
-                    if (unstartedApps.await(1, TimeUnit.SECONDS)) {
-                        break;
-                    }
-                } while (System.nanoTime() < endTime);
-
+                unstartedApps.await(getApplicationStartTimeout(), TimeUnit.SECONDS);
             } catch (InterruptedException e) {
                 // Auto FFDC
             }
@@ -185,19 +172,12 @@ public final class ApplicationStateCoordinator {
     }
 
     public static String[] getSlowlyStoppingApps() {
-        TimeUnit unit = TimeUnit.SECONDS;
         if (appConfigurator == null) {
             return null;
         }
         appConfigurator.readyForAppsToStop();
-        long endTime = System.nanoTime() + unit.toNanos(getApplicationStopTimeout());
         try {
-            do {
-                if (unstoppedApps.await(1, TimeUnit.SECONDS)) {
-                    break;
-                }
-            } while (System.nanoTime() < endTime);
-
+            unstoppedApps.await(getApplicationStopTimeout(), TimeUnit.SECONDS);
         } catch (InterruptedException e) {
             // Auto FFDC
         }

--- a/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/internal/ConcurrentPriorityBlockingQueue.java
+++ b/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/internal/ConcurrentPriorityBlockingQueue.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2025 IBM Corporation and others.
+ * Copyright (c) 2020, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -19,6 +19,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
+import com.ibm.websphere.ras.annotation.Trivial;
 import com.ibm.ws.ffdc.annotation.FFDCIgnore;
 
 /**
@@ -714,6 +715,7 @@ public class ConcurrentPriorityBlockingQueue<T> extends AbstractQueue<T> impleme
      * @return string representing this data structure.
      */
     @Override
+    @Trivial
     public String toString() {
         StringBuilder b = new StringBuilder();
         b.append(size.get()).append(' ');

--- a/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/internal/ExecutorServiceImpl.java
+++ b/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/internal/ExecutorServiceImpl.java
@@ -24,15 +24,16 @@ import java.util.Set;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CopyOnWriteArraySet;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
-import java.util.concurrent.Phaser;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.RejectedExecutionHandler;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
@@ -46,7 +47,6 @@ import org.osgi.service.component.annotations.ReferencePolicy;
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.websphere.ras.annotation.Trivial;
-import com.ibm.ws.ffdc.annotation.FFDCIgnore;
 import com.ibm.ws.kernel.boot.internal.KernelUtils;
 import com.ibm.ws.kernel.feature.ServerStarted;
 import com.ibm.ws.kernel.service.util.AvailableProcessorsListener;
@@ -156,7 +156,7 @@ public final class ExecutorServiceImpl implements WSExecutorService, ThreadQuies
      */
     ThreadFactory threadFactory = null;
 
-    private boolean serverStopping = false;
+    private volatile boolean serverStopping = false;
 
     @Reference(cardinality = ReferenceCardinality.OPTIONAL,
                policy = ReferencePolicy.DYNAMIC,
@@ -337,20 +337,32 @@ public final class ExecutorServiceImpl implements WSExecutorService, ThreadQuies
          */
         @Override
         public void run() {
-            phaser.register();
+            activeThreadCount.incrementAndGet();
             Thread currentThread = Thread.currentThread();
             ClassLoader beforeContextCL = getContextClassLoader(currentThread);
             try {
                 this.wrappedTask.run();
             } finally {
                 setContextClassLoaderIfChanged(currentThread, beforeContextCL);
-                phaser.arriveAndDeregister();
+
+                // Decrement and check if quiescing
+                // Order matters here.  Need to decrement first and then
+                // check for quiesceLatch to avoid race condition
+                if (activeThreadCount.decrementAndGet() == 0) {
+                    // If we are quiescing and this is the last active thread,
+                    // call the quiesceLatch
+                    CountDownLatch latch = quiesceLatch;
+                    if (latch != null) {
+                        latch.countDown();
+                    }
+                }
             }
         }
     }
 
     // Used to keep track of the number of threads that are not finished
-    protected final Phaser phaser = new Phaser(1);
+    protected final AtomicInteger activeThreadCount = new AtomicInteger(0);
+    volatile CountDownLatch quiesceLatch = null;
 
     private class CallableWrapper<T> implements Callable<T> {
         private final Callable<T> callable;
@@ -366,14 +378,25 @@ public final class ExecutorServiceImpl implements WSExecutorService, ThreadQuies
          */
         @Override
         public T call() throws Exception {
-            phaser.register();
+            activeThreadCount.incrementAndGet();
             Thread currentThread = Thread.currentThread();
             ClassLoader beforeContextCL = getContextClassLoader(currentThread);
             try {
                 return this.callable.call();
             } finally {
                 setContextClassLoaderIfChanged(currentThread, beforeContextCL);
-                phaser.arriveAndDeregister();
+
+                // Decrement and check if quiescing
+                // Order matters here.  Need to decrement first and then
+                // check for quiesceLatch to avoid race condition
+                if (activeThreadCount.decrementAndGet() == 0) {
+                    // If we are quiescing and this is the last active thread,
+                    // call the quiesceLatch
+                    CountDownLatch latch = quiesceLatch;
+                    if (latch != null) {
+                        latch.countDown();
+                    }
+                }
             }
         }
     }
@@ -619,20 +642,26 @@ public final class ExecutorServiceImpl implements WSExecutorService, ThreadQuies
      * @see com.ibm.ws.threading.ThreadQuiesce#quiesceThreads()
      */
     @Override
-    @FFDCIgnore(TimeoutException.class)
     public boolean quiesceThreads() {
         this.serverStopping = true;
 
-        try {
-            // Wait for all pre-quiesce work to complete.
-            phaser.arriveAndDeregister();
-            phaser.awaitAdvanceInterruptibly(0, quiesceTimeout, TimeUnit.SECONDS);
-        } catch (InterruptedException e) {
-            //FFDC and fail quiesce notification
-            return false;
-        } catch (TimeoutException e) {
-            // If we time out, quiesce has failed. This is normal, so no FFDC.
-            return false;
+        // Wait for all pre-quiesce work to complete.
+        // Order matters: Set latch BEFORE checking count to ensure
+        // any task that decrements to 0 after this point will see the latch
+        // and signal it. If count is already 0, we return immediately.
+        quiesceLatch = new CountDownLatch(1);
+        if (activeThreadCount.get() != 0) {
+            try {
+                // Wait for all active threads to finish.  The last thread that finishes
+                // will call the latch.
+                if (!quiesceLatch.await(quiesceTimeout, TimeUnit.SECONDS)) {
+                    // If we time out, quiesce has failed.
+                    return false;
+                }
+            } catch (InterruptedException e) {
+                //FFDC and fail quiesce notification
+                return false;
+            }
         }
 
         return true;
@@ -640,11 +669,7 @@ public final class ExecutorServiceImpl implements WSExecutorService, ThreadQuies
 
     @Override
     public int getActiveThreads() {
-        int count = phaser.getUnarrivedParties();
-        if (this.serverStopping)
-            return count;
-
-        return count - 1;
+        return activeThreadCount.get();
     }
 
     @Override


### PR DESCRIPTION
- Switch ApplicationStateCoordinator logic to not do waiting for 1 second over and over and just do wait the normal way for the full time. No reason to wake up over and over again.
- Switch from using a Phaser in ExecutorServiceImpl to using an AtomicInteger and a CountDownLatch to avoid extra overhead that Phaser introduces and that is not needed when we are not currently in quiesce state.

Co-authored-by-AI: IBM Bob 1.0.1

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [ ] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
