### PR TITLE
Reduce and expected Ciphers for JDK 8

### DIFF
--- a/dev/com.ibm.ws.security.client_fat/fat/src/com/ibm/ws/security/client/fat/ClientSSLHandshakeTest.java
+++ b/dev/com.ibm.ws.security.client_fat/fat/src/com/ibm/ws/security/client/fat/ClientSSLHandshakeTest.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import componenttest.topology.impl.JavaInfo;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -412,11 +413,12 @@ public class ClientSSLHandshakeTest extends CommonTest {
                         effectiveCiphers.subList(0, Math.min(5, effectiveCiphers.size())));
             }
             
-            // Verify we have a reasonable number of ciphers in the JDK effective list.
-            // FIPS mode restricts the available cipher suites, resulting in fewer ciphers
-            // compared to non-FIPS mode where the JDK typically provides more cipher options.
+            // JDKs with version ?=11 are currently returning 30+ cipher entries.
+            // If FIPS140-3 is enabled we get 10+
+            // Oracle JDK 8 returning between 20 and 30.
             boolean isFipsEnabled = testServer.isFIPS140_3EnabledAndSupported();
-            int expectedMinCiphers = isFipsEnabled ? 10 : 30;
+            JavaInfo ji = JavaInfo.forServer(testServer);
+            int expectedMinCiphers = isFipsEnabled ? 10 : ji.majorVersion() == 8 ? 20 : 30;
             assertTrue("Expected JDK default cipher list to have at least " + expectedMinCiphers +
                     " ciphers (FIPS=" + isFipsEnabled + "), but found: " + effectiveCiphers.size(),
                     effectiveCiphers.size() >= expectedMinCiphers);


### PR DESCRIPTION
Oracle JDK 8 is also failing as it has less then 30 ciphers available when run on. Given this list is expected to shrink, not gain any replacements over time given Oracle dropping support for it. We need to diffentiate it from the rest of the JDKS.

There is no reliable way to determine Oracle JDK vs non-Oracle, we just reduce the Java 8 expectations

Fixes [#309614](https://wasrtc.hursley.ibm.com:9443/jazz/web/projects/WS-CD#action=com.ibm.team.workitem.viewWorkItem&id=309614)

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [ ] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".