### PR TITLE
Workaround to include extra space before backslash in feature description

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/public/data-1.0/resources/l10n/io.openliberty.data-1.0.properties
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/data-1.0/resources/l10n/io.openliberty.data-1.0.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2022,2024 IBM Corporation and others.
+# Copyright (c) 2022,2026 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -16,9 +16,9 @@
 #NLS_MESSAGEFORMAT_NONE
 #
 
-description=Jakarta Data is a programming model for data access.\
- You can use Jakarta Data to represent data with Java objects called entities\
- and to define operations on data as methods of a repository interface.\
- A Jakarta Data provider supplies the repository implementation to an application.\
- The data-1.0 feature includes a built-in Jakarta Data provider for relational\
+description=Jakarta Data is a programming model for data access. \
+ You can use Jakarta Data to represent data with Java objects called entities \
+ and to define operations on data as methods of a repository interface. \
+ A Jakarta Data provider supplies the repository implementation to an application. \
+ The data-1.0 feature includes a built-in Jakarta Data provider for relational \
  database access.

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/data-1.1/resources/l10n/io.openliberty.data-1.1.properties
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/data-1.1/resources/l10n/io.openliberty.data-1.1.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2024 IBM Corporation and others.
+# Copyright (c) 2024,2026 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -16,4 +16,9 @@
 #NLS_MESSAGEFORMAT_NONE
 #
 
-description=Jakarta Data provides a repository-based data access pattern where the application defines custom data repository interfaces and the container or runtime provides the implementation.
+description=Jakarta Data is a programming model for data access. \
+ You can use Jakarta Data to represent data with Java objects called entities \
+ and to define operations on data as methods of a repository interface. \
+ A Jakarta Data provider supplies the repository implementation to an application. \
+ The data-1.1 feature includes a built-in Jakarta Data provider for relational \
+ database access.

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/dataContainer-1.0/resources/l10n/io.openliberty.dataContainer-1.0.properties
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/dataContainer-1.0/resources/l10n/io.openliberty.dataContainer-1.0.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2024 IBM Corporation and others.
+# Copyright (c) 2024,2026 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -16,9 +16,9 @@
 #NLS_MESSAGEFORMAT_NONE
 #
 
-description=Jakarta Data is a programming model for data access.\
- You can use Jakarta Data to represent data with Java objects called entities\
- and to define operations on data as methods of a repository interface.\
- A Jakarta Data provider supplies the repository implementation to an application.\
- The dataContainer-1.0 feature only includes the Jakarta Data 1.0 specification\
+description=Jakarta Data is a programming model for data access. \
+ You can use Jakarta Data to represent data with Java objects called entities \
+ and to define operations on data as methods of a repository interface. \
+ A Jakarta Data provider supplies the repository implementation to an application. \
+ The dataContainer-1.0 feature only includes the Jakarta Data 1.0 specification \
  interfaces. The dataContainer-1.0 feature does not include a Jakarta Data provider.


### PR DESCRIPTION
Work around a bug where, when the feature description is written on multiple lines, and the last word of a line is followed on the next line by a space and a subsequent word, the space is lost by the tooling that generates documentation from the description. The workaround is to add an extra space before the backslash character that indicates continuation on the next line.  Descriptions for some other features are already doing this.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
