### PR TITLE
Netty: Skip checks when maxContentLength = -1

### DIFF
--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/netty/pipeline/inbound/LibertyHttpObjectAggregator.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/netty/pipeline/inbound/LibertyHttpObjectAggregator.java
@@ -49,7 +49,7 @@ public class LibertyHttpObjectAggregator extends SimpleChannelInboundHandler<Htt
 
     public LibertyHttpObjectAggregator(long maxContentLength, com.ibm.ws.http.netty.NettyHttpChannelConfig config) {
         if (maxContentLength <= 0) {
-            throw new IllegalArgumentException("maxContentLength must be a positive integer.");
+            throw new IllegalArgumentException("maxContentLength must be a positive integer or -1 for unlimited.");
         }
         this.maxContentLength = maxContentLength;
         this.config = config;
@@ -120,9 +120,12 @@ public class LibertyHttpObjectAggregator extends SimpleChannelInboundHandler<Htt
                 HttpContent httpContent = (HttpContent) msg;
                 int sizeOfCurrentChunk = httpContent.content().readableBytes();
 
-                if (sizeOfCurrentChunk > maxContentLength ||
-                    (content.readableBytes() + sizeOfCurrentChunk) > maxContentLength) {
-                    throw new TooLongFrameException("Content length exceeded max of " + maxContentLength + " bytes.");
+                // Skip content length checks when maxContentLength is Long.MAX_VALUE (-1, per the config -- unlimited)
+                if (maxContentLength != Long.MAX_VALUE) {
+                    if (sizeOfCurrentChunk > maxContentLength ||
+                        (content.readableBytes() + sizeOfCurrentChunk) > maxContentLength) {
+                        throw new TooLongFrameException("Content length exceeded max of " + maxContentLength + " bytes.");
+                    }
                 }
 
                 content.addComponent(true, httpContent.content().retain());


### PR DESCRIPTION
- [ ] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [ ] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

-1 means unlimited, so it will skip some validations for performance 

Set by MessageSizeLimit -- https://openliberty.io/docs/latest/reference/config/httpEndpoint.html