### PR TITLE
Warn whitespace in @FormParam: Fixes #34688

### DIFF
--- a/dev/io.openliberty.org.jboss.resteasy.common.ee10/src/org/jboss/resteasy/core/FormParamInjector.java
+++ b/dev/io.openliberty.org.jboss.resteasy.common.ee10/src/org/jboss/resteasy/core/FormParamInjector.java
@@ -68,6 +68,13 @@ public class FormParamInjector extends StringParameterInjector implements ValueI
         this.encode = encode;
         this.factory = factory; //Liberty change
         this.annotations = annotations; //Liberty change
+        
+        //Liberty change: Warn about leading/trailing whitespace in parameter names
+        if (header != null && !header.equals(header.trim())) {
+            if (TraceComponent.isAnyTracingEnabled() && tc.isWarningEnabled()) {
+                Tr.warning(tc, "Parameter annotation '@FormParam(\"" + header + "\")' contains leading or trailing whitespace which may cause parameter matching issues. Consider using '@FormParam(\"" + header.trim() + "\")'.");
+            }
+        }
     }
 
    @SuppressWarnings({ "unchecked", "rawtypes", "serial" })

--- a/dev/io.openliberty.org.jboss.resteasy.common.ee11/src/org/jboss/resteasy/core/FormParamInjector.java
+++ b/dev/io.openliberty.org.jboss.resteasy.common.ee11/src/org/jboss/resteasy/core/FormParamInjector.java
@@ -55,6 +55,13 @@ public class FormParamInjector extends StringParameterInjector implements ValueI
         this.encode = encode;
         this.factory = factory; //Liberty change
         this.annotations = annotations; //Liberty change
+        
+        //Liberty change: Warn about leading/trailing whitespace in parameter names
+        if (header != null && !header.equals(header.trim())) {
+            if (TraceComponent.isAnyTracingEnabled() && tc.isWarningEnabled()) {
+                Tr.warning(tc, "Parameter annotation '@FormParam(\"" + header + "\")' contains leading or trailing whitespace which may cause parameter matching issues. Consider using '@FormParam(\"" + header.trim() + "\")'.");
+            }
+        }
     }
 
    @SuppressWarnings({ "unchecked", "rawtypes", "serial" }) //Liberty change


### PR DESCRIPTION



- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

- Add runtime warning when @FormParam annotation contains leading/trailing whitespace
- Helps identify parameter matching issues early
- Applied to both EE10 and EE11 FormParamInjector