### PR TITLE
prepare for EntityAgent

### DIFF
--- a/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/CursoredPageImpl.java
+++ b/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/CursoredPageImpl.java
@@ -38,7 +38,6 @@ import jakarta.data.exceptions.MappingException;
 import jakarta.data.page.CursoredPage;
 import jakarta.data.page.PageRequest;
 import jakarta.data.page.PageRequest.Cursor;
-import jakarta.persistence.EntityManager;
 import jakarta.persistence.TypedQuery;
 
 /**
@@ -52,7 +51,7 @@ public class CursoredPageImpl<T> extends PageImpl<T> implements CursoredPage<T> 
      * Construct a new CursoredPage.
      *
      * @param queryInfo            query information.
-     * @param em                   the entity manager.
+     * @param entityHandler        EntityAgent or EntityManager
      * @param pageRequest          the request for this page.
      * @param args                 values that are supplied to the repository method.
      * @param deferredConstraints  map of method parameter index to non-Literal
@@ -64,7 +63,7 @@ public class CursoredPageImpl<T> extends PageImpl<T> implements CursoredPage<T> 
      */
     @Trivial // avoid tracing customer data
     CursoredPageImpl(QueryInfo queryInfo,
-                     EntityManager em,
+                     AutoCloseable entityHandler,
                      PageRequest pageRequest,
                      Object[] args,
                      Map<Integer, Object> deferredConstraints,
@@ -103,8 +102,9 @@ public class CursoredPageImpl<T> extends PageImpl<T> implements CursoredPage<T> 
             addedJPQLParams = constraintJPQLParams;
         }
 
-        @SuppressWarnings("unchecked")
-        TypedQuery<T> query = (TypedQuery<T>) em.createQuery(jpql, Object.class);
+        TypedQuery<T> query = queryInfo.ehCreateTypedQuery(entityHandler,
+                                                           jpql,
+                                                           Object.class);
         queryInfo.setParameters(query, args, deferredConstraints, addedJPQLParams);
 
         query.setFirstResult(firstResult);

--- a/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/DataProvider.java
+++ b/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/DataProvider.java
@@ -81,7 +81,7 @@ import com.ibm.wsspi.resource.ResourceFactory;
 import io.openliberty.cdi.spi.CDIExtensionMetadata;
 import io.openliberty.checkpoint.spi.CheckpointPhase;
 import io.openliberty.data.internal.cdi.DataExtension;
-import io.openliberty.data.internal.cdi.FutureEMBuilder;
+import io.openliberty.data.internal.cdi.FutureEHFactory;
 import io.openliberty.data.internal.cdi.RepositoryProducer;
 import io.openliberty.data.internal.metadata.DataComponentMetaData;
 import io.openliberty.data.internal.metadata.DataModuleMetaData;
@@ -191,8 +191,8 @@ public class DataProvider implements //
      * Entries are removed when the application stops,
      * at which point the services are unregistered.
      */
-    public final Map<String, Queue<ServiceRegistration<DDLGenerationParticipant>>> ddlgeneratorsAllApps = //
-                    new ConcurrentHashMap<>();
+    public final Map<String, Queue<ServiceRegistration<DDLGenerationParticipant>>> //
+    ddlgeneratorsAllApps = new ConcurrentHashMap<>();
 
     /**
      * Configured value for dropTables.
@@ -205,23 +205,23 @@ public class DataProvider implements //
     final ExecutorService executor;
 
     /**
-     * EntityManagerBuilder futures for repositories, grouped by application,
+     * EntityHandlerFactory futures for repositories, grouped by application,
      * to complete as the respective application artifact starts.
      * After the application starts, these are kept around for the introspector.
      * The map is cleared on application stop.
      */
-    private final ConcurrentHashMap<String, Set<FutureEMBuilder>> futureEMBuilders = //
+    private final Map<String, Set<FutureEHFactory>> futureEHFactories = //
                     new ConcurrentHashMap<>();
 
     /**
-     * EntityManagerBuilder futures, grouped by application, for EJB modules
+     * EntityHandlerFactory futures, grouped by application, for EJB modules
      * that are triggered to initialize on module starting rather than waiting
      * for application start.
-     * The Set values in this map are subsets of the Set values in futureEMBuilders.
+     * The Set values in this map are subsets of the Set values in futureEHFactories.
      * The entries are removed on application start, which uses the values to avoid
      * duplicated initalization attempts.
      */
-    private final ConcurrentHashMap<String, Set<FutureEMBuilder>> futureEMBuildersInEJB = //
+    private final Map<String, Set<FutureEHFactory>> futureEHFactoriesInEJB = //
                     new ConcurrentHashMap<>();
 
     /**
@@ -336,27 +336,31 @@ public class DataProvider implements //
 
         //Use deployment name but fall back to generated name
         String appName = appInfo.getDeploymentName() == null ? appInfo.getName() : appInfo.getDeploymentName();
-        Set<FutureEMBuilder> futures = futureEMBuilders.get(appName);
-        Set<FutureEMBuilder> skip = futureEMBuildersInEJB.remove(appName);
+        Set<FutureEHFactory> futures = futureEHFactories.get(appName);
+        Set<FutureEHFactory> skip = futureEHFactoriesInEJB.remove(appName);
         if (futures != null) {
-            for (FutureEMBuilder futureEMBuilder : futures) {
-                if (skip == null || !skip.contains(futureEMBuilder)) {
-                    // This delays createEMBuilder until restore.
-                    // While this works by avoiding all connections to the data source, it does make restore much slower.
-                    // TODO figure out how to do more work on restore without having to make a connection to the data source
+            for (FutureEHFactory futureEHFactory : futures) {
+                if (skip == null || !skip.contains(futureEHFactory)) {
+                    // This delays createFactory until restore.
+                    // While this works by avoiding all connections to the
+                    // data source, it does make restore much slower.
+                    // TODO figure out how to do more work on restore without
+                    // having to make a connection to the data source
                     if (trace && tc.isDebugEnabled())
                         Tr.debug(this, tc,
-                                 "completing futureEMBuilder " + futureEMBuilder,
-                                 futureEMBuilder.jeeName);
+                                 "completing futureEHFactory " + futureEHFactory,
+                                 futureEHFactory.jeeName);
 
-                    CheckpointPhase.onRestore(() -> futureEMBuilder.completeAsync(futureEMBuilder::createEMBuilder, executor));
+                    CheckpointPhase.onRestore(() -> futureEHFactory //
+                                    .completeAsync(futureEHFactory::createFactory,
+                                                   executor));
 
                 }
                 // Application is ready for DDL generation; register with DDLGen MBean.
                 // Only those using the Persistence Service will participate, but all will
-                // be registered since that is not known until createEMBuilder completes.
+                // be registered since that is not known until createFactory completes.
                 // Those not participating will return a null DDL file name and be skipped.
-                futureEMBuilder.registerDDLGenerationParticipant(appName);
+                futureEHFactory.registerDDLGenerationParticipant(appName);
             }
         }
 
@@ -396,9 +400,9 @@ public class DataProvider implements //
             for (ServiceRegistration<?> reg; (reg = ddlgenRegistrations.poll()) != null;)
                 reg.unregister();
 
-        // TODO also cancel the FutureEMBuilders if not done yet, and for those
+        // TODO also cancel each FutureEHFactory if not done yet, and for those
         // that are done, also cancel each Future in its entityInfoMap ?
-        futureEMBuilders.remove(appName);
+        futureEHFactories.remove(appName);
 
         Map<String, Configuration> configurations = dbStoreConfigAllApps.remove(appName);
         if (configurations != null)
@@ -451,10 +455,10 @@ public class DataProvider implements //
         if (jeeName.getComponent() == null)
             componentMetadatasForModules.put(jeeName, metadata);
 
-        // TODO it would be more direct to map from appName+moduleName -> FutureEMBuilder,
+        // TODO it would be more direct to map from appName+moduleName -> FutureEHFactory,
         // but we would need to take into account the difference in module names
         // including or not including .jar at the end.
-        Set<FutureEMBuilder> futures = futureEMBuilders.get(appName);
+        Set<FutureEHFactory> futures = futureEHFactories.get(appName);
 
         if (futures != null && // repositories are defined somewhere in the app
             metadata instanceof IdentifiableComponentMetaData i &&
@@ -463,19 +467,19 @@ public class DataProvider implements //
             if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
                 Tr.debug(tc, i.getPersistentIdentifier() + " is an EJB");
 
-            Set<FutureEMBuilder> processed = futureEMBuildersInEJB.get(appName);
+            Set<FutureEHFactory> processed = futureEHFactoriesInEJB.get(appName);
 
-            for (FutureEMBuilder futureEMBuilder : futures) {
+            for (FutureEHFactory futureEHFactory : futures) {
                 // only request completion of processing here if the module matches
                 // and if we haven't already requested completion
-                String m = futureEMBuilder.jeeName.getModule();
+                String m = futureEHFactory.jeeName.getModule();
                 if (m != null && m.equals(jeeName.getModule()) &&
-                    (processed == null || !processed.contains(futureEMBuilder))) {
+                    (processed == null || !processed.contains(futureEHFactory))) {
 
                     if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
                         Tr.debug(this, tc,
-                                 "request completion of " + futureEMBuilder,
-                                 futureEMBuilder.jeeName,
+                                 "request completion of " + futureEHFactory,
+                                 futureEHFactory.jeeName,
                                  metadata);
 
                     // Allow CheckpointPhase to override the eager processing and
@@ -483,19 +487,19 @@ public class DataProvider implements //
                     // prior to application start).
                     // TODO This is undesirable because it slows down restore and
                     // makes checkpoint/restore less useful.
-                    CheckpointPhase.onRestore(() -> futureEMBuilder //
-                                    .completeAsync(futureEMBuilder::createEMBuilder,
+                    CheckpointPhase.onRestore(() -> futureEHFactory //
+                                    .completeAsync(futureEHFactory::createFactory,
                                                    executor));
 
                     if (processed == null) {
                         processed = new ConcurrentSkipListSet<>();
-                        Set<FutureEMBuilder> previous = futureEMBuildersInEJB //
+                        Set<FutureEHFactory> previous = futureEHFactoriesInEJB //
                                         .putIfAbsent(appName, processed);
                         if (previous != null)
                             processed = previous;
                     }
 
-                    processed.add(futureEMBuilder);
+                    processed.add(futureEHFactory);
                 }
             }
         }
@@ -672,7 +676,7 @@ public class DataProvider implements //
     public void introspect(PrintWriter writer) {
         List<RepositoryImpl<?>> repositoryImpls = new ArrayList<>();
         Set<QueryInfo> queryInfos = new LinkedHashSet<>();
-        Set<EntityManagerBuilder> builders = new LinkedHashSet<>();
+        Set<EntityHandlerFactory> factories = new LinkedHashSet<>();
 
         Package p = Sort.class.getPackage();
         writer.println("specification: " + p.getSpecificationTitle());
@@ -695,12 +699,12 @@ public class DataProvider implements //
         });
 
         writer.println();
-        writer.println("EntityManager builder futures:");
-        futureEMBuilders.forEach((appName, futureEMBuilders) -> {
+        writer.println("EntityHandlerFactory futures:");
+        futureEHFactories.forEach((appName, futureEHFactories) -> {
             writer.println("  for application " + appName);
-            for (FutureEMBuilder futureEMBuilder : futureEMBuilders) {
-                futureEMBuilder.introspect(writer, "    ") //
-                                .ifPresent(builders::add);
+            for (FutureEHFactory futureEHFactory : futureEHFactories) {
+                futureEHFactory.introspect(writer, "    ") //
+                                .ifPresent(factories::add);
                 writer.println();
             }
         });
@@ -726,12 +730,12 @@ public class DataProvider implements //
         }
 
         writer.println();
-        writer.println("EntityManager builders:");
-        builders.forEach(builder -> {
-            builder.introspect(writer, "  ");
+        writer.println("EntityHandlerFactory instances:");
+        factories.forEach(factory -> {
+            factory.introspect(writer, "  ");
             writer.println();
 
-            builder.entityInfoMap.forEach((userEntityClass, entityInfoFuture) -> {
+            factory.entityInfoMap.forEach((userEntityClass, entityInfoFuture) -> {
                 writer.println("    entity: " + userEntityClass.getName());
 
                 EntityInfo entityInfo = null;
@@ -1038,22 +1042,22 @@ public class DataProvider implements //
     }
 
     /**
-     * Arrange for the specified EntityManagerBuilders to initialize once the
+     * Arrange for each specified EntityHandlerFactory to initialize once the
      * respective application artifact that defines the repository is started.
      *
-     * @param appName  application name.
-     * @param builders list of EntityManagerBuilder.
+     * @param appName   application name.
+     * @param factories list of FutureEHFactory
      */
-    public void onStart(String appName, Set<FutureEMBuilder> builders) {
-        for (Set<FutureEMBuilder> merged = builders, previous; //
-                        null != (previous = futureEMBuilders //
+    public void onStart(String appName, Set<FutureEHFactory> factories) {
+        for (Set<FutureEHFactory> merged = factories, previous; //
+                        null != (previous = futureEHFactories //
                                         .putIfAbsent(appName, merged));) {
             // In the unlikely case this is invoked twice for the same app,
             // merge previous and new into a single set:
-            ConcurrentHashMap<FutureEMBuilder, Boolean> m = new ConcurrentHashMap<>();
-            for (FutureEMBuilder b : previous)
+            ConcurrentHashMap<FutureEHFactory, Boolean> m = new ConcurrentHashMap<>();
+            for (FutureEHFactory b : previous)
                 m.put(b, Boolean.TRUE);
-            for (FutureEMBuilder b : builders)
+            for (FutureEHFactory b : factories)
                 m.put(b, Boolean.TRUE);
             merged = m.keySet();
         }

--- a/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/EntityHandlerFactory.java
+++ b/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/EntityHandlerFactory.java
@@ -72,12 +72,12 @@ import jakarta.transaction.Transaction;
  * Creates EntityManager instances from an EntityManagerFactory (from a persistence unit reference)
  * or from a PersistenceServiceUnit of a databaseStore.
  */
-public abstract class EntityManagerBuilder {
-    private static final TraceComponent tc = Tr.register(EntityManagerBuilder.class);
+public abstract class EntityHandlerFactory {
+    private static final TraceComponent tc = Tr.register(EntityHandlerFactory.class);
 
     /**
      * Entity attribute types that have an AttributeConverter.
-     * Only available when invoked by DBStoreEMBuilder. Otherwise null.
+     * Only available when invoked by DBStoreEHFactory. Otherwise null.
      */
     Set<Class<?>> convertibleTypes;
 
@@ -97,7 +97,7 @@ public abstract class EntityManagerBuilder {
 
     /**
      * Map of Transaction to EntityManager that allows stateful repositories to
-     * reuse the same EnityManager within a transaction when there is no request
+     * reuse the same EntityManager within a transaction when there is no request
      * scope. Otherwise, the EntityManager life cycle is tied to the request scope.
      */
     private final Map<Transaction, EntityManager> entityManagerPerTx = //
@@ -128,7 +128,7 @@ public abstract class EntityManagerBuilder {
      *                                  Repository annotation
      */
     @Trivial
-    protected EntityManagerBuilder(DataProvider provider,
+    protected EntityHandlerFactory(DataProvider provider,
                                    ClassLoader repositoryClassLoader,
                                    Set<Class<?>> repositoryInterfaces,
                                    String dataStore) {
@@ -144,7 +144,7 @@ public abstract class EntityManagerBuilder {
      *
      * @param entityTypes      entity classes as known by the user, not generated.
      * @param convertibleTypes types that have an AttributeConverter. Only available
-     *                             when invoked by DBStoreEMBuilder. Otherwise null.
+     *                             when invoked by DBStoreEHFactory. Otherwise null.
      * @throws Exception if an error occurs.
      */
     // FFDC is not needed because exceptions are logged to Tr.error
@@ -465,7 +465,8 @@ public abstract class EntityManagerBuilder {
      * @throws Exception if an error occurs.
      */
     AutoCloseable getEntityAgent() throws Exception {
-        // TODO EntityAgent
+        // TODO EntityAgent, which can be reused within a transaction, but
+        // otherwise should be a new instance
         return getEntityManager(false);
     }
 

--- a/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/EntityInfo.java
+++ b/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/EntityInfo.java
@@ -67,12 +67,11 @@ public class EntityInfo {
     // properly cased/qualified JPQL attribute name --> type
     final SortedMap<String, Class<?>> attributeTypes;
 
-    final EntityManagerBuilder builder;
-
     // properly cased/qualified JPQL attribute name --> type of collection
     final Map<String, Class<?>> collectionElementTypes;
 
     final Class<?> entityClass; // will be a generated class for entity records
+    final EntityHandlerFactory factory;
     final Class<?> idType; // type of the id, which could be a JPA IdClass for composite ids
     final SortedMap<String, Member> idClassAttributeAccessors; // null if no IdClass
     final boolean inheritance;
@@ -99,9 +98,9 @@ public class EntityInfo {
                SortedMap<String, Member> idClassAttributeAccessors,
                boolean isHibernate,
                String versionAttributeName,
-               EntityManagerBuilder entityManagerBuilder) {
+               EntityHandlerFactory entityHandlerFactory) {
         this.name = entityName;
-        this.builder = entityManagerBuilder;
+        this.factory = entityHandlerFactory;
         this.entityClass = entityClass;
         this.attributeAccessors = attributeAccessors;
         this.attributeNames = attributeNames;
@@ -194,7 +193,7 @@ public class EntityInfo {
         writer.println(indent + "  entity class: " + entityClass.getName());
         writer.println(indent + "  record class: " +
                        (recordClass == null ? null : recordClass.getName()));
-        writer.println(indent + "  builder: " + builder);
+        writer.println(indent + "  factory: " + factory);
         writer.println(indent + "  persistence provider is Hibernate? " +
                        isHibernate);
         writer.println(indent + "  idType: " +
@@ -285,12 +284,12 @@ public class EntityInfo {
     @Trivial
     private void validate() {
         // Unable to validate attribute types when we don't know which are converted
-        if (builder.convertibleTypes == null)
+        if (factory.convertibleTypes == null)
             return;
 
         for (Entry<String, Class<?>> attrTypeEntry : attributeTypes.entrySet()) {
             Class<?> attrType = attrTypeEntry.getValue();
-            if (!builder.convertibleTypes.contains(attrType) &&
+            if (!factory.convertibleTypes.contains(attrType) &&
                 Util.UNSUPPORTED_ATTR_TYPES.contains(attrType))
                 throw exc(MappingException.class,
                           "CWWKD1055.unsupported.entity.attr",

--- a/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/EntityInfo.java
+++ b/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/EntityInfo.java
@@ -246,6 +246,17 @@ public class EntityInfo {
     }
 
     /**
+     * Indicates if stateless repositories must be simulated by using EntityManager.
+     *
+     * @return whether to simulate stateless repositories with EntityManager.
+     */
+    @Trivial
+    boolean simulateStateless() {
+        // TODO temporarily approximated by assuming only Hibernate has EntityAgent
+        return !isHibernate;
+    }
+
+    /**
      * Converts a generated entity back to its record equivalent.
      *
      * @param entity generated entity.

--- a/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/EntityManagerBuilder.java
+++ b/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/EntityManagerBuilder.java
@@ -459,6 +459,17 @@ public abstract class EntityManagerBuilder {
                                              Class<?> repoInterface);
 
     /**
+     * Obtains an EntityAgent from the Jakarta Persistence provider.
+     *
+     * @return the EntityAgent.
+     * @throws Exception if an error occurs.
+     */
+    AutoCloseable getEntityAgent() throws Exception {
+        // TODO EntityAgent
+        return getEntityManager(false);
+    }
+
+    /**
      * Obtains a shared EntityManager instance if running in a transaction
      * and the repository is stateful. Otherwise create a new instance.
      *

--- a/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/Fail.java
+++ b/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/Fail.java
@@ -1164,7 +1164,7 @@ public class Fail {
      *                                          a query parameter.
      */
     private static void validateParameterPositions(QueryInfo info) {
-        DataVersionCompatibility compat = info.entityInfo.builder.provider.compat;
+        DataVersionCompatibility compat = info.entityInfo.factory.provider.compat;
 
         Class<?>[] paramTypes = info.method.getParameterTypes();
         Set<Class<?>> specParamTypes = compat.specialParamTypes();

--- a/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/PageImpl.java
+++ b/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/PageImpl.java
@@ -210,13 +210,13 @@ public class PageImpl<T> implements Page<T> {
                       queryInfo.jpqlCount,
                       queryInfo.jpql);
 
-        EntityManagerBuilder builder = queryInfo.entityInfo.builder;
+        EntityHandlerFactory factory = queryInfo.entityInfo.factory;
         boolean stateful = queryInfo.producer.stateful();
         AutoCloseable entityHandler = null;
         try {
             entityHandler = stateful || queryInfo.entityInfo.simulateStateless() //
-                            ? builder.getEntityManager(stateful) //
-                            : builder.getEntityAgent();
+                            ? factory.getEntityManager(stateful) //
+                            : factory.getEntityAgent();
 
             if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
                 Tr.debug(this, tc, "query for count: " + queryInfo.jpqlCount);
@@ -228,13 +228,13 @@ public class PageImpl<T> implements Page<T> {
 
             return query.getSingleResult();
         } catch (Exception x) {
-            throw RepositoryImpl.failure(x, builder);
+            throw RepositoryImpl.failure(x, factory);
         } finally {
             if (!stateful && entityHandler != null)
                 try {
                     entityHandler.close();
                 } catch (Exception x) {
-                    throw RepositoryImpl.failure(x, builder);
+                    throw RepositoryImpl.failure(x, factory);
                 }
         }
     }

--- a/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/PageImpl.java
+++ b/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/PageImpl.java
@@ -31,7 +31,6 @@ import jakarta.data.page.CursoredPage;
 import jakarta.data.page.Page;
 import jakarta.data.page.PageRequest;
 import jakarta.data.page.PageRequest.Mode;
-import jakarta.persistence.EntityManager;
 import jakarta.persistence.TypedQuery;
 
 /**
@@ -90,7 +89,7 @@ public class PageImpl<T> implements Page<T> {
      * Construct a new Page.
      *
      * @param queryInfo           query information.
-     * @param em                  the entity manager.
+     * @param entityHandler       EntityAgent or EntityManager
      * @param pageRequest         the request for this page.
      * @param args                values that are supplied to the repository method.
      * @param deferredConstraints map of method parameter index to non-Literal
@@ -102,7 +101,7 @@ public class PageImpl<T> implements Page<T> {
      */
     @Trivial
     PageImpl(QueryInfo queryInfo,
-             EntityManager em,
+             AutoCloseable entityHandler,
              PageRequest pageRequest,
              Object[] args,
              Map<Integer, Object> deferredConstraints,
@@ -122,9 +121,9 @@ public class PageImpl<T> implements Page<T> {
                       queryInfo.method.getGenericReturnType().getTypeName(),
                       CursoredPage.class.getName());
 
-        @SuppressWarnings("unchecked")
-        TypedQuery<T> query = (TypedQuery<T>) em.createQuery(queryInfo.jpql,
-                                                             Object.class);
+        TypedQuery<T> query = queryInfo.ehCreateTypedQuery(entityHandler,
+                                                           queryInfo.jpql,
+                                                           Object.class);
         queryInfo.setParameters(query, args, deferredConstraints, addedJPQLParams);
 
         int maxPageSize = pageRequest.size();
@@ -213,22 +212,30 @@ public class PageImpl<T> implements Page<T> {
 
         EntityManagerBuilder builder = queryInfo.entityInfo.builder;
         boolean stateful = queryInfo.producer.stateful();
-        EntityManager em = null;
+        AutoCloseable entityHandler = null;
         try {
-            em = builder.getEntityManager(stateful);
+            entityHandler = stateful || queryInfo.entityInfo.simulateStateless() //
+                            ? builder.getEntityManager(stateful) //
+                            : builder.getEntityAgent();
 
             if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
                 Tr.debug(this, tc, "query for count: " + queryInfo.jpqlCount);
 
-            TypedQuery<Long> query = em.createQuery(queryInfo.jpqlCount, Long.class);
+            TypedQuery<Long> query = queryInfo.ehCreateTypedQuery(entityHandler,
+                                                                  queryInfo.jpqlCount,
+                                                                  Long.class);
             queryInfo.setParameters(query, args, deferredConstraints, addedJPQLParams);
 
             return query.getSingleResult();
         } catch (Exception x) {
             throw RepositoryImpl.failure(x, builder);
         } finally {
-            if (!stateful && em != null)
-                em.close();
+            if (!stateful && entityHandler != null)
+                try {
+                    entityHandler.close();
+                } catch (Exception x) {
+                    throw RepositoryImpl.failure(x, builder);
+                }
         }
     }
 

--- a/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/QueryInfo.java
+++ b/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/QueryInfo.java
@@ -848,7 +848,7 @@ public abstract class QueryInfo {
                            Map<Object, Object> jpqlParams,
                            PageRequest pageReq,
                            List<Sort<Object>> sortsOverride) {
-        DataVersionCompatibility compat = entityInfo.builder.provider.compat;
+        DataVersionCompatibility compat = entityInfo.factory.provider.compat;
 
         QueryInfo info = compat.createQueryInfo(producer, //
                                                 repositoryInterface, //
@@ -1575,7 +1575,7 @@ public abstract class QueryInfo {
         if (trace && tc.isEntryEnabled())
             Tr.entry(this, tc, "find", type);
 
-        DataVersionCompatibility compat = entityInfo.builder.provider.compat;
+        DataVersionCompatibility compat = entityInfo.factory.provider.compat;
         Limit limit = null;
         int max = maxResults;
         PageRequest pageReq = null;
@@ -2654,7 +2654,7 @@ public abstract class QueryInfo {
 
         String o = entityVar;
         String o_ = entityVar_;
-        DataVersionCompatibility compat = entityInfo.builder.provider.compat;
+        DataVersionCompatibility compat = entityInfo.factory.provider.compat;
 
         Boolean isNamePresent = null; // unknown
         Parameter[] params = null;
@@ -2911,7 +2911,7 @@ public abstract class QueryInfo {
         StringBuilder q = new StringBuilder(200);
         String o = entityVar;
 
-        String[] cols, selections = entityInfo.builder.provider.compat.getSelections(method);
+        String[] cols, selections = entityInfo.factory.provider.compat.getSelections(method);
         if (selections.length == 0) {
             cols = null;
         } else if (type == FIND_AND_DELETE) {
@@ -2969,7 +2969,7 @@ public abstract class QueryInfo {
 
                     String[] names = new String[recordComponents.length];
                     for (int i = 0; i < recordComponents.length; i++) {
-                        String[] select = entityInfo.builder.provider.compat //
+                        String[] select = entityInfo.factory.provider.compat //
                                         .getSelections(recordComponents[i]);
                         if (select == null || select.length == 0)
                             names[i] = recordComponents[i].getName();
@@ -4291,7 +4291,7 @@ public abstract class QueryInfo {
      *         method parameters.
      */
     private int locateSpecialParameters(Class<?>[] paramTypes) {
-        DataVersionCompatibility compat = entityInfo.builder.provider.compat;
+        DataVersionCompatibility compat = entityInfo.factory.provider.compat;
         Set<Class<?>> specialParamTypes = compat.specialParamTypes();
         int specialParamsStartAt = paramTypes.length; // not found yet
 
@@ -4333,7 +4333,7 @@ public abstract class QueryInfo {
      */
     @Trivial
     final Object loggable(Object value) {
-        return entityInfo.builder.provider.loggable(repositoryInterface,
+        return entityInfo.factory.provider.loggable(repositoryInterface,
                                                     method,
                                                     value);
     }
@@ -4348,7 +4348,7 @@ public abstract class QueryInfo {
      */
     @Trivial
     final String loggableAppend(String prefix, Object... possibleSuffix) {
-        return entityInfo.builder.provider.loggableAppend(repositoryInterface,
+        return entityInfo.factory.provider.loggableAppend(repositoryInterface,
                                                           method,
                                                           prefix,
                                                           possibleSuffix);

--- a/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/QueryInfo.java
+++ b/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/QueryInfo.java
@@ -968,8 +968,8 @@ public abstract class QueryInfo {
     /**
      * Execute a repository count query.
      *
-     * @param em   entity manager.
-     * @param args method parameters.
+     * @param entityHandler the EntityAgent or EntityManager
+     * @param args          method parameters
      * @return the count, converted to a type that is compatible with the
      *         method signature.
      * @throws Exception        if an error occurs.
@@ -977,7 +977,7 @@ public abstract class QueryInfo {
      *                              requested type.
      */
     @Trivial
-    Object count(EntityManager em, Object... args) throws Exception {
+    Object count(AutoCloseable entityHandler, Object... args) throws Exception {
         final boolean trace = TraceComponent.isAnyTracingEnabled();
         if (trace && tc.isEntryEnabled())
             Tr.entry(this, tc, "count",
@@ -985,8 +985,9 @@ public abstract class QueryInfo {
                      "to be returned as " + singleType.getName());
 
         @SuppressWarnings("unchecked")
-        TypedQuery<Long> query = //
-                        (TypedQuery<Long>) createQuery(em, Long.class, args);
+        TypedQuery<Long> query = (TypedQuery<Long>) createQuery(entityHandler,
+                                                                Long.class,
+                                                                args);
 
         Long count = query.getSingleResult();
 
@@ -1041,14 +1042,14 @@ public abstract class QueryInfo {
      * Creates and prepares a query, including setting parameters basd on the
      * repository method arguments and any Constraints and Restrictions.
      *
-     * @param em               entity manager.
+     * @param entityHandler    the EntityAgent or EntityManager
      * @param typeOfTypedQuery TypedQuery type. Null to avoid using TypedQuery
      *                             (for UPDATE or DELETE).
      * @param args             method parameters.
      * @return the query, ready to execute.
      */
     @Trivial // avoid tracing repository method args
-    private jakarta.persistence.Query createQuery(EntityManager em,
+    private jakarta.persistence.Query createQuery(AutoCloseable entityHandler,
                                                   Class<?> typeOfTypedQuery,
                                                   Object[] args) {
         final boolean trace = TraceComponent.isAnyTracingEnabled();
@@ -1097,8 +1098,10 @@ public abstract class QueryInfo {
                         : this;
 
         jakarta.persistence.Query query = typeOfTypedQuery == null //
-                        ? em.createQuery(queryInfo.jpql) //
-                        : em.createQuery(queryInfo.jpql, typeOfTypedQuery);
+                        ? ehCreateQuery(entityHandler, queryInfo.jpql) //
+                        : ehCreateTypedQuery(entityHandler,
+                                             queryInfo.jpql,
+                                             typeOfTypedQuery);
 
         if (trace && tc.isDebugEnabled())
             Tr.debug(this, tc, "created query " + query);
@@ -1133,12 +1136,12 @@ public abstract class QueryInfo {
     /**
      * Deletes entities that were found by a find-and-delete operation.
      *
-     * @param results entities or record entities to delete from the database.
-     * @param em      entity manager.
+     * @param results       entities or record entities to delete from the database
+     * @param entityHandler EntityAgent or EntityManager
      * @throws Exception if an error occurs.
      */
     @Trivial
-    private void delete(List<?> results, EntityManager em) throws Exception {
+    private void delete(List<?> results, AutoCloseable entityHandler) throws Exception {
         final boolean trace = TraceComponent.isAnyTracingEnabled();
         if (trace && tc.isEntryEnabled())
             Tr.entry(this, tc, "delete", loggable(results));
@@ -1147,9 +1150,10 @@ public abstract class QueryInfo {
             if (result == null) {
                 throw Fail.resultConversion(this, null, null);
             } else if (entityInfo.entityClass.isInstance(result)) {
-                em.remove(result);
+                ehDelete(entityHandler, result);
             } else if (entityInfo.idClassAttributeAccessors != null) {
-                jakarta.persistence.Query delete = em.createQuery(jpqlDelete);
+                jakarta.persistence.Query delete = ehCreateQuery(entityHandler,
+                                                                 jpqlDelete);
                 int numParams = 0;
                 for (Member accessor : entityInfo.idClassAttributeAccessors.values()) {
                     Object value = accessor instanceof Method //
@@ -1184,7 +1188,8 @@ public abstract class QueryInfo {
                         throw Fail.returnTypeInvalidForDelete(this);
                 }
 
-                jakarta.persistence.Query delete = em.createQuery(jpqlDelete);
+                jakarta.persistence.Query delete = ehCreateQuery(entityHandler,
+                                                                 jpqlDelete);
                 if (trace && tc.isDebugEnabled())
                     Tr.debug(this, tc, jpqlDelete,
                              "set ?1 " + loggable(value));
@@ -1201,14 +1206,14 @@ public abstract class QueryInfo {
      * An error is raised if any of the entities (or records) are not found
      * in the database.
      *
-     * @param arg the entity or record, or array/Iterable/Stream of entity or record
-     * @param em  the entity manager
+     * @param arg           the entity or record, or array/Iterable/Stream of entity or record
+     * @param entityHandler EntityAgent or EntityManager
      * @return the deleted entity count, boolean indicator of any deletion, or void
      *         return type that is required by the Delete method signature.
      * @throws Exception if an error occurs.
      */
     @Trivial
-    Object delete(Object arg, EntityManager em) throws Exception {
+    Object delete(Object arg, AutoCloseable entityHandler) throws Exception {
         arg = arg instanceof Stream //
                         ? ((Stream<?>) arg).sequential().toList() //
                         : arg;
@@ -1223,15 +1228,15 @@ public abstract class QueryInfo {
         if (arg instanceof Iterable) {
             for (Object e : ((Iterable<?>) arg)) {
                 numExpected++;
-                updateCount += deleteOne(e, em);
+                updateCount += deleteOne(e, entityHandler);
             }
         } else if (entityParamType.isArray()) {
             numExpected = Array.getLength(arg);
             for (int i = 0; i < numExpected; i++)
-                updateCount += deleteOne(Array.get(arg, i), em);
+                updateCount += deleteOne(Array.get(arg, i), entityHandler);
         } else {
             numExpected = 1;
-            updateCount = deleteOne(arg, em);
+            updateCount = deleteOne(arg, entityHandler);
         }
 
         if (numExpected == 0)
@@ -1251,14 +1256,14 @@ public abstract class QueryInfo {
      * Removes the entity (or record) from the database if its attributes
      * match the database.
      *
-     * @param e  the entity or record.
-     * @param em the entity manager.
+     * @param e             the entity or record.
+     * @param entityHandler the EntityAgent or EntityManager
      * @return the number of entities deleted (1 or 0).
      * @throws Exception if an error occurs or the repository method return type is
      *                       void and the entity (or correct version of the entity)
      *                       was not found.
      */
-    private int deleteOne(Object e, EntityManager em) throws Exception {
+    private int deleteOne(Object e, AutoCloseable entityHandler) throws Exception {
         final boolean trace = TraceComponent.isAnyTracingEnabled();
         if (trace && tc.isEntryEnabled())
             Tr.entry(this, tc, "deleteOne", loggable(e));
@@ -1295,7 +1300,7 @@ public abstract class QueryInfo {
             && jpql != this.jpql)
             Tr.debug(this, tc, "JPQL adjusted for NULL id or version", jpql);
 
-        jakarta.persistence.Query delete = em.createQuery(jpql);
+        jakarta.persistence.Query delete = ehCreateQuery(entityHandler, jpql);
 
         if (entityInfo.idClassAttributeAccessors == null) {
             int p = 1;
@@ -1369,6 +1374,82 @@ public abstract class QueryInfo {
         return null;
     }
 
+    // TODO EntityAgent impl in QueryInfo_1_1 for the next 6 methods
+    /**
+     * Delegates to the EntityAgent or EntityManager to create a
+     * Jakarta Persistence Query, typically used for DELETE and
+     * UPDATE.
+     *
+     * @param entityHandler EntityAgent or EntityManager
+     * @param jpql          the query represented as JPQL
+     * @return the query, ready to execute
+     */
+    protected jakarta.persistence.Query ehCreateQuery(AutoCloseable entityHandler,
+                                                      String jpql) {
+        return ((EntityManager) entityHandler).createQuery(jpql);
+    }
+
+    /**
+     * Delegates to the EntityAgent or EntityManager to create a TypedQuery.
+     *
+     * @param <T>           result type of the query
+     * @param entityHandler EntityAgent or EntityManager
+     * @param jpql          the query represented as JPQL
+     * @param resultType    the result type of the query
+     * @return the query, ready to execute
+     */
+    @SuppressWarnings("unchecked")
+    protected <T> TypedQuery<T> ehCreateTypedQuery(AutoCloseable entityHandler,
+                                                   String jpql,
+                                                   Class<?> resultType) {
+        return (TypedQuery<T>) ((EntityManager) entityHandler) //
+                        .createQuery(jpql, Object.class);
+    }
+
+    /**
+     * Delegates to the EntityAgent or EntityManager to delete or remove
+     * an entity.
+     *
+     * @param entityHandler EntityAgent or EntityManager
+     * @param entity        the entity to remove
+     */
+    protected void ehDelete(AutoCloseable entityHandler, Object entity) {
+        ((EntityManager) entityHandler).remove(entity);
+    }
+
+    /**
+     * Delegates to the EntityAgent or EntityManager to insert or persist
+     * an entity.
+     *
+     * @param entityHandler EntityAgent or EntityManager
+     * @param entity        the entity to insert
+     */
+    protected void ehInsert(AutoCloseable entityHandler, Object entity) {
+        ((EntityManager) entityHandler).persist(entity);
+    }
+
+    /**
+     * Delegates to the EntityAgent or EntityManager to update or merge
+     * an entity.
+     *
+     * @param entityHandler EntityAgent or EntityManager
+     * @param entity        the entity to update
+     */
+    protected Object ehUpdate(AutoCloseable entityHandler, Object entity) {
+        return ((EntityManager) entityHandler).merge(entity);
+    }
+
+    /**
+     * Delegates to the EntityAgent or EntityManager to upsert or merge
+     * an entity.
+     *
+     * @param entityHandler EntityAgent or EntityManager
+     * @param entity        the entity to update or insert
+     */
+    protected Object ehUpsert(AutoCloseable entityHandler, Object entity) {
+        return ((EntityManager) entityHandler).merge(entity);
+    }
+
     /**
      * Indicates if the characters leading up to, but not including, the endBefore position
      * in the text matches the searchFor. For example, a true value will be returned by
@@ -1406,20 +1487,20 @@ public abstract class QueryInfo {
     /**
      * Execute JPQL for a repository delete or update query.
      *
-     * @param em   entity manager.
-     * @param args method parameters.
+     * @param entityHandler the EntityManager or EntityAgent
+     * @param args          method parameters
      * @return void, boolean, int, or long value representing a count of
      *         matching entities, or a CompletableFuture for the value,
      *         whichever is compatible with the method signature.
      * @throws Exception if an error occurs.
      */
-    @Trivial // em and method args have already been logged if loggable
-    Object execute(EntityManager em, Object... args) throws Exception {
+    @Trivial // entityHandler and method args have already been logged if loggable
+    Object execute(AutoCloseable entityHandler, Object... args) throws Exception {
         final boolean trace = TraceComponent.isAnyTracingEnabled();
         if (trace && tc.isEntryEnabled())
             Tr.entry(this, tc, "execute", type); // DELETE or UPDATE
 
-        jakarta.persistence.Query update = createQuery(em, null, args);
+        jakarta.persistence.Query update = createQuery(entityHandler, null, args);
 
         int updateCount = update.executeUpdate();
 
@@ -1439,19 +1520,21 @@ public abstract class QueryInfo {
     /**
      * Execute a repository exists query.
      *
-     * @param em   entity manager.
-     * @param args method parameters.
+     * @param entityHandler the EntityAgent or EntityManager
+     * @param args          method parameters
      * @return boolean value or CompletableFuture for a boolean value,
      *         whichever is compatible with the method signature.
      * @throws Exception if an error occurs.
      */
-    @Trivial // em and method args have already been logged if loggable
-    Object exists(EntityManager em, Object... args) throws Exception {
+    @Trivial // entityHandler and method args have already been logged if loggable
+    Object exists(AutoCloseable entityHandler, Object... args) throws Exception {
         final boolean trace = TraceComponent.isAnyTracingEnabled();
         if (trace && tc.isEntryEnabled())
             Tr.entry(this, tc, "exists");
 
-        jakarta.persistence.Query query = createQuery(em, Object.class, args);
+        jakarta.persistence.Query query = createQuery(entityHandler,
+                                                      Object.class,
+                                                      args);
         query.setMaxResults(1);
 
         List<?> results = query.getResultList();
@@ -1479,15 +1562,15 @@ public abstract class QueryInfo {
      * Execute a repository find query, and possibly also a delete operation
      * if find-and-delete.
      *
-     * @param em       entity manager.
+     * @param eh       EntityAgent or EntityManager, both of which are EntityHandler
      * @param txStatus transaction status.
      * @param args     method parameters.
      * @return results, after wrapping in an Optional or CompletionStage if required
      *         by the repository method signature.
      * @throws Exception if an error occurs.
      */
-    @Trivial // em, txStatus, and method args have already been logged if loggable
-    Object find(EntityManager em, int txStatus, Object... args) throws Exception {
+    @Trivial // eh, txStatus, and method args have already been logged if loggable
+    Object find(AutoCloseable eh, int txStatus, Object... args) throws Exception {
         final boolean trace = TraceComponent.isAnyTracingEnabled();
         if (trace && tc.isEntryEnabled())
             Tr.entry(this, tc, "find", type);
@@ -1580,7 +1663,7 @@ public abstract class QueryInfo {
         Object returnValue = queryInfo.find(limit,
                                             max,
                                             pageReq,
-                                            em,
+                                            eh,
                                             txStatus,
                                             args,
                                             deferredConstraints,
@@ -1614,7 +1697,7 @@ public abstract class QueryInfo {
      * @param limit               Limit, if a repository method parameter
      * @param max                 maximum number of results to return
      * @param pageReq             PageRequest, if a repository method parameter
-     * @param em                  entity manager.
+     * @param entityHandler       EntityAgent or EntityManager
      * @param txStatus            transaction status.
      * @param args                method parameters.
      * @param deferredConstraints map of method parameter index to non-Literal
@@ -1629,7 +1712,7 @@ public abstract class QueryInfo {
     private Object find(Limit limit,
                         int max,
                         PageRequest pageReq,
-                        EntityManager em,
+                        AutoCloseable entityHandler,
                         int txStatus,
                         Object[] args,
                         Map<Integer, Object> deferredConstraints,
@@ -1650,7 +1733,7 @@ public abstract class QueryInfo {
         if (CursoredPage.class.equals(multiType)) {
             returnValue = new CursoredPageImpl<>(//
                             this, //
-                            em, //
+                            entityHandler, //
                             pageReq, //
                             args, //
                             deferredConstraints, //
@@ -1659,7 +1742,7 @@ public abstract class QueryInfo {
             PageRequest req = limit == null ? pageReq : toPageRequest(limit);
             returnValue = new PageImpl<>(//
                             this, //
-                            em, //
+                            entityHandler, //
                             req, //
                             args, //
                             deferredConstraints, //
@@ -1673,7 +1756,9 @@ public abstract class QueryInfo {
                          jpql,
                          entityInfo.entityClass.getName());
 
-            TypedQuery<?> query = em.createQuery(jpql, Object.class);
+            TypedQuery<?> query = ehCreateTypedQuery(entityHandler,
+                                                     jpql,
+                                                     Object.class);
             setParameters(query, args, deferredConstraints, addedJPQLParams);
 
             if (type == FIND_AND_DELETE)
@@ -1727,7 +1812,7 @@ public abstract class QueryInfo {
                 }
 
                 if (type == FIND_AND_DELETE)
-                    delete(results, em);
+                    delete(results, entityHandler);
 
                 if (results.isEmpty() && isOptional) {
                     returnValue = null;
@@ -1839,14 +1924,15 @@ public abstract class QueryInfo {
     /**
      * Finds and updates entities (or records) in the database.
      *
-     * @param arg the entity or record, or array/Iterable/Stream of entity or record
-     * @param em  the entity manager.
+     * @param arg           the entity or record, or array/Iterable/Stream
+     *                          of entity or record
+     * @param entityHandler the EntityAgent or EntityManager
      * @return the updated entities, using the return type that is required by the
      *         repository Update method signature.
      * @throws OptimisticLockingFailureException if an entity is not found in the database.
      * @throws Exception                         if an error occurs.
      */
-    Object findAndUpdate(Object arg, EntityManager em) throws Exception {
+    Object findAndUpdate(Object arg, AutoCloseable entityHandler) throws Exception {
         final boolean trace = TraceComponent.isAnyTracingEnabled();
         if (trace && tc.isEntryEnabled())
             Tr.entry(this, tc, "findAndUpdate", loggable(arg));
@@ -1858,7 +1944,7 @@ public abstract class QueryInfo {
             int length = Array.getLength(arg);
             results = new ArrayList<>(length);
             for (int i = 0; i < length; i++)
-                results.add(findAndUpdateOne(Array.get(arg, i), em));
+                results.add(findAndUpdateOne(Array.get(arg, i), entityHandler));
         } else {
             arg = arg instanceof Stream //
                             ? ((Stream<?>) arg).sequential().toList() //
@@ -1867,15 +1953,15 @@ public abstract class QueryInfo {
             results = new ArrayList<>();
             if (arg instanceof Iterable) {
                 for (Object e : ((Iterable<?>) arg))
-                    results.add(findAndUpdateOne(e, em));
+                    results.add(findAndUpdateOne(e, entityHandler));
             } else {
                 hasSingularEntityParam = true;
                 results = new ArrayList<>(1);
-                results.add(findAndUpdateOne(arg, em));
+                results.add(findAndUpdateOne(arg, entityHandler));
             }
         }
 
-        if (!results.isEmpty()) {
+        if (!results.isEmpty() && entityHandler instanceof EntityManager em) {
             if (trace && tc.isDebugEnabled())
                 Tr.debug(this, tc, "flush");
             em.flush();
@@ -1947,13 +2033,14 @@ public abstract class QueryInfo {
      * and updates the entity found in the database to match the desired state
      * of the supplied entity.
      *
-     * @param e  the entity or record.
-     * @param em the entity manager.
+     * @param e             the entity or record
+     * @param entityHandler the EntityAgent or Entitymanager
      * @return the entity that is written to the database. Never null.
      * @throws OptimisticLockingException if the entity is not found.
      * @throws Exception                  if an error occurs.
      */
-    private Object findAndUpdateOne(Object e, EntityManager em) throws Exception {
+    private Object findAndUpdateOne(Object e, AutoCloseable entityHandler) //
+                    throws Exception {
         final boolean trace = TraceComponent.isAnyTracingEnabled();
         if (trace && tc.isEntryEnabled())
             Tr.entry(this, tc, "findAndUpdateOne", loggable(e));
@@ -1987,7 +2074,7 @@ public abstract class QueryInfo {
         if (TraceComponent.isAnyTracingEnabled() && jpql != this.jpql)
             Tr.debug(this, tc, "JPQL adjusted for NULL id or version", jpql);
 
-        TypedQuery<?> query = em.createQuery(jpql, Object.class);
+        TypedQuery<?> query = ehCreateTypedQuery(entityHandler, jpql, Object.class);
         query.setLockMode(LockModeType.PESSIMISTIC_WRITE);
 
         if (entityInfo.idClassAttributeAccessors == null) {
@@ -2014,12 +2101,12 @@ public abstract class QueryInfo {
         if (trace && tc.isDebugEnabled())
             Tr.debug(this, tc, "found", loggable(results.get(0)));
 
-        e = toEntity(e, em);
+        e = toEntity(e);
 
         if (trace && tc.isDebugEnabled())
             Tr.debug(this, tc, "merge", loggable(e));
 
-        Object returnValue = em.merge(e);
+        Object returnValue = ehUpdate(entityHandler, e);
 
         if (trace && tc.isEntryEnabled())
             Tr.exit(this, tc, "findAndUpdateOne", loggable(returnValue));
@@ -3897,14 +3984,15 @@ public abstract class QueryInfo {
      * An error is raised if any of the entities (or records) already exist
      * in the database.
      *
-     * @param arg the entity or record, or array/Iterable/Stream of entity or record
-     * @param em  the entity manager
+     * @param arg           the entity or record, or array/Iterable/Stream
+     *                          of entity or record
+     * @param entityHandler the EntityAgent or EntityManager
      * @return the inserted entities, using the return type that is required by the
      *         Insert method signature.
      * @throws Exception if an error occurs.
      */
     @Trivial
-    Object insert(Object arg, EntityManager em) throws Exception {
+    Object insert(Object arg, AutoCloseable entityHandler) throws Exception {
         arg = arg instanceof Stream //
                         ? ((Stream<?>) arg).sequential().toList() //
                         : arg;
@@ -3923,8 +4011,8 @@ public abstract class QueryInfo {
             int length = Array.getLength(arg);
             results = resultVoid ? null : new ArrayList<>(length);
             for (; entityCount < length; entityCount++) {
-                Object entity = toEntity(Array.get(arg, entityCount), em);
-                em.persist(entity);
+                Object entity = toEntity(Array.get(arg, entityCount));
+                ehInsert(entityHandler, entity); // TODO entityAgent.insertMultiple?
                 if (results != null)
                     results.add(entity);
             }
@@ -3932,8 +4020,8 @@ public abstract class QueryInfo {
             results = resultVoid ? null : new ArrayList<>();
             for (Object e : ((Iterable<?>) arg)) {
                 entityCount++;
-                Object entity = toEntity(e, em);
-                em.persist(entity);
+                Object entity = toEntity(e);
+                ehInsert(entityHandler, entity);
                 if (results != null)
                     results.add(entity);
             }
@@ -3941,8 +4029,8 @@ public abstract class QueryInfo {
             entityCount = 1;
             hasSingularEntityParam = true;
             results = resultVoid ? null : new ArrayList<>(1);
-            Object entity = toEntity(arg, em);
-            em.persist(entity);
+            Object entity = toEntity(arg);
+            ehInsert(entityHandler, entity);
             if (results != null)
                 results.add(entity);
         }
@@ -3950,9 +4038,11 @@ public abstract class QueryInfo {
         if (entityCount == 0)
             throw Fail.emptyLifeCycleParam(this);
 
-        if (trace && tc.isDebugEnabled())
-            Tr.debug(this, tc, "flush");
-        em.flush();
+        if (entityHandler instanceof EntityManager em) {
+            if (trace && tc.isDebugEnabled())
+                Tr.debug(this, tc, "flush");
+            em.flush();
+        }
 
         Class<?> returnType = method.getReturnType();
         Object returnValue;
@@ -5230,14 +5320,15 @@ public abstract class QueryInfo {
      * Saves entities (or records) to the database, which can involve an update
      * or an insert, depending on whether the entity already exists.
      *
-     * @param arg the entity or record, or array/Iterable/Stream of entity or record
-     * @param em  the entity manager.
+     * @param arg           the entity or record, or array/Iterable/Stream
+     *                          of entity or record
+     * @param entityHandler the EntityAgent or EntityManager
      * @return the updated entities, using the return type that is required by the
      *         repository Save method signature.
      * @throws Exception if an error occurs.
      */
     @Trivial // avoid logging customer data
-    Object save(Object arg, EntityManager em) throws Exception {
+    Object save(Object arg, AutoCloseable entityHandler) throws Exception {
         arg = arg instanceof Stream //
                         ? ((Stream<?>) arg).sequential().toList() //
                         : arg;
@@ -5257,19 +5348,22 @@ public abstract class QueryInfo {
             int length = Array.getLength(arg);
             for (; entityCount < length; entityCount++)
                 // workaround is not possible when multiple entities
-                results.add(em.merge(toEntity(Array.get(arg, entityCount), null)));
+                results.add(ehUpsert(entityHandler,
+                                     toEntity(Array.get(arg, entityCount))));
         } else if (Iterable.class.isAssignableFrom(entityParamType)) {
             results = new ArrayList<>();
             for (Object e : ((Iterable<?>) arg)) {
                 entityCount++;
                 // workaround is not possible when multiple entities
-                results.add(em.merge(toEntity(e, null)));
+                results.add(ehUpsert(entityHandler,
+                                     toEntity(e)));
             }
         } else {
             entityCount = 1;
             hasSingularEntityParam = true;
             results = resultVoid ? null : new ArrayList<>(1);
-            Object entity = em.merge(toEntity(arg, em));
+            Object entity = ehUpsert(entityHandler,
+                                     toEntity(arg));
             if (results != null)
                 results.add(entity);
         }
@@ -5277,9 +5371,11 @@ public abstract class QueryInfo {
         if (entityCount == 0)
             throw Fail.emptyLifeCycleParam(this);
 
-        if (trace && tc.isDebugEnabled())
-            Tr.debug(this, tc, "flush");
-        em.flush();
+        if (entityHandler instanceof EntityManager em) {
+            if (trace && tc.isDebugEnabled())
+                Tr.debug(this, tc, "flush");
+            em.flush();
+        }
 
         Class<?> returnType = method.getReturnType();
         Object returnValue;
@@ -5688,16 +5784,15 @@ public abstract class QueryInfo {
      * Converts a record to its generated entity equivalent,
      * or does nothing if not a record.
      *
-     * @param o  a record that needs conversion to an entity,
-     *               or an entity that is already an entity and does not
-     *               need conversion.
-     * @param em entity manager.
+     * @param o a record that needs conversion to an entity,
+     *              or an entity that is already an entity and does not
+     *              need conversion.
      * @return entity.
      * @throws NullPointerException if the record is null, with a CWWKD1015 message
      *                                  that is appropriate for life cycle operations
      */
     @Trivial
-    private final Object toEntity(Object o, EntityManager em) {
+    private final Object toEntity(Object o) {
         if (o == null)
             throw Fail.entityNull(this);
 
@@ -5835,14 +5930,15 @@ public abstract class QueryInfo {
      * An error is raised if any of the entities (or records) are not found
      * in the database.
      *
-     * @param arg the entity or record, or array/Iterable/Stream of entity or record
-     * @param em  the entity manager
+     * @param arg           the entity or record, or array/Iterable/Stream
+     *                          of entity or record
+     * @param entityHandler the EntityAgent or EntityManager
      * @return count of matching entities, boolean indicator of whether any matched,
      *         or void return type that is required by the Update method signature.
      * @throws Exception if an error occurs.
      */
     @Trivial
-    Object update(Object arg, EntityManager em) throws Exception {
+    Object update(Object arg, AutoCloseable entityHandler) throws Exception {
         arg = arg instanceof Stream //
                         ? ((Stream<?>) arg).sequential().toList() //
                         : arg;
@@ -5857,20 +5953,22 @@ public abstract class QueryInfo {
         if (arg instanceof Iterable) {
             for (Object e : ((Iterable<?>) arg)) {
                 numExpected++;
-                updateCount += updateOne(e, em);
+                updateCount += updateOne(e, entityHandler);
             }
         } else if (entityParamType.isArray()) {
             numExpected = Array.getLength(arg);
             for (int i = 0; i < numExpected; i++)
-                updateCount += updateOne(Array.get(arg, i), em);
+                updateCount += updateOne(Array.get(arg, i), entityHandler);
         } else {
             numExpected = 1;
-            updateCount = updateOne(arg, em);
+            updateCount = updateOne(arg, entityHandler);
         }
 
-        if (trace && tc.isDebugEnabled())
-            Tr.debug(this, tc, "flush");
-        em.flush();
+        if (entityHandler instanceof EntityManager em) {
+            if (trace && tc.isDebugEnabled())
+                Tr.debug(this, tc, "flush");
+            em.flush();
+        }
 
         if (numExpected == 0)
             throw Fail.emptyLifeCycleParam(this);
@@ -5889,13 +5987,13 @@ public abstract class QueryInfo {
      * Updates the entity (or record) from the database if its attributes match
      * the database.
      *
-     * @param e  the entity or record.
-     * @param em the entity manager.
+     * @param e             the entity or record
+     * @param entityHandler the EntityAgent or EntityManager
      * @return the number of entities updated (1 or 0).
      * @throws Exception if an error occurs.
      */
     @Trivial
-    private int updateOne(Object e, EntityManager em) throws Exception {
+    private int updateOne(Object e, AutoCloseable entityHandler) throws Exception {
         final boolean trace = TraceComponent.isAnyTracingEnabled();
         if (trace && tc.isEntryEnabled())
             Tr.entry(this, tc, "updateOne", loggable(e));
@@ -5924,7 +6022,7 @@ public abstract class QueryInfo {
         if (TraceComponent.isAnyTracingEnabled() && jpql != this.jpql)
             Tr.debug(this, tc, "JPQL adjusted for NULL id", jpql);
 
-        jakarta.persistence.Query update = em.createQuery(jpql);
+        jakarta.persistence.Query update = ehCreateQuery(entityHandler, jpql);
 
         // parameters for entity attributes to update:
         int p = 1;

--- a/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/QueryInfo.java
+++ b/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/QueryInfo.java
@@ -1374,7 +1374,6 @@ public abstract class QueryInfo {
         return null;
     }
 
-    // TODO EntityAgent impl in QueryInfo_1_1 for the next 6 methods
     /**
      * Delegates to the EntityAgent or EntityManager to create a
      * Jakarta Persistence Query, typically used for DELETE and
@@ -1384,10 +1383,9 @@ public abstract class QueryInfo {
      * @param jpql          the query represented as JPQL
      * @return the query, ready to execute
      */
-    protected jakarta.persistence.Query ehCreateQuery(AutoCloseable entityHandler,
-                                                      String jpql) {
-        return ((EntityManager) entityHandler).createQuery(jpql);
-    }
+    protected abstract jakarta.persistence.Query //
+                    ehCreateQuery(AutoCloseable entityHandler,
+                                  String jpql);
 
     /**
      * Delegates to the EntityAgent or EntityManager to create a TypedQuery.
@@ -1398,13 +1396,10 @@ public abstract class QueryInfo {
      * @param resultType    the result type of the query
      * @return the query, ready to execute
      */
-    @SuppressWarnings("unchecked")
-    protected <T> TypedQuery<T> ehCreateTypedQuery(AutoCloseable entityHandler,
-                                                   String jpql,
-                                                   Class<?> resultType) {
-        return (TypedQuery<T>) ((EntityManager) entityHandler) //
-                        .createQuery(jpql, Object.class);
-    }
+    protected abstract <T> TypedQuery<T> //
+                    ehCreateTypedQuery(AutoCloseable entityHandler,
+                                       String jpql,
+                                       Class<?> resultType);
 
     /**
      * Delegates to the EntityAgent or EntityManager to delete or remove
@@ -1413,9 +1408,7 @@ public abstract class QueryInfo {
      * @param entityHandler EntityAgent or EntityManager
      * @param entity        the entity to remove
      */
-    protected void ehDelete(AutoCloseable entityHandler, Object entity) {
-        ((EntityManager) entityHandler).remove(entity);
-    }
+    protected abstract void ehDelete(AutoCloseable entityHandler, Object entity);
 
     /**
      * Delegates to the EntityAgent or EntityManager to insert or persist
@@ -1424,9 +1417,7 @@ public abstract class QueryInfo {
      * @param entityHandler EntityAgent or EntityManager
      * @param entity        the entity to insert
      */
-    protected void ehInsert(AutoCloseable entityHandler, Object entity) {
-        ((EntityManager) entityHandler).persist(entity);
-    }
+    protected abstract void ehInsert(AutoCloseable entityHandler, Object entity);
 
     /**
      * Delegates to the EntityAgent or EntityManager to update or merge
@@ -1435,9 +1426,7 @@ public abstract class QueryInfo {
      * @param entityHandler EntityAgent or EntityManager
      * @param entity        the entity to update
      */
-    protected Object ehUpdate(AutoCloseable entityHandler, Object entity) {
-        return ((EntityManager) entityHandler).merge(entity);
-    }
+    protected abstract Object ehUpdate(AutoCloseable entityHandler, Object entity);
 
     /**
      * Delegates to the EntityAgent or EntityManager to upsert or merge
@@ -1446,9 +1435,8 @@ public abstract class QueryInfo {
      * @param entityHandler EntityAgent or EntityManager
      * @param entity        the entity to update or insert
      */
-    protected Object ehUpsert(AutoCloseable entityHandler, Object entity) {
-        return ((EntityManager) entityHandler).merge(entity);
-    }
+    @Trivial
+    protected abstract Object ehUpsert(AutoCloseable entityHandler, Object entity);
 
     /**
      * Indicates if the characters leading up to, but not including, the endBefore position

--- a/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/RepositoryImpl.java
+++ b/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/RepositoryImpl.java
@@ -77,7 +77,7 @@ public class RepositoryImpl<R> implements InvocationHandler {
     /**
      * Creates EntityAgent and EntityManager instances.
      */
-    private final EntityManagerBuilder builder;
+    private final EntityHandlerFactory factory;
 
     /**
      * Indicates if the bean for the repository has been disposed.
@@ -117,7 +117,7 @@ public class RepositoryImpl<R> implements InvocationHandler {
      * @param provider              OSGi service for the built-in Jakarta Data
      *                                  provider for EclipseLink.
      * @param extension             CDI extension for the Jakarta Data provider.
-     * @param builder               Builder of EntityManager instances.
+     * @param factory               Creates EntityAgent and EntityManager
      * @param repositoryInterface   The repository interface.
      * @param primaryEntityClass    The primary entity class for the repository.
      *                                  Null if the repository does not have one.
@@ -127,17 +127,17 @@ public class RepositoryImpl<R> implements InvocationHandler {
      */
     public RepositoryImpl(DataProvider provider,
                           DataExtension extension,
-                          EntityManagerBuilder builder,
+                          EntityHandlerFactory factory,
                           Class<R> repositoryInterface,
                           Class<?> primaryEntityClass,
                           Map<Class<?>, List<QueryInfo>> queriesPerEntityClass) {
-        this.builder = builder;
+        this.factory = factory;
 
-        // EntityManagerBuilder implementations guarantee that the future
+        // EntityHandlerFactory implementations guarantee that the future
         // in the following map will be completed even if an error occurs
         this.primaryEntityInfoFuture = primaryEntityClass == null //
                         ? null //
-                        : builder.entityInfoMap.computeIfAbsent(primaryEntityClass,
+                        : factory.entityInfoMap.computeIfAbsent(primaryEntityClass,
                                                                 EntityInfo::newFuture);
         this.provider = provider;
         this.repositoryInterface = repositoryInterface;
@@ -161,7 +161,7 @@ public class RepositoryImpl<R> implements InvocationHandler {
                 entitylessQueryInfos = entry.getValue();
             } else {
                 CompletableFuture<EntityInfo> entityInfoFuture = //
-                                builder.entityInfoMap.computeIfAbsent(entityClass,
+                                factory.entityInfoMap.computeIfAbsent(entityClass,
                                                                       EntityInfo::newFuture);
                 entityInfoFutures.add(entityInfoFuture);
 
@@ -287,11 +287,11 @@ public class RepositoryImpl<R> implements InvocationHandler {
      * jakarta.persistence.PersistenceException (and subclasses).
      *
      * @param original exception to possibly replace.
-     * @param emb      entity manager builder.
+     * @param factory  creates EntityAgent and EntityManager
      * @return exception to replace with, if any. Otherwise, the original.
      */
     @Trivial
-    static RuntimeException failure(Exception original, EntityManagerBuilder emb) {
+    static RuntimeException failure(Exception original, EntityHandlerFactory factory) {
         final boolean trace = TraceComponent.isAnyTracingEnabled();
         RuntimeException x = null;
         if (original instanceof PersistenceException) {
@@ -302,7 +302,7 @@ public class RepositoryImpl<R> implements InvocationHandler {
                 String sqlState = null;
                 if (cause instanceof SQLException c) {
                     sqlState = c.getSQLState();
-                    if (emb.isConnectionError(c))
+                    if (factory.isConnectionError(c))
                         x = new DataConnectionException(original);
                 }
                 if (x == null)
@@ -395,19 +395,19 @@ public class RepositoryImpl<R> implements InvocationHandler {
         Class<?> type = info.method.getReturnType();
 
         if (EntityManager.class.equals(type)) {
-            resource = builder.getEntityManager(stateful);
+            resource = factory.getEntityManager(stateful);
             resourceAutoCloses = stateful;
         } else if (DataSource.class.equals(type)) {
-            resource = builder.getDataSource(info.method, repositoryInterface);
+            resource = factory.getDataSource(info.method, repositoryInterface);
         } else if (Connection.class.equals(type)) {
             try {
-                resource = builder.getDataSource(info.method, repositoryInterface) //
+                resource = factory.getDataSource(info.method, repositoryInterface) //
                                 .getConnection();
             } catch (SQLException x) {
                 throw new DataConnectionException(x);
             }
         } else if ("jakarta.persistence.EntityAgent".equals(type.getName())) {
-            resource = builder.getEntityAgent();
+            resource = factory.getEntityAgent();
         }
 
         if (resource == null)
@@ -459,7 +459,7 @@ public class RepositoryImpl<R> implements InvocationHandler {
     public void introspect(PrintWriter writer, String indent) {
 
         writer.println(indent + "RepositoryImpl@" + Integer.toHexString(hashCode()));
-        writer.println(indent + "  builder: " + builder);
+        writer.println(indent + "  factory: " + factory);
         writer.println(indent + "  isDisposed? " + isDisposed);
         writer.println(indent + "  primary entity future: " + primaryEntityInfoFuture);
         writer.println(indent + "  provider: " + provider);
@@ -588,8 +588,8 @@ public class RepositoryImpl<R> implements InvocationHandler {
 
                 if (queryType != RESOURCE_ACCESS)
                     eh = stateful || queryInfo.entityInfo.simulateStateless() //
-                                    ? builder.getEntityManager(stateful) //
-                                    : builder.getEntityAgent();
+                                    ? factory.getEntityManager(stateful) //
+                                    : factory.getEntityAgent();
 
                 returnValue = switch (queryType) {
                     case FIND, FIND_AND_DELETE -> queryInfo.find(eh, txStatus, args);
@@ -679,7 +679,7 @@ public class RepositoryImpl<R> implements InvocationHandler {
             return returnValue;
         } catch (Throwable x) {
             if (!isDefaultMethod && x instanceof Exception)
-                x = failure((Exception) x, builder);
+                x = failure((Exception) x, factory);
             if (trace && tc.isEntryEnabled())
                 Tr.exit(this, tc, "invoke " + repositoryInterface.getSimpleName() +
                                   '.' + method.getName(),

--- a/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/RepositoryImpl.java
+++ b/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/RepositoryImpl.java
@@ -75,7 +75,7 @@ public class RepositoryImpl<R> implements InvocationHandler {
                     new ThreadLocal<>();
 
     /**
-     * Creates EntityManager instances.
+     * Creates EntityAgent and EntityManager instances.
      */
     private final EntityManagerBuilder builder;
 
@@ -406,6 +406,8 @@ public class RepositoryImpl<R> implements InvocationHandler {
             } catch (SQLException x) {
                 throw new DataConnectionException(x);
             }
+        } else if ("jakarta.persistence.EntityAgent".equals(type.getName())) {
+            resource = builder.getEntityAgent();
         }
 
         if (resource == null)
@@ -508,7 +510,9 @@ public class RepositoryImpl<R> implements InvocationHandler {
                                '.' + method.getName(),
                      provider.loggable(repositoryInterface, method, args));
 
-        EntityManager em = null;
+        // EntityManager and EntityAgent inherit from AutoCloseable
+        // via their common superclass, EntityHandler:
+        AutoCloseable eh = null;
         try {
             if (isDisposed.get())
                 throw exc(IllegalStateException.class,
@@ -583,23 +587,25 @@ public class RepositoryImpl<R> implements InvocationHandler {
                 }
 
                 if (queryType != RESOURCE_ACCESS)
-                    em = builder.getEntityManager(stateful);
+                    eh = stateful || queryInfo.entityInfo.simulateStateless() //
+                                    ? builder.getEntityManager(stateful) //
+                                    : builder.getEntityAgent();
 
                 returnValue = switch (queryType) {
-                    case FIND, FIND_AND_DELETE -> queryInfo.find(em, txStatus, args);
-                    case COUNT -> queryInfo.count(em, args);
-                    case EXISTS -> queryInfo.exists(em, args);
-                    case INSERT -> queryInfo.insert(args[0], em);
-                    case SAVE -> queryInfo.save(args[0], em);
-                    case QM_UPDATE, QM_DELETE -> queryInfo.execute(em, args);
-                    case LC_DELETE -> queryInfo.delete(args[0], em);
-                    case LC_UPDATE -> queryInfo.update(args[0], em);
-                    case LC_UPDATE_MERGE -> queryInfo.findAndUpdate(args[0], em);
-                    case DETACH -> queryInfo.detach(args[0], em);
-                    case MERGE -> queryInfo.merge(args[0], em);
-                    case PERSIST -> queryInfo.persist(args[0], em);
-                    case REFRESH -> queryInfo.refresh(args[0], em);
-                    case REMOVE -> queryInfo.remove(args[0], em);
+                    case FIND, FIND_AND_DELETE -> queryInfo.find(eh, txStatus, args);
+                    case COUNT -> queryInfo.count(eh, args);
+                    case EXISTS -> queryInfo.exists(eh, args);
+                    case INSERT -> queryInfo.insert(args[0], eh);
+                    case SAVE -> queryInfo.save(args[0], eh);
+                    case QM_UPDATE, QM_DELETE -> queryInfo.execute(eh, args);
+                    case LC_DELETE -> queryInfo.delete(args[0], eh);
+                    case LC_UPDATE -> queryInfo.update(args[0], eh);
+                    case LC_UPDATE_MERGE -> queryInfo.findAndUpdate(args[0], eh);
+                    case DETACH -> queryInfo.detach(args[0], (EntityManager) eh);
+                    case MERGE -> queryInfo.merge(args[0], (EntityManager) eh);
+                    case PERSIST -> queryInfo.persist(args[0], (EntityManager) eh);
+                    case REFRESH -> queryInfo.refresh(args[0], (EntityManager) eh);
+                    case REMOVE -> queryInfo.remove(args[0], (EntityManager) eh);
                     case RESOURCE_ACCESS -> getResource(queryInfo);
                     default -> throw new UnsupportedOperationException(queryType.operationName);
                 };
@@ -624,14 +630,15 @@ public class RepositoryImpl<R> implements InvocationHandler {
                             provider.tranMgr.commit();
                         }
                     } else {
-                        boolean detach = em != null &&
+                        boolean detach = eh != null &&
                                          queryType.detachEntities(stateful);
                         if (Status.STATUS_ACTIVE == provider.tranMgr.getStatus()) {
                             if (failed) {
                                 if (trace && tc.isDebugEnabled())
                                     Tr.debug(this, tc, "set rollback only");
                                 provider.tranMgr.setRollbackOnly();
-                            } else if (detach) {
+                            } else if (detach &&
+                                       eh instanceof EntityManager em) {
                                 // flush changes first because detach interferes with updates
                                 if (trace && tc.isDebugEnabled())
                                     Tr.debug(this, tc, "flush");
@@ -640,7 +647,8 @@ public class RepositoryImpl<R> implements InvocationHandler {
                                     Tr.debug(this, tc, "clear");
                                 em.clear();
                             }
-                        } else if (detach) {
+                        } else if (detach &&
+                                   eh instanceof EntityManager em) {
                             if (trace && tc.isDebugEnabled())
                                 Tr.debug(this, tc, "clear");
                             em.clear();
@@ -654,8 +662,8 @@ public class RepositoryImpl<R> implements InvocationHandler {
                             provider.localTranCurrent.resume(suspendedLTC);
                         }
                     } finally {
-                        if (!stateful && em != null)
-                            em.close();
+                        if (!stateful && eh != null)
+                            eh.close();
                     }
                 }
             }

--- a/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/cdi/DataExtension.java
+++ b/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/cdi/DataExtension.java
@@ -137,9 +137,10 @@ public class DataExtension implements Extension {
                             .createAnnotatedType(StatefulPersistenceContext.class));
 
         // Group entities by data access provider and class loader
-        Map<FutureEMBuilder, FutureEMBuilder> entityGroups = new HashMap<>();
+        Map<FutureEHFactory, FutureEHFactory> entityGroups = new HashMap<>();
 
-        for (Iterator<AnnotatedType<?>> it = repositoryAnnos.keySet().iterator(); it.hasNext();) {
+        for (Iterator<AnnotatedType<?>> it = repositoryAnnos.keySet().iterator(); //
+                        it.hasNext();) {
             AnnotatedType<?> repositoryType = it.next();
             it.remove();
 
@@ -156,28 +157,31 @@ public class DataExtension implements Extension {
             // This needs to be done with the correct metadata on the thread,
             // but that might not be available yet.
 
-            FutureEMBuilder futureEMBuilder = new FutureEMBuilder( //
-                            provider, repositoryInterface, loader, dataStore);
+            FutureEHFactory futureEHFactory = new FutureEHFactory( //
+                            provider, //
+                            repositoryInterface, //
+                            loader, //
+                            dataStore);
 
             RepositoryProducer<Object> producer = discoverEntityClasses(repositoryType,
                                                                         provider,
                                                                         beanMgr);
             if (producer != null) {
 
-                FutureEMBuilder previous = entityGroups.putIfAbsent(futureEMBuilder,
-                                                                    futureEMBuilder);
+                FutureEHFactory previous = entityGroups.putIfAbsent(futureEHFactory,
+                                                                    futureEHFactory);
                 if (previous != null) {
-                    futureEMBuilder = previous;
-                    futureEMBuilder.addRepositoryInterface(repositoryInterface);
+                    futureEHFactory = previous;
+                    futureEHFactory.addRepositoryInterface(repositoryInterface);
                 }
 
                 for (Class<?> entityClass : producer.queriesPerEntityClass.keySet())
                     if (!QueryInfo.ENTITY_TBD.equals(entityClass))
-                        futureEMBuilder.addEntity(entityClass);
+                        futureEHFactory.addEntity(entityClass);
 
-                producer.setFutureEMBuilder(futureEMBuilder);
+                producer.setFutureEHFactory(futureEHFactory);
 
-                provider.producerCreated(futureEMBuilder.jeeName.getApplication(),
+                provider.producerCreated(futureEHFactory.jeeName.getApplication(),
                                          producer);
 
                 @SuppressWarnings("unchecked")
@@ -193,16 +197,17 @@ public class DataExtension implements Extension {
     }
 
     /**
-     * Identifies entity classes that are referenced by an interface that is annotated as a Repository
-     * and determines the primary entity class.
+     * Identifies entity classes that are referenced by an interface that is
+     * annotated as a Repository and determines the primary entity class.
      *
-     * Many repository interfaces will inherit from DataRepository or another built-in repository class,
-     * all of which are parameterized with the entity class as the first parameter.
+     * Many repository interfaces will inherit from DataRepository or another
+     * built-in repository class, all of which are parameterized with the
+     * entity class as the first parameter.
      *
      * @param repositoryType the repository interface as an annotated type.
      * @param provider       OSGi service that provides the CDI extension.
      * @param beanMgr        CDI bean manager.
-     * @return a RepositoryProducer instance (with its futureEMBuilder unassigned)
+     * @return a RepositoryProducer instance (with its futureEHFactory unassigned)
      *         if all entity types that appear on the repository interface are
      *         supported. Otherwise null.
      */

--- a/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/cdi/FutureEHFactory.java
+++ b/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/cdi/FutureEHFactory.java
@@ -12,7 +12,7 @@
  *******************************************************************************/
 package io.openliberty.data.internal.cdi;
 
-import static io.openliberty.data.internal.EntityManagerBuilder.getClassNames;
+import static io.openliberty.data.internal.EntityHandlerFactory.getClassNames;
 import static io.openliberty.data.internal.cdi.DataExtension.exc;
 
 import java.io.PrintWriter;
@@ -49,19 +49,20 @@ import com.ibm.ws.threadContext.ComponentMetaDataAccessorImpl;
 import com.ibm.wsspi.persistence.DDLGenerationParticipant;
 
 import io.openliberty.data.internal.DataProvider;
-import io.openliberty.data.internal.EntityManagerBuilder;
+import io.openliberty.data.internal.EntityHandlerFactory;
 import io.openliberty.data.internal.Util;
-import io.openliberty.data.internal.provider.PUnitEMBuilder;
-import io.openliberty.data.internal.service.DBStoreEMBuilder;
+import io.openliberty.data.internal.provider.PUnitEHFactory;
+import io.openliberty.data.internal.service.DBStoreEHFactory;
 import jakarta.data.exceptions.DataException;
 import jakarta.persistence.EntityManagerFactory;
 
 /**
- * A completable future for an EntityManagerBuilder that can be
- * completed by invoking the createEMBuilder method.
+ * A completable future for an EntityHandlerFactory that can be
+ * completed by invoking the createFactory method.
  */
-public class FutureEMBuilder extends CompletableFuture<EntityManagerBuilder> implements DDLGenerationParticipant, Comparable<FutureEMBuilder> {
-    private static final TraceComponent tc = Tr.register(FutureEMBuilder.class);
+public class FutureEHFactory extends CompletableFuture<EntityHandlerFactory> //
+                implements DDLGenerationParticipant, Comparable<FutureEHFactory> {
+    private static final TraceComponent tc = Tr.register(FutureEHFactory.class);
     private static final long DDLGEN_WAIT_TIME = 30;
 
     /**
@@ -123,7 +124,7 @@ public class FutureEMBuilder extends CompletableFuture<EntityManagerBuilder> imp
      * @param emf                   entity manager factory.
      * @param dataStore             configured dataStore value of the Repository annotation.
      */
-    FutureEMBuilder(DataProvider provider,
+    FutureEHFactory(DataProvider provider,
                     Class<?> repositoryInterface,
                     ClassLoader repositoryClassLoader,
                     String dataStore) {
@@ -179,7 +180,7 @@ public class FutureEMBuilder extends CompletableFuture<EntityManagerBuilder> imp
     }
 
     /**
-     * Adds a Repository interface represented by this FutureEmBuilder
+     * Adds a Repository interface represented by this FutureEHFactory.
      *
      * @param repositoryInterface repository interface
      */
@@ -192,106 +193,13 @@ public class FutureEMBuilder extends CompletableFuture<EntityManagerBuilder> imp
     }
 
     /**
-     * Registers this future with the DDL generation MBean so that the ddlgen command
-     * will generate DDL for the EntityManagerBuilder produced by this future. <p>
+     * Invoked to complete this future with the resulting EntityHandlerFactory value.
      *
-     * Not all EntityManagerBuilder instances will participate in DDL generation;
-     * only those that use the Persistence Service. This is not determined until the
-     * EntityManagerBuilder has been created. If not participating, a null DDL file
-     * name will be provided and the DDL generation command will skip generation.
-     *
-     * @param appName application name
-     */
-    public void registerDDLGenerationParticipant(String appName) {
-        // Register as a DDL generator for use by the ddlGen command and add to list for cleanup on application stop
-        BundleContext thisbc = FrameworkUtil.getBundle(getClass()).getBundleContext();
-        ServiceRegistration<DDLGenerationParticipant> ddlgenreg = thisbc.registerService(DDLGenerationParticipant.class, this, null);
-        Queue<ServiceRegistration<DDLGenerationParticipant>> ddlgenRegistrations = provider.ddlgeneratorsAllApps.get(appName);
-        if (ddlgenRegistrations == null) {
-            Queue<ServiceRegistration<DDLGenerationParticipant>> empty = new ConcurrentLinkedQueue<>();
-            if ((ddlgenRegistrations = provider.ddlgeneratorsAllApps.putIfAbsent(appName, empty)) == null)
-                ddlgenRegistrations = empty;
-        }
-        ddlgenRegistrations.add(ddlgenreg);
-    }
-
-    @Override
-    @Trivial // defer to EntityManagerBuilder
-    public String getDDLFileName() {
-        try {
-            EntityManagerBuilder builder = get(DDLGEN_WAIT_TIME, TimeUnit.SECONDS);
-            if (builder instanceof DDLGenerationParticipant) {
-                return ((DDLGenerationParticipant) builder).getDDLFileName();
-            }
-        } catch (TimeoutException e) {
-            // DDL generation MBean does not log errors; The following covers both
-            // logging the error and raising an exception with the same message.
-            throw exc(DataException.class,
-                      "CWWKD1067.ddlgen.emf.timeout",
-                      getClassNames(repositoryInterfaces),
-                      dataStore,
-                      DDLGEN_WAIT_TIME,
-                      entityTypes.stream().map(Class::getName).collect(Collectors.toList()));
-        } catch (Throwable ex) {
-            // DDL generation MBean does not log errors; The following covers both
-            // logging the error and raising an exception with the same message.
-            Throwable cause = (ex instanceof ExecutionException) ? ex.getCause() : ex;
-            DataException dx = exc(DataException.class,
-                                   "CWWKD1066.ddlgen.failed",
-                                   getClassNames(repositoryInterfaces),
-                                   dataStore,
-                                   entityTypes.stream() //
-                                                   .map(Class::getName) //
-                                                   .collect(Collectors.toList()),
-                                   cause.getMessage());
-            throw (DataException) dx.initCause(ex);
-        }
-
-        // Not using persistence service; return null and DDL generation will skip this future
-        return null;
-    }
-
-    @Override
-    @Trivial // defer to EntityManagerBuilder
-    public void generate(Writer out) throws Exception {
-        try {
-            EntityManagerBuilder builder = get(DDLGEN_WAIT_TIME, TimeUnit.SECONDS);
-            if (builder instanceof DDLGenerationParticipant) {
-                ((DDLGenerationParticipant) builder).generate(out);
-            }
-        } catch (TimeoutException e) {
-            // DDL generation MBean does not log errors; The following covers both
-            // logging the error and raising an exception with the same message.
-            throw exc(DataException.class,
-                      "CWWKD1065.ddlgen.timeout",
-                      getClassNames(repositoryInterfaces),
-                      dataStore,
-                      DDLGEN_WAIT_TIME,
-                      entityTypes.stream().map(Class::getName).collect(Collectors.toList()));
-        } catch (Throwable ex) {
-            // DDL generation MBean does not log errors; The following covers both
-            // logging the error and raising an exception with the same message.
-            Throwable cause = (ex instanceof ExecutionException) ? ex.getCause() : ex;
-            DataException dx = exc(DataException.class,
-                                   "CWWKD1066.ddlgen.failed",
-                                   getClassNames(repositoryInterfaces),
-                                   dataStore,
-                                   entityTypes.stream() //
-                                                   .map(Class::getName) //
-                                                   .collect(Collectors.toList()),
-                                   cause.getMessage());
-            throw (DataException) dx.initCause(ex);
-        }
-    }
-
-    /**
-     * Invoked to complete this future with the resulting EntityManagerBuilder value.
-     *
-     * @return PUnitEMBuilder (for persistence unit references) or
-     *         DBStoreEMBuilder (data sources, databaseStore)
+     * @return PUnitEHFactory (for persistence units) or
+     *         DBStoreEHFactory (data sources, databaseStore)
      */
     @FFDCIgnore({ NamingException.class, Throwable.class })
-    public EntityManagerBuilder createEMBuilder() {
+    public EntityHandlerFactory createFactory() {
         final boolean trace = TraceComponent.isAnyTracingEnabled();
 
         // Avoid a web container deadlock (#31106) on metadataIdSvc.getMetaData
@@ -384,7 +292,8 @@ public class FutureEMBuilder extends CompletableFuture<EntityManagerBuilder> imp
                                      jndiName + " is the JNDI name for " + resource);
 
                         if (resource instanceof EntityManagerFactory)
-                            return new PUnitEMBuilder(provider, //
+                            return new PUnitEHFactory( //
+                                            provider, //
                                             repositoryClassLoader, //
                                             repositoryInterfaces, //
                                             (EntityManagerFactory) resource, //
@@ -405,7 +314,7 @@ public class FutureEMBuilder extends CompletableFuture<EntityManagerBuilder> imp
 
             boolean javacolon = namespace != null; // any java: namespace
 
-            return new DBStoreEMBuilder(provider, //
+            return new DBStoreEHFactory(provider, //
                             repositoryClassLoader, //
                             repositoryInterfaces, //
                             dataStore, //
@@ -434,12 +343,110 @@ public class FutureEMBuilder extends CompletableFuture<EntityManagerBuilder> imp
         }
     }
 
+    /**
+     * Registers this future with the DDL generation MBean so that the ddlgen command
+     * will generate DDL for the EntityHandlerFactory produced by this future. <p>
+     *
+     * Not all EntityHandlerFactory instances will participate in DDL generation;
+     * only those that use the Persistence Service. This is not determined until the
+     * EntityHandlerFactory has been created. If not participating, a null DDL file
+     * name will be provided and the DDL generation command will skip generation.
+     *
+     * @param appName application name
+     */
+    public void registerDDLGenerationParticipant(String appName) {
+        // Register as a DDL generator for use by the ddlGen command and add to list
+        // for cleanup on application stop
+        BundleContext thisbc = FrameworkUtil.getBundle(getClass()).getBundleContext();
+        ServiceRegistration<DDLGenerationParticipant> ddlgenreg = //
+                        thisbc.registerService(DDLGenerationParticipant.class, this, null);
+        Queue<ServiceRegistration<DDLGenerationParticipant>> ddlgenRegistrations = //
+                        provider.ddlgeneratorsAllApps.get(appName);
+        if (ddlgenRegistrations == null) {
+            Queue<ServiceRegistration<DDLGenerationParticipant>> empty = //
+                            new ConcurrentLinkedQueue<>();
+            if ((ddlgenRegistrations = provider.ddlgeneratorsAllApps //
+                            .putIfAbsent(appName, empty)) == null)
+                ddlgenRegistrations = empty;
+        }
+        ddlgenRegistrations.add(ddlgenreg);
+    }
+
+    @Override
+    @Trivial // defer to EntityHandlerFactory
+    public String getDDLFileName() {
+        try {
+            EntityHandlerFactory factory = get(DDLGEN_WAIT_TIME, TimeUnit.SECONDS);
+            if (factory instanceof DDLGenerationParticipant participant) {
+                return participant.getDDLFileName();
+            }
+        } catch (TimeoutException e) {
+            // DDL generation MBean does not log errors; The following covers both
+            // logging the error and raising an exception with the same message.
+            throw exc(DataException.class,
+                      "CWWKD1067.ddlgen.emf.timeout",
+                      getClassNames(repositoryInterfaces),
+                      dataStore,
+                      DDLGEN_WAIT_TIME,
+                      entityTypes.stream().map(Class::getName).collect(Collectors.toList()));
+        } catch (Throwable ex) {
+            // DDL generation MBean does not log errors; The following covers both
+            // logging the error and raising an exception with the same message.
+            Throwable cause = (ex instanceof ExecutionException) ? ex.getCause() : ex;
+            DataException dx = exc(DataException.class,
+                                   "CWWKD1066.ddlgen.failed",
+                                   getClassNames(repositoryInterfaces),
+                                   dataStore,
+                                   entityTypes.stream() //
+                                                   .map(Class::getName) //
+                                                   .collect(Collectors.toList()),
+                                   cause.getMessage());
+            throw (DataException) dx.initCause(ex);
+        }
+
+        // Not using persistence service; return null and DDL generation will skip this future
+        return null;
+    }
+
+    @Override
+    @Trivial // defer to EntityHandlerFactory
+    public void generate(Writer out) throws Exception {
+        try {
+            EntityHandlerFactory factory = get(DDLGEN_WAIT_TIME, TimeUnit.SECONDS);
+            if (factory instanceof DDLGenerationParticipant participant) {
+                participant.generate(out);
+            }
+        } catch (TimeoutException e) {
+            // DDL generation MBean does not log errors; The following covers both
+            // logging the error and raising an exception with the same message.
+            throw exc(DataException.class,
+                      "CWWKD1065.ddlgen.timeout",
+                      getClassNames(repositoryInterfaces),
+                      dataStore,
+                      DDLGEN_WAIT_TIME,
+                      entityTypes.stream().map(Class::getName).collect(Collectors.toList()));
+        } catch (Throwable ex) {
+            // DDL generation MBean does not log errors; The following covers both
+            // logging the error and raising an exception with the same message.
+            Throwable cause = (ex instanceof ExecutionException) ? ex.getCause() : ex;
+            DataException dx = exc(DataException.class,
+                                   "CWWKD1066.ddlgen.failed",
+                                   getClassNames(repositoryInterfaces),
+                                   dataStore,
+                                   entityTypes.stream() //
+                                                   .map(Class::getName) //
+                                                   .collect(Collectors.toList()),
+                                   cause.getMessage());
+            throw (DataException) dx.initCause(ex);
+        }
+    }
+
     @Override
     @Trivial
     public boolean equals(Object o) {
-        FutureEMBuilder b;
-        return this == o || o instanceof FutureEMBuilder
-                            && dataStore.equals((b = (FutureEMBuilder) o).dataStore)
+        FutureEHFactory b;
+        return this == o || o instanceof FutureEHFactory
+                            && dataStore.equals((b = (FutureEHFactory) o).dataStore)
                             && Objects.equals(application, b.application)
                             && Objects.equals(module, b.module)
                             && Objects.equals(repositoryClassLoader, b.repositoryClassLoader);
@@ -712,12 +719,14 @@ public class FutureEMBuilder extends CompletableFuture<EntityManagerBuilder> imp
      *
      * @param writer writes to the introspection file.
      * @param indent indentation for lines.
-     * @return EntityManagerBuilder if available from this FutureEMBuilder.
+     * @return EntityHandlerFactory if available from this FutureEHFactory
      */
     @FFDCIgnore(Throwable.class)
     @Trivial
-    public Optional<EntityManagerBuilder> introspect(PrintWriter writer, String indent) {
-        writer.println(indent + "FutureEMBuilder@" + Integer.toHexString(hashCode()));
+    public Optional<EntityHandlerFactory> introspect(PrintWriter writer,
+                                                     String indent) {
+        writer.println(indent + "FutureEHFactory@" +
+                       Integer.toHexString(hashCode()));
         writer.println(indent + "  dataStore: " + dataStore);
         writer.println(indent + "  namespace: " + namespace);
         writer.println(indent + "    application: " + application);
@@ -733,13 +742,13 @@ public class FutureEMBuilder extends CompletableFuture<EntityManagerBuilder> imp
             writer.println(indent + "  entity: " + (e == null ? null : e.getName()));
         });
 
-        EntityManagerBuilder builder = null;
+        EntityHandlerFactory factory = null;
         writer.print(indent + "  state: ");
         if (isCancelled())
             writer.println("cancelled");
         else if (isDone())
             try {
-                builder = join();
+                factory = join();
                 writer.println("completed");
             } catch (Throwable x) {
                 writer.println("failed");
@@ -748,8 +757,8 @@ public class FutureEMBuilder extends CompletableFuture<EntityManagerBuilder> imp
         else
             writer.println("not completed");
 
-        writer.println(indent + "  builder: " + builder);
-        return Optional.ofNullable(builder);
+        writer.println(indent + "  factory: " + factory);
+        return Optional.ofNullable(factory);
     }
 
     @Override
@@ -762,7 +771,7 @@ public class FutureEMBuilder extends CompletableFuture<EntityManagerBuilder> imp
         // output in Liberty trace, which prints toString for values and method args
         // but uses uses identityHashCode (id=...) when printing trace for a class
         StringBuilder b = new StringBuilder(len) //
-                        .append("FutureEMBuilder@") //
+                        .append(getClass().getSimpleName()).append('@') //
                         .append(Integer.toHexString(hashCode())) //
                         .append("(id=") //
                         .append(Integer.toHexString(System.identityHashCode(this))) //
@@ -775,7 +784,7 @@ public class FutureEMBuilder extends CompletableFuture<EntityManagerBuilder> imp
     // Ensures order of DDL generation based on fields
     @Override
     @Trivial
-    public int compareTo(FutureEMBuilder o) {
+    public int compareTo(FutureEHFactory o) {
         if (this.equals(o)) {
             return 0;
         }

--- a/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/cdi/RepositoryProducer.java
+++ b/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/cdi/RepositoryProducer.java
@@ -42,7 +42,7 @@ import com.ibm.ws.threadContext.ComponentMetaDataAccessorImpl;
 import io.openliberty.checkpoint.spi.CheckpointPhase;
 import io.openliberty.data.internal.DataProvider;
 import io.openliberty.data.internal.DataVersionCompatibility;
-import io.openliberty.data.internal.EntityManagerBuilder;
+import io.openliberty.data.internal.EntityHandlerFactory;
 import io.openliberty.data.internal.QueryInfo;
 import io.openliberty.data.internal.RepositoryImpl;
 import io.openliberty.data.internal.Util;
@@ -71,7 +71,7 @@ public class RepositoryProducer<R> implements Producer<R>, ProducerFactory<R>, B
     private final static TraceComponent tc = Tr.register(RepositoryProducer.class);
 
     /**
-     * Amount of time in seconds to wait for an EntityManagerBuilder to become
+     * Amount of time in seconds to wait for an EntityHandlerFactory to become
      * available.
      */
     private static final long INIT_TIMEOUT_SEC = TimeUnit.MINUTES.toSeconds(5);
@@ -93,9 +93,9 @@ public class RepositoryProducer<R> implements Producer<R>, ProducerFactory<R>, B
     private final Set<Type> beanTypes;
 
     /**
-     * Future for the EntityManagerBuilder.
+     * Future for the EntityHandlerFactory.
      */
-    private FutureEMBuilder futureEMBuilder;
+    private FutureEHFactory futureEHFactory;
 
     /**
      * CDI extension for the Jakarta Data provider.
@@ -143,7 +143,7 @@ public class RepositoryProducer<R> implements Producer<R>, ProducerFactory<R>, B
 
     /**
      * Construct an instance of RepositoryProducer.
-     * The instance is not usable until setFutureEMBuilder and setPrimaryEntityClass
+     * The instance is not usable until setFutureEHFactory and setPrimaryEntityClass
      * are invoked on it.
      *
      * @param repositoryInterface   the repository interface.
@@ -186,7 +186,7 @@ public class RepositoryProducer<R> implements Producer<R>, ProducerFactory<R>, B
 
     /**
      * Error handling for a timeout that occurs when attempting to obtain an
-     * EntityManagerBuilder.
+     * EntityHandlerFactory.
      *
      * @param repositoryInterface the repository interface.
      * @param cause               the TimeoutException.
@@ -201,15 +201,15 @@ public class RepositoryProducer<R> implements Producer<R>, ProducerFactory<R>, B
             x = exc(DataException.class,
                     "CWWKD1106.init.timed.out",
                     repositoryInterface.getName(),
-                    futureEMBuilder.dataStore,
-                    futureEMBuilder.jeeName,
+                    futureEHFactory.dataStore,
+                    futureEHFactory.jeeName,
                     INIT_TIMEOUT_SEC);
         } else { // during checkpoint
             ComponentMetaData metadata = ComponentMetaDataAccessorImpl //
                             .getComponentMetaDataAccessor() //
                             .getComponentMetaData();
             J2EEName jeeName = metadata == null //
-                            ? futureEMBuilder.jeeName //
+                            ? futureEHFactory.jeeName //
                             : metadata.getJ2EEName();
 
             x = exc(DataException.class,
@@ -313,8 +313,8 @@ public class RepositoryProducer<R> implements Producer<R>, ProducerFactory<R>, B
         });
 
         writer.println();
-        if (futureEMBuilder != null)
-            futureEMBuilder.introspect(writer, "  " + indent);
+        if (futureEHFactory != null)
+            futureEHFactory.introspect(writer, "  " + indent);
 
         return queryInfos;
     }
@@ -357,15 +357,21 @@ public class RepositoryProducer<R> implements Producer<R>, ProducerFactory<R>, B
                             Tr.debug(this, tc, "add " + anno + " for " + method.getAnnotated().getJavaMember());
                     }
 
-            EntityManagerBuilder builder = futureEMBuilder.get(INIT_TIMEOUT_SEC, //
+            EntityHandlerFactory factory = futureEHFactory.get(INIT_TIMEOUT_SEC, //
                                                                TimeUnit.SECONDS);
 
-            RepositoryImpl<?> handler = new RepositoryImpl<>(provider, extension, builder, //
-                            repositoryInterface, primaryEntityClass, queriesPerEntityClass);
+            RepositoryImpl<?> handler = new RepositoryImpl<>( //
+                            provider, //
+                            extension, //
+                            factory, //
+                            repositoryInterface, //
+                            primaryEntityClass, //
+                            queriesPerEntityClass);
 
-            R instance = repositoryInterface.cast(Proxy.newProxyInstance(repositoryInterface.getClassLoader(),
-                                                                         new Class<?>[] { repositoryInterface },
-                                                                         handler));
+            R instance = repositoryInterface.cast(Proxy //
+                            .newProxyInstance(repositoryInterface.getClassLoader(),
+                                              new Class<?>[] { repositoryInterface },
+                                              handler));
 
             if (intercept) {
                 R r = interception.createInterceptedInstance(instance);
@@ -420,16 +426,16 @@ public class RepositoryProducer<R> implements Producer<R>, ProducerFactory<R>, B
     }
 
     /**
-     * Assigns the FutureEMBuilder for this repository producer.
+     * Assigns the FutureEHFactory for this repository producer.
      *
-     * @param futureEMBuilder future for an EntityManagerBuilder.
+     * @param futureEHFactory future for an EntityHandlerFactory
      */
     @Trivial
-    void setFutureEMBuilder(FutureEMBuilder futureEMBuilder) {
+    void setFutureEHFactory(FutureEHFactory futureEHFactory) {
         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
-            Tr.debug(this, tc, "setFutureEMBuilder", futureEMBuilder);
+            Tr.debug(this, tc, "setFutureEHFactory", futureEHFactory);
 
-        this.futureEMBuilder = futureEMBuilder;
+        this.futureEHFactory = futureEHFactory;
     }
 
     /**

--- a/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/cdi/StatefulPersistenceContext.java
+++ b/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/cdi/StatefulPersistenceContext.java
@@ -19,7 +19,7 @@ import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.ws.LocalTransaction.LocalTransactionCoordinator;
 
 import io.openliberty.data.internal.DataProvider;
-import io.openliberty.data.internal.EntityManagerBuilder;
+import io.openliberty.data.internal.EntityHandlerFactory;
 import io.openliberty.data.internal.Util;
 import jakarta.annotation.PreDestroy;
 import jakarta.enterprise.context.RequestScoped;
@@ -30,7 +30,7 @@ import jakarta.transaction.Status;
  * Manages the life cycle of persistence context (an EntityManager)
  * for each (request scope, repository group) combination in which a
  * stateful repository is accessed. A repository group is represented
- * by an EntityManagerBuilder. The same EntityManager should be used
+ * by an EntityHandlerFactory. The same EntityManager should be used
  * throughout the life cycle of the request scope and closed when the
  * scope ends.
  */
@@ -41,10 +41,10 @@ public class StatefulPersistenceContext {
 
     /**
      * Keeps track of the active EntityManager instance for each
-     * repository group (EntityManagerBuilder) that is used within
+     * repository group (EntityHandlerFactory) that is used within
      * the scope of the current request.
      */
-    private final Map<EntityManagerBuilder, EntityManager> entityManagers = //
+    private final Map<EntityHandlerFactory, EntityManager> entityManagers = //
                     new ConcurrentHashMap<>();
 
     /**
@@ -54,11 +54,11 @@ public class StatefulPersistenceContext {
     private void dispose() throws Exception {
         final boolean trace = TraceComponent.isAnyTracingEnabled();
 
-        for (Iterator<Entry<EntityManagerBuilder, EntityManager>> it = //
+        for (Iterator<Entry<EntityHandlerFactory, EntityManager>> it = //
                         entityManagers.entrySet().iterator(); //
                         it.hasNext();)
             try {
-                Entry<EntityManagerBuilder, EntityManager> entry = it.next();
+                Entry<EntityHandlerFactory, EntityManager> entry = it.next();
                 DataProvider provider = entry.getKey().provider;
                 EntityManager em = entry.getValue();
 
@@ -133,17 +133,17 @@ public class StatefulPersistenceContext {
 
     /**
      * Obtains the EntityManager instance for the current request scope and
-     * the given builder, which represents a group of one or more repositories
+     * the given factory, which represents a group of one or more repositories
      * that share the same dataStore. If one does not exist yet, then the
-     * builder is used to create a new EntityManager to associate with the
+     * factory is used to create a new EntityManager to associate with the
      * current request scope.
      *
-     * @param builder builder that creates an EntityManager for a group of
+     * @param factory factory that creates an EntityManager for a group of
      *                    one or more repositories that have the same dataStore.
      * @return EntityManager instance.
      */
-    public EntityManager get(EntityManagerBuilder builder) {
-        return entityManagers.computeIfAbsent(builder,
-                                              EntityManagerBuilder::createEntityManager);
+    public EntityManager get(EntityHandlerFactory factory) {
+        return entityManagers.computeIfAbsent(factory,
+                                              EntityHandlerFactory::createEntityManager);
     }
 }

--- a/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/provider/PUnitEHFactory.java
+++ b/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/provider/PUnitEHFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023,2025 IBM Corporation and others.
+ * Copyright (c) 2023,2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -26,17 +26,19 @@ import com.ibm.websphere.ras.annotation.Trivial;
 import com.ibm.ws.ffdc.annotation.FFDCIgnore;
 
 import io.openliberty.data.internal.DataProvider;
-import io.openliberty.data.internal.EntityManagerBuilder;
+import io.openliberty.data.internal.EntityHandlerFactory;
 import jakarta.persistence.CacheRetrieveMode;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.EntityManagerFactory;
 import jakarta.persistence.PersistenceException;
 
 /**
- * This builder is used when a persistence unit reference JNDI name is configured as the repository dataStore.
+ * This factory is used when the repository dataStore is configure to be a
+ * persistence unit name (Data 1.1+) or
+ * persistence unit reference JNDI name.
  */
-public class PUnitEMBuilder extends EntityManagerBuilder {
-    private static final TraceComponent tc = Tr.register(PUnitEMBuilder.class);
+public class PUnitEHFactory extends EntityHandlerFactory {
+    private static final TraceComponent tc = Tr.register(PUnitEHFactory.class);
 
     private final EntityManagerFactory emf;
 
@@ -52,7 +54,7 @@ public class PUnitEMBuilder extends EntityManagerBuilder {
      * @param entityTypes           entity classes as known by the user, not generated.
      * @throws Exception if an error occurs.
      */
-    public PUnitEMBuilder(DataProvider provider,
+    public PUnitEHFactory(DataProvider provider,
                           ClassLoader repositoryClassLoader,
                           Set<Class<?>> repositoryInterfaces,
                           EntityManagerFactory emf,
@@ -116,7 +118,7 @@ public class PUnitEMBuilder extends EntityManagerBuilder {
     @Trivial
     public String toString() {
         return new StringBuilder(27 + dataStore.length()) //
-                        .append("PUnitEMBuilder@") //
+                        .append(getClass().getSimpleName()).append('@') //
                         .append(Integer.toHexString(hashCode())) //
                         .append(":").append(dataStore) //
                         .toString();

--- a/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/service/DBStoreEHFactory.java
+++ b/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/service/DBStoreEHFactory.java
@@ -64,8 +64,8 @@ import com.ibm.wsspi.resource.ResourceConfig;
 import com.ibm.wsspi.resource.ResourceFactory;
 
 import io.openliberty.data.internal.DataProvider;
+import io.openliberty.data.internal.EntityHandlerFactory;
 import io.openliberty.data.internal.EntityInfo;
-import io.openliberty.data.internal.EntityManagerBuilder;
 import io.openliberty.data.internal.Util;
 import io.openliberty.data.internal.orm.EntityParser;
 import jakarta.data.exceptions.DataException;
@@ -75,14 +75,18 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.EntityManager;
 
 /**
- * This builder is used when a data source JNDI name, id, resource reference,
- * or a dataStore id is configured as the repository dataStore.
- * It creates entity managers from a PersistenceServiceUnit from the persistence service.
+ * This factory is used when the repository dataStore is configured to be a
+ * data source JNDI name,
+ * data source id,
+ * data source resource reference, or
+ * dataStore id.
+ * It uses a PersistenceServiceUnit from the persistence service to create
+ * EntityAgent and EntityManager instances.
  */
-public class DBStoreEMBuilder extends EntityManagerBuilder implements DDLGenerationParticipant {
+public class DBStoreEHFactory extends EntityHandlerFactory implements DDLGenerationParticipant {
     private static final long MAX_WAIT_FOR_SERVICE_NS = TimeUnit.SECONDS.toNanos(60);
 
-    private static final TraceComponent tc = Tr.register(DBStoreEMBuilder.class);
+    private static final TraceComponent tc = Tr.register(DBStoreEHFactory.class);
 
     private final ClassDefiner classDefiner = new ClassDefiner();
 
@@ -129,7 +133,7 @@ public class DBStoreEMBuilder extends EntityManagerBuilder implements DDLGenerat
      * @param entityTypes           entity classes as known by the user, not generated.
      * @throws Exception if an error occurs.
      */
-    public DBStoreEMBuilder(DataProvider provider,
+    public DBStoreEHFactory(DataProvider provider,
                             ClassLoader repositoryClassLoader,
                             Set<Class<?>> repositoryInterfaces,
                             String dataStore,
@@ -669,7 +673,7 @@ public class DBStoreEMBuilder extends EntityManagerBuilder implements DDLGenerat
     @Trivial
     public String toString() {
         return new StringBuilder(26 + configDisplayId.length()) //
-                        .append("DBStoreEMBuilder@") //
+                        .append(getClass().getSimpleName()).append('@') //
                         .append(Integer.toHexString(hashCode())) //
                         .append(":").append(configDisplayId) //
                         .toString();
@@ -683,8 +687,8 @@ public class DBStoreEMBuilder extends EntityManagerBuilder implements DDLGenerat
      */
     @Override
     public void generate(Writer out) throws Exception {
-        // Note that exceptions thrown here or by the persistence service will be logged by the
-        // direct caller (FutureEMBuilder) or the DDL generation MBean.
+        // Note that exceptions thrown here or by the persistence service will be
+        // logged by the direct caller (FutureEHFactory) or the DDL generation MBean.
         if (persistenceServiceUnit == null) {
             throw new IllegalStateException("EntityManagerFactory for Jakarta Data repository has not been initialized for the " + configDisplayId + " DatabaseStore.");
         }

--- a/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/service/RecordTransformer.java
+++ b/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/service/RecordTransformer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024,2025 IBM Corporation and others.
+ * Copyright (c) 2024,2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -9,7 +9,7 @@
  *******************************************************************************/
 package io.openliberty.data.internal.service;
 
-import static io.openliberty.data.internal.EntityManagerBuilder.getClassNames;
+import static io.openliberty.data.internal.EntityHandlerFactory.getClassNames;
 import static io.openliberty.data.internal.cdi.DataExtension.exc;
 import static org.objectweb.asm.Opcodes.ACC_PRIVATE;
 import static org.objectweb.asm.Opcodes.ACC_PUBLIC;

--- a/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/v1_0/QueryInfo_1_0.java
+++ b/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/v1_0/QueryInfo_1_0.java
@@ -38,6 +38,8 @@ import jakarta.data.repository.OrderBy;
 import jakarta.data.repository.Query;
 import jakarta.data.repository.Save;
 import jakarta.data.repository.Update;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.TypedQuery;
 
 /**
  * QueryInfo implementation for Jakarta Data 1.0.
@@ -124,6 +126,47 @@ public class QueryInfo_1_0 extends QueryInfo {
                         expression, //
                         sort.isAscending(), //
                         sort.ignoreCase());
+    }
+
+    @Override
+    @Trivial
+    protected jakarta.persistence.Query ehCreateQuery(AutoCloseable entityHandler,
+                                                      String jpql) {
+        return ((EntityManager) entityHandler).createQuery(jpql);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    @Trivial
+    protected <T> TypedQuery<T> ehCreateTypedQuery(AutoCloseable entityHandler,
+                                                   String jpql,
+                                                   Class<?> resultType) {
+        return (TypedQuery<T>) ((EntityManager) entityHandler) //
+                        .createQuery(jpql, resultType);
+    }
+
+    @Override
+    @Trivial
+    protected void ehDelete(AutoCloseable entityHandler, Object entity) {
+        ((EntityManager) entityHandler).remove(entity);
+    }
+
+    @Override
+    @Trivial
+    protected void ehInsert(AutoCloseable entityHandler, Object entity) {
+        ((EntityManager) entityHandler).persist(entity);
+    }
+
+    @Override
+    @Trivial
+    protected Object ehUpdate(AutoCloseable entityHandler, Object entity) {
+        return ((EntityManager) entityHandler).merge(entity);
+    }
+
+    @Override
+    @Trivial
+    protected Object ehUpsert(AutoCloseable entityHandler, Object entity) {
+        return ((EntityManager) entityHandler).merge(entity);
     }
 
     @Override

--- a/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/v1_1/QueryInfo_1_1.java
+++ b/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/v1_1/QueryInfo_1_1.java
@@ -103,6 +103,7 @@ import jakarta.data.spi.expression.function.TextFunctionExpression;
 import jakarta.data.spi.expression.literal.Literal;
 import jakarta.data.spi.expression.path.NavigablePath;
 import jakarta.data.spi.expression.path.Path;
+import jakarta.persistence.Entity;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.TypedQuery;
 
@@ -416,7 +417,9 @@ public class QueryInfo_1_1 extends QueryInfo {
             manager.remove(entity);
         else
             try {
-                entityHandler.getClass().getMethod("delete").invoke(entity);
+                entityHandler.getClass() //
+                                .getMethod("delete", Entity.class) //
+                                .invoke(entityHandler, entity);
             } catch (IllegalAccessException | NoSuchMethodException x) {
                 throw new RuntimeException(x); // should be impossible
             } catch (InvocationTargetException x) {
@@ -437,7 +440,9 @@ public class QueryInfo_1_1 extends QueryInfo {
             manager.persist(entity);
         else
             try {
-                entityHandler.getClass().getMethod("insert").invoke(entity);
+                entityHandler.getClass() //
+                                .getMethod("insert", Entity.class) //
+                                .invoke(entityHandler, entity);
             } catch (IllegalAccessException | NoSuchMethodException x) {
                 throw new RuntimeException(x); // should be impossible
             } catch (InvocationTargetException x) {
@@ -459,8 +464,9 @@ public class QueryInfo_1_1 extends QueryInfo {
             updated = manager.merge(entity);
         else
             try {
-                updated = entityHandler.getClass().getMethod("update") //
-                                .invoke(entity);
+                updated = entityHandler.getClass() //
+                                .getMethod("update", Entity.class) //
+                                .invoke(entityHandler, entity);
             } catch (IllegalAccessException | NoSuchMethodException x) {
                 throw new RuntimeException(x); // should be impossible
             } catch (InvocationTargetException x) {
@@ -483,8 +489,9 @@ public class QueryInfo_1_1 extends QueryInfo {
             upserted = manager.merge(entity);
         else
             try {
-                upserted = entityHandler.getClass().getMethod("upsert") //
-                                .invoke(entity);
+                upserted = entityHandler.getClass() //
+                                .getMethod("upsert", Entity.class) //
+                                .invoke(entityHandler, entity);
             } catch (IllegalAccessException | NoSuchMethodException x) {
                 throw new RuntimeException(x); // should be impossible
             } catch (InvocationTargetException x) {

--- a/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/v1_1/QueryInfo_1_1.java
+++ b/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/v1_1/QueryInfo_1_1.java
@@ -24,6 +24,7 @@ import static io.openliberty.data.internal.QueryType.REMOVE;
 import static io.openliberty.data.internal.QueryType.SAVE;
 
 import java.lang.annotation.Annotation;
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -71,6 +72,7 @@ import jakarta.data.constraint.NotIn;
 import jakarta.data.constraint.NotLike;
 import jakarta.data.constraint.NotNull;
 import jakarta.data.constraint.Null;
+import jakarta.data.exceptions.DataException;
 import jakarta.data.expression.Expression;
 import jakarta.data.expression.NavigableExpression;
 import jakarta.data.expression.TemporalExpression;
@@ -101,6 +103,8 @@ import jakarta.data.spi.expression.function.TextFunctionExpression;
 import jakarta.data.spi.expression.literal.Literal;
 import jakarta.data.spi.expression.path.NavigablePath;
 import jakarta.data.spi.expression.path.Path;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.TypedQuery;
 
 /**
  * QueryInfo implementation for Jakarta Data 1.1.
@@ -358,6 +362,136 @@ public class QueryInfo_1_1 extends QueryInfo {
                         sort.isAscending(), //
                         sort.ignoreCase(), //
                         sort.nullOrdering());
+    }
+
+    @Override
+    @Trivial
+    protected jakarta.persistence.Query ehCreateQuery(AutoCloseable entityHandler,
+                                                      String jpql) {
+        // TODO Persistence 4.0 API
+        //return entityHandler instanceof EntityHandler handler //
+        //                ? handler.createQuery(jpql) //
+        //                : super.ehCreateQuery(entityHandler, jpql);
+        try {
+            return (jakarta.persistence.Query) entityHandler.getClass() //
+                            .getMethod("createQuery", String.class) //
+                            .invoke(entityHandler, jpql);
+        } catch (IllegalAccessException | //
+                        InvocationTargetException | //
+                        NoSuchMethodException x) {
+            throw new RuntimeException(x); // should be impossible
+        }
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    @Trivial
+    protected <T> TypedQuery<T> ehCreateTypedQuery(AutoCloseable entityHandler,
+                                                   String jpql,
+                                                   Class<?> resultType) {
+        // TODO Persistence 4.0 API
+        //return entityHandler instanceof EntityHandler handler //
+        //                ? handler.createQuery(jpql, resultType) //
+        //                : super.ehCreateQuery(entityHandler, jpql, resultType);
+        try {
+            return (TypedQuery<T>) entityHandler.getClass() //
+                            .getMethod("createQuery", String.class, Class.class) //
+                            .invoke(entityHandler, jpql, resultType);
+        } catch (IllegalAccessException | //
+                        InvocationTargetException | //
+                        NoSuchMethodException x) {
+            throw new RuntimeException(x); // should be impossible
+        }
+    }
+
+    @Override
+    @Trivial
+    protected void ehDelete(AutoCloseable entityHandler, Object entity) {
+        // TODO Persistence 4.0 API
+        // return entityHandler instanceof EntityAgent agent //
+        //                ? agent.delete(entity) //
+        //                : ((EntityManager) entityHandler).remove(entity);
+
+        if (entityHandler instanceof EntityManager manager)
+            manager.remove(entity);
+        else
+            try {
+                entityHandler.getClass().getMethod("delete").invoke(entity);
+            } catch (IllegalAccessException | NoSuchMethodException x) {
+                throw new RuntimeException(x); // should be impossible
+            } catch (InvocationTargetException x) {
+                throw new DataException(x.getCause());
+            }
+        // TODO deleteMultiple
+    }
+
+    @Override
+    @Trivial
+    protected void ehInsert(AutoCloseable entityHandler, Object entity) {
+        // TODO Persistence 4.0 API
+        // return entityHandler instanceof EntityAgent agent //
+        //                ? agent.insert(entity) //
+        //                : ((EntityManager) entityHandler).persist(entity);
+
+        if (entityHandler instanceof EntityManager manager)
+            manager.persist(entity);
+        else
+            try {
+                entityHandler.getClass().getMethod("insert").invoke(entity);
+            } catch (IllegalAccessException | NoSuchMethodException x) {
+                throw new RuntimeException(x); // should be impossible
+            } catch (InvocationTargetException x) {
+                throw new DataException(x.getCause());
+            }
+        // TODO insertMultiple
+    }
+
+    @Override
+    @Trivial
+    protected Object ehUpdate(AutoCloseable entityHandler, Object entity) {
+        // TODO Persistence 4.0 API
+        // return entityHandler instanceof EntityAgent agent //
+        //                ? agent.update(entity) //
+        //                : ((EntityManager) entityHandler).merge(entity);
+
+        Object updated;
+        if (entityHandler instanceof EntityManager manager)
+            updated = manager.merge(entity);
+        else
+            try {
+                updated = entityHandler.getClass().getMethod("update") //
+                                .invoke(entity);
+            } catch (IllegalAccessException | NoSuchMethodException x) {
+                throw new RuntimeException(x); // should be impossible
+            } catch (InvocationTargetException x) {
+                throw new DataException(x.getCause());
+            }
+        // TODO updateMultiple
+        return updated;
+    }
+
+    @Override
+    @Trivial
+    protected Object ehUpsert(AutoCloseable entityHandler, Object entity) {
+        // TODO Persistence 4.0 API
+        // return entityHandler instanceof EntityAgent agent //
+        //                ? agent.upsert(entity) //
+        //                : ((EntityManager) entityHandler).merge(entity);
+
+        Object upserted;
+        if (entityHandler instanceof EntityManager manager)
+            upserted = manager.merge(entity);
+        else
+            try {
+                upserted = entityHandler.getClass().getMethod("upsert") //
+                                .invoke(entity);
+            } catch (IllegalAccessException | NoSuchMethodException x) {
+                throw new RuntimeException(x); // should be impossible
+            } catch (InvocationTargetException x) {
+                throw new DataException(x.getCause());
+            }
+        // TODO upsertMultiple
+        return upserted;
     }
 
     /**


### PR DESCRIPTION
In Data 1.1, EntityManager and the new EntityAgent both inherit from EntityHandler (also new) which inherits from AutoCloseable.  Rename Data classes, methods, and fields, and use common types so an implementation can be either 1.0 or 1.1.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
