### PR TITLE
refactor: migrate io.openliberty.data.internal_fat_ddlgen to H2

### DIFF
--- a/.bob/custom_modes.yaml
+++ b/.bob/custom_modes.yaml
@@ -1,43 +1,96 @@
 customModes:
   - slug: derby-to-h2
-    name: Derby to H2
+    name: 🔼 Derby to H2
     description: >-
       Convert test buckets from Derby to H2
     roleDefinition: >-
       You are Bob, an Open Liberty test bucket migration specialist focused on converting
-      test infrastructure and related code from Derby to H2. Your expertise includes:
-      - Identifying Derby-specific configuration, dependencies, JDBC usage, and SQL usage in Open Liberty test buckets
-      - Updating test bucket configuration, server config, datasource definitions, and supporting code for H2
-      - Detecting compatibility differences between Derby and H2 that affect tests, schema creation, or runtime behavior
-      - Making minimal, targeted changes that preserve the original test intent while modernizing the database setup
-      - Verifying impacted files, references, and migration consistency across the bucket
+      test infrastructure and related code from Derby to H2.
     whenToUse: >-
       Use this mode when migrating an Open Liberty test bucket, FAT bucket, or related
-      test assets from Derby to H2, especially when the work involves locating Derby
-      references, updating datasource or JDBC configuration, adjusting SQL/schema
-      behavior for H2 compatibility, and validating that all bucket-specific references
-      have been converted consistently.
+      test assets from Derby to H2.
     groups:
       - read
       - edit
       - command
       - browser
     customInstructions: >-
-      Focus on Open Liberty test bucket migration work from Derby to H2.
-      Start by locating all Derby-related references in the target bucket and nearby shared test assets before editing.
-      Read the key bucket files together before changing anything, prioritizing build.gradle, publish/servers/**/server.xml, persistence.xml, datasource definitions, and repository or test classes that name the datastore.
+      # Instructions
+      Focus on a single Open Liberty test bucket migration.
       Prefer minimal, bucket-scoped changes over broad refactors.
-      For Gradle-based FAT buckets, check for shared library wiring patterns such as addRequiredLibraries.dependsOn addDerby and convert them to the matching H2 helper when appropriate.
-      When updating build.gradle, also check bnd.bnd for source path additions if creating new test applications (such as H2 initialization apps). Add the new application's source directory to the src: block to ensure proper compilation and packaging.
-      In server config, check application classloader library refs, shared resource jar paths, and javaPermission entries together so Derby library IDs and derby.jar references are converted consistently to H2 equivalents.
-      For server.xml datasource configuration, use properties.h2 (not properties.h2.embedded nor properties.h2.client) with the URL attribute for H2 connection strings.
-      In application code, update datasource definitions and references as one coordinated change set: datasource JNDI names, @Repository(dataStore = ...), persistence-unit jta-data-source entries, and any other in-app datasource lookups.
-      For annotation-based datasource definitions, expect Derby EmbeddedXADataSource patterns to become H2 JdbcDataSource patterns; common H2 replacements include org.h2.jdbcx.JdbcDataSource and jdbc:h2:mem:<db>;DB_CLOSE_DELAY=-1, while removing Derby-only properties such as createDatabase=create unless the bucket explicitly still needs an H2-specific alternative.
-      Check for JDBC driver coordinates, datasource IDs, URL formats, SQL dialect differences, schema initialization behavior, and test assumptions tied to Derby.
-      Assertions on DatabaseMetaData.getUserName() must tolerate H2 uppercasing the user name.
-      H2 has reserved keywords that may conflict with entity attribute names. Common conflicts include VALUE, which must be renamed to VAL or another non-reserved name. When renaming columns: (1) Add @Column(name = "VAL") annotations to all affected entity class attributes, (2) Update all corresponding DDL files to use the new column name in CREATE TABLE statements, (3) Ensure consistency across all entity classes, repositories, and DDL files that reference the renamed column. Check the H2 documentation for the complete list of reserved keywords if encountering SQL syntax errors.
-      H2 in-memory databases don't support multiple different user credentials by default. The preferred approach is to create a dedicated initialization web application that starts before all other applications and creates the required database users. This application should: (1) Be added to bnd.bnd source paths (e.g., test-applications/H2InitApp/src), (2) Contain a ServletContextListener that implements contextInitialized() to create users via JDBC, (3) Connect to each database identified in a server.xml dataSource by injecting the DataSource. For each database identified by a data source definition, connect using DriverManager.getConnection() with the primary user (which creates that user automatically), (4) Execute CREATE USER IF NOT EXISTS statements for additional users with ADMIN privileges, (5) Be configured in server.xml with the startAfter attribute on dependent applications to ensure proper initialization order. This approach is superior to using INIT parameters in JDBC URLs or servlet init methods, as it centralizes user creation, executes once at server startup, and clearly documents the multi-user database requirements.
-      Preserve existing test intent and naming unless a Derby-specific name must change for clarity or correctness, but do rename datasource IDs or library IDs when they are Derby-branded and actively used.
-      Make related edits in as few targeted edit operations as practical to keep datasource migrations internally consistent.
-      After changes, search again for stale Derby references in the impacted scope and distinguish active references from commented-out or TODO-gated code that may need manual follow-up.
-      Ignore any file named cognitiveMetadata.yml.
+
+      You have two modes you can operate in: MIGRATION or DEBUG mode
+      If cognativeMetadata.yml contains the line "Migrated from derby to h2" use DEBUG mode otherwise use MIGRATION mode.
+
+      ## Mode: MIGRATION
+
+      Use a subagent to perform the following investigation:
+      Read bnd.bnd file:
+        - Determine the minimum java level required to run the test bucket?
+      Read build.gradle file:
+      - Is the test bucket using databaseRotation? 
+        - If copyTestContainers task is used -- then databaseRotation is true
+        - If copyTestContainer task is not used -- then databaseRotation is false
+
+      Use a subagent to perform the following search:
+      - Local all Derby related references in the target bucket and nearby shared test assets
+      - Prioritize build.gradle, publish/servers/**/server.xml, persistence.xml, datasource definitions, and repository or test classes that name the datastore.
+
+      Use a subagent to perform the code changes:
+      - build.gradle
+        - replace addRequiredLibraries.dependsOn tasks with the H2 equivalent
+          - If minimum java level is >= 11 then use the gradle task `addH2`
+          - If minimum java level is < 11 then use the gradle task `addH2Java8`
+      - bnd.bnd
+        - check for source path additions if creating new test applications (such as H2 initialization apps). 
+        - add the new application's source directory to the src: block to ensure proper compilation and packaging.
+      - server configs (publish/servers/**/server.xml)
+        - check application classloader library refs, shared resource jar paths, and javaPermission entries together so Derby library IDs and derby.jar references are converted consistently to H2 equivalents.
+        - datasource configuration, use properties.h2 (not properties.h2.embedded nor properties.h2.client) with the URL attribute configured to ${env.DB_URL}.
+        - make note of the number and frequency of user/password configured.
+        - make note of the databaseName
+      - test setup (java classes under fat/ directory that contain @RunWith(FATRunner.class))
+        - Use builder H2Database.create() with an admin user set to the most frequent user/password in server.xml
+          - add additional user/password using the `withUser()` method
+          - add the databaseName with using the 'withDatabaseName()' method (remove `memory:` prefix)
+        - If using database rotation:
+          - Setup a @ClassRule that creates and passes in the previously configured H2Database
+          - Example: DatabaseContainerFactory.createH2(Optional.of(h2Database))
+        - If not using database rotation:
+          - Add @ClassRule to the previously created H2Database
+      - application code (files under test-applications/ directory)
+        - update datasource definitions and references as one coordinated change set: datasource JNDI names, @Repository(dataStore = ...), persistence-unit jta-data-source entries, and any other in-app datasource lookups.
+        - for annotation-based datasource definitions, expect Derby EmbeddedXADataSource patterns to become H2 JdbcDataSource patterns; common H2 replacements include org.h2.jdbcx.JdbcDataSource and ${env.DB_URL}, while removing Derby-only properties such as createDatabase=create unless the bucket explicitly still needs an H2-specific alternative.
+        - check for JDBC driver coordinates, datasource IDs, URL formats, SQL dialect differences, schema initialization behavior, and test assumptions tied to Derby.
+        - assertions on DatabaseMetaData.getUserName() must tolerate H2 uppercasing the user name.
+        - H2 has reserved keywords that may conflict with entity attribute names. Common conflicts include VALUE, which must be renamed to VAL or another non-reserved name. When renaming columns:
+          - Add @Column(name = "VAL") annotations to all affected entity class attributes
+          - Update all corresponding DDL files to use the new column name in CREATE TABLE statements
+          - Ensure consistency across all entity classes, repositories, and DDL files that reference the renamed column.
+          - Check the H2 documentation for the complete list of reserved keywords if encountering SQL syntax errors.
+        - Preserve existing test intent and naming unless a Derby-specific name must change for clarity or correctness, but do rename datasource IDs or library IDs when they are Derby-branded and actively used.
+
+      Use a subagent to re-search the bucket:
+      - stale Derby references in the impacted scope and distinguish active references from commented-out or TODO-gated code that may need manual follow-up.
+
+      After migrating the bucket add/append the following value "Migrated from derby to h2" to the property "description" in cognitiveMetadata.yml
+      Suggest the user to manually test the bucket using the gradle command:
+        - ./gradlew <test-bucket-name>:buildandrun
+
+      ## Mode: DEBUG
+
+      The user has already performed migration
+      If the directory build/libs/autoFVT does not exist, prompt the user to manually run the test bucket.
+
+      Use a subagent to identify the error:
+      - build/libs/autoFVT/results/ contains the test client output and junit results
+        - Did an error occur prior to a server starting?
+        - Did an error get returned while running a test on the server? If so which server?
+
+      Use a subagent to investigate error cause:
+      - build/libs/autoFVT/output/servers/ contains the test server output
+        - Investigate any servers which had errors.
+
+      Use a subagent to attempt to fix any errors
+
+      After making code changes, prompt the user to re-run the test bucket, do not attempt to re-run the test bucket yourself. 

--- a/.bob/custom_modes.yaml
+++ b/.bob/custom_modes.yaml
@@ -18,25 +18,25 @@ customModes:
       # Instructions
       Focus on a single Open Liberty test bucket migration.
       Prefer minimal, bucket-scoped changes over broad refactors.
+      Use the new_task tool to spawn subagents.
 
       You have two modes you can operate in: MIGRATION or DEBUG mode
       If cognativeMetadata.yml contains the line "Migrated from derby to h2" use DEBUG mode otherwise use MIGRATION mode.
 
       ## Mode: MIGRATION
 
-      Use a subagent to perform the following investigation:
+      Use a subagent (ask) to perform the following investigation:
       Read bnd.bnd file:
         - Determine the minimum java level required to run the test bucket?
       Read build.gradle file:
       - Is the test bucket using databaseRotation? 
         - If copyTestContainers task is used -- then databaseRotation is true
         - If copyTestContainer task is not used -- then databaseRotation is false
-
-      Use a subagent to perform the following search:
+      Perform the following search:
       - Local all Derby related references in the target bucket and nearby shared test assets
       - Prioritize build.gradle, publish/servers/**/server.xml, persistence.xml, datasource definitions, and repository or test classes that name the datastore.
 
-      Use a subagent to perform the code changes:
+      Use a subagent (code) to perform the code changes:
       - build.gradle
         - replace addRequiredLibraries.dependsOn tasks with the H2 equivalent
           - If minimum java level is >= 11 then use the gradle task `addH2`
@@ -47,6 +47,9 @@ customModes:
       - server configs (publish/servers/**/server.xml)
         - check application classloader library refs, shared resource jar paths, and javaPermission entries together so Derby library IDs and derby.jar references are converted consistently to H2 equivalents.
         - datasource configuration, use properties.h2 (not properties.h2.embedded nor properties.h2.client) with the URL attribute configured to ${env.DB_URL}.
+        - replace the driver location ${shared.resource.dir}/derby
+          - If minimum java level is >= 11 then use location ${shared.resource.dir}/h2
+          - If minimum java level is < 11 then use location ${shared.resource.dir}/h2Java8
         - make note of the number and frequency of user/password configured.
         - make note of the databaseName
       - test setup (java classes under fat/ directory that contain @RunWith(FATRunner.class))
@@ -70,7 +73,7 @@ customModes:
           - Check the H2 documentation for the complete list of reserved keywords if encountering SQL syntax errors.
         - Preserve existing test intent and naming unless a Derby-specific name must change for clarity or correctness, but do rename datasource IDs or library IDs when they are Derby-branded and actively used.
 
-      Use a subagent to re-search the bucket:
+      Use a subagent (ask) to re-search the bucket:
       - stale Derby references in the impacted scope and distinguish active references from commented-out or TODO-gated code that may need manual follow-up.
 
       After migrating the bucket add/append the following value "Migrated from derby to h2" to the property "description" in cognitiveMetadata.yml
@@ -82,15 +85,13 @@ customModes:
       The user has already performed migration
       If the directory build/libs/autoFVT does not exist, prompt the user to manually run the test bucket.
 
-      Use a subagent to identify the error:
+      Use a subagent (advanced) to identify the error:
       - build/libs/autoFVT/results/ contains the test client output and junit results
         - Did an error occur prior to a server starting?
         - Did an error get returned while running a test on the server? If so which server?
-
-      Use a subagent to investigate error cause:
       - build/libs/autoFVT/output/servers/ contains the test server output
         - Investigate any servers which had errors.
 
-      Use a subagent to attempt to fix any errors
+      Use a subagent (code) to attempt to fix any errors
 
       After making code changes, prompt the user to re-run the test bucket, do not attempt to re-run the test bucket yourself. 

--- a/.bob/custom_modes.yaml
+++ b/.bob/custom_modes.yaml
@@ -21,7 +21,7 @@ customModes:
       Use the new_task tool to spawn subagents.
 
       You have two modes you can operate in: MIGRATION or DEBUG mode
-      If cognativeMetadata.yml contains the line "Migrated from derby to h2" use DEBUG mode otherwise use MIGRATION mode.
+      If cognitiveMetadata.yml contains the line "Migrated from derby to h2" use DEBUG mode otherwise use MIGRATION mode.
 
       ## Mode: MIGRATION
 
@@ -33,7 +33,7 @@ customModes:
         - If copyTestContainers task is used -- then databaseRotation is true
         - If copyTestContainer task is not used -- then databaseRotation is false
       Perform the following search:
-      - Local all Derby related references in the target bucket and nearby shared test assets
+      - Locate all Derby related references in the target bucket and nearby shared test assets
       - Prioritize build.gradle, publish/servers/**/server.xml, persistence.xml, datasource definitions, and repository or test classes that name the datastore.
 
       Use a subagent (code) to perform the code changes:
@@ -57,7 +57,7 @@ customModes:
           - add additional user/password using the `withUser()` method
           - add the databaseName with using the 'withDatabaseName()' method (remove `memory:` prefix)
         - If using database rotation:
-          - Setup a @ClassRule that creates and passes in the previously configured H2Database
+          - Set up a @ClassRule that creates and passes in the previously configured H2Database
           - Example: DatabaseContainerFactory.createH2(Optional.of(h2Database))
         - If not using database rotation:
           - Add @ClassRule to the previously created H2Database

--- a/.bob/rules/contributing.md
+++ b/.bob/rules/contributing.md
@@ -2,6 +2,3 @@
 
 - IBM Bob MUST adhere to the rules laid out in AGENTS.md
   - Note, in particular, the Git commit message format requirements for commits containing AI-generated code
-- IBM Bob MUST maintain valid copyright headers when creating or modifying source files
-  - New files must be created with a valid copyright header with the current year using valid programming language comments based on the file type.
-  - Exising files must be updated to include the current year in the copyright header if the current year is missing.

--- a/.bob/rules/contributing.md
+++ b/.bob/rules/contributing.md
@@ -2,3 +2,6 @@
 
 - IBM Bob MUST adhere to the rules laid out in AGENTS.md
   - Note, in particular, the Git commit message format requirements for commits containing AI-generated code
+- IBM Bob MUST maintain valid copyright headers when creating or modifying source files
+  - New files must be created with a valid copyright header with the current year using valid programming language comments based on the file type.
+  - Exising files must be updated to include the current year in the copyright header if the current year is missing.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,3 +99,30 @@ Co-authored-by-AI: GitHub Copilot (GPT-5.4)
 2. **Blank Line**: Include a blank line before the co-authorship attribution if your commit message has a body.
 
 3. **Version Accuracy**: Always use the actual version numbers of the AI tool and the model at the time of code generation.
+
+## Creating and updating source code
+
+### Copyright Header
+
+All source code and configuration files must have and maintain a copyright header at the top of the file.
+
+- License Type: Eclipse Public License - v 2.0
+- Format: Use the appropriate comment block for the file type (e.g., `/* ... */` for Java/Gradle, `<!-- ... -->` for XML/HTML, or `# ... #` for bnd/properties).
+- Copyright dates: Include the year of creation and the current year, if different than the current year, delimited by a comma (,).
+- Example:
+
+```java
+/*******************************************************************************
+ * Copyright (c) 2017, 2026 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+```
+

--- a/dev/fattest.simplicity/src/componenttest/topology/database/H2Database.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/database/H2Database.java
@@ -15,6 +15,7 @@ import java.sql.Connection;
 import java.sql.Driver;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.Statement;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -180,11 +181,20 @@ public class H2Database extends ExternalResource {
      * @return          this
      */
     public H2Database withUser(String user, String password) {
-        // H2 requires file-based mode when additional users are configured
-        // because user creation requires persistent storage
-        mode = MODE.IN_FILE;
-
         additionalUsers.put(user, password);
+        return withFileMode();
+    }
+
+    /**
+     * Typically, file mode is reserved for when multiple users are required,
+     * but you can force file mode by calling this method.
+     *
+     * Useful, when you need to execute a DDL or create tables prior to running a test.
+     *
+     * @return this
+     */
+    public H2Database withFileMode() {
+        mode = MODE.IN_FILE;
         return this;
     }
 
@@ -269,17 +279,9 @@ public class H2Database extends ExternalResource {
         }
 
         Log.info(c, "before", "Adding the following users to the database " + additionalUsers);
-        Log.info(c, "before", "  Using URL " + getURL());
-        Log.info(c, "before", "  Using the admin auth data " + getAdminUser() + ":" + getAdminPassword());
 
-        Properties properties = new Properties();
-        properties.put("user", getAdminUser());
-        properties.put("password", getAdminPassword());
-
-        Driver driver = getDriverInstance();
-
-        try (Connection con = driver.connect(getURL(), properties);
-                        java.sql.Statement stmt = con.createStatement()) {
+        try (Connection con = createConnection("");
+                        Statement stmt = con.createStatement()) {
             for (Map.Entry<String, String> e : additionalUsers.entrySet()) {
                 stmt.executeUpdate("create user if not exists " + e.getKey() +
                                    " password '" + e.getValue() + "' admin;");
@@ -289,8 +291,8 @@ public class H2Database extends ExternalResource {
         }
 
         if (additionalConfig.containsKey("TRACE_LEVEL_SYSTEM_OUT")) {
-            try (Connection con = driver.connect(getURL(), properties);
-                            java.sql.Statement stmt = con.createStatement()) {
+            try (Connection con = createConnection("");
+                            Statement stmt = con.createStatement()) {
                 try (ResultSet rs = stmt.executeQuery("SELECT * FROM INFORMATION_SCHEMA.USERS;")) {
                     while (rs.next()) {
                         String userName = rs.getString("USER_NAME");
@@ -371,7 +373,10 @@ public class H2Database extends ExternalResource {
                 return existing;
             }
             try {
-                return (Driver) Class.forName(this.getDriverClassName()).getDeclaredConstructor().newInstance();
+                Class<?> c = Class.forName(this.getDriverClassName());
+                Driver d = (Driver) c.getDeclaredConstructor().newInstance();
+                Log.info(c, "getDriverInstance", "Driver loaded from: " + c.getProtectionDomain().getCodeSource().getLocation());
+                return d;
             } catch (Exception e) {
                 throw new RuntimeException("Could not get Driver", e);
             }
@@ -383,5 +388,22 @@ public class H2Database extends ExternalResource {
      */
     public String getTestQueryString() {
         return "SELECT 1";
+    }
+
+    public Connection createConnection(String queryString) throws SQLException {
+        return createConnection(queryString, null);
+    }
+
+    public Connection createConnection(String queryString, Properties info) throws SQLException {
+        String q = queryString.isEmpty() ? queryString : //
+                        queryString.startsWith(";") ? queryString : ";" + queryString;
+
+        Properties i = info == null ? new Properties() : info;
+        i.put("user", getAdminUser());
+        i.put("password", getAdminPassword());
+
+        Log.info(c, "createConnection", "Creating a connection using URL=" + getURL() + " queryString=" + q + " and properties=" + i);
+
+        return getDriverInstance().connect(getURL() + q, i);
     }
 }

--- a/dev/fattest.simplicity/src/componenttest/topology/database/container/H2Container.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/database/container/H2Container.java
@@ -12,6 +12,10 @@
  *******************************************************************************/
 package componenttest.topology.database.container;
 
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.Properties;
+
 import org.testcontainers.containers.JdbcDatabaseContainer;
 import org.testcontainers.utility.DockerImageName;
 
@@ -87,6 +91,18 @@ public class H2Container extends JdbcDatabaseContainer<H2Container> {
     @Override
     public void close() {
         //DO NOTHING
+    }
+
+    //// Utility methods ///
+
+    @Override
+    public Connection createConnection(String queryString) throws SQLException, NoDriverFoundException {
+        return db.createConnection(queryString);
+    }
+
+    @Override
+    public Connection createConnection(String queryString, Properties info) throws SQLException, NoDriverFoundException {
+        return db.createConnection(queryString, info);
     }
 
     //// Getters ////

--- a/dev/io.openliberty.data.internal_fat_ddlgen/build.gradle
+++ b/dev/io.openliberty.data.internal_fat_ddlgen/build.gradle
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 IBM Corporation and others.
+ * Copyright (c) 2024, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -10,8 +10,6 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-
-addRequiredLibraries.dependsOn addDerby
 
 // Copy bundle io.openliberty.org.testcontainers to AutoFVT/lib/
 // This bundle is required both at compiletime and runtime.

--- a/dev/io.openliberty.data.internal_fat_ddlgen/cognitiveMetadata.yml
+++ b/dev/io.openliberty.data.internal_fat_ddlgen/cognitiveMetadata.yml
@@ -1,6 +1,6 @@
 ---
 # YML metadata file made use of by the Cognitive Ecosystem.
 # Reference Cognitive Metadata is available at: https://github.com/OpenLiberty/open-liberty/tree/integration/dev/build.example_fat/cognitiveMetadata.yml
-# description: Uncomment this field and add a description to give some notes about this bucket.
+description: Migrated from derby to h2
 # triageNotes: Uncomment this field if there are some short notes you would like Pipeline Monitors to see when triaging this bucket.
 functionalArea: Jakarta Data

--- a/dev/io.openliberty.data.internal_fat_ddlgen/fat/src/test/jakarta/data/ddlgen/DDLGenTest.java
+++ b/dev/io.openliberty.data.internal_fat_ddlgen/fat/src/test/jakarta/data/ddlgen/DDLGenTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024, 2025 IBM Corporation and others.
+ * Copyright (c) 2024, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -129,7 +129,13 @@ public class DDLGenTest extends FATServletClient {
 
                     preamble = "set schema " + user;
                     break;
-                case Derby: // Working - uses user instead of admin when executing ddl statements
+                case H2: // Working - admin and user share PUBLIC schema when none is defined
+                         // Additional user is created by H2Container on start
+                    try (Connection con = testContainer.createConnection(""); Statement stmt = con.createStatement()) {
+                        stmt.executeUpdate("create schema if not exists " + user + " authorization " + user);
+                    }
+                    break;
+                case Derby: // Unnecessary
                     break;
                 case DerbyClient: // Unnecessary
                     break;

--- a/dev/io.openliberty.data.internal_fat_ddlgen/fat/src/test/jakarta/data/ddlgen/DDLGenTest.java
+++ b/dev/io.openliberty.data.internal_fat_ddlgen/fat/src/test/jakarta/data/ddlgen/DDLGenTest.java
@@ -129,7 +129,7 @@ public class DDLGenTest extends FATServletClient {
 
                     preamble = "set schema " + user;
                     break;
-                case H2: // Working - admin and user share PUBLIC schema when none is defined
+                case H2: // Working - admin user will set schema to user
                          // Additional user is created by H2Container on start
                     try (Connection con = testContainer.createConnection(""); Statement stmt = con.createStatement()) {
                         stmt.executeUpdate("create schema if not exists " + user + " authorization " + user);

--- a/dev/io.openliberty.data.internal_fat_ddlgen/fat/src/test/jakarta/data/ddlgen/FATSuite.java
+++ b/dev/io.openliberty.data.internal_fat_ddlgen/fat/src/test/jakarta/data/ddlgen/FATSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 IBM Corporation and others.
+ * Copyright (c) 2024, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -12,6 +12,8 @@
  *******************************************************************************/
 package test.jakarta.data.ddlgen;
 
+import java.util.Optional;
+
 import org.junit.ClassRule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
@@ -20,6 +22,7 @@ import org.testcontainers.containers.JdbcDatabaseContainer;
 
 import componenttest.containers.TestContainerSuite;
 import componenttest.custom.junit.runner.AlwaysPassesTest;
+import componenttest.topology.database.H2Database;
 import componenttest.topology.database.container.DatabaseContainerFactory;
 
 @RunWith(Suite.class)
@@ -28,6 +31,11 @@ import componenttest.topology.database.container.DatabaseContainerFactory;
                 DDLGenTest.class
 })
 public class FATSuite extends TestContainerSuite {
+
+    private static H2Database h2Database = H2Database.create("admin1", "password1")
+                    .withUser("dbuser", "DB!userPassw0rd")
+                    .withDatabaseName("testdb");
+
     @ClassRule
-    public static final JdbcDatabaseContainer<?> testContainer = DatabaseContainerFactory.create();
+    public static final JdbcDatabaseContainer<?> testContainer = DatabaseContainerFactory.createH2(Optional.of(h2Database));
 }

--- a/dev/io.openliberty.data.internal_fat_ddlgen/publish/servers/io.openliberty.data.internal.fat.ddlgen/server.xml
+++ b/dev/io.openliberty.data.internal_fat_ddlgen/publish/servers/io.openliberty.data.internal.fat.ddlgen/server.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2024 IBM Corporation and others.
+    Copyright (c) 2024, 2026 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -37,53 +37,49 @@
 	</application>
 	
 	<!-- Administrative user - used to execute DDL files -->
-	<!-- NOTE: For derby we do not use the database admin since by default
-	     every user has it's own schema so you cannot use the admin user
-	     to create a table accessible by the database user
-	-->
 	<dataSource id="AdminDataSource" jndiName="jdbc/AdminDataSource" fat.modify="true">
 		<jdbcDriver libraryRef="JDBCLibrary" />
-		<properties.derby.embedded createDatabase="create" databaseName="memory:testdb"
+		<properties.h2 URL="${env.DB_URL}"
 			user="dbuser" password="DB!userPassw0rd" />
 	</dataSource>
 
 	<!-- Test 1: the default database -->
 	<dataSource id="DefaultDataSource" fat.modify="true">
 		<jdbcDriver libraryRef="JDBCLibrary" />
-		<properties.derby.embedded createDatabase="create" databaseName="memory:testdb"
+		<properties.h2 URL="${env.DB_URL}"
 			user="${env.DB_USER}" password="${env.DB_PASS}"/>
 	</dataSource>
 	
 	<!-- Test 2: DataSource id -->
 	<dataSource id="TestDataSource" jndiName="jdbc/TestDataSource" fat.modify="true">
 		<jdbcDriver libraryRef="JDBCLibrary" />
-		<properties.derby.embedded createDatabase="create" databaseName="memory:testdb"
+		<properties.h2 URL="${env.DB_URL}"
 			user="${env.DB_USER}" password="${env.DB_PASS}"/>
 	</dataSource>
 	
 	<!-- Test 3: DataSource jndiName -->
 	<dataSource id="TestDataSourceJndi" jndiName="jdbc/TestDataSourceJndi" fat.modify="true">
 		<jdbcDriver libraryRef="JDBCLibrary" />
-		<properties.derby.embedded createDatabase="create" databaseName="memory:testdb"
+		<properties.h2 URL="${env.DB_URL}"
 			user="${env.DB_USER}" password="${env.DB_PASS}"/>
 	</dataSource>
 	
 	<!-- Test 4: Resource reference -->
 	<dataSource id="TestDataSourceResource" jndiName="jdbc/TestDataSourceResource" fat.modify="true">
 		<jdbcDriver libraryRef="JDBCLibrary" />
-		<properties.derby.embedded createDatabase="create" databaseName="memory:testdb"/>
+		<properties.h2 URL="${env.DB_URL}"/>
 		<containerAuthData user="${env.DB_USER}" password="${env.DB_PASS}" />
 	</dataSource>
 
 	<!-- Test 5: @DataSourceDefinition -->
 	<!-- NOTE: @DataSourceDefinition cannot be used with Database rotation since annotations are statically defined.
-	     DDLGen with DataSourceDefinition is tested against derby in io.openliberty.data.internal_fat_datastore
+	     DDLGen with DataSourceDefinition is tested against H2 in io.openliberty.data.internal_fat_datastore
 	 -->
 	
 	<!-- Test 6: Persistence Unit -->
 	<dataSource id="TestDataSourcePersistence" jndiName="jdbc/TestDataSourcePersistence" fat.modify="true">
 		<jdbcDriver libraryRef="JDBCLibrary" />
-		<properties.derby.embedded createDatabase="create" databaseName="memory:testdb"/>
+		<properties.h2 URL="${env.DB_URL}"/>
 		<containerAuthData user="${env.DB_USER}" password="${env.DB_PASS}" />
 	</dataSource>
 	
@@ -96,7 +92,7 @@
 
 	<dataSource id="forDatabaseStore" jndiName="jdbc/forDatabaseStore" fat.modify="true">
 		<jdbcDriver libraryRef="JDBCLibrary" />
-		<properties.derby.embedded createDatabase="create" databaseName="memory:testdb" />
+		<properties.h2 URL="${env.DB_URL}" />
 	</dataSource>
 
 


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

Fixes https://github.com/OpenLiberty/open-liberty/issues/34745

- Update mode to account for database rotation changes
- Use the update mode to convert a bucket
- Refactor infrastructure for new use cases

