### PR TITLE
add faux config for beta test input

### DIFF
--- a/dev/io.openliberty.netty.internal.impl/test/io/openliberty/netty/internal/impl/NettyFrameworkImplTest.java
+++ b/dev/io.openliberty.netty.internal.impl/test/io/openliberty/netty/internal/impl/NettyFrameworkImplTest.java
@@ -74,9 +74,21 @@ public class NettyFrameworkImplTest {
         // Skip test if beta edition is not set
         Assume.assumeTrue(ProductInfo.getBetaEdition());
         testChannels = new ArrayList<Channel>();
+        Map<String, Object> config = new HashMap<>();
+        config.put(NettyConstants.SCALER_MIN_THREADS_PROPERTY, NettyConstants.SCALER_MIN_THREADS);
+        config.put(NettyConstants.SCALER_MAX_THREADS_PROPERTY, NettyConstants.SCALER_MAX_THREADS);
+        config.put(NettyConstants.SCALER_WINDOW_PROPERTY, NettyConstants.SCALER_WINDOW);
+        config.put(NettyConstants.SCALER_DOWN_THRESHOLD_PROPERTY, NettyConstants.SCALER_DOWN_THRESHOLD);
+        config.put(NettyConstants.SCALER_UP_THRESHOLD_PROPERTY, NettyConstants.SCALER_UP_THRESHOLD);
+        config.put(NettyConstants.SCALER_UP_STEP_PROPERTY, NettyConstants.SCALER_UP_STEP);
+        config.put(NettyConstants.SCALER_DOWN_STEP_PROPERTY, NettyConstants.SCALER_DOWN_STEP);
+        config.put(NettyConstants.SCALER_CYCLES_PROPERTY, NettyConstants.SCALER_CYCLES);
+        config.put(NettyConstants.SCALER_METRICS_WINDOW_PROPERTY, NettyConstants.SCALER_METRICS_WINDOW);
+        config.put(NettyConstants.USE_NATIVE_TRANSPORT, false);
+
         framework = new NettyFrameworkImpl();
         framework.setExecutorService(GlobalEventExecutor.INSTANCE);
-        framework.activate(null, null);
+        framework.activate(null, config);
         options = new HashMap<String, Object>();
     }
 


### PR DESCRIPTION
Co-authored-by-AI: IBM Bob 1.0.1
Fixes #34790 

The unit tests in io.openliberty.netty.internal.impl would fail with NPE beta mode.  This change adds a config value for testing to continue in beta mode.