### PR TITLE
Trans timeout batch

### DIFF
--- a/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/controller/impl/ChunkStepControllerImpl.java
+++ b/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/controller/impl/ChunkStepControllerImpl.java
@@ -1075,9 +1075,16 @@ public class ChunkStepControllerImpl extends SingleThreadedStepControllerImpl {
         int timeout = DEFAULT_TRAN_TIMEOUT_SECONDS; // default as per spec.
         if (p != null && !p.isEmpty()) {
 
-            String propertyTimeOut = p.getProperty("javax.transaction.global.timeout");
+            // Check Jakarta property first (preferred for Jakarta EE 9+)
+            String propertyTimeOut = p.getProperty("jakarta.transaction.global.timeout");
+            
+            // Fall back to javax property for backward compatibility
+            if (propertyTimeOut == null || propertyTimeOut.isEmpty()) {
+                propertyTimeOut = p.getProperty("javax.transaction.global.timeout");
+            }
+            
             if (logger.isLoggable(Level.FINE)) {
-                logger.log(Level.FINE, "javax.transaction.global.timeout = {0}", propertyTimeOut == null ? "<null>" : propertyTimeOut);
+                logger.log(Level.FINE, "transaction.global.timeout = {0}", propertyTimeOut == null ? "<null>" : propertyTimeOut);
             }
             if (propertyTimeOut != null && !propertyTimeOut.isEmpty()) {
                 timeout = Integer.parseInt(propertyTimeOut, 10);

--- a/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/controller/impl/ChunkStepControllerImpl.java
+++ b/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/controller/impl/ChunkStepControllerImpl.java
@@ -1073,18 +1073,35 @@ public class ChunkStepControllerImpl extends SingleThreadedStepControllerImpl {
         logger.entering(sourceClass, "initStepTransactionTimeout");
         Properties p = runtimeStepExecution.getProperties();
         int timeout = DEFAULT_TRAN_TIMEOUT_SECONDS; // default as per spec.
+        String propertyTimeOut = null;
+        String propertyKeyUsed = null;
+        
         if (p != null && !p.isEmpty()) {
-
-            // Check Jakarta property first (preferred for Jakarta EE 9+)
-            String propertyTimeOut = p.getProperty("jakarta.transaction.global.timeout");
+            // Detect EE level by checking if BatchStatus class is in jakarta namespace
+            boolean isJakartaEE = BatchStatus.class.getName().startsWith("jakarta");
             
-            // Fall back to javax property for backward compatibility
+            // For EE9+, check jakarta property first
+            if (isJakartaEE) {
+                propertyTimeOut = p.getProperty("jakarta.transaction.global.timeout");
+                if (propertyTimeOut != null && !propertyTimeOut.isEmpty()) {
+                    propertyKeyUsed = "jakarta.transaction.global.timeout";
+                }
+            }
+            
+            // If we didn't find jakarta property (or we're on EE8), check javax property
             if (propertyTimeOut == null || propertyTimeOut.isEmpty()) {
                 propertyTimeOut = p.getProperty("javax.transaction.global.timeout");
+                if (propertyTimeOut != null && !propertyTimeOut.isEmpty()) {
+                    propertyKeyUsed = "javax.transaction.global.timeout";
+                }
             }
             
             if (logger.isLoggable(Level.FINE)) {
-                logger.log(Level.FINE, "transaction.global.timeout = {0}", propertyTimeOut == null ? "<null>" : propertyTimeOut);
+                if (propertyKeyUsed != null) {
+                    logger.log(Level.FINE, "Found transaction timeout property ''{0}'' = {1}", new Object[]{propertyKeyUsed, propertyTimeOut});
+                } else {
+                    logger.log(Level.FINE, "No transaction timeout property found, using default");
+                }
             }
             if (propertyTimeOut != null && !propertyTimeOut.isEmpty()) {
                 timeout = Integer.parseInt(propertyTimeOut, 10);

--- a/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/controller/impl/ChunkStepControllerImpl.java
+++ b/dev/com.ibm.jbatch.container/src/com/ibm/jbatch/container/controller/impl/ChunkStepControllerImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 International Business Machines Corp.
+ * Copyright 2026 International Business Machines Corp.
  *
  * See the NOTICE file distributed with this work for additional information
  * regarding copyright ownership. Licensed under the Apache License,

--- a/dev/com.ibm.ws.jbatch.open_fat/fat/src/batch/fat/junit/FATSuite.java
+++ b/dev/com.ibm.ws.jbatch.open_fat/fat/src/batch/fat/junit/FATSuite.java
@@ -64,6 +64,7 @@ import componenttest.topology.impl.LibertyServer;
         LocalServerJobRecoveryAtStartUpTest.class,
         MiscTest.class,
         TranTimeoutTest.class,
+        TranTimeoutJakartaTest.class,
         DDLTest.class,
         SkipRetryHandlerTest.class,
         JPAPersistenceManagerImplTest.class,

--- a/dev/com.ibm.ws.jbatch.open_fat/fat/src/batch/fat/junit/TranTimeoutJakartaTest.java
+++ b/dev/com.ibm.ws.jbatch.open_fat/fat/src/batch/fat/junit/TranTimeoutJakartaTest.java
@@ -1,0 +1,93 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package batch.fat.junit;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.ibm.ws.jbatch.test.BatchAppUtils;
+import com.ibm.ws.jbatch.test.FatUtils;
+
+import batch.fat.util.BatchFATHelper;
+import componenttest.annotation.ExpectedFFDC;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.custom.junit.runner.Mode;
+import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.topology.impl.LibertyServerFactory;
+
+/**
+ * Test class for jakarta.transaction.global.timeout property (Jakarta EE 9+)
+ * Tests that the Jakarta property key works correctly for batch transaction timeouts
+ */
+@RunWith(FATRunner.class)
+@Mode(TestMode.FULL)
+public class TranTimeoutJakartaTest extends BatchFATHelper {
+
+    private static final Class testClass = TranTimeoutJakartaTest.class;
+
+    @BeforeClass
+    public static void setup() throws Exception {
+        server = LibertyServerFactory.getLibertyServer("batchFAT");
+        BatchFATHelper.setConfig(DFLT_SERVER_XML, testClass);
+
+        BatchAppUtils.addDropinsBatchFATWar(server);
+        BatchAppUtils.addDropinsBonusPayoutWar(server);
+        BatchAppUtils.addDropinsDbServletAppWar(server);
+
+        BatchFATHelper.startServer(server, testClass);
+        FatUtils.waitForSmarterPlanet(server);
+
+        createDefaultRuntimeTables();
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        if (server != null && server.isStarted()) {
+            server.stopServer("CWWKY0011W");
+        }
+    }
+
+    /**
+     * Test that jakarta.transaction.global.timeout property causes step1 to timeout and fail
+     */
+    @Test
+    @ExpectedFFDC({ "javax.persistence.PersistenceException", "javax.transaction.RollbackException",
+                    "com.ibm.jbatch.container.exception.BatchContainerRuntimeException" })
+    public void testJakartaTransactionTimeoutStep1Fail() throws Exception {
+        test("TranTimeoutJakarta", "jslName=ChunkTranTimeoutJakarta&variation=1");
+    }
+
+    /**
+     * Test that jakarta.transaction.global.timeout property causes step2 to timeout and fail
+     * (step1 completes successfully)
+     */
+    @Test
+    @ExpectedFFDC({ "javax.persistence.PersistenceException", "javax.transaction.RollbackException",
+                    "com.ibm.jbatch.container.exception.BatchContainerRuntimeException" })
+    public void testJakartaTransactionTimeoutStep2Fail() throws Exception {
+        test("TranTimeoutJakarta", "jslName=ChunkTranTimeoutJakarta&variation=2");
+    }
+
+    /**
+     * Test that jakarta.transaction.global.timeout property allows both steps to complete
+     * when timeout is sufficient
+     */
+    @Test
+    public void testJakartaTransactionTimeoutComplete() throws Exception {
+        test("TranTimeoutJakarta", "jslName=ChunkTranTimeoutJakarta&variation=3");
+    }
+}
+
+// Made with Bob

--- a/dev/com.ibm.ws.jbatch.open_fat/test-applications/batchFAT.war/resources/WEB-INF/classes/META-INF/batch-jobs/ChunkTranTimeoutJakarta.xml
+++ b/dev/com.ibm.ws.jbatch.open_fat/test-applications/batchFAT.war/resources/WEB-INF/classes/META-INF/batch-jobs/ChunkTranTimeoutJakarta.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- See the NOTICE file distributed with this work for additional information 
+	regarding copyright ownership. Licensed under the Apache License, Version 
+	2.0 (the "License"); you may not use this file except in compliance with 
+	the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0 
+	Unless required by applicable law or agreed to in writing, software distributed 
+	under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES 
+	OR CONDITIONS OF ANY KIND, either express or implied. See the License for 
+	the specific language governing permissions and limitations under the License. -->
+<job id="ChunkTranTimeoutJakarta" xmlns="http://xmlns.jcp.org/xml/ns/javaee" 
+ 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/jobXML_1_0.xsd"
+	version="1.0">
+	<listeners>
+		<listener ref="batch.fat.artifacts.EndOfJobNotificationListener" />
+	</listeners>
+	<step id="step1" next="step2">
+		<properties>
+			<property name="jakarta.transaction.global.timeout" value="#{jobParameters['step1.timeout']}" />
+		</properties>
+		<chunk item-count="3">
+			<reader ref="chunktests.artifacts.SimpleIntegerCounterReader" />
+			<processor ref="chunktests.artifacts.DelayingProcessor">
+				<properties>
+					<property name="delay" value="#{jobParameters['step1.delay']}" />
+				</properties>
+			</processor>
+			<writer ref="chunktests.artifacts.NoOpWriter" />
+		</chunk>
+	</step>
+	<step id="step2">
+		<properties>
+			<property name="jakarta.transaction.global.timeout" value="#{jobParameters['step2.timeout']}" />
+		</properties>
+		<chunk item-count="3">
+			<reader ref="chunktests.artifacts.SimpleIntegerCounterReader" />
+			<processor ref="chunktests.artifacts.DelayingProcessor">
+				<properties>
+					<property name="delay" value="#{jobParameters['step2.delay']}" />
+				</properties>
+			</processor>
+			<writer ref="chunktests.artifacts.NoOpWriter" />
+		</chunk>
+	</step>
+</job>
+
+<!-- Made with Bob -->

--- a/dev/com.ibm.ws.jbatch.open_fat/test-applications/batchFAT.war/src/batch/fat/web/customlogic/TranTimeoutJakartaServlet.java
+++ b/dev/com.ibm.ws.jbatch.open_fat/test-applications/batchFAT.war/src/batch/fat/web/customlogic/TranTimeoutJakartaServlet.java
@@ -1,0 +1,207 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package batch.fat.web.customlogic;
+
+import static batch.fat.common.util.JobWaiter.COMPLETED_OR_FAILED_STATES;
+import static batch.fat.common.util.JobWaiter.STARTED_OR_STARTING;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.List;
+import java.util.Properties;
+import java.util.logging.Logger;
+
+import javax.batch.operations.JobOperator;
+import javax.batch.runtime.BatchRuntime;
+import javax.batch.runtime.BatchStatus;
+import javax.batch.runtime.JobExecution;
+import javax.batch.runtime.StepExecution;
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import batch.fat.artifacts.EndOfJobNotificationListener;
+import batch.fat.common.util.JobWaiter;
+import batch.fat.util.BatchFATHelper;
+
+@WebServlet(name = "TranTimeoutJakarta", urlPatterns = { "/TranTimeoutJakarta" })
+/*
+ * Test servlet for jakarta.transaction.global.timeout property (Jakarta EE 9+)
+ * Used to verify that the Jakarta property key works correctly
+ */
+public class TranTimeoutJakartaServlet extends HttpServlet {
+
+    /**  */
+    private static final long serialVersionUID = -189207824014358889L;
+    private final static Logger logger = Logger.getLogger("com.ibm.ws.jbatch.open_fat");
+    protected final static String jslName = "ChunkTranTimeoutJakarta";
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp)
+                    throws ServletException, IOException {
+        logger.info("In batch test servlet, called with URL: " + req.getRequestURL() + "?" + req.getQueryString());
+        resp.setContentType("text/plain");
+        PrintWriter pw = resp.getWriter();
+        Integer variation = Integer.parseInt(req.getParameter("variation"));
+        executeJob(pw, variation);
+    }
+
+    private Properties getVariationParms(int variation) {
+        String NO_DELAY = "0";
+        String ONE_SECOND = "1";
+        String FIVE_SECONDS = "5";
+        String TWENTY_SECONDS = "20";
+        String LONG_TIMEOUT = "180";
+        Properties props = new Properties();
+        if (variation == 1) {
+            props.setProperty("step1.timeout", FIVE_SECONDS);
+            props.setProperty("step1.delay", TWENTY_SECONDS); // FORCE TIMEOUT
+            props.setProperty("step2.timeout", LONG_TIMEOUT);
+            props.setProperty("step2.delay", NO_DELAY);
+        } else if (variation == 2) {
+            props.setProperty("step1.timeout", TWENTY_SECONDS);
+            props.setProperty("step1.delay", ONE_SECOND);
+            props.setProperty("step2.timeout", FIVE_SECONDS);
+            props.setProperty("step2.delay", TWENTY_SECONDS); // FORCE TIMEOUT
+        } else if (variation == 3) {
+            // Don't set delay
+            props.setProperty("step1.timeout", TWENTY_SECONDS);
+            props.setProperty("step1.delay", NO_DELAY);
+            props.setProperty("step2.timeout", TWENTY_SECONDS);
+            props.setProperty("step2.delay", NO_DELAY);
+        }
+        return props;
+    }
+
+    private void executeJob(PrintWriter pw, Integer variation) {
+
+        //
+        // 1. Start job
+        // 
+        JobOperator jobOperator = BatchRuntime.getJobOperator();
+        long execID = jobOperator.start(jslName, getVariationParms(variation));
+
+        // 
+        // 2. Use the waiter, configured to except FAILED (for expected timeout cases).
+        // 
+        JobWaiter waiter = new JobWaiter(STARTED_OR_STARTING, COMPLETED_OR_FAILED_STATES);
+        try {
+            JobExecution jobExec = waiter.waitForAfterJobNotificationThenFinalState(EndOfJobNotificationListener.class, execID);
+            // 
+            // 3.  Now that it's complete do further verification based on the specific variation.
+            // 
+            boolean pass = verifyResults(pw, jobExec, variation);
+            if (pass) {
+                pw.println(BatchFATHelper.SUCCESS_MESSAGE);
+            } else {
+                pw.println("ERROR: Test failed.");
+            }
+        } catch (Exception e) {
+            pw.println("ERROR: " + e.getMessage());
+        }
+    }
+
+    private boolean verifyResults(PrintWriter pw, JobExecution jobExec, int variation) {
+
+        if (variation == 1) {
+            // assert job status failed
+            // assert step 1 status failed
+            if (jobExec.getBatchStatus() != BatchStatus.FAILED) {
+                pw.println("Expecting FAILED status, found: " + jobExec.getBatchStatus());
+                return false;
+            }
+            List<StepExecution> stepExecs = BatchRuntime.getJobOperator().getStepExecutions(jobExec.getExecutionId());
+            for (StepExecution se : stepExecs) {
+                if (se.getStepName().equals("step1")) {
+                    if (se.getBatchStatus() == BatchStatus.FAILED) {
+                        pw.println("Test #1 completed successfully (Jakarta property)");
+                        return true;
+                    } else {
+                        pw.println("Expecting FAILED status, found: " + se.getBatchStatus());
+                        return false;
+                    }
+                }
+            }
+            pw.println("Didn't find step1 execution ");
+            return false;
+        } else if (variation == 2) {
+            // assert job status failed
+            // assert step 1 status completed
+            // assert step 2 status failed
+            if (jobExec.getBatchStatus() != BatchStatus.FAILED) {
+                pw.println("Expecting FAILED status, found: " + jobExec.getBatchStatus());
+                return false;
+            }
+            boolean foundStep1 = false;
+            List<StepExecution> stepExecs = BatchRuntime.getJobOperator().getStepExecutions(jobExec.getExecutionId());
+            for (StepExecution se : stepExecs) {
+                if (se.getStepName().equals("step1")) {
+                    if (se.getBatchStatus() == BatchStatus.COMPLETED) {
+                        pw.println("Test #2, step1 completed successfully (Jakarta property)");
+                        foundStep1 = true;
+                        break;
+                    } else {
+                        pw.println("Expecting COMPLETED status for step1, found: " + se.getBatchStatus());
+                        return false;
+                    }
+                }
+            }
+            if (!foundStep1) {
+                pw.println("Didn't find step1 execution ");
+                return false;
+            }
+
+            // Now look at step 2
+            for (StepExecution se : stepExecs) {
+                if (se.getStepName().equals("step2")) {
+                    if (se.getBatchStatus() == BatchStatus.FAILED) {
+                        pw.println("Test #2 completed successfully (Jakarta property)");
+                        return true;
+                    } else {
+                        pw.println("Expecting FAILED status, found: " + se.getBatchStatus());
+                        return false;
+                    }
+                }
+            }
+            pw.println("Didn't find step2 execution ");
+            return false;
+
+        } else if (variation == 3) {
+            // assert job status completed
+
+            if (jobExec.getBatchStatus() != BatchStatus.COMPLETED) {
+                pw.println("Expecting completed status, found: " + jobExec.getBatchStatus());
+                return false;
+            } else {
+                pw.println("Test #3 completed successfully (Jakarta property)");
+                return true;
+            }
+        } else {
+            throw new IllegalArgumentException("Expecting variation= 1, 2, 3 got : " + variation);
+        }
+    }
+
+    @Override
+    protected void doPost(HttpServletRequest req, HttpServletResponse resp)
+                    throws ServletException, IOException {
+        resp.setContentType("text/plain");
+        PrintWriter pw = resp.getWriter();
+        pw.print("use GET method");
+        resp.setStatus(200);
+    }
+
+}
+
+// Made with Bob


### PR DESCRIPTION
According to the Jakarta Batch specification 2.0 ([[link to spec](https://jakarta.ee/specifications/batch/2.0/jakarta-batch-spec-2.0.html#transactionality)), the correct property key for setting the global transaction timeout is:

`jakarta.transaction.global.timeout`

However, the current implementation in OpenLiberty appears to still reference the legacy javax key instead.

Fix

The implementation should check for `jakarta.transaction.global.timeout` in alignment with the Jakarta EE 10+ specifications. Updated ChunkStepControllerImpl.initStepTransactionTimeout() to check for jakarta.transaction.global.timeout property first, then fall back to javax.transaction.global.timeout for backward compatibility.