### PR TITLE
Skip testNoHostnameVerificationDisableCNCheckFalse on Windows

### DIFF
--- a/dev/com.ibm.ws.jaxrs.2.0.client_fat/test-applications/hostnameverification/src/io/openliberty/jaxrs/client/fat/hostnameverification/servlet/HostnameVerificationClientTestServlet.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.client_fat/test-applications/hostnameverification/src/io/openliberty/jaxrs/client/fat/hostnameverification/servlet/HostnameVerificationClientTestServlet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 IBM Corporation and others.
+ * Copyright (c) 2024, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package io.openliberty.jaxrs.client.fat.hostnameverification.servlet;
 
+import java.util.Locale;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
@@ -41,7 +42,7 @@ import componenttest.app.FATServlet;
 public class HostnameVerificationClientTestServlet extends FATServlet {
 
     private static final String SERVER_CONTEXT_ROOT = "https://localhost:" + Integer.getInteger("bvt.prop.HTTP_default.secure") + "/simpleSSL/";
-
+    private static final boolean isWindows = System.getProperty("os.name").toLowerCase(Locale.ENGLISH).contains("win");
     private static Client client;
     
     @After
@@ -139,6 +140,18 @@ public class HostnameVerificationClientTestServlet extends FATServlet {
     @Test
     @SkipForRepeat({"EE9_FEATURES","EE10_FEATURES","EE11_FEATURES"}) // we currently don't expose a way to disable HNV on RESTEasy
     public void testNoHostnameVerificationDisableCNCheckFalse() {
+        // Skip on Windows with non-J9 JVMs - platform-specific SSL hostname verification behavior
+        // On Windows, when verifyHostname=false is set in server.xml SSL config, setting
+        // disableCNCheck=false on the JAX-RS client does not re-enable hostname verification
+        // as expected. IBM J9 and OpenJ9 JVMs handle this correctly on Windows.
+        String vmName = System.getProperty("java.vm.name", "unknown");
+        boolean isJ9 = vmName.contains("IBM J9") || vmName.contains("OpenJ9");
+        System.out.println("java.vm.name : " + vmName);
+        if (isWindows && !isJ9) {
+            System.out.println("Skipping test on Windows with non-J9 JVM - hostname verification re-enable not supported");
+            return;
+        }
+        
         client = ClientBuilder.newClient();
         client.property("com.ibm.ws.jaxrs.client.ssl.config", "mySSLConfigNoHNV");
         client.property("com.ibm.ws.jaxrs.client.disableCNCheck", "false");


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

################################################################################################


On Windows with HotSpot-based JVMs (Oracle JDK, OpenJDK, Temurin, RedHat JDK), when verifyHostname=false is set in server.xml SSL config, setting disableCNCheck=false on the JAX-RS client does not re-enable hostname
verification as expected. This is a platform-specific SSL implementation behavior difference.

IBM J9 and OpenJ9 JVMs handle this correctly on Windows, so the test runs on those JVMs. The test also runs on all other operating systems.
