### PR TITLE
Update to checkAppClassAndResourceAccess

### DIFF
--- a/dev/com.ibm.ws.kernel.boot_fat/fat/src/com/ibm/wsspi/kernel/embeddable/EmbeddedServerDriver.java
+++ b/dev/com.ibm.ws.kernel.boot_fat/fat/src/com/ibm/wsspi/kernel/embeddable/EmbeddedServerDriver.java
@@ -290,7 +290,7 @@ public class EmbeddedServerDriver implements ServerEventListener {
         }
 
         for (String resourceName : expectResourceFailure) {
-            checkBootstrapAccess("/simpleApp/bootstrapAccess?resosurcename=" + resourceName + "&expectFailure=" + true);
+            checkBootstrapAccess("/simpleApp/bootstrapAccess?resourcename=" + resourceName + "&expectFailure=" + true);
         }
     }
 


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

################################################################################################

Test fix:

- Before the fix, the negative resource requests sent resosurcename=...
- The servlet never reads that parameter, because it only looks for "resourcename"
- Therefore resourcename == null
- Then the entire resource-check block is skipped:
     no getClass().getResource(...)
     no validation of expected failure
    no servlet exception if the resource is unexpectedly visible
- The request would return successfully unless some unrelated failure occurred