### PR TITLE
fix: error during DB2TestServlet.testVerifyDefaultWithoutURL

### DIFF
--- a/dev/com.ibm.ws.jdbc_fat_db2/test-applications/db2fat/src/db2/web/DB2TestServlet.java
+++ b/dev/com.ibm.ws.jdbc_fat_db2/test-applications/db2fat/src/db2/web/DB2TestServlet.java
@@ -354,8 +354,16 @@ public class DB2TestServlet extends FATServlet {
             stmt.execute();
             fail("Should not have been able to create a connection using default serverName.");
         } catch (SQLException e) {
-            //Expect the default to be localhost and for the connection to fail.
-            assertTrue("serverName was not correctly defaulted to localhost", e.getMessage().contains("Error opening socket to server localhost"));
+            if (e.getCause() == null) {
+                throw e; // unexpected
+            }
+
+            if (e.getCause() instanceof java.net.SocketException)
+                return; // expected -- but error message does not contain serverName thus no assertion
+            else if (e.getCause() instanceof java.net.ConnectException)
+                assertTrue("serverName was not correctly defaulted to localhost", e.getMessage().contains("Error opening socket to server localhost"));
+            else
+                throw e; // unexpected
         }
     }
 


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

Driver will sometimes throw java.net.SocketException instead of java.net.ConnectException for this test scenario
