### PR TITLE
Small performance and cleanup updates in a few places

### DIFF
--- a/dev/com.ibm.ws.anno/src/com/ibm/ws/annocache/util/internal/UtilImpl_ReadBufferFull.java
+++ b/dev/com.ibm.ws.anno/src/com/ibm/ws/annocache/util/internal/UtilImpl_ReadBufferFull.java
@@ -1,14 +1,11 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2025 IBM Corporation and others.
+ * Copyright (c) 2019, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
- * SPDX-License-Identifier: EPL-2.0
  *
- * Contributors:
- *     IBM Corporation - initial API and implementation
+ * SPDX-License-Identifier: EPL-2.0
  *******************************************************************************/
 package com.ibm.ws.annocache.util.internal;
 
@@ -156,7 +153,14 @@ public final class UtilImpl_ReadBufferFull implements UtilImpl_ReadBuffer {
                 " from [ " + getPath() + " ]");
         }
 
-        System.arraycopy(buffer, bufferPos, bytes, offset, len);
+        // Manual copy for small arrays (faster than System.arraycopy overhead)
+        if (len <= 8) {
+            for (int i = 0; i < len; i++) {
+                bytes[offset + i] = buffer[bufferPos + i];
+            }
+        } else {
+            System.arraycopy(buffer, bufferPos, bytes, offset, len);
+        }
         bufferPos += len;
         bufferAvail -= len;
         return;

--- a/dev/com.ibm.ws.anno/src/com/ibm/ws/annocache/util/internal/UtilImpl_ReadBufferPartial.java
+++ b/dev/com.ibm.ws.anno/src/com/ibm/ws/annocache/util/internal/UtilImpl_ReadBufferPartial.java
@@ -1,14 +1,11 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2025 IBM Corporation and others.
+ * Copyright (c) 2019, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
- * SPDX-License-Identifier: EPL-2.0
  *
- * Contributors:
- *     IBM Corporation - initial API and implementation
+ * SPDX-License-Identifier: EPL-2.0
  *******************************************************************************/
 package com.ibm.ws.annocache.util.internal;
 
@@ -233,7 +230,14 @@ public final class UtilImpl_ReadBufferPartial implements UtilImpl_ReadBuffer {
         // Most expected case ...
 
         if ( len < bufferAvail ) {
-            System.arraycopy(buffer, bufferPos, bytes, offset, len);
+            // Manual copy for small arrays (faster than System.arraycopy overhead)
+            if (len <= 8) {
+                for (int i = 0; i < len; i++) {
+                    bytes[offset + i] = buffer[bufferPos + i];
+                }
+            } else {
+                System.arraycopy(buffer, bufferPos, bytes, offset, len);
+            }
             bufferPos += len;
             bufferAvail -= len;
             return;

--- a/dev/com.ibm.ws.artifact.zip/src/com/ibm/ws/artifact/zip/internal/ZipFileContainer.java
+++ b/dev/com.ibm.ws.artifact.zip/src/com/ibm/ws/artifact/zip/internal/ZipFileContainer.java
@@ -888,6 +888,9 @@ public class ZipFileContainer implements com.ibm.wsspi.artifact.ArtifactContaine
                             isMultiRelease = isMultiRelease(useZipFile);
                             // Using a LinkedHashMap to have it be in insert order to give the same
                             // sort characteristics as putting entries into a list.
+                            // The ZipFile Enumeration has things in a better order than random
+                            // hash order from a normal HashMap which makes the sort that is done
+                            // perform much faster.
                             zipEntryDataMap = new LinkedHashMap<String, ZipEntryData>();
                             useZipEntryData = ZipFileContainerUtils.collectZipEntries(useZipFile, zipEntryDataMap, isMultiRelease);
                         } finally {
@@ -1280,7 +1283,7 @@ public class ZipFileContainer implements com.ibm.wsspi.artifact.ArtifactContaine
                 return null; // There is no next entry; cannot match even partially.
             } else {
                 ZipEntryData nextEntryData = useEntryData[location];
-                if ( !isChildOf(r_entryPath, nextEntryData.r_getPath() ) ) {
+                if ( !isChildOf(r_entryPath, nextEntryData.r_path ) ) {
                      // There is a next entry, but it is not a child of the target.
                     return null;
                 } else {

--- a/dev/com.ibm.ws.artifact.zip/src/com/ibm/ws/artifact/zip/internal/ZipFileContainerUtils.java
+++ b/dev/com.ibm.ws.artifact.zip/src/com/ibm/ws/artifact/zip/internal/ZipFileContainerUtils.java
@@ -119,7 +119,7 @@ public class ZipFileContainerUtils {
             int location = locations[index++];
 
             ZipEntryData nextEntryData = allEntryData[location];
-            String nextPath = nextEntryData.r_getPath();
+            String nextPath = nextEntryData.r_path;
 
             int parentLen;
             if ( parentPath.isEmpty() ) {
@@ -312,7 +312,7 @@ public class ZipFileContainerUtils {
             if (zipEntryData[nextOffset].isPhantom()) {
                 continue;
             }
-            String r_nextPath = zipEntryData[nextOffset].r_getPath();
+            String r_nextPath = zipEntryData[nextOffset].r_path;
             int r_nextPathLen = r_nextPath.length();
 
             // The next path may be on a different branch.
@@ -737,7 +737,7 @@ public class ZipFileContainerUtils {
     @Trivial
     public static void setLocations(ZipEntryData[] entryData) {
     	
-    	for ( int entryNo = 0; entryNo < entryData.length; entryNo++ ) {
+    	for ( int entryNo = 0, len = entryData.length; entryNo < len; entryNo++ ) {
     		ZipEntryData entry = entryData[entryNo];
     		entry.setOffset(entryNo);
     	}

--- a/dev/com.ibm.ws.artifact.zip/src/com/ibm/ws/artifact/zip/internal/ZipFileEntry.java
+++ b/dev/com.ibm.ws.artifact.zip/src/com/ibm/ws/artifact/zip/internal/ZipFileEntry.java
@@ -343,7 +343,7 @@ public class ZipFileEntry implements ExtractableArtifactEntry {
         if (zipEntryData != null) {
             // If the zip entry data is available always use its source of truth
             // for the relative path within the zip file.
-            String rPath = zipEntryData.r_getPath();
+            String rPath = zipEntryData.r_path;
             if (zipEntryData.isDirectory()) {
                 rPath += "/";
             }

--- a/dev/com.ibm.ws.artifact/src/com/ibm/ws/artifact/internal/ArtifactContainerFactoryService.java
+++ b/dev/com.ibm.ws.artifact/src/com/ibm/ws/artifact/internal/ArtifactContainerFactoryService.java
@@ -1,14 +1,11 @@
 /*******************************************************************************
- * Copyright (c) 2010, 2013 IBM Corporation and others.
+ * Copyright (c) 2010, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
- * SPDX-License-Identifier: EPL-2.0
  *
- * Contributors:
- *     IBM Corporation - initial API and implementation
+ * SPDX-License-Identifier: EPL-2.0
  *******************************************************************************/
 package com.ibm.ws.artifact.internal;
 
@@ -257,14 +254,20 @@ public class ArtifactContainerFactoryService implements ArtifactContainerFactory
                         if (handlesEntries instanceof String) {
                             values.add((String) handlesEntries);
                         } else if (handlesEntries instanceof String[]) {
-                            List<String> s = Arrays.asList((String[]) handlesEntries);
-                            values.addAll(s);
+                            for (String value : (String[]) handlesEntries) {
+                                values.add(value);
+                            }
+                        } else {
+                            // no values to add, do not create container.
+                            return null;
                         }
                         //compare list against name
                         String name = e.getName();
+                        int nameLength = name.length();
                         for (String s : values) {
                             // endsWith ignore case
-                            if (name.regionMatches(true, name.length() - s.length(), s, 0, s.length())) {
+                            int sLength = s.length();
+                            if (name.regionMatches(true, nameLength - sLength, s, 0, sLength)) {
                                 //hit, send to cfh.
                                 return cfh.createContainer(cacheDir, parent, e, e);
                             }

--- a/dev/com.ibm.ws.classloading/src/com/ibm/ws/classloading/internal/AppClassLoader.java
+++ b/dev/com.ibm.ws.classloading/src/com/ibm/ws/classloading/internal/AppClassLoader.java
@@ -1,14 +1,11 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2025 IBM Corporation and others.
+ * Copyright (c) 2011, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package com.ibm.ws.classloading.internal;
 
@@ -531,24 +528,21 @@ public class AppClassLoader extends ContainerClassLoader implements SpringLoader
 
     @Trivial // injected trace calls ProtectedDomain.toString() which requires privileged access
     private ProtectionDomain getClassSpecificProtectionDomain(final ContainerURL containerUrl) {
+        ProtectionDomain pd;
         if (containerUrl == null) {
             // not expected; there will have been some FFDCs if this is null
-            return config.getProtectionDomain();
-        }
-        ProtectionDomain pd = null;
-        try {
-            pd = AccessController.doPrivileged(new PrivilegedExceptionAction<ProtectionDomain>() {
+            pd = config.getProtectionDomain();
+        } else if (System.getSecurityManager() == null) {
+            pd = getClassSpecificProtectionDomainPrivileged(containerUrl);
+        } else {
+            pd = AccessController.doPrivileged(new PrivilegedAction<ProtectionDomain>() {
                 @Override
                 public ProtectionDomain run() {
                     return getClassSpecificProtectionDomainPrivileged(containerUrl);
                 }
             });
-        } catch (PrivilegedActionException paex) {
-            //auto FFDC
-            pd = config.getProtectionDomain();
         }
         return pd;
-
     }
 
     ProtectionDomain getClassSpecificProtectionDomainPrivileged(ContainerURL containerUrl) {

--- a/dev/com.ibm.ws.kernel.security.thread/src/com/ibm/ws/kernel/security/thread/ThreadIdentityManager.java
+++ b/dev/com.ibm.ws.kernel.security.thread/src/com/ibm/ws/kernel/security/thread/ThreadIdentityManager.java
@@ -4,11 +4,8 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
- * SPDX-License-Identifier: EPL-2.0
  *
- * Contributors:
- *     IBM Corporation - initial API and implementation
+ * SPDX-License-Identifier: EPL-2.0
  *******************************************************************************/
 package com.ibm.ws.kernel.security.thread;
 
@@ -52,6 +49,8 @@ public class ThreadIdentityManager {
 
     private static final Object emptyToken = Collections.EMPTY_MAP;
 
+    private static volatile boolean hasThreadIdentityServices = false;
+
     /**
      * Add a ThreadIdentityService reference. This method is called by
      * ThreadIdentityManagerConfigurator when a ThreadIdentityService shows
@@ -61,7 +60,10 @@ public class ThreadIdentityManager {
      */
     public static void addThreadIdentityService(ThreadIdentityService tis) {
         if (tis != null) {
-            threadIdentityServices.add(tis);
+            synchronized (ThreadIdentityManager.class) {
+                hasThreadIdentityServices = true;
+                threadIdentityServices.add(tis);
+            }
             if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
                 Tr.debug(tc, "A ThreadIdentityService implementation was added.", tis.getClass().getName());
             }
@@ -93,7 +95,12 @@ public class ThreadIdentityManager {
      */
     public static void removeThreadIdentityService(ThreadIdentityService tis) {
         if (tis != null) {
-            threadIdentityServices.remove(tis);
+            synchronized (ThreadIdentityManager.class) {
+                threadIdentityServices.remove(tis);
+                if (threadIdentityServices.isEmpty()) {
+                    hasThreadIdentityServices = false;
+                }
+            }
             if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
                 Tr.debug(tc, "A ThreadIdentityService implementation was removed.", tis.getClass().getName());
             }
@@ -121,7 +128,10 @@ public class ThreadIdentityManager {
      * ThreadIdentityManagerConfigurator when the ThreadIdentityService service tracker is closed.
      */
     public static void removeAllThreadIdentityServices() {
-        threadIdentityServices.clear();
+        synchronized (ThreadIdentityManager.class) {
+            threadIdentityServices.clear();
+            hasThreadIdentityServices = false;
+        }
         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
             Tr.debug(tc, "All the ThreadIdentityService implementations were removed.");
         }
@@ -155,9 +165,11 @@ public class ThreadIdentityManager {
      * @return true if application thread identity is enabled; false otherwise.
      */
     public static boolean isAppThreadIdentityEnabled() {
-        for (ThreadIdentityService tis : threadIdentityServices) {
-            if (tis.isAppThreadIdentityEnabled()) {
-                return true;
+        if (hasThreadIdentityServices) {
+            for (ThreadIdentityService tis : threadIdentityServices) {
+                if (tis.isAppThreadIdentityEnabled()) {
+                    return true;
+                }
             }
         }
         return false;
@@ -239,6 +251,9 @@ public class ThreadIdentityManager {
      * @throws ThreadIdentityException
      */
     public static Object setAppThreadIdentity(Subject subject) throws ThreadIdentityException {
+        if (!hasThreadIdentityServices) {
+            return null;
+        }
         LinkedHashMap<ThreadIdentityService, Object> token = null;
         for (ThreadIdentityService tis : threadIdentityServices) {
             if (tis.isAppThreadIdentityEnabled()) {
@@ -322,6 +337,11 @@ public class ThreadIdentityManager {
      *         This token must be passed to the subsequent reset call.
      */
     public static Object runAsServer() {
+        // most times there are no services, so can skip out fast and avoid the
+        // thread local and iterator calls.
+        if (!hasThreadIdentityServices) {
+            return emptyToken;
+        }
         LinkedHashMap<ThreadIdentityService, Object> token = null;
 
         if (!checkForRecursionAndSet()) {

--- a/dev/com.ibm.ws.kernel.service/src/com/ibm/wsspi/kernel/service/utils/PathUtils.java
+++ b/dev/com.ibm.ws.kernel.service/src/com/ibm/wsspi/kernel/service/utils/PathUtils.java
@@ -1,14 +1,11 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2025 IBM Corporation and others.
+ * Copyright (c) 2011, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
- * SPDX-License-Identifier: EPL-2.0
  *
- * Contributors:
- *     IBM Corporation - initial API and implementation
+ * SPDX-License-Identifier: EPL-2.0
  *******************************************************************************/
 package com.ibm.wsspi.kernel.service.utils;
 
@@ -145,7 +142,7 @@ public class PathUtils {
             String osName = System.getProperty("os.name", "unknown");
             String userName = System.getProperty("user.name", "unknown");
             FFDCFilter.processException(e, PathUtils.class.getName(), "isOsCaseSensitive",
-                                       new Object[] { "java.io.tmpdir=" + tmpDir, "os.name=" + osName, "user.name=" + userName });
+                                        new Object[] { "java.io.tmpdir=" + tmpDir, "os.name=" + osName, "user.name=" + userName });
             return false;
         } finally {
             if (caseSensitiveFile != null) {
@@ -682,16 +679,16 @@ public class PathUtils {
         @Trivial
         public int compare(String o1, String o2) {
             int len1 = o1.length(), l2 = o2.length();
-            int minLen = Math.min(len1, l2);
+            int minLen = len1 <= l2 ? len1 : l2;
             for (int i = 0; i < minLen; i++) {
                 char c1 = o1.charAt(i), c2 = o2.charAt(i);
-                if (c1 == c2)
-                    continue;
-                if (c1 == PATH_SEPARATOR)
-                    return CMP_LT;
-                if (c2 == PATH_SEPARATOR)
-                    return CMP_GT;
-                return c1 - c2;
+                if (c1 != c2) {
+                    if (c1 == PATH_SEPARATOR)
+                        return CMP_LT;
+                    if (c2 == PATH_SEPARATOR)
+                        return CMP_GT;
+                    return c1 - c2;
+                }
             }
             // Strings differ in length only - shorter string should come first
             return len1 - l2;
@@ -776,14 +773,13 @@ public class PathUtils {
      */
     public static String getName(String pathAndName) {
         int i = pathAndName.lastIndexOf('/');
-        int l = pathAndName.length();
         if (i == -1) {
             return pathAndName;
-        } else if (l == i) {
-            return "/";
-        } else {
-            return pathAndName.substring(i + 1);
         }
+        if (pathAndName.length() == i) {
+            return "/";
+        }
+        return pathAndName.substring(i + 1);
     }
 
     /**


### PR DESCRIPTION
- In AppClassLoader switch from using PrivilegedExceptionAction to PrivilegedAction since the method no longer throws an exception with the previous changes.  Also don't do the doPriv logic if security manager is not enabled since this code is in the main line for classloading
- Small improvement in ArtifactContainerFactoryService to skip the logic if it is not a String or String[] and not to get the String length over and over again
- In PathUtils$PathComparator, inline the Math.min function to avoid the method call and change the if statement to remove the continue.  This comparator is called for every app classloader call and this allows the JRE to optimize the method better
- In ThreadIdentityManager, avoid the extra logic in runAsServer() when there are no ThreadIdentityServices
- In UtilImpl_ReadBuffer* classes, optimize the small byte[] reads that are done in the class to not use System.arraycopy which perform worse with small byte[] copies and can be done better with a normal for loop
- In ZipFile* classes update to reference the relative path final field directly instead of the method and change a for loop to not get the length on each loop, but to set it locally.

Co-authored-by-AI: IBM Bob 1.0.2


- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [ ] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
