### PR TITLE
Issue 34857: Fix AlreadyBound exception with EJB remote JNDI

### DIFF
--- a/dev/com.ibm.ws.ejbcontainer.core/src/com/ibm/ejs/container/HomeRecord.java
+++ b/dev/com.ibm.ws.ejbcontainer.core/src/com/ibm/ejs/container/HomeRecord.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2004, 2013 IBM Corporation and others.
+ * Copyright (c) 2004, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -66,6 +66,11 @@ public class HomeRecord
     // d457053
     private Boolean ivShortDefaultBindingsEnabled = null;
 
+    /**
+     * Remote bindings were deferred until the ORB service is available.
+     */
+    public volatile boolean remoteBindingDeferred;
+
     //LIDB859-4
     public HomeRecord(BeanMetaData bmd,
                       HomeOfHomes homeOfHomes) //d200714
@@ -91,7 +96,7 @@ public class HomeRecord
     /**
      * getAppName returns the <code>String</code> that represents
      * the name of the application that this EJB resides in.
-     * 
+     *
      * @return <code>String</code> representing the name of the Application
      */
     //d390389
@@ -103,9 +108,9 @@ public class HomeRecord
     /**
      * getTargetHome returns the <code>EJSHome</code> associated with the indicated
      * child bean.
-     * 
+     *
      * @param child String representing the child bean to be found.
-     * 
+     *
      * @return <code>EJSHome</code> associated with the child HomeRecord.
      */
     public EJSHome getTargetHome(String child)
@@ -132,7 +137,7 @@ public class HomeRecord
 
     /**
      * getBeanMetaData returns the bean metadata for this <code>HomeRecord</code>.
-     * 
+     *
      * @return <code>BeanMetaData</code> associated with this HomeRecord.
      */
     public BeanMetaData getBeanMetaData() {
@@ -141,7 +146,7 @@ public class HomeRecord
 
     /**
      * getJ2EEName returns the Java EE name of the EJB associated with this <code>HomeRecord</code>.<p>
-     * 
+     *
      * @return <code>J2EEName</code> associated with this HomeRecord.
      */
     public J2EEName getJ2EEName() {
@@ -150,7 +155,7 @@ public class HomeRecord
 
     /**
      * getJndiName returns the jndiname of the EJB associated with this <code>HomeRecord</code>.<p>
-     * 
+     *
      * @return <code>String</code> representing the jndiName associated with this HomeRecord.
      */
     public String getJndiName() {
@@ -160,9 +165,9 @@ public class HomeRecord
     /**
      * getJndiName returns the jndiname of the EJB associated with this <code>HomeRecord</code>.
      * This method is only needed because HomeRecord implements PMHomeInfo. <p>
-     * 
+     *
      * @param pkey <code>Object</code> representing the PrimaryKey... however it is not used.
-     * 
+     *
      * @return <code>String</code> representing the jndiName associated with this HomeRecord.
      */
     public String getJNDIName(Object pkey)
@@ -187,7 +192,7 @@ public class HomeRecord
     /**
      * getHome() is called to return the <code>EJSHome</code> reference
      * stored in this HomeRecord. <p>
-     * 
+     *
      * @return <code>EJSHome</code> associated with this HomeRecord.
      **/
     //199071
@@ -202,7 +207,7 @@ public class HomeRecord
      * of this EJB has been deferred. In that case the EJB initialization will be triggered
      * from this method.
      * <p>
-     * 
+     *
      * @return <code>EJSHome</code> associated with this HomeRecord.
      */
     public EJSHome getHomeAndInitialize() // d648522
@@ -266,7 +271,7 @@ public class HomeRecord
 
     /**
      * Return string representation of this HomeRecord. <p>
-     * 
+     *
      * Overridden to improve trace.
      */
     // d196581.1
@@ -284,12 +289,12 @@ public class HomeRecord
     /**
      * Provides a mechanism for reading the system property for disabling short
      * form default bindings. <p>
-     * 
+     *
      * com.ibm.websphere.ejbcontainer.disableShortDefaultBindings <p>
-     * 
+     *
      * This property can be used to identify applications for which Short form
      * default jndi bindings are to be disabled.
-     * 
+     *
      * @return true if short default interface bindings are enabled, and false
      *         if the property indicated they were to be disabled for
      *         the specified application name.
@@ -320,8 +325,8 @@ public class HomeRecord
         // bind all session beans and named managed beans
         return ((bmd.isSessionBean() &&
                  bmd._moduleMetaData.getEJBApplicationMetaData().isBindToJavaGlobal() && // F743-33812CdRv
-        bmd.enterpriseBeanName.indexOf('/') == -1) || // d724614
-        (bmd.isManagedBean() && !bmd.enterpriseBeanName.startsWith("$")));
+                 bmd.enterpriseBeanName.indexOf('/') == -1) || // d724614
+                (bmd.isManagedBean() && !bmd.enterpriseBeanName.startsWith("$")));
     }
 
     /**
@@ -353,7 +358,7 @@ public class HomeRecord
         // All bean types except managed beans are bound here
         return !bmd.isManagedBean() &&
                (!bmd.isSessionBean() ||
-               bmd._moduleMetaData.getEJBApplicationMetaData().isBindToServerRoot()); // F743-33812CdRv
+                bmd._moduleMetaData.getEJBApplicationMetaData().isBindToServerRoot()); // F743-33812CdRv
     }
 
 } // HomeRecord

--- a/dev/com.ibm.ws.ejbcontainer.core/src/com/ibm/ws/ejbcontainer/runtime/AbstractEJBRuntime.java
+++ b/dev/com.ibm.ws.ejbcontainer.core/src/com/ibm/ws/ejbcontainer/runtime/AbstractEJBRuntime.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 1997, 2022 IBM Corporation and others.
+ * Copyright (c) 1997, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -1038,7 +1038,7 @@ public abstract class AbstractEJBRuntime implements EJBRuntime, InjectionMetaDat
             List<HomeRecord> hrs = ivContainer.getHomeOfHomes().getAllHomeRecords();
 
             for (HomeRecord hr : hrs) {
-                if (hr.bindToContextRoot()) {
+                if (hr.remoteBindingDeferred && hr.bindToContextRoot()) {
                     BeanMetaData bmd = hr.getBeanMetaData();
 
                     if (isTraceOn && tc.isDebugEnabled())
@@ -1054,6 +1054,7 @@ public abstract class AbstractEJBRuntime implements EJBRuntime, InjectionMetaDat
                             bindRemoteInterfaceToContextRoot(binders, hr, remoteInterfaceName, interfaceIndex++);
                         }
                     }
+                    hr.remoteBindingDeferred = false;
                 }
             }
         }

--- a/dev/com.ibm.ws.ejbcontainer.remote.config_fat/fat/src/com/ibm/ws/ejbcontainer/remote/config/fat/tests/RebindConfigUpdateTest.java
+++ b/dev/com.ibm.ws.ejbcontainer.remote.config_fat/fat/src/com/ibm/ws/ejbcontainer/remote/config/fat/tests/RebindConfigUpdateTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023, 2025 IBM Corporation and others.
+ * Copyright (c) 2023, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -14,6 +14,7 @@ package com.ibm.ws.ejbcontainer.remote.config.fat.tests;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 import java.util.HashSet;
 import java.util.List;
@@ -319,7 +320,6 @@ public class RebindConfigUpdateTest extends FATServletClient {
      * Note: For this scenario, the application should not be restarted after the configuration update.
      */
     @Test
-    @Ignore("ORB restart not supported on Liberty") //TODO
     public void testRebindAfterEjbContainerUpdated() throws Exception {
         server.startServer();
         verifyBindings(server, ALL_LOCAL_BINDINGS, ALL_REMOTE_BINDINGS);
@@ -364,9 +364,10 @@ public class RebindConfigUpdateTest extends FATServletClient {
     public void testRebindAfterOrbLateStart() throws Exception {
         List<Element> removed = removeQuickStartConfig();
         server_ssl.startServer();
-        assertNotNull("Security service did not report it was ready", server.waitForStringInLogUsingMark("CWWKS0008I"));
-        assertNotNull("LTPA configuration did not report it was ready", server.waitForStringInLogUsingMark("CWWKS4105I"));
-        assertNotNull("ORB did not report it was ready", server.waitForStringInLogUsingMark("CWWKI0001I"));
+        // Security service and ORB will not start without QuickStartSecurity
+        assertTrue("Security service reported it was ready", server_ssl.findStringsInLogsUsingMark("CWWKS0008I", server_ssl.getDefaultLogFile()).isEmpty());
+        assertNotNull("LTPA configuration did not report it was ready", server_ssl.waitForStringInLogUsingMark("CWWKS4105I"));
+        assertTrue("ORB reported it was ready", server_ssl.findStringsInLogsUsingMark("CWWKI0001I", server_ssl.getDefaultLogFile()).isEmpty());
         expected_ssl_exceptions = new String[] { "CWWKS9582E", "CWWKS9660E" }; // No user registry
 
         verifyBindings(server_ssl, ALL_LOCAL_BINDINGS, 0);
@@ -389,9 +390,9 @@ public class RebindConfigUpdateTest extends FATServletClient {
     @ExpectedFFDC("com.ibm.wsspi.injectionengine.InjectionException")
     public void testRebindAfterOrbStoppedStarted() throws Exception {
         server_ssl.startServer();
-        assertNotNull("Security service did not report it was ready", server.waitForStringInLogUsingMark("CWWKS0008I"));
-        assertNotNull("LTPA configuration did not report it was ready", server.waitForStringInLogUsingMark("CWWKS4105I"));
-        assertNotNull("ORB did not report it was ready", server.waitForStringInLogUsingMark("CWWKI0001I"));
+        assertNotNull("Security service did not report it was ready", server_ssl.waitForStringInLogUsingMark("CWWKS0008I"));
+        assertNotNull("LTPA configuration did not report it was ready", server_ssl.waitForStringInLogUsingMark("CWWKS4105I"));
+        assertNotNull("ORB did not report it was ready", server_ssl.waitForStringInLogUsingMark("CWWKI0001I"));
         expected_ssl_exceptions = new String[] { "CWWKS9582E" }; // ORB did not start in 10 seconds
 
         verifyBindings(server_ssl, ALL_LOCAL_BINDINGS, ALL_REMOTE_BINDINGS);

--- a/dev/com.ibm.ws.ejbcontainer.remote.config_fat/publish/servers/com.ibm.ws.ejbcontainer.remote.config.fat.server.ssl/server.xml
+++ b/dev/com.ibm.ws.ejbcontainer.remote.config_fat/publish/servers/com.ibm.ws.ejbcontainer.remote.config.fat.server.ssl/server.xml
@@ -36,5 +36,6 @@
     <ssl id="defaultSSLConfig" keyStoreRef="defaultKeyStore" clientAuthenticationSupported="true" />
     <keyStore id="defaultKeyStore" password="{xor}EzY9Oi0rJg==" /> <!-- pwd: Liberty, expires1/4/2099 -->
     <quickStartSecurity userName="bob" userPassword="mypwd" />
+    <ltpa keysPassword="WebAS" /> <!-- pragma: allowlist secret -->
 
 </server>

--- a/dev/com.ibm.ws.ejbcontainer/src/com/ibm/ws/ejbcontainer/osgi/internal/EJBRuntimeImpl.java
+++ b/dev/com.ibm.ws.ejbcontainer/src/com/ibm/ws/ejbcontainer/osgi/internal/EJBRuntimeImpl.java
@@ -247,6 +247,7 @@ public class EJBRuntimeImpl extends AbstractEJBRuntime implements ApplicationSta
     private final AtomicServiceReference<ManagedObjectService> managedObjectServiceRef = new AtomicServiceReference<ManagedObjectService>(REFERENCE_MANAGED_OBJECT_SERVICE);
 
     private volatile CountDownLatch remoteFeatureLatch = null;
+    private volatile boolean remoteFeatureSupported = false;
     private volatile boolean ejbRuntimeActive = false;
     private volatile boolean serverStopping = false;
 
@@ -1457,7 +1458,9 @@ public class EJBRuntimeImpl extends AbstractEJBRuntime implements ApplicationSta
 
     @Override
     public void unregisterServant(EJSRemoteWrapper remoteObject) {
-        // Ignore silently.
+        // Remove the cached stub and tie
+        remoteObject.instub = null;
+        remoteObject.intie = null;
     }
 
     @Override
@@ -1602,8 +1605,25 @@ public class EJBRuntimeImpl extends AbstractEJBRuntime implements ApplicationSta
             remoteLatch.countDown();
         }
 
-        // bind any Remote interfaces to COS Naming for beans already started
-        bindAllRemoteInterfacesToContextRoot();
+        // Bind remote interfaces to COS Naming for beans already started. Use a separate thread
+        // to avoid delaying OSGi component activation.
+        ScheduledExecutorService executor = getScheduledExecutorService();
+        if (executor != null && ejbRuntimeActive && !serverStopping) {
+            Runnable bindAllRemoteInterfaces = new Runnable() {
+                @Override
+                public void run() {
+                    bindAllRemoteInterfacesToContextRoot();
+                }
+            };
+
+            if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
+                Tr.debug(tc, "Scheduling binding of all deferred remote interfaces");
+            // Use slight delay to provide an allowance for ORB to finish starting
+            executor.schedule(bindAllRemoteInterfaces, 250, TimeUnit.MILLISECONDS);
+        } else {
+            if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
+                Tr.debug(tc, "Binding deferred remote interfaces skipped : " + executor + ", " + ejbRuntimeActive + ", " + serverStopping);
+        }
     }
 
     protected void unsetEJBRemoteRuntime(ServiceReference<EJBRemoteRuntime> ref) {
@@ -1743,23 +1763,33 @@ public class EJBRuntimeImpl extends AbstractEJBRuntime implements ApplicationSta
     protected void setLibertyFeature(ServiceReference<LibertyFeature> feature) {
         // If the remote runtime hasn't come up yet, but remote is configured,
         // then create a latch to support a pause in starting remote EJBs.
-        if (remoteFeatureLatch == null && ejbRemoteRuntimeServiceRef.getReference() == null) {
+        if (!remoteFeatureSupported) {
             String featureName = (String) feature.getProperty("ibm.featureName");
             if (featureName != null && (featureName.startsWith("enterpriseBeansRemote") || featureName.startsWith("ejbRemote"))) {
-                remoteFeatureLatch = new CountDownLatch(1);
+                remoteFeatureSupported = true;
+                if (remoteFeatureLatch == null && ejbRemoteRuntimeServiceRef.getReference() == null) {
+                    remoteFeatureLatch = new CountDownLatch(1);
+                }
+                if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
+                    Tr.debug(tc, "remoteFeatureSupported = " + remoteFeatureSupported + ", remoteFeatureLatch = " + remoteFeatureLatch);
             }
         }
     }
 
     protected void unsetLibertyFeature(ServiceReference<LibertyFeature> feature) {
         // If the remote feature was configured, but never came up, and now
-        // is being removed, then also remove the remote latch.
-        CountDownLatch remoteLatch = remoteFeatureLatch;
-        if (remoteLatch != null) {
+        // is being removed, then also remove the remote latch and clear remote supported
+        if (remoteFeatureSupported) {
             String featureName = (String) feature.getProperty("ibm.featureName");
             if (featureName != null && (featureName.startsWith("enterpriseBeansRemote") || featureName.startsWith("ejbRemote"))) {
-                remoteFeatureLatch = null;
-                remoteLatch.countDown();
+                remoteFeatureSupported = false;
+                CountDownLatch remoteLatch = remoteFeatureLatch;
+                if (remoteLatch != null) {
+                    remoteFeatureLatch = null;
+                    remoteLatch.countDown();
+                }
+                if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
+                    Tr.debug(tc, "remoteFeatureSupported = " + remoteFeatureSupported + ", remoteFeatureLatch = " + remoteFeatureLatch);
             }
         }
     }
@@ -1864,10 +1894,8 @@ public class EJBRuntimeImpl extends AbstractEJBRuntime implements ApplicationSta
 
     @Override
     public boolean isRemoteSupported() {
-        if (remoteFeatureLatch != null || ejbRemoteRuntimeServiceRef.getReference() != null) {
-            return true;
-        }
-        return false;
+        // true if remote feature enabled in server.xml; may not be active yet
+        return remoteFeatureSupported;
     }
 
     @Override

--- a/dev/com.ibm.ws.ejbcontainer/src/com/ibm/ws/ejbcontainer/osgi/internal/NameSpaceBinderImpl.java
+++ b/dev/com.ibm.ws.ejbcontainer/src/com/ibm/ws/ejbcontainer/osgi/internal/NameSpaceBinderImpl.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2022 IBM Corporation and others.
+ * Copyright (c) 2012, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -265,22 +265,22 @@ public class NameSpaceBinderImpl implements NameSpaceBinder<EJBBinding> {
      * @param hr               the HomeRecord of the EJB
      * @param bindingName      the JNDI binding name
      * @param isSimpleName     Flag used to force creation of an AmbiguousEJBReference if an
-     *                          ambiguous simple name binding is detected
+     *                             ambiguous simple name binding is detected
      * @param isDefaultBinding Flag used if this is a default binding
      */
     private void bindLegacyRemoteBinding(EJBBinding bindingObject, HomeRecord hr, String bindingName, boolean isSimpleName, boolean isDefaultBinding) throws NamingException {
         final boolean isTraceOn = TraceComponent.isAnyTracingEnabled();
         EJBRemoteRuntime remoteRuntime = ejbRemoteRuntimeServiceRef.getService();
         if (remoteRuntime != null) {
-            
+
             if (!remoteRuntime.isRemoteEjbAdapterAvailable()) {
                 //UNABLE_TO_BIND_REMOTE_BINDING_CNTR0341W=CNTR0341W: Unable to bind the {0} interface of the {1} bean in the {2} module of the {3} application to the {4} name location. The ORB service is unavailable.
                 BeanMetaData bmd = hr.getBeanMetaData();
                 Tr.warning(tc, "UNABLE_TO_BIND_REMOTE_BINDING_CNTR0341W",
-                       new Object[] { bindingObject.interfaceName, bmd.j2eeName.getComponent(), bmd.j2eeName.getModule(), bmd.j2eeName.getApplication(), bindingName });
+                           new Object[] { bindingObject.interfaceName, bmd.j2eeName.getComponent(), bmd.j2eeName.getModule(), bmd.j2eeName.getApplication(), bindingName });
                 return;
             }
-            
+
             BindingsHelper bh = BindingsHelper.getRemoteHelper(hr);
             BundleContext bc = ejbRemoteRuntimeServiceRef.getReference().getBundle().getBundleContext();
             BeanMetaData bmd = hr.getBeanMetaData();
@@ -556,25 +556,30 @@ public class NameSpaceBinderImpl implements NameSpaceBinder<EJBBinding> {
                              boolean local,
                              boolean deferred) throws NamingException {
         EJBRemoteRuntime remoteRuntime = ejbRemoteRuntimeServiceRef.getService();
-        if (!local && remoteRuntime != null) {
-            if (remoteRuntime.isRemoteEjbAdapterAvailable()) {
-              
-                HomeRecordImpl hrImpl = HomeRecordImpl.cast(hr);
-                if (hrImpl.remoteBindingData == null) {
-                    BeanMetaData bmd = hr.getBeanMetaData();
-                    EJBModuleMetaDataImpl mmd = bmd._moduleMetaData;
-                    EJBApplicationMetaData amd = mmd.getEJBApplicationMetaData();
-                    String appLogicalName = amd.isStandaloneModule() ? null : amd.getLogicalName();
-                    hrImpl.remoteBindingData = remoteRuntime.createBindingData(bmd, appLogicalName, mmd.ivLogicalName);
-                }
+        if (!local) {
+            if (remoteRuntime != null) {
+                if (remoteRuntime.isRemoteEjbAdapterAvailable()) {
 
-                remoteRuntime.bind(hrImpl.remoteBindingData, interfaceIndex, interfaceName);
+                    HomeRecordImpl hrImpl = HomeRecordImpl.cast(hr);
+                    if (hrImpl.remoteBindingData == null) {
+                        BeanMetaData bmd = hr.getBeanMetaData();
+                        EJBModuleMetaDataImpl mmd = bmd._moduleMetaData;
+                        EJBApplicationMetaData amd = mmd.getEJBApplicationMetaData();
+                        String appLogicalName = amd.isStandaloneModule() ? null : amd.getLogicalName();
+                        hrImpl.remoteBindingData = remoteRuntime.createBindingData(bmd, appLogicalName, mmd.ivLogicalName);
+                    }
+
+                    remoteRuntime.bind(hrImpl.remoteBindingData, interfaceIndex, interfaceName);
+                } else {
+                    //UNABLE_TO_BIND_REMOTE_BINDING_CNTR0341W=CNTR0341W: Unable to bind the {0} interface of the {1} bean in the {2} module of the {3} application to the {4} name location. The ORB service is unavailable.
+                    BeanMetaData bmd = hr.getBeanMetaData();
+                    String bindingName = bmd.enterpriseBeanName + '!' + interfaceName;
+                    Tr.warning(tc, "UNABLE_TO_BIND_REMOTE_BINDING_CNTR0341W",
+                               new Object[] { interfaceName, bmd.j2eeName.getComponent(), bmd.j2eeName.getModule(), bmd.j2eeName.getApplication(), bindingName });
+                    hr.remoteBindingDeferred = true;
+                }
             } else {
-                //UNABLE_TO_BIND_REMOTE_BINDING_CNTR0341W=CNTR0341W: Unable to bind the {0} interface of the {1} bean in the {2} module of the {3} application to the {4} name location. The ORB service is unavailable.
-                BeanMetaData bmd = hr.getBeanMetaData();
-                String bindingName = bmd.enterpriseBeanName + '!' + interfaceName;
-                Tr.warning(tc, "UNABLE_TO_BIND_REMOTE_BINDING_CNTR0341W",
-                           new Object[] { interfaceName, bmd.j2eeName.getComponent(), bmd.j2eeName.getModule(), bmd.j2eeName.getApplication(), bindingName });      
+                hr.remoteBindingDeferred = true;
             }
         }
 
@@ -647,7 +652,7 @@ public class NameSpaceBinderImpl implements NameSpaceBinder<EJBBinding> {
      * Unbind the names from the java:app name space.
      *
      * @param names List of names to remove from the
-     *            application name space.
+     *                  application name space.
      */
     @Override
     public void unbindJavaApp(List<String> names) {
@@ -679,6 +684,7 @@ public class NameSpaceBinderImpl implements NameSpaceBinder<EJBBinding> {
                 }
             } finally {
                 writeLock.unlock();
+                hr.remoteBindingDeferred = true;
             }
         }
 
@@ -732,7 +738,7 @@ public class NameSpaceBinderImpl implements NameSpaceBinder<EJBBinding> {
      * Unbind the names from the ejblocal: name space.
      *
      * @param names List of names to remove from the
-     *            application name space.
+     *                  application name space.
      */
     @Override
     public void unbindEJBLocal(List<String> names) throws NamingException {
@@ -743,7 +749,7 @@ public class NameSpaceBinderImpl implements NameSpaceBinder<EJBBinding> {
      * Undoes the bindings from local namespace.
      *
      * @param names List of names to remove from the
-     *            application name space.
+     *                  application name space.
      */
     @Override
     public void unbindLocalColonEJB(List<String> names) throws NamingException {
@@ -754,7 +760,7 @@ public class NameSpaceBinderImpl implements NameSpaceBinder<EJBBinding> {
      * Undoes the root remote bindings.
      *
      * @param names List of names to remove from the
-     *            application name space.
+     *                  application name space.
      */
     @Override
     public void unbindRemote(List<String> names) {


### PR DESCRIPTION
When security is enabled, the ORB can start after application start which may result in two JNDI bindings; one for application start and one for ORB start. Avoid this by:
- during application start, mark EJB remote bindings that have been deferred
- during ORB start only binding those EJB remote interfaces marked as deferred
- submit EJB remote bindings triggered by ORB start to run asynchronously
- fix determination that EJB remote feature is enabled; it was being incorrectly cleared
- enable an EJB remote configuration test that was previusly skipped

Co-authored-by-AI: IBM Bob 1.0.1

fixes #34857 

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".