### PR TITLE
Use vendor-specific Hibernate methods that behave like EntityAgent

### DIFF
--- a/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/EntityHandlerFactory.java
+++ b/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/EntityHandlerFactory.java
@@ -412,6 +412,16 @@ public abstract class EntityHandlerFactory {
     }
 
     /**
+     * Creates a new EntityAgent instance.
+     * Requires Jakarta Persistence 4.0+, which corresponds to Jakarta EE 12+.
+     * Use the getEntityAgent method instead to ensure the same EntityAgent
+     * is reused within a transaction.
+     *
+     * @return a new EntityAgent instance.
+     */
+    public abstract AutoCloseable createEntityAgent();
+
+    /**
      * Creates a new EntityManager instance.
      * Use the getEntityManager method instead to ensure the same EntityManager
      * and its persistence context are reused within a transaction.
@@ -460,6 +470,7 @@ public abstract class EntityHandlerFactory {
 
     /**
      * Obtains an EntityAgent from the Jakarta Persistence provider.
+     * Requires Jakarta Persistence 4.0+, which corresponds to Jakarta EE 12+.
      *
      * @return the EntityAgent.
      * @throws Exception if an error occurs.
@@ -467,7 +478,7 @@ public abstract class EntityHandlerFactory {
     AutoCloseable getEntityAgent() throws Exception {
         // TODO EntityAgent, which can be reused within a transaction, but
         // otherwise should be a new instance
-        return getEntityManager(false);
+        return createEntityAgent();
     }
 
     /**

--- a/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/EntityInfo.java
+++ b/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/EntityInfo.java
@@ -252,7 +252,7 @@ public class EntityInfo {
     @Trivial
     boolean simulateStateless() {
         // TODO temporarily approximated by assuming only Hibernate has EntityAgent
-        return !isHibernate;
+        return !isHibernate || !factory.provider.compat.atLeast(1, 1);
     }
 
     /**

--- a/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/Fail.java
+++ b/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/Fail.java
@@ -125,6 +125,27 @@ public class Fail {
     }
 
     /**
+     * Raises IllegalStateException because the repository bean was disposed.
+     *
+     * @param impl   repository implementation
+     * @param proxy  proxy instance upon which the repository method is invoked
+     * @param method repository method that the application invoked
+     * @throws IllegalStateException
+     */
+    static IllegalStateException disposed(RepositoryImpl<?> impl,
+                                          Object proxy,
+                                          Method method) {
+        throw exc(IllegalStateException.class,
+                  "CWWKD1076.repo.disposed",
+                  method.getName(),
+                  impl.repositoryInterface.getName(),
+                  new StringBuilder("RepositoryImpl@") //
+                                  .append(Integer.toHexString(impl.hashCode())) //
+                                  .append("/(proxy)@") //
+                                  .append(Integer.toHexString(System.identityHashCode(proxy))));
+    }
+
+    /**
      * Raises a new UnsupportedOperationException for a repository method that
      * has two or more of the same special parameter type.
      *

--- a/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/RepositoryImpl.java
+++ b/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/RepositoryImpl.java
@@ -39,7 +39,6 @@ import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.websphere.ras.annotation.Trivial;
 import com.ibm.ws.LocalTransaction.LocalTransactionCoordinator;
-import com.ibm.ws.ffdc.FFDCFilter;
 import com.ibm.ws.ffdc.annotation.FFDCIgnore;
 
 import io.openliberty.data.internal.cdi.DataExtension;
@@ -316,7 +315,9 @@ public class RepositoryImpl<R> implements InvocationHandler {
             if (x == null) {
                 if (original instanceof OptimisticLockException)
                     x = new OptimisticLockingFailureException(original);
-                else if (original instanceof jakarta.persistence.EntityExistsException)
+                else if (original instanceof jakarta.persistence.EntityExistsException ||
+                         "org.hibernate.exception.ConstraintViolationException" //
+                                         .equals(original.getClass().getName()))
                     x = new EntityExistsException(original);
                 else if (original instanceof NoResultException)
                     x = new EmptyResultException(original);
@@ -515,43 +516,15 @@ public class RepositoryImpl<R> implements InvocationHandler {
         AutoCloseable eh = null;
         try {
             if (isDisposed.get())
-                throw exc(IllegalStateException.class,
-                          "CWWKD1076.repo.disposed",
-                          method.getName(),
-                          repositoryInterface.getName(),
-                          new StringBuilder("RepositoryImpl@") //
-                                          .append(Integer.toHexString(hashCode())) //
-                                          .append("/(proxy)@") //
-                                          .append(Integer.toHexString(System.identityHashCode(proxy))));
+                throw Fail.disposed(this, proxy, method);
 
             if (isDefaultMethod) {
-                Deque<AutoCloseable> resourceStack = defaultMethodResources.get();
-                boolean added;
-                if (added = (resourceStack == null))
-                    defaultMethodResources.set(resourceStack = new LinkedList<>());
-                else
-                    resourceStack.add(null); // indicator of nested default method
-                try {
-                    Object returnValue = InvocationHandler.invokeDefault(proxy, method, args);
-                    if (trace && tc.isEntryEnabled())
-                        Tr.exit(this, tc, "invoke " + repositoryInterface.getSimpleName() +
-                                          '.' + method.getName(),
-                                returnValue);
-                    return returnValue;
-                } finally {
-                    for (AutoCloseable resource; (resource = resourceStack.pollLast()) != null;)
-                        if (!(resource instanceof EntityManager) ||
-                            ((EntityManager) resource).isOpen())
-                            try {
-                                if (trace && tc.isDebugEnabled())
-                                    Tr.debug(this, tc, "close " + resource);
-                                resource.close();
-                            } catch (Throwable x) {
-                                FFDCFilter.processException(x, getClass().getName(), "1827", this);
-                            }
-                    if (added)
-                        defaultMethodResources.remove();
-                }
+                Object returnValue = invokeDefaultMethod(proxy, method, args);
+                if (trace && tc.isEntryEnabled())
+                    Tr.exit(this, tc, "invoke " + repositoryInterface.getSimpleName() +
+                                      '.' + method.getName(),
+                            provider.loggable(repositoryInterface, method, returnValue));
+                return returnValue;
             }
 
             Object returnValue;
@@ -688,4 +661,39 @@ public class RepositoryImpl<R> implements InvocationHandler {
         }
     }
 
+    /**
+     * Invokes a default method on a repository.
+     *
+     * @param proxy  instance upon which the application invoked the default method
+     * @param method the default method
+     * @param args   arguments to the default method
+     * @return the result of the default method
+     * @throws Throwable if thrown by the default method
+     */
+    @Trivial // avoid tracing customer data
+    private Object invokeDefaultMethod(Object proxy, Method method, Object... args) //
+                    throws Throwable {
+        Deque<AutoCloseable> resourceStack = defaultMethodResources.get();
+        boolean added;
+        if (added = (resourceStack == null))
+            defaultMethodResources.set(resourceStack = new LinkedList<>());
+        else
+            resourceStack.add(null); // indicator of nested default method
+        try {
+            return InvocationHandler.invokeDefault(proxy, method, args);
+        } finally {
+            for (AutoCloseable resource; (resource = resourceStack.pollLast()) != null;)
+                if (!(resource instanceof EntityManager) ||
+                    ((EntityManager) resource).isOpen())
+                    try {
+                        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
+                            Tr.debug(this, tc, "close " + resource);
+                        resource.close();
+                    } catch (Throwable x) {
+                        // auto FFDC
+                    }
+            if (added)
+                defaultMethodResources.remove();
+        }
+    }
 }

--- a/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/cdi/StatefulPersistenceContext.java
+++ b/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/cdi/StatefulPersistenceContext.java
@@ -51,7 +51,7 @@ public class StatefulPersistenceContext {
      * Closes all EntityManagers at the end of the request scope.
      */
     @PreDestroy
-    private void dispose() throws Exception {
+    private void dispose() {
         final boolean trace = TraceComponent.isAnyTracingEnabled();
 
         for (Iterator<Entry<EntityHandlerFactory, EntityManager>> it = //
@@ -93,7 +93,7 @@ public class StatefulPersistenceContext {
                 } catch (Exception x) {
                     // TODO better NLS message for error writing changes to database
                     Tr.error(tc, "CWWKD1000.repo.general.err", "", "", x.toString());
-                    throw x;
+                    x.printStackTrace(System.err);
                 } finally {
                     try {
                         if (startedTransaction)
@@ -121,7 +121,7 @@ public class StatefulPersistenceContext {
                     } catch (Exception x) {
                         // TODO better NLS message for error comitting changes to database
                         Tr.error(tc, "CWWKD1000.repo.general.err", "", "", x.toString());
-                        throw x;
+                        x.printStackTrace(System.err);
                     } finally {
                         em.close();
                     }

--- a/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/provider/PUnitEHFactory.java
+++ b/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/provider/PUnitEHFactory.java
@@ -15,6 +15,7 @@ package io.openliberty.data.internal.provider;
 import static io.openliberty.data.internal.cdi.DataExtension.exc;
 
 import java.io.PrintWriter;
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.Set;
 
@@ -27,6 +28,7 @@ import com.ibm.ws.ffdc.annotation.FFDCIgnore;
 
 import io.openliberty.data.internal.DataProvider;
 import io.openliberty.data.internal.EntityHandlerFactory;
+import jakarta.data.exceptions.DataException;
 import jakarta.persistence.CacheRetrieveMode;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.EntityManagerFactory;
@@ -67,6 +69,36 @@ public class PUnitEHFactory extends EntityHandlerFactory {
         this.emf = emf;
 
         collectEntityInfo(entityTypes, null);
+    }
+
+    @Override
+    @Trivial
+    public AutoCloseable createEntityAgent() {
+        AutoCloseable agent;
+        // TODO Persistence 4.0 API
+        // agent = emf.getEntityAgent();
+
+        try {
+            // Because persistence-4.0 is unavailable and persistence-3.2 must
+            // be used in the meantime, emf is a
+            // com.ibm.ws.jpa.container.v32.JPAEMFactoryV32, which does not
+            // have the createEntityAgent method.
+            // A workaround is to unwrap it.
+            EntityManagerFactory factory = //
+                            emf.unwrap(EntityManagerFactory.class);
+
+            agent = (AutoCloseable) factory.getClass() //
+                            .getMethod("openStatelessSession") // TODO "createEntityAgent") //
+                            .invoke(factory);
+        } catch (IllegalAccessException | NoSuchMethodException x) {
+            throw new RuntimeException(x); // should be impossible
+        } catch (InvocationTargetException x) {
+            throw new DataException(x.getCause());
+        }
+
+        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
+            Tr.debug(this, tc, "createEntityAgent: " + agent);
+        return agent;
     }
 
     @Override

--- a/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/service/DBStoreEHFactory.java
+++ b/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/service/DBStoreEHFactory.java
@@ -464,6 +464,15 @@ public class DBStoreEHFactory extends EntityHandlerFactory implements DDLGenerat
 
     @Override
     @Trivial
+    public AutoCloseable createEntityAgent() {
+        throw new UnsupportedOperationException("createEntityAgent");
+
+        // TODO Persistence 4.0 API
+        // agent = persistenceServiceUnit.getEntityAgent();
+    }
+
+    @Override
+    @Trivial
     public EntityManager createEntityManager() {
         EntityManager em = persistenceServiceUnit.createEntityManager();
         em.setCacheRetrieveMode(CacheRetrieveMode.BYPASS);

--- a/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/v1_1/QueryInfo_1_1.java
+++ b/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/v1_1/QueryInfo_1_1.java
@@ -37,6 +37,7 @@ import java.util.stream.Stream;
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.websphere.ras.annotation.Trivial;
+import com.ibm.ws.ffdc.annotation.FFDCIgnore;
 
 import io.openliberty.data.internal.AttributeConstraint;
 import io.openliberty.data.internal.QueryInfo;
@@ -103,7 +104,6 @@ import jakarta.data.spi.expression.function.TextFunctionExpression;
 import jakarta.data.spi.expression.literal.Literal;
 import jakarta.data.spi.expression.path.NavigablePath;
 import jakarta.data.spi.expression.path.Path;
-import jakarta.persistence.Entity;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.TypedQuery;
 
@@ -377,10 +377,12 @@ public class QueryInfo_1_1 extends QueryInfo {
             return (jakarta.persistence.Query) entityHandler.getClass() //
                             .getMethod("createQuery", String.class) //
                             .invoke(entityHandler, jpql);
-        } catch (IllegalAccessException | //
-                        InvocationTargetException | //
-                        NoSuchMethodException x) {
+        } catch (IllegalAccessException | NoSuchMethodException x) {
             throw new RuntimeException(x); // should be impossible
+        } catch (InvocationTargetException x) {
+            if (x.getCause() instanceof RuntimeException rx)
+                throw rx;
+            throw new DataException(x.getCause());
         }
     }
 
@@ -398,13 +400,16 @@ public class QueryInfo_1_1 extends QueryInfo {
             return (TypedQuery<T>) entityHandler.getClass() //
                             .getMethod("createQuery", String.class, Class.class) //
                             .invoke(entityHandler, jpql, resultType);
-        } catch (IllegalAccessException | //
-                        InvocationTargetException | //
-                        NoSuchMethodException x) {
+        } catch (IllegalAccessException | NoSuchMethodException x) {
             throw new RuntimeException(x); // should be impossible
+        } catch (InvocationTargetException x) {
+            if (x.getCause() instanceof RuntimeException rx)
+                throw rx;
+            throw new DataException(x.getCause());
         }
     }
 
+    @FFDCIgnore(InvocationTargetException.class)
     @Override
     @Trivial
     protected void ehDelete(AutoCloseable entityHandler, Object entity) {
@@ -418,16 +423,19 @@ public class QueryInfo_1_1 extends QueryInfo {
         else
             try {
                 entityHandler.getClass() //
-                                .getMethod("delete", Entity.class) //
+                                .getMethod("delete", Object.class) //
                                 .invoke(entityHandler, entity);
             } catch (IllegalAccessException | NoSuchMethodException x) {
                 throw new RuntimeException(x); // should be impossible
             } catch (InvocationTargetException x) {
+                if (x.getCause() instanceof RuntimeException rx)
+                    throw rx;
                 throw new DataException(x.getCause());
             }
         // TODO deleteMultiple
     }
 
+    @FFDCIgnore(InvocationTargetException.class)
     @Override
     @Trivial
     protected void ehInsert(AutoCloseable entityHandler, Object entity) {
@@ -441,16 +449,19 @@ public class QueryInfo_1_1 extends QueryInfo {
         else
             try {
                 entityHandler.getClass() //
-                                .getMethod("insert", Entity.class) //
+                                .getMethod("insert", Object.class) //
                                 .invoke(entityHandler, entity);
             } catch (IllegalAccessException | NoSuchMethodException x) {
                 throw new RuntimeException(x); // should be impossible
             } catch (InvocationTargetException x) {
+                if (x.getCause() instanceof RuntimeException rx)
+                    throw rx;
                 throw new DataException(x.getCause());
             }
         // TODO insertMultiple
     }
 
+    @FFDCIgnore(InvocationTargetException.class)
     @Override
     @Trivial
     protected Object ehUpdate(AutoCloseable entityHandler, Object entity) {
@@ -464,18 +475,22 @@ public class QueryInfo_1_1 extends QueryInfo {
             updated = manager.merge(entity);
         else
             try {
-                updated = entityHandler.getClass() //
-                                .getMethod("update", Entity.class) //
+                entityHandler.getClass() //
+                                .getMethod("update", Object.class) //
                                 .invoke(entityHandler, entity);
+                updated = entity;
             } catch (IllegalAccessException | NoSuchMethodException x) {
                 throw new RuntimeException(x); // should be impossible
             } catch (InvocationTargetException x) {
+                if (x.getCause() instanceof RuntimeException rx)
+                    throw rx;
                 throw new DataException(x.getCause());
             }
         // TODO updateMultiple
         return updated;
     }
 
+    @FFDCIgnore(InvocationTargetException.class)
     @Override
     @Trivial
     protected Object ehUpsert(AutoCloseable entityHandler, Object entity) {
@@ -489,12 +504,15 @@ public class QueryInfo_1_1 extends QueryInfo {
             upserted = manager.merge(entity);
         else
             try {
-                upserted = entityHandler.getClass() //
-                                .getMethod("upsert", Entity.class) //
+                entityHandler.getClass() //
+                                .getMethod("upsert", Object.class) //
                                 .invoke(entityHandler, entity);
+                upserted = entity;
             } catch (IllegalAccessException | NoSuchMethodException x) {
                 throw new RuntimeException(x); // should be impossible
             } catch (InvocationTargetException x) {
+                if (x.getCause() instanceof RuntimeException rx)
+                    throw rx;
                 throw new DataException(x.getCause());
             }
         // TODO upsertMultiple

--- a/dev/io.openliberty.data.internal_fat_1_1/build.gradle
+++ b/dev/io.openliberty.data.internal_fat_1_1/build.gradle
@@ -14,7 +14,7 @@
 apply from: '../wlp-gradle/subprojects/maven-central-mirror.gradle'
 
 ext {
-    hibernateVersion = '7.0.9.Final'
+    hibernateVersion = '8.0.0.Alpha1'
   }
 
 configurations {

--- a/dev/io.openliberty.data.internal_fat_1_1/build.gradle
+++ b/dev/io.openliberty.data.internal_fat_1_1/build.gradle
@@ -14,7 +14,7 @@
 apply from: '../wlp-gradle/subprojects/maven-central-mirror.gradle'
 
 ext {
-    hibernateVersion = '8.0.0.Alpha1'
+    hibernateVersion = '7.0.9.Final'
   }
 
 configurations {


### PR DESCRIPTION
We can obtain a Hibernate vendor specific form of an EntityAgent with the openStatelessSession method.  Temporarily use this method to allow us to experiment with EntityAgent methods.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
