### PR TITLE
Allow ServerQuiesceListener services to register with quiesce.phase=PRE

### DIFF
--- a/dev/com.ibm.ws.classloading.bells/src/com/ibm/ws/classloading/bells/internal/Bell.java
+++ b/dev/com.ibm.ws.classloading.bells/src/com/ibm/ws/classloading/bells/internal/Bell.java
@@ -45,6 +45,7 @@ import org.osgi.framework.Constants;
 import org.osgi.framework.Filter;
 import org.osgi.framework.InvalidSyntaxException;
 import org.osgi.framework.PrototypeServiceFactory;
+import org.osgi.framework.ServiceFactory;
 import org.osgi.framework.ServiceReference;
 import org.osgi.framework.ServiceRegistration;
 import org.osgi.service.component.ComponentContext;
@@ -440,6 +441,17 @@ public class Bell implements LibraryChangeListener {
             serviceProperties.putAll(serviceInfo.props);
             serviceProperties.put("implementation.class", serviceInfo.implClass);
             serviceProperties.put("exported.from", library.id());
+            serviceProperties.put("liberty.bell", library.id());
+            serviceProperties.computeIfPresent(Constants.SERVICE_RANKING, (k, e) -> {
+                if (e instanceof String) {
+                    try {
+                        return Integer.valueOf((String) e);
+                    } catch (NumberFormatException nfe) {
+                        return e;
+                    }
+                }
+                return e;
+            });
 
             final ServiceRegistration<?> reg = context.registerService(interfaceName, createServiceFactory(serviceInfo, library, fileUrl, spiVisibility, properties),
                                                                        serviceProperties);
@@ -481,35 +493,60 @@ public class Bell implements LibraryChangeListener {
     }
 
     @SuppressWarnings("rawtypes")
-    private static PrototypeServiceFactory<?> createServiceFactory(final ServiceInfo serviceInfo, final Library library, final URL fileUrl,
-                                                                   final boolean spiVisibility, final Map<String, String> properties) {
-        // A prototype factory is used in case the consumer wants to get multiple instances of the service object.
-        // A typical user of the service will simply use the R5 ways to get the service which will fall back to
-        // behaving like a normal ServiceFactory.
-        return new PrototypeServiceFactory() {
-            @Override
-            public Object getService(Bundle bundle, ServiceRegistration registration) {
-                if (library.id() == null) {
-                    // this is a case where the library has been deleted but we have not
-                    // gotten to unregister the service factory yet;
-                    // just return null instead of failing out here with exceptions
-                    return null;
-                }
-                // Note the following methods will produce messages if something goes wrong
-                Class<?> serviceType = findClass(serviceInfo.implClass, library, fileUrl, spiVisibility);
-                if (serviceType != null) {
-                    return createService(serviceType, library.id(), fileUrl, properties);
-                }
-                // something went wrong have to return null.
-                // TODO may want to throw a ServiceException with our message here so we don't
-                // get a generic message from the framework when null is returned.
-                return null;
-            }
+    private static Object createServiceFactory(final ServiceInfo serviceInfo, final Library library, final URL fileUrl,
+                                               final boolean spiVisibility, final Map<String, String> properties) {
+        String scope = serviceInfo.props.get(Constants.SERVICE_SCOPE);
+        if (scope == null) {
+            scope = Constants.SCOPE_PROTOTYPE;
+        }
+        switch (scope) {
+            case Constants.SCOPE_SINGLETON:
+                return createServiceObject(serviceInfo, library, fileUrl, spiVisibility, properties);
+            case Constants.SCOPE_BUNDLE:
+                return new ServiceFactory() {
+                    @Override
+                    public Object getService(Bundle bundle, ServiceRegistration registration) {
+                        return createServiceObject(serviceInfo, library, fileUrl, spiVisibility, properties);
+                    }
 
-            @Override
-            public void ungetService(Bundle bundle, ServiceRegistration registration, Object service) {
-            }
-        };
+                    @Override
+                    public void ungetService(Bundle bundle, ServiceRegistration registration, Object service) {
+                    }
+                };
+            default:
+                // A prototype factory is used by default in case the consumer wants to get multiple instances of the service object.
+                // A typical user of the service will simply use the R5 ways to get the service which will fall back to
+                // behaving like a normal ServiceFactory.
+                return new PrototypeServiceFactory() {
+                    @Override
+                    public Object getService(Bundle bundle, ServiceRegistration registration) {
+                        return createServiceObject(serviceInfo, library, fileUrl, spiVisibility, properties);
+                    }
+
+                    @Override
+                    public void ungetService(Bundle bundle, ServiceRegistration registration, Object service) {
+                    }
+                };
+        }
+    }
+
+    private static Object createServiceObject(final ServiceInfo serviceInfo, final Library library, final URL fileUrl,
+                                              final boolean spiVisibility, final Map<String, String> properties) {
+        if (library.id() == null) {
+            // this is a case where the library has been deleted but we have not
+            // gotten to unregister the service factory yet;
+            // just return null instead of failing out here with exceptions
+            return null;
+        }
+        // Note the following methods will produce messages if something goes wrong
+        Class<?> serviceType = findClass(serviceInfo.implClass, library, fileUrl, spiVisibility);
+        if (serviceType != null) {
+            return createServiceImpl(serviceType, library.id(), fileUrl, properties);
+        }
+        // something went wrong have to return null.
+        // TODO may want to throw a ServiceException with our message here so we don't
+        // get a generic message from the framework when null is returned.
+        return null;
     }
 
     /**
@@ -540,7 +577,7 @@ public class Bell implements LibraryChangeListener {
         return service;
     }
 
-    private static Object createService(final Class<?> serviceType, final String libID, final URL fileUrl, final Map<String, String> properties) {
+    private static Object createServiceImpl(final Class<?> serviceType, final String libID, final URL fileUrl, final Map<String, String> properties) {
         Object service = null;
         Constructor<?> singleArgCtor;
         Method updateMethod;

--- a/dev/com.ibm.ws.runtime.update/src/com/ibm/ws/runtime/update/internal/RuntimeUpdateManagerImpl.java
+++ b/dev/com.ibm.ws.runtime.update/src/com/ibm/ws/runtime/update/internal/RuntimeUpdateManagerImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2023 IBM Corporation and others.
+ * Copyright (c) 2013, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -68,6 +68,13 @@ import com.ibm.wsspi.kernel.service.utils.ServerQuiesceListener;
            property = { "service.vendor=IBM" })
 public class RuntimeUpdateManagerImpl implements RuntimeUpdateManager, SynchronousBundleListener {
     private static final TraceComponent tc = Tr.register(RuntimeUpdateManagerImpl.class);
+
+    static final String QUIESCE_PHASE_PROPERTY = "quiesce.phase";
+
+    enum QuiescePhase {
+        PRE,
+        DEFAULT
+    }
 
     private volatile FutureMonitor futureMonitor;
     private final AtomicBoolean normalServerStop = new AtomicBoolean(true);
@@ -309,14 +316,48 @@ public class RuntimeUpdateManagerImpl implements RuntimeUpdateManager, Synchrono
                 normalServerStop.set(false);
             } else {
                 // NICE / NORMAL STOP
-                // Find all ServerQueisceListeners and notify them
+                // Find all PRE quiesce listeners and notify them first
                 try {
-                    quiesceListeners(bundleCtx.getServiceReferences(ServerQuiesceListener.class, null));
+                    quiesceListeners();
                 } catch (InvalidSyntaxException e) {
                     // not going to happen with a null filter.
                 }
             }
         }
+    }
+
+    private boolean callQuiesceListeners(long startTime, int quiesceTimeout, final ConcurrentLinkedQueue<Object> invoking,
+                                         Collection<ServiceReference<ServerQuiesceListener>> listenerRefs, ThreadQuiesce tq) {
+        FutureCollection quiesceListenerFutures = new FutureCollection();
+        // Queue the notification of each hook (unbounded queue)
+        for (ServiceReference<ServerQuiesceListener> ref : listenerRefs) {
+            final ServerQuiesceListener listener = bundleCtx.getService(ref);
+            if (listener != null) {
+                quiesceListenerFutures.add(executorService.submit(new Runnable() {
+                    @Override
+                    public void run() {
+                        try {
+                            invoking.add(listener);
+                            if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                                Tr.debug(tc, "Invoking serverStopping() on listener: " + ref);
+                            }
+                            listener.serverStopping();
+                            if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                                Tr.debug(tc, "serverStopping() method completed on listener: " + ref);
+                            }
+
+                        } catch (Throwable t) {
+                            // Auto-FFDC here..
+                        } finally {
+                            invoking.remove(listener);
+                        }
+                    }
+                }));
+            }
+        }
+        // Notify the executor service that we are quiescing, if available
+        boolean quiesceListenerSuccess = quiesceListenerFutures.isComplete(startTime, quiesceTimeout);
+        return quiesceListenerSuccess && (tq != null ? tq.quiesceThreads(startTime) : true);
     }
 
     /**
@@ -325,9 +366,9 @@ public class RuntimeUpdateManagerImpl implements RuntimeUpdateManager, Synchrono
      * All invocations are then allowed to complete.
      *
      * @param listenerRefs Collection of {@code ServiceReference}s for {@code ServerQuiesceListener}s
+     * @throws InvalidSyntaxException
      */
-
-    private void quiesceListeners(Collection<ServiceReference<ServerQuiesceListener>> listenerRefs) {
+    private void quiesceListeners() throws InvalidSyntaxException {
         // Make a copy of existing notifications: we can't hold the lock around notifications
         // to iterate while waiting for the existing notifications to complete because that would
         // lock-out cleanupNotifications.
@@ -336,7 +377,12 @@ public class RuntimeUpdateManagerImpl implements RuntimeUpdateManager, Synchrono
             existingNotifications.putAll(notifications);
         }
 
-        if (listenerRefs.isEmpty() && existingNotifications.isEmpty())
+        Collection<ServiceReference<ServerQuiesceListener>> preListenerRefs = bundleCtx.getServiceReferences(ServerQuiesceListener.class,
+                                                                                                             "(" + QUIESCE_PHASE_PROPERTY + "=" + QuiescePhase.PRE + ")");
+        // NOTE this filter will need to change if another phase is defined for quiesce
+        Collection<ServiceReference<ServerQuiesceListener>> defaultListenerRefs = bundleCtx.getServiceReferences(ServerQuiesceListener.class,
+                                                                                                                 "(!(" + QUIESCE_PHASE_PROPERTY + "=" + QuiescePhase.PRE + "))");
+        if (preListenerRefs.isEmpty() && defaultListenerRefs.isEmpty() && existingNotifications.isEmpty())
             return;
 
         ThreadQuiesce tq = (ThreadQuiesce) executorService;
@@ -364,45 +410,33 @@ public class RuntimeUpdateManagerImpl implements RuntimeUpdateManager, Synchrono
             });
         }
 
-        FutureCollection quiesceListenerFutures = new FutureCollection();
-
-        // Queue the notification of each listener (unbounded queue)
-        final ConcurrentLinkedQueue<ServerQuiesceListener> listeners = new ConcurrentLinkedQueue<ServerQuiesceListener>();
-        for (ServiceReference<ServerQuiesceListener> ref : listenerRefs) {
-            final ServerQuiesceListener listener = bundleCtx.getService(ref);
-            if (listener != null) {
-
-                quiesceListenerFutures.add(executorService.submit(new Runnable() {
-                    @Override
-                    public void run() {
-                        try {
-                            listeners.add(listener);
-                            if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-                                Tr.debug(tc, "Invoking serverStopping() on listener: " + listener);
-                            }
-                            listener.serverStopping();
-                            if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-                                Tr.debug(tc, "serverStopping() method completed on listener: " + listener);
-                            }
-
-                        } catch (Throwable t) {
-                            // Auto-FFDC here..
-                        } finally {
-                            listeners.remove(listener);
-                        }
-                    }
-                }));
-
-            }
-        }
-
         if (tc.isDebugEnabled())
             Tr.debug(tc, "About to begin quiesce of executor service threads.");
 
-        // Notify the executor service that we are quiescing
-
+        final ConcurrentLinkedQueue<Object> invoking = new ConcurrentLinkedQueue<>();
         long startTime = System.currentTimeMillis();
-        if (tq.quiesceThreads() && quiesceListenerFutures.isComplete(startTime, quiesceTimeout)) {
+        // now call the listeners
+        boolean preListenerSuccess = callQuiesceListeners(startTime, quiesceTimeout, invoking, preListenerRefs, null);
+        long currentTime = System.currentTimeMillis();
+        long preQuiesceTime = (currentTime - startTime) / 1000;
+        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+            Tr.debug(tc, "Done calling pre-quiesce listeners, time taken: " + preQuiesceTime);
+        }
+
+        // check if pre listener time took more than half the configured timeout
+        if (preQuiesceTime > (quiesceTimeout / 2)) {
+            // Pre listeners took more than half the timeout;
+            // Resetting the startTime and setting the timeout to give normal listeners
+            // half the configured timeout.
+            startTime = currentTime;
+            quiesceTimeout = quiesceTimeout / 2;
+            if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                Tr.debug(tc, "Extending timeout for default listeners after pre listeners timed out: " + quiesceTimeout);
+            }
+        }
+        boolean defaultListenerSuccess = callQuiesceListeners(startTime, quiesceTimeout, invoking, defaultListenerRefs, tq);
+
+        if (preListenerSuccess && defaultListenerSuccess) {
             if (isServer())
                 Tr.info(tc, "quiesce.end");
             else
@@ -432,17 +466,17 @@ public class RuntimeUpdateManagerImpl implements RuntimeUpdateManager, Synchrono
                 Tr.warning(tc, "notifications.not.complete", notificationCount, String.join(", ", incompleteNotifications));
             }
 
-            List<String> runningListenerClasses = Collections.emptyList();
-            if (listeners.size() > 0) {
-                // snapshot listener classes to avoid timing issues
-                runningListenerClasses = listeners.stream().map(l -> l.getClass().getName()).collect(Collectors.toList());
-                if (runningListenerClasses.size() > 0) {
-                    Tr.warning(tc, "quiesce.listeners.not.complete", runningListenerClasses.size(),
-                               String.join(", ", runningListenerClasses));
+            List<String> invokingObjects = Collections.emptyList();
+            if (invoking.size() > 0) {
+                // snapshot invoking classes to avoid timing issues
+                invokingObjects = invoking.stream().map(Object::toString).collect(Collectors.toList());
+                if (invokingObjects.size() > 0) {
+                    Tr.warning(tc, "quiesce.listeners.not.complete", invokingObjects.size(),
+                               String.join(", ", invokingObjects));
                 }
             }
 
-            count = count - notificationCount - runningListenerClasses.size();
+            count = count - notificationCount - invokingObjects.size();
             if (count > 0) {
                 Tr.warning(tc, "quiesce.waiting.on.threads", count);
             }

--- a/dev/com.ibm.ws.runtime.update_fat/bnd.bnd
+++ b/dev/com.ibm.ws.runtime.update_fat/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017 IBM Corporation and others.
+# Copyright (c) 2017, 2026 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -25,6 +25,7 @@ fat.project: true
 
 -buildpath: \
     com.ibm.websphere.javaee.servlet.3.1;version=latest,\
+	com.ibm.websphere.org.osgi.core;version=latest,\
     com.ibm.wsspi.org.osgi.service.component.annotations;version=latest, \
     com.ibm.websphere.org.osgi.service.component;version=latest, \
 	com.ibm.ws.runtime.update;version=latest,\

--- a/dev/com.ibm.ws.runtime.update_fat/fat/src/com/ibm/ws/runtime/update/fat/ConfigUpdateDeliveryTest.java
+++ b/dev/com.ibm.ws.runtime.update_fat/fat/src/com/ibm/ws/runtime/update/fat/ConfigUpdateDeliveryTest.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2018 IBM Corporation and others.
+ * Copyright (c) 2018, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -32,10 +32,12 @@ import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
+import org.junit.runner.RunWith;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
 import com.ibm.websphere.simplicity.log.Log;
 
+import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.impl.LibertyServerFactory;
 
@@ -43,6 +45,7 @@ import componenttest.topology.impl.LibertyServerFactory;
  * Tests that applications on the Liberty profile can access the RuntimeUpdateNotificationMBean, register
  * a NotificationListener and receive notifications for updates to the server.xml configuration.
  */
+@RunWith(FATRunner.class)
 public class ConfigUpdateDeliveryTest {
 
     private static LibertyServer server = LibertyServerFactory.getLibertyServer("com.ibm.ws.runtime.update.fat");

--- a/dev/com.ibm.ws.runtime.update_fat/fat/src/com/ibm/ws/runtime/update/fat/RuntimeQuiesceTest.java
+++ b/dev/com.ibm.ws.runtime.update_fat/fat/src/com/ibm/ws/runtime/update/fat/RuntimeQuiesceTest.java
@@ -12,6 +12,8 @@
  *******************************************************************************/
 package com.ibm.ws.runtime.update.fat;
 
+import static org.junit.Assert.assertNotNull;
+
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.After;
 import org.junit.AfterClass;
@@ -50,6 +52,7 @@ public class RuntimeQuiesceTest {
     private static final String QUIESCE_LISTENER_HUNG_WARNING = "CWWKE1106W";
     private static final String QUIESCE_FAILURE_WARNING = "CWWKE1102W";
     private static final String QUIESCE_SUCCESS_MESSAGE = "CWWKE1101I";
+    private static final String QUIESCE_LISTENER_ORDER_MESSAGE_PREFIX = "QuiesceListenerOrderRecordingService:";
     private static final String QUIESCE_LISTENER_ORDER_MESSAGE = "QuiesceListenerOrderRecordingService: called type=PRE: 0 called type=PRE: 1 called type=PRE: 2 called type=DEFAULT: 3";
 
     private static final Class<?> c = RuntimeQuiesceTest.class;
@@ -314,8 +317,13 @@ public class RuntimeQuiesceTest {
                              server.waitForStringInLog(QUIESCE_LISTENER_CALLED_MESSAGE, 0));
 
         // Check we called the PRE listeners before the default ones
-        Assert.assertNotNull("FAIL for " + method.getMethodName() + ": " + server.getServerName() + " listeners not called in correct order",
-                             server.waitForStringInLog(QUIESCE_LISTENER_ORDER_MESSAGE, 0));
+        String listenerCallOrder = server.waitForStringInLog(QUIESCE_LISTENER_ORDER_MESSAGE_PREFIX, 0);
+        assertNotNull("Did not find message: " + QUIESCE_LISTENER_ORDER_MESSAGE_PREFIX, listenerCallOrder);
+        listenerCallOrder = listenerCallOrder.substring(listenerCallOrder.indexOf(QUIESCE_LISTENER_ORDER_MESSAGE_PREFIX));
+        Assert.assertEquals("FAIL for " + method.getMethodName() + ": " + server.getServerName() + " listeners not called in correct order",
+                            QUIESCE_LISTENER_ORDER_MESSAGE,
+                            listenerCallOrder);
+
         if (type == TestType.EXCEPTION) {
             Assert.assertNotNull("FAIL for " + method.getMethodName() + ": " + server.getServerName()
                                  + " should contain WOOPS! because the test quiesce listener threw an exception",

--- a/dev/com.ibm.ws.runtime.update_fat/fat/src/com/ibm/ws/runtime/update/fat/RuntimeQuiesceTest.java
+++ b/dev/com.ibm.ws.runtime.update_fat/fat/src/com/ibm/ws/runtime/update/fat/RuntimeQuiesceTest.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2018 IBM Corporation and others.
+ * Copyright (c) 2018, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -21,11 +21,13 @@ import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
+import org.junit.runner.RunWith;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
 import com.ibm.websphere.simplicity.log.Log;
 
 import componenttest.annotation.ExpectedFFDC;
+import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.impl.LibertyServerFactory;
 
@@ -37,6 +39,7 @@ import componenttest.topology.impl.LibertyServerFactory;
  *
  * The server logs will be collected at the end, in the tearDown.
  */
+@RunWith(FATRunner.class)
 public class RuntimeQuiesceTest {
 
     private static final String QUIESCE_LISTENER_EXCEPTION_MESSAGE = "WOOPS!";
@@ -47,6 +50,7 @@ public class RuntimeQuiesceTest {
     private static final String QUIESCE_LISTENER_HUNG_WARNING = "CWWKE1106W";
     private static final String QUIESCE_FAILURE_WARNING = "CWWKE1102W";
     private static final String QUIESCE_SUCCESS_MESSAGE = "CWWKE1101I";
+    private static final String QUIESCE_LISTENER_ORDER_MESSAGE = "QuiesceListenerOrderRecordingService: called type=PRE: 0 called type=PRE: 1 called type=PRE: 2 called type=DEFAULT: 3";
 
     private static final Class<?> c = RuntimeQuiesceTest.class;
     private static LibertyServer server = LibertyServerFactory.getLibertyServer("com.ibm.ws.runtime.quiesce.fat");
@@ -149,6 +153,21 @@ public class RuntimeQuiesceTest {
     }
 
     /**
+     * Define/invoke a runtime-level quiesce listener
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testSinglePreRuntimeQuiesceListener() throws Exception {
+        // Add a single quiesce listener as a runtime feature/bundle (internal)
+        server.setServerConfigurationFile("pre-quiesce-listener.server.xml");
+        server.installSystemBundle("test.server.quiesce");
+        server.installSystemFeature("quiescelistener-1.0");
+
+        startStopServer(TestType.SUCCESS);
+    }
+
+    /**
      * Make sure a user feature/product extension can provide a quiesce listener
      * (SPI is defined properly).
      *
@@ -183,6 +202,23 @@ public class RuntimeQuiesceTest {
     }
 
     /**
+     * Try a quiesce service that throws an exception, and make sure that doesn't
+     * prevent the quiesce activity from completing.
+     *
+     * @throws Exception
+     */
+    @Test
+    @ExpectedFFDC("java.lang.RuntimeException")
+    public void testQuiesceListenerPreException() throws Exception {
+        // Add a single quiesce listener as a usr feature/bundle (SPI)
+        server.setServerConfigurationFile("bad-pre-quiesce-listener.server.xml");
+        server.installSystemBundle("test.server.quiesce");
+        server.installSystemFeature("quiescelistener-1.0");
+
+        startStopServer(TestType.EXCEPTION);
+    }
+
+    /**
      * Long running test (at least 30s), push this into the full bucket.
      * This triggers a quiesce listener that takes longer than 30s to complete.
      * Make sure we get a warning that not all quiesce activity completed (and that
@@ -201,24 +237,56 @@ public class RuntimeQuiesceTest {
     }
 
     @Test
+    public void testLongRunningPreQuiesceListener() throws Exception {
+        // Add a single quiesce listener as a usr feature/bundle (SPI)
+        server.setServerConfigurationFile("longrunning-pre-quiesce-listener.server.xml");
+        server.installSystemBundle("test.server.quiesce");
+        server.installSystemFeature("quiescelistener-1.0");
+
+        startStopServer(TestType.QUIESCE_HANG);
+    }
+
+    @Test
     public void testLongRunningThreads() throws Exception {
         server.setServerConfigurationFile("longrunning-threads-server.xml");
         server.installSystemBundle("test.server.quiesce");
         server.installSystemFeature("quiescelistener-1.0");
 
-        startStopServer(TestType.THREAD_HANG);
+        startStopServer(TestType.THREAD_HANG, 4);
     }
 
     @Test
-    public void testNonBlockingThreads() throws Exception {
+    public void testLongRunningPreThreads() throws Exception {
+        server.setServerConfigurationFile("longrunning-pre-threads-server.xml");
+        server.installSystemBundle("test.server.quiesce");
+        server.installSystemFeature("quiescelistener-1.0");
+
+        startStopServer(TestType.THREAD_HANG, 8);
+    }
+
+    @Test
+    public void testBlockingPreThreads() throws Exception {
+        server.setServerConfigurationFile("blocking-threads-server.xml");
+        server.installSystemBundle("test.server.quiesce");
+        server.installSystemFeature("quiescelistener-1.0");
+
+        startStopServer(TestType.THREAD_HANG, 6);
+    }
+
+    @Test
+    public void testBlockingThreads() throws Exception {
         server.setServerConfigurationFile("non-blocking-threads-server.xml");
         server.installSystemBundle("test.server.quiesce");
         server.installSystemFeature("quiescelistener-1.0");
 
-        startStopServer(TestType.SUCCESS);
+        startStopServer(TestType.THREAD_HANG, 2);
     }
 
     private void startStopServer(TestType type) throws Exception {
+        startStopServer(type, 0);
+    }
+
+    private void startStopServer(TestType type, int numExpectedHungThreads) throws Exception {
         // start the server, do a clean start, and do not pre-clean the logs dir
         server.startServer(method.getMethodName() + ".console.log", true, false);
 
@@ -245,6 +313,9 @@ public class RuntimeQuiesceTest {
         Assert.assertNotNull("FAIL for " + method.getMethodName() + ": " + server.getServerName() + " should contain WHEE! because the test quiesce listener was called",
                              server.waitForStringInLog(QUIESCE_LISTENER_CALLED_MESSAGE, 0));
 
+        // Check we called the PRE listeners before the default ones
+        Assert.assertNotNull("FAIL for " + method.getMethodName() + ": " + server.getServerName() + " listeners not called in correct order",
+                             server.waitForStringInLog(QUIESCE_LISTENER_ORDER_MESSAGE, 0));
         if (type == TestType.EXCEPTION) {
             Assert.assertNotNull("FAIL for " + method.getMethodName() + ": " + server.getServerName()
                                  + " should contain WOOPS! because the test quiesce listener threw an exception",
@@ -267,8 +338,9 @@ public class RuntimeQuiesceTest {
                                  threadWarning);
             threadWarning = threadWarning.substring(threadWarning.indexOf(QUIESCE_THREADS_HUNG_WARNING));
             // We should report two hung threads, not four
-            Assert.assertTrue("FAIL for " + method.getMethodName() + ": " + server.getServerName() + " should be blocked by two threads, not four",
-                              threadWarning.contains("2") && !threadWarning.contains("4"));
+            Assert.assertTrue("FAIL for " + method.getMethodName() + ": " + server.getServerName() + " should be blocked by " + numExpectedHungThreads + " threads: "
+                              + threadWarning,
+                              threadWarning.contains(String.valueOf(numExpectedHungThreads)));
 
         } else {
             Assert.assertNotNull("FAIL for " + method.getMethodName() + ": " + server.getServerName() + " should contain information about the completion of server quiesce",

--- a/dev/com.ibm.ws.runtime.update_fat/publish/files/bad-pre-quiesce-listener.server.xml
+++ b/dev/com.ibm.ws.runtime.update_fat/publish/files/bad-pre-quiesce-listener.server.xml
@@ -1,0 +1,12 @@
+<server>
+
+    <featureManager>
+        <feature>servlet-3.1</feature>
+        <feature>quiescelistener-1.0</feature>
+    </featureManager>
+    
+    <testPreServerQuiesce throwException="true" />
+    
+    <include location="../fatTestPorts.xml"/>
+
+</server>

--- a/dev/com.ibm.ws.runtime.update_fat/publish/files/blocking-threads-server.xml
+++ b/dev/com.ibm.ws.runtime.update_fat/publish/files/blocking-threads-server.xml
@@ -1,0 +1,23 @@
+<!--
+    Copyright (c) 2018 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License 2.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-2.0/
+    
+    SPDX-License-Identifier: EPL-2.0
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<server>
+
+    <featureManager>
+        <feature>servlet-3.1</feature>
+        <feature>quiescelistener-1.0</feature>
+    </featureManager>
+    
+    <testPreServerQuiesce  startThreadsAfterStop="true"/>
+    <include location="../fatTestPorts.xml"/>
+
+</server>

--- a/dev/com.ibm.ws.runtime.update_fat/publish/files/longrunning-pre-quiesce-listener.server.xml
+++ b/dev/com.ibm.ws.runtime.update_fat/publish/files/longrunning-pre-quiesce-listener.server.xml
@@ -1,0 +1,12 @@
+<server>
+
+    <featureManager>
+        <feature>servlet-3.1</feature>
+        <feature>quiescelistener-1.0</feature>
+    </featureManager>
+    
+    <testPreServerQuiesce takeForever="true" />
+    
+    <include location="../fatTestPorts.xml"/>
+
+</server>

--- a/dev/com.ibm.ws.runtime.update_fat/publish/files/longrunning-pre-quiesce-listener.server.xml
+++ b/dev/com.ibm.ws.runtime.update_fat/publish/files/longrunning-pre-quiesce-listener.server.xml
@@ -9,4 +9,5 @@
     
     <include location="../fatTestPorts.xml"/>
 
+    <executor coreThreads="10" maxThreads="20" />
 </server>

--- a/dev/com.ibm.ws.runtime.update_fat/publish/files/longrunning-pre-threads-server.xml
+++ b/dev/com.ibm.ws.runtime.update_fat/publish/files/longrunning-pre-threads-server.xml
@@ -1,0 +1,25 @@
+<!--
+    Copyright (c) 2018 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License 2.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-2.0/
+    
+    SPDX-License-Identifier: EPL-2.0
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<server>
+
+    <featureManager>
+        <feature>servlet-3.1</feature>
+        <feature>quiescelistener-1.0</feature>
+    </featureManager>
+    
+     <testPreServerQuiesce startThreadsWhileRunning="true" startThreadsAfterStop="true"/>
+  
+    
+    <include location="../fatTestPorts.xml"/>
+
+</server>

--- a/dev/com.ibm.ws.runtime.update_fat/publish/files/pre-quiesce-listener.server.xml
+++ b/dev/com.ibm.ws.runtime.update_fat/publish/files/pre-quiesce-listener.server.xml
@@ -1,0 +1,10 @@
+<server>
+
+    <featureManager>
+        <feature>servlet-3.1</feature>
+        <feature>quiescelistener-1.0</feature>
+    </featureManager>
+    
+    <include location="../fatTestPorts.xml"/>
+
+</server>

--- a/dev/com.ibm.ws.runtime.update_fat/test-bundles/test.server.quiesce/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.runtime.update_fat/test-bundles/test.server.quiesce/resources/OSGI-INF/metatype/metatype.xml
@@ -35,5 +35,20 @@
     <Designate pid="test.server.quiesce">
         <Object ocdref="test.server.quiesce"/>
     </Designate>
-    
+
+    <OCD name="internal" description="internal" 
+         id="test.server.pre.quiesce" ibm:alias="testPreServerQuiesce">
+        <AD name="internal" description="internal" 
+            id="throwException" required="false" type="Boolean" default="false" />  
+        <AD name="internal" description="internal" 
+            id="takeForever" required="false" type="Boolean" default="false" />  
+        <AD name="internal" description="internal" 
+            id="startThreadsAfterStop" required="false" type="Boolean" default="false" />  
+        <AD name="internal" description="internal"
+            id="startThreadsWhileRunning" required="false" type="Boolean" default="false"/>
+    </OCD>
+  
+    <Designate pid="test.server.pre.quiesce">
+        <Object ocdref="test.server.pre.quiesce"/>
+    </Designate>
 </metatype:MetaData>

--- a/dev/com.ibm.ws.runtime.update_fat/test-bundles/test.server.quiesce/src/test/server/quiesce/QuiesceListenerOrderRecordingService.java
+++ b/dev/com.ibm.ws.runtime.update_fat/test-bundles/test.server.quiesce/src/test/server/quiesce/QuiesceListenerOrderRecordingService.java
@@ -1,0 +1,63 @@
+/*******************************************************************************n * Copyright (c) 2026 IBM Corporation and others.n * All rights reserved. This program and the accompanying materialsn * are made available under the terms of the Eclipse Public License 2.0n * which accompanies this distribution, and is available atn * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0n *n * Contributors:n *     IBM Corporation - initial API and implementationn *******************************************************************************/
+package test.server.quiesce;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
+
+import com.ibm.wsspi.kernel.service.utils.ServerQuiesceListener;
+
+/**
+ *
+ */
+@Component(service = QuiesceListenerOrderRecordingService.class)
+public class QuiesceListenerOrderRecordingService {
+    private final AtomicInteger listenerOrder = new AtomicInteger();
+    private final List<String> listenersCalled = new ArrayList<>();
+
+    private class TestOrderQuiesceListener implements ServerQuiesceListener {
+        private final String type;
+        private final Runnable stopServerAction;
+
+        public TestOrderQuiesceListener(String type, Runnable stopServeAction) {
+            this.type = type;
+            this.stopServerAction = stopServeAction;
+        }
+
+        @Override
+        public void serverStopping() {
+            try {
+                // add small delay to all test listeners to help test that all PRE listeners are called first
+                Thread.sleep(1000);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+            // sync on recorder to ensure we print the order number "in order"
+            synchronized (QuiesceListenerOrderRecordingService.this) {
+                listenersCalled.add(" called type=" + type + ": " + listenerOrder.getAndIncrement());
+            }
+            stopServerAction.run();
+        }
+
+        @Override
+        public String toString() {
+            return "TestOrderQuiesceListener: type=" + type + " runnable=" + stopServerAction;
+        }
+    }
+
+    @Deactivate
+    void deactivate() {
+        StringBuilder sb = new StringBuilder("QuiesceListenerOrderRecordingService:");
+        listenersCalled.forEach(sb::append);
+        System.out.println(sb);
+    }
+
+    public ServerQuiesceListener createQuiesceListener(String type, Runnable stopServerAction) {
+        return new TestOrderQuiesceListener(type, stopServerAction);
+    }
+}

--- a/dev/com.ibm.ws.runtime.update_fat/test-bundles/test.server.quiesce/src/test/server/quiesce/TestPreQuiesceListener.java
+++ b/dev/com.ibm.ws.runtime.update_fat/test-bundles/test.server.quiesce/src/test/server/quiesce/TestPreQuiesceListener.java
@@ -98,6 +98,11 @@ public class TestPreQuiesceListener {
                 @Override
                 public void run() {
                     while (true) {
+                        try {
+                            Thread.sleep(1000);
+                        } catch (InterruptedException e) {
+                            Thread.currentThread().interrupt();
+                        }
                     }
 
                 }
@@ -153,6 +158,11 @@ public class TestPreQuiesceListener {
                 @Override
                 public void run() {
                     while (true) {
+                        try {
+                            Thread.sleep(1000);
+                        } catch (InterruptedException e) {
+                            Thread.currentThread().interrupt();
+                        }
                     }
 
                 }

--- a/dev/com.ibm.ws.runtime.update_fat/test-bundles/test.server.quiesce/src/test/server/quiesce/TestPreQuiesceListener.java
+++ b/dev/com.ibm.ws.runtime.update_fat/test-bundles/test.server.quiesce/src/test/server/quiesce/TestPreQuiesceListener.java
@@ -1,0 +1,164 @@
+/*******************************************************************************n * Copyright (c) 2026 IBM Corporation and others.n * All rights reserved. This program and the accompanying materialsn * are made available under the terms of the Eclipse Public License 2.0n * which accompanies this distribution, and is available atn * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0n *n * Contributors:n *     IBM Corporation - initial API and implementationn *******************************************************************************/
+package test.server.quiesce;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ConfigurationPolicy;
+import org.osgi.service.component.annotations.Reference;
+
+import com.ibm.ws.threading.ThreadQuiesce;
+import com.ibm.wsspi.kernel.service.utils.ServerQuiesceListener;
+
+/**
+ *
+ */
+@Component(immediate = true, configurationPid = "test.server.pre.quiesce", configurationPolicy = ConfigurationPolicy.REQUIRE)
+public class TestPreQuiesceListener {
+    private static final AtomicInteger nextId = new AtomicInteger();
+
+    private final QuiesceListenerOrderRecordingService recorder;
+    private final ExecutorService executorService;
+
+    abstract class AbstractTestHook implements Runnable {
+        private final int id;
+
+        public AbstractTestHook() {
+            this.id = nextId.getAndIncrement();
+        }
+
+        @Override
+        public String toString() {
+            return getClass().getName() + ": id=" + id;
+        }
+
+        public void register(BundleContext context) {
+            context.registerService(ServerQuiesceListener.class, recorder.createQuiesceListener("PRE", this),
+                                    FrameworkUtil.asDictionary(Collections.singletonMap("quiesce.phase", "PRE")));
+        }
+
+    }
+
+    class ThrowExceptionHook extends AbstractTestHook {
+        @Override
+        public void run() {
+            System.out.println("PRE quiesce listener throwing an exception: " + this);
+            throw new RuntimeException("WOOPS! I was told to do this, honest." + this);
+        }
+    }
+
+    class TakeForeverHook extends AbstractTestHook {
+        @Override
+        public void run() {
+            System.out.println("PRE quiesce listener taking forever! " + this);
+
+            //Rather than deal with slow hardware or possible timing windows, just wait forever
+            //The server will still stop. But this gives it ample time to get to the timeout
+            //without having to worry about failures that aren't really failures
+            //This now relies on the quiesce thread pool to hit the timeout and shutdown
+            while (true) {
+            }
+        }
+    }
+
+    class TestShutdownHook extends AbstractTestHook {
+        @Override
+        public void run() {
+            System.out.println("Running: " + this);
+        }
+
+    }
+
+    class StartThreadsAfterStopHook extends AbstractTestHook {
+        @Override
+        public void run() {
+            System.out.println("PRE quiesce listener start threads after stop! " + this);
+            // Normally the executor service will already be quiescing at this point, but wait just in case
+            for (int i = 0; i < 20; i++) {
+                if (((ThreadQuiesce) executorService).quiesceStarted()) {
+                    break;
+                }
+                try {
+                    Thread.sleep(1000);
+                } catch (InterruptedException e) {
+                    e.printStackTrace();
+                }
+            }
+            // Start a couple of threads. These should not block shutdown
+            Runnable r = new Runnable() {
+
+                @Override
+                public void run() {
+                    while (true) {
+                    }
+
+                }
+            };
+            executorService.submit(r);
+            executorService.submit(r);
+        }
+
+    }
+
+    @Activate
+    public TestPreQuiesceListener(Map<String, Object> config, BundleContext context,
+                                  @Reference QuiesceListenerOrderRecordingService recorder,
+                                  @Reference ExecutorService executorService) {
+        boolean throwException = (Boolean) config.get("throwException");
+        boolean takeForever = (Boolean) config.get("takeForever");
+        boolean startThreadsAfterStop = (Boolean) config.get("startThreadsAfterStop");
+        boolean startThreadsWhileRunning = (Boolean) config.get("startThreadsWhileRunning");
+        this.recorder = recorder;
+        this.executorService = executorService;
+
+        System.out.println("TEST PRE CONFIGURATION: " + config);
+        AbstractTestHook hook1 = null;
+        AbstractTestHook hook2 = null;
+        AbstractTestHook hook3 = null;
+        if (throwException) {
+            hook1 = new ThrowExceptionHook();
+            hook2 = new ThrowExceptionHook();
+            hook3 = new ThrowExceptionHook();
+        } else if (takeForever) {
+            hook1 = new TakeForeverHook();
+            hook2 = new TakeForeverHook();
+            hook3 = new TakeForeverHook();
+        } else if (startThreadsAfterStop) {
+            hook1 = new StartThreadsAfterStopHook();
+            hook2 = new StartThreadsAfterStopHook();
+            hook3 = new StartThreadsAfterStopHook();
+        } else {
+            // everything else
+            hook1 = new TestShutdownHook();
+            hook2 = new TestShutdownHook();
+            hook3 = new TestShutdownHook();
+        }
+
+        hook1.register(context);
+        hook2.register(context);
+        hook3.register(context);
+
+        if (startThreadsWhileRunning) {
+            // Start a couple of threads. These should block shutdown
+            Runnable r = new Runnable() {
+
+                @Override
+                public void run() {
+                    while (true) {
+                    }
+
+                }
+            };
+            executorService.submit(r);
+            executorService.submit(r);
+        }
+    }
+}

--- a/dev/com.ibm.ws.runtime.update_fat/test-bundles/test.server.quiesce/src/test/server/quiesce/TestQuiesceListener.java
+++ b/dev/com.ibm.ws.runtime.update_fat/test-bundles/test.server.quiesce/src/test/server/quiesce/TestQuiesceListener.java
@@ -51,6 +51,11 @@ public class TestQuiesceListener {
                 @Override
                 public void run() {
                     while (true) {
+                        try {
+                            Thread.sleep(1000);
+                        } catch (InterruptedException e) {
+                            Thread.currentThread().interrupt();
+                        }
                     }
 
                 }
@@ -87,6 +92,11 @@ public class TestQuiesceListener {
                 @Override
                 public void run() {
                     while (true) {
+                        try {
+                            Thread.sleep(1000);
+                        } catch (InterruptedException e) {
+                            Thread.currentThread().interrupt();
+                        }
                     }
 
                 }

--- a/dev/com.ibm.ws.runtime.update_fat/test-bundles/test.server.quiesce/src/test/server/quiesce/TestQuiesceListener.java
+++ b/dev/com.ibm.ws.runtime.update_fat/test-bundles/test.server.quiesce/src/test/server/quiesce/TestQuiesceListener.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -15,29 +15,31 @@ package test.server.quiesce;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
 
+import org.osgi.framework.BundleContext;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
-import org.osgi.service.component.annotations.ReferenceCardinality;
 
-import com.ibm.ws.threading.ThreadQuiesce;
 import com.ibm.wsspi.kernel.service.utils.ServerQuiesceListener;
 
 /**
  *
  */
 @Component(immediate = true, configurationPid = "test.server.quiesce")
-public class TestQuiesceListener implements ServerQuiesceListener {
+public class TestQuiesceListener {
 
-    boolean throwException = false;
-    boolean takeForever = false;
-    boolean startThreadsAfterStop = false;
-    ExecutorService executorService;
+    final boolean throwException;
+    final boolean takeForever;
+    final boolean startThreadsAfterStop;
+    final ExecutorService executorService;
 
     @Activate
-    protected void activate(Map<String, Object> newConfig) {
+    public TestQuiesceListener(BundleContext context, Map<String, Object> newConfig,
+                               @Reference QuiesceListenerOrderRecordingService recorder,
+                               @Reference ExecutorService executorService) {
         System.out.println("TEST CONFIGURATION: " + newConfig);
 
+        this.executorService = executorService;
         throwException = (Boolean) newConfig.get("throwException");
         takeForever = (Boolean) newConfig.get("takeForever");
         startThreadsAfterStop = (Boolean) newConfig.get("startThreadsAfterStop");
@@ -56,10 +58,9 @@ public class TestQuiesceListener implements ServerQuiesceListener {
             executorService.submit(r);
             executorService.submit(r);
         }
-
+        context.registerService(ServerQuiesceListener.class, recorder.createQuiesceListener("DEFAULT", this::serverStopping), null);
     }
 
-    @Override
     public void serverStopping() {
 
         System.out.println("WHEE! THE SERVER IS STOPPING AND I GOT TOLD!");
@@ -80,18 +81,7 @@ public class TestQuiesceListener implements ServerQuiesceListener {
         }
 
         if (startThreadsAfterStop) {
-            // Normally the executor service will already be quiescing at this point, but wait just in case
-            for (int i = 0; i < 20; i++) {
-                if (((ThreadQuiesce) executorService).quiesceStarted()) {
-                    break;
-                }
-                try {
-                    Thread.sleep(1000);
-                } catch (InterruptedException e) {
-                    e.printStackTrace();
-                }
-            }
-            // Start a couple of threads. These should not block shutdown
+            // Start a couple of threads. These SHOULD block shutdown
             Runnable r = new Runnable() {
 
                 @Override
@@ -104,12 +94,6 @@ public class TestQuiesceListener implements ServerQuiesceListener {
             executorService.submit(r);
             executorService.submit(r);
         }
-    }
-
-    @Reference(service = ExecutorService.class,
-               cardinality = ReferenceCardinality.MANDATORY)
-    protected void setExecutorService(ExecutorService executorService) {
-        this.executorService = executorService;
     }
 
 }

--- a/dev/com.ibm.ws.runtime.update_fat/test.server.quiesce.bnd
+++ b/dev/com.ibm.ws.runtime.update_fat/test.server.quiesce.bnd
@@ -27,7 +27,9 @@ Private-Package: \
   test.server.quiesce
   
 -dsannotations: \
-  test.server.quiesce.TestQuiesceListener
+  test.server.quiesce.TestQuiesceListener, \
+  test.server.quiesce.TestPreQuiesceListener, \
+  test.server.quiesce.QuiesceListenerOrderRecordingService
 
 
  

--- a/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/ThreadQuiesce.java
+++ b/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/ThreadQuiesce.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 IBM Corporation and others.
+ * Copyright (c) 2018, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -12,12 +12,17 @@
  *******************************************************************************/
 package com.ibm.ws.threading;
 
+import org.osgi.annotation.versioning.ProviderType;
+
 /**
  * Used to signal the executor service that threads should be quiesced
  */
+@ProviderType
 public interface ThreadQuiesce {
 
     boolean quiesceThreads();
+
+    boolean quiesceThreads(long startTime);
 
     int getActiveThreads();
 

--- a/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/internal/ExecutorServiceImpl.java
+++ b/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/internal/ExecutorServiceImpl.java
@@ -636,13 +636,17 @@ public final class ExecutorServiceImpl implements WSExecutorService, ThreadQuies
         return wrappedTasks;
     }
 
+    @Override
+    public boolean quiesceThreads() {
+        throw new UnsupportedOperationException();
+    }
     /*
      * (non-Javadoc)
      *
      * @see com.ibm.ws.threading.ThreadQuiesce#quiesceThreads()
      */
     @Override
-    public boolean quiesceThreads() {
+    public boolean quiesceThreads(long startTime) {
         this.serverStopping = true;
 
         // Wait for all pre-quiesce work to complete.
@@ -651,10 +655,15 @@ public final class ExecutorServiceImpl implements WSExecutorService, ThreadQuies
         // and signal it. If count is already 0, we return immediately.
         quiesceLatch = new CountDownLatch(1);
         if (activeThreadCount.get() != 0) {
+            long endTime = startTime + (quiesceTimeout * 1000);
+            long waitTime = endTime - System.currentTimeMillis();
+            if (waitTime <= 0) {
+                return false;
+            }
             try {
                 // Wait for all active threads to finish.  The last thread that finishes
                 // will call the latch.
-                if (!quiesceLatch.await(quiesceTimeout, TimeUnit.SECONDS)) {
+                if (!quiesceLatch.await(waitTime, TimeUnit.MILLISECONDS)) {
                     // If we time out, quiesce has failed.
                     return false;
                 }

--- a/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/package-info.java
+++ b/dev/com.ibm.ws.threading/src/com/ibm/ws/threading/package-info.java
@@ -1,17 +1,17 @@
 /*******************************************************************************
- * Copyright (c) 2010 IBM Corporation and others.
+ * Copyright (c) 2010, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 /**
- * @version 1.0
+ * @version 1.1
  */
-@org.osgi.annotation.versioning.Version("1.0")
+@org.osgi.annotation.versioning.Version("1.1")
 package com.ibm.ws.threading;


### PR DESCRIPTION
If a `ServerQuiesceListener` is registered with the attribute `quiesce.phase=PRE` then the listener is called BEFORE the quiesce phase begins.   Note that this is before the executor service is notified that quiesced has started (`com.ibm.ws.threading.ThreadQuiesce.quiesceThreads()` has not been called yet).  Any work started by the PRE listener with the executor service will be blocked for completion before quiesce ends (or timesout).

Note that the waiting for the work running on the executor to complete is done "in parallel" with calling the other "default" listeners.  That is the same behavior as any other work that the executor is doing that the application may have on-going when the server enters quiesce.

In addition to this the default listeners are called and wait for completion before `ThreadQuiesce.quiesceThreads()` is called.  This is to get rid of a timing issue where `quiesceThreads` may or may not have been called when the listeners are called async.  The new order is the following:

1. Call all registered "PRE" ServerQuiesceListener services.
2. Wait for the "PRE" listeners to complete.
3. Call all registered ServerQuiesceListener services
4. Wait for all ServerQuiesceListener calls to complete.
5. Inform the Liberty executor service that we are quiescing threads
6. Wait for all current application all ongoing work to complete

- [ ] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [ ] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

