### PR TITLE
Disable some H2 tests on IBM i due to jdk db2 driver

### DIFF
--- a/dev/com.ibm.ws.jdbc_fat_h2/test-applications/H2TestApp/src/test/jdbc/h2/web/H2TestServlet.java
+++ b/dev/com.ibm.ws.jdbc_fat_h2/test-applications/H2TestApp/src/test/jdbc/h2/web/H2TestServlet.java
@@ -22,7 +22,6 @@ import static org.junit.Assert.fail;
 
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
-import java.sql.Driver;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -46,6 +45,7 @@ import javax.sql.XADataSource;
 
 import org.junit.Test;
 
+import componenttest.annotation.SkipIfSysProp;
 import componenttest.app.FATServlet;
 
 @DataSourceDefinition(name = "java:app/jdbc/H2ConnectionPoolDataSource",
@@ -186,6 +186,7 @@ public class H2TestServlet extends FATServlet {
      * javax.sql.ConnectionPoolDataSource interface.
      */
     @Test
+    @SkipIfSysProp(SkipIfSysProp.OS_IBMI) //Skip on IBM i due to Db2 native driver in JDK
     public void testConnectionPoolDataSource() throws Exception {
         try (Connection con = h2cpDataSource.getConnection()) {
             assertEquals(true, con.getAutoCommit());
@@ -249,6 +250,7 @@ public class H2TestServlet extends FATServlet {
      * javax.sql.DataSource interface.
      */
     @Test
+    @SkipIfSysProp(SkipIfSysProp.OS_IBMI) //Skip on IBM i due to Db2 native driver in JDK
     public void testDataSource() throws Exception {
         try (Connection con = h2DataSource.getConnection()) {
             assertEquals(true, con.getAutoCommit());
@@ -301,6 +303,7 @@ public class H2TestServlet extends FATServlet {
      * java.sql.Driver interface.
      */
     @Test
+    @SkipIfSysProp(SkipIfSysProp.OS_IBMI) //Skip on IBM i due to Db2 native driver in JDK
     public void testDriver() throws Exception {
         try (Connection con = h2driverDataSource.getConnection()) {
             assertEquals(true, con.getAutoCommit());
@@ -350,6 +353,7 @@ public class H2TestServlet extends FATServlet {
      * javax.sql.XADataSource interface.
      */
     @Test
+    @SkipIfSysProp(SkipIfSysProp.OS_IBMI) //Skip on IBM i due to Db2 native driver in JDK
     public void testXADataSource() throws Exception {
         try (Connection con = h2xaDataSource.getConnection()) {
             assertEquals(true, con.getAutoCommit());


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".