### PR TITLE
Fixes PH70798: Hash Ltpa LoggedOut Token in Jcache

### DIFF
--- a/dev/com.ibm.ws.webcontainer.security/bnd.bnd
+++ b/dev/com.ibm.ws.webcontainer.security/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017,2025 IBM Corporation and others.
+# Copyright (c) 2017,2026 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.webcontainer.security/bnd.bnd
+++ b/dev/com.ibm.ws.webcontainer.security/bnd.bnd
@@ -105,6 +105,7 @@ instrument.classesExcludes: com/ibm/ws/webcontainer/security/resources/*.class
 	com.ibm.ws.security.mp.jwt.proxy;version=latest,\
 	io.openliberty.jcache.internal;version=latest,\
 	com.ibm.websphere.javaee.jcache.1.1.core;version=latest,\
+	com.ibm.ws.kernel.boot;version=latest, \
 	com.ibm.ws.kernel.boot.core;version=latest
 	
 

--- a/dev/com.ibm.ws.webcontainer.security/resources/com/ibm/ws/webcontainer/security/resources/WebAppSecurityMessages.nlsprops
+++ b/dev/com.ibm.ws.webcontainer.security/resources/com/ibm/ws/webcontainer/security/resources/WebAppSecurityMessages.nlsprops
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2011, 2021 IBM Corporation and others.
+# Copyright (c) 2011, 2026 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -163,13 +163,11 @@ JCACHE_PUT_FAILURE.useraction=Address the cause of the error.
 JCACHE_CONTAINSKEY_FAILURE=CWWKS9131E: The logged-out-cookie cache was unable to check the JCache cache for the cookie. The error is: {0}
 JCACHE_CONTAINSKEY_FAILURE.explanation=The logged-out-cookie cache encountered an error when it tried to check the JCache cache for the cookie. 
 JCACHE_CONTAINSKEY_FAILURE.useraction=Address the cause of the error.
-OLD_LOGOUT_TOKENS_MIGRATED_TO_HASHED=CWWKS9132W: Detected logged-out tokens of previous version. Please ensure all servers in your environment are upgraded to the latest version to avoid logged-out cache not being shared properly.
-OLD_LOGOUT_TOKENS_MIGRATED_TO_HASHED.explanation=The system detected logged-out tokens that were stored using an older format without hash encoding. These tokens have been automatically migrated to the new hashed format for improved security and consistency.
-OLD_LOGOUT_TOKENS_MIGRATED_TO_HASHED.useraction=Ensure that all servers in your cluster or environment are upgraded to the latest version that supports hashed token storage. Once all servers are upgraded, this migration will no longer be necessary.
+
+OLD_LOGOUT_TOKENS_MIGRATED=CWWKS9132W: Logged-out tokens with an older format are detected. For the logged-out cache to be shared properly, ensure all servers in your environment are upgraded to the latest version.
+OLD_LOGOUT_TOKENS_MIGRATED.explanation=The system detected logged-out tokens that have an older format. For improved security and consistency, logged-out tokens have been migrated to the newer format.
+OLD_LOGOUT_TOKENS_MIGRATED.useraction=To ensure that logged-out tokens use the most recent format, upgrade all servers in your cluster or environment to the latest version.
 
 JCACHE_MIGRATION_FAILURE=CWWKS9133E: The logged-out-cookie cache encountered an error while migrating old tokens to hashed versions. The error is: {0}
 JCACHE_MIGRATION_FAILURE.explanation=The logged-out-cookie cache encountered an error during the one-time migration of old logged-out tokens to the new hashed format.
 JCACHE_MIGRATION_FAILURE.useraction=Review the error message and server logs to determine the cause of the failure. The migration will be retried on the next server restart.
-LOGOUT_TOKEN_CACHE_SIZE_DOUBLED_BY_MIGRATION=CWWKS9134W: Migrated {0} tokens out of a total cache size of {1} entries. If your cache has a size limit configured, older entries may be evicted.
-LOGOUT_TOKEN_CACHE_SIZE_DOUBLED_BY_MIGRATION.explanation=The migration process creates new hashed versions of existing logged-out tokens while keeping the old versions temporarily. This doubles the number of entries in the cache during the migration period.
-LOGOUT_TOKEN_CACHE_SIZE_DOUBLED_BY_MIGRATION.useraction=Consider increasing your cache size limit to accommodate both old and new token formats during the migration period. Once all servers are upgraded and the old tokens expire, the cache size will return to normal.

--- a/dev/com.ibm.ws.webcontainer.security/resources/com/ibm/ws/webcontainer/security/resources/WebAppSecurityMessages.nlsprops
+++ b/dev/com.ibm.ws.webcontainer.security/resources/com/ibm/ws/webcontainer/security/resources/WebAppSecurityMessages.nlsprops
@@ -163,3 +163,13 @@ JCACHE_PUT_FAILURE.useraction=Address the cause of the error.
 JCACHE_CONTAINSKEY_FAILURE=CWWKS9131E: The logged-out-cookie cache was unable to check the JCache cache for the cookie. The error is: {0}
 JCACHE_CONTAINSKEY_FAILURE.explanation=The logged-out-cookie cache encountered an error when it tried to check the JCache cache for the cookie. 
 JCACHE_CONTAINSKEY_FAILURE.useraction=Address the cause of the error.
+OLD_LOGOUT_TOKENS_MIGRATED_TO_HASHED=CWWKS9132W: Detected logged-out tokens of previous version. Please ensure all servers in your environment are upgraded to the latest version to avoid logged-out cache not being shared properly.
+OLD_LOGOUT_TOKENS_MIGRATED_TO_HASHED.explanation=The system detected logged-out tokens that were stored using an older format without hash encoding. These tokens have been automatically migrated to the new hashed format for improved security and consistency.
+OLD_LOGOUT_TOKENS_MIGRATED_TO_HASHED.useraction=Ensure that all servers in your cluster or environment are upgraded to the latest version that supports hashed token storage. Once all servers are upgraded, this migration will no longer be necessary.
+
+JCACHE_MIGRATION_FAILURE=CWWKS9133E: The logged-out-cookie cache encountered an error while migrating old tokens to hashed versions. The error is: {0}
+JCACHE_MIGRATION_FAILURE.explanation=The logged-out-cookie cache encountered an error during the one-time migration of old logged-out tokens to the new hashed format.
+JCACHE_MIGRATION_FAILURE.useraction=Review the error message and server logs to determine the cause of the failure. The migration will be retried on the next server restart.
+LOGOUT_TOKEN_CACHE_SIZE_DOUBLED_BY_MIGRATION=CWWKS9134W: Migrated {0} tokens out of a total cache size of {1} entries. If your cache has a size limit configured, older entries may be evicted.
+LOGOUT_TOKEN_CACHE_SIZE_DOUBLED_BY_MIGRATION.explanation=The migration process creates new hashed versions of existing logged-out tokens while keeping the old versions temporarily. This doubles the number of entries in the cache during the migration period.
+LOGOUT_TOKEN_CACHE_SIZE_DOUBLED_BY_MIGRATION.useraction=Consider increasing your cache size limit to accommodate both old and new token formats during the migration period. Once all servers are upgraded and the old tokens expire, the cache size will return to normal.

--- a/dev/com.ibm.ws.webcontainer.security/src/com/ibm/ws/webcontainer/security/LoggedOutCookieCacheHelper.java
+++ b/dev/com.ibm.ws.webcontainer.security/src/com/ibm/ws/webcontainer/security/LoggedOutCookieCacheHelper.java
@@ -36,7 +36,7 @@ public class LoggedOutCookieCacheHelper {
     private static LoggedOutCookieCache cookieCacheService = null;
     
     public static final String LOGOUT_KEY_PREFIX = "LOGOUT:";
-    private static final String SHA_512 = "SHA-512";
+    private static final String SHA_512 = CryptoUtils.MESSAGE_DIGEST_ALGORITHM_SHA512;
     private static final Object SYNC_OBJECT = new Object();
     private static MessageDigest CLONEABLE_MESSAGE_DIGEST = null;
 

--- a/dev/com.ibm.ws.webcontainer.security/src/com/ibm/ws/webcontainer/security/LoggedOutCookieCacheHelper.java
+++ b/dev/com.ibm.ws.webcontainer.security/src/com/ibm/ws/webcontainer/security/LoggedOutCookieCacheHelper.java
@@ -35,7 +35,7 @@ public class LoggedOutCookieCacheHelper {
 
     private static LoggedOutCookieCache cookieCacheService = null;
     
-    private static final String LOGOUT_KEY_PREFIX = "LOGOUT:";
+    public static final String LOGOUT_KEY_PREFIX = "LOGOUT:";
     private static final String SHA_512 = "SHA-512";
     private static final Object SYNC_OBJECT = new Object();
     private static MessageDigest CLONEABLE_MESSAGE_DIGEST = null;

--- a/dev/com.ibm.ws.webcontainer.security/src/com/ibm/ws/webcontainer/security/LoggedOutCookieCacheHelper.java
+++ b/dev/com.ibm.ws.webcontainer.security/src/com/ibm/ws/webcontainer/security/LoggedOutCookieCacheHelper.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2021, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -14,6 +14,15 @@ package com.ibm.ws.webcontainer.security;
 
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.websphere.ras.annotation.Trivial;
+import com.ibm.ws.common.crypto.CryptoUtils;
+import com.ibm.ws.common.encoder.Base64Coder;
+import com.ibm.ws.ffdc.annotation.FFDCIgnore;
+import com.ibm.ws.webcontainer.security.internal.StringUtil;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 
 /**
  * Utility 'helper' class to get the singleton {@link LoggedOutCookieCache}
@@ -25,6 +34,11 @@ public class LoggedOutCookieCacheHelper {
     private static final TraceComponent tc = Tr.register(LoggedOutCookieCacheHelper.class, "LoggedOutCookieCache");
 
     private static LoggedOutCookieCache cookieCacheService = null;
+    
+    private static final String LOGOUT_KEY_PREFIX = "LOGOUT:";
+    private static final String SHA_512 = "SHA-512";
+    private static final Object SYNC_OBJECT = new Object();
+    private static MessageDigest CLONEABLE_MESSAGE_DIGEST = null;
 
     /**
      * Get the singleton {@link LoggedOutCookieCache} instance.
@@ -43,5 +57,82 @@ public class LoggedOutCookieCacheHelper {
      */
     public static void setLoggedOutCookieCacheService(LoggedOutCookieCache service) {
         cookieCacheService = service;
+    }
+
+    /**
+     * Generate a hash key from the token string for cache storage using SHA-512.
+     * Uses a cloneable MessageDigest for better performance (approximately 50% faster).
+     * This method is used for both LTPA and JWT SSO tokens.
+     *
+     * @param tokenString The token string (LTPA or JWT SSO)
+     * @return Hash string with LOGOUT: prefix, or null if error
+     */
+    public static String generateTokenHashKey(String tokenString) {
+        if (tc.isEntryEnabled()) Tr.entry(tc, "generateTokenHashKey()", tokenString);
+
+        if (tokenString == null || tokenString.isEmpty()) {
+            if (tc.isEntryEnabled()) Tr.exit(tc, "generateTokenHashKey()", "null or empty token");
+            return null;
+        }
+
+        MessageDigest md = getCloneableMessageDigest();
+        if (md == null) {
+            if (tc.isDebugEnabled()) Tr.debug(tc, "MessageDigest unavailable; token hash cannot be generated. Logout tracking is disabled.");
+            if (tc.isEntryEnabled()) Tr.exit(tc, "generateTokenHashKey()", null);
+            return null;
+        }
+        
+        md.update(tokenString.getBytes(StandardCharsets.UTF_8));
+        String hashKey = LOGOUT_KEY_PREFIX + Base64Coder.base64EncodeToString(md.digest());
+        
+        if (tc.isEntryEnabled()) Tr.exit(tc, "generateTokenHashKey()", hashKey);
+        return hashKey;
+    }
+
+    /**
+     * Get a MessageDigest instance using clone() for better performance.
+     * Uses SHA-512 algorithm. Approximately 50% faster than creating new instances.
+     *
+     * @return A MessageDigest instance, or null if unavailable
+     */
+    @Trivial
+    @FFDCIgnore({ CloneNotSupportedException.class, NoSuchAlgorithmException.class })
+    private static MessageDigest getCloneableMessageDigest() {
+        /*
+         * If we've never been asked for a MessageDigest, create the parent of
+         * our clones.
+         */
+        if (CLONEABLE_MESSAGE_DIGEST == null) {
+            synchronized (SYNC_OBJECT) {
+                if (CLONEABLE_MESSAGE_DIGEST == null) {
+                    try {
+                        CLONEABLE_MESSAGE_DIGEST = MessageDigest.getInstance(SHA_512);
+                    } catch (NoSuchAlgorithmException nsae) {
+                        // Not possible. SHA-512 is required by all JREs.
+                    }
+                }
+            }
+        }
+
+        /*
+         * Try to clone the parent. If we can't, then we'll ignore the FFDC and create a
+         * new instance. If the clone fails, which is REALLY unlikely, as we
+         * know the SHA MessageDigest is cloneable on IBM and Sun JDKs
+         */
+        try {
+            return (MessageDigest) CLONEABLE_MESSAGE_DIGEST.clone();
+        } catch (CloneNotSupportedException cnse) {
+            if (tc.isDebugEnabled()) {
+                Tr.debug(tc, "CloneNotSupportedException caught while trying to clone MessageDigest with algorithm " + SHA_512
+                             + ". This is pretty unlikely, and we need to get details about the JDK which is in use.",
+                         cnse);
+            }
+            try {
+                return MessageDigest.getInstance(SHA_512);
+            } catch (NoSuchAlgorithmException nsae) {
+                // Not possible. SHA-512 is required by all JREs.
+                return null;
+            }
+        }
     }
 }

--- a/dev/com.ibm.ws.webcontainer.security/src/com/ibm/ws/webcontainer/security/LoggedOutTokenCacheImpl.java
+++ b/dev/com.ibm.ws.webcontainer.security/src/com/ibm/ws/webcontainer/security/LoggedOutTokenCacheImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2022 IBM Corporation and others.
+ * Copyright (c) 2014, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -12,9 +12,13 @@
  *******************************************************************************/
 package com.ibm.ws.webcontainer.security;
 
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.util.Map;
 import java.util.Properties;
 
+import com.ibm.ws.common.crypto.CryptoUtils;
+import com.ibm.ws.webcontainer.security.internal.StringUtil;
 import org.osgi.framework.ServiceReference;
 import org.osgi.service.component.ComponentContext;
 
@@ -39,6 +43,10 @@ public class LoggedOutTokenCacheImpl implements LoggedOutTokenCache {
     private static final TraceComponent tc = Tr.register(LoggedOutTokenCacheImpl.class);
 
     private static final AtomicServiceReference<TokenManager> tokenManager = new AtomicServiceReference<TokenManager>("tokenManager");
+    
+    private static MessageDigest messageDigest = null;
+
+    private static final String LOGOUT_KEY_PREFIX = "LOGOUT:";
 
     private final InMemoryLoggedOutTokenCache inMemoryCookieCache = new InMemoryLoggedOutTokenCache();
 
@@ -72,10 +80,11 @@ public class LoggedOutTokenCacheImpl implements LoggedOutTokenCache {
         String keyStr = (String) key;
 
         LoggedOutCookieCache jCacheCookieCache = LoggedOutCookieCacheHelper.getLoggedOutCookieCacheService();
+        String hashedKeyStr = generateTokenHashKey(keyStr);
         if (jCacheCookieCache != null) {
-            return jCacheCookieCache.contains(keyStr);
+            return jCacheCookieCache.contains(hashedKeyStr);
         } else {
-            return inMemoryCookieCache.contains(keyStr);
+            return inMemoryCookieCache.contains(hashedKeyStr);
         }
     }
 
@@ -116,10 +125,11 @@ public class LoggedOutTokenCacheImpl implements LoggedOutTokenCache {
          * Choose between using the in-memory logged out cookie cache, or the JCache logged out cookie cache.
          */
         LoggedOutCookieCache jCacheCookieCache = LoggedOutCookieCacheHelper.getLoggedOutCookieCacheService();
+        String hashedKeyStr = generateTokenHashKey(keyStr);
         if (jCacheCookieCache != null) {
-            jCacheCookieCache.put(keyStr, value);
+            jCacheCookieCache.put(hashedKeyStr, value);
         } else {
-            inMemoryCookieCache.put(keyStr, value, timeOut);
+            inMemoryCookieCache.put(hashedKeyStr, value, timeOut);
         }
     }
 
@@ -129,6 +139,43 @@ public class LoggedOutTokenCacheImpl implements LoggedOutTokenCache {
          * Indicate we should always track tokens if LoggedOutCookieCacheService is available.
          */
         return LoggedOutCookieCacheHelper.getLoggedOutCookieCacheService() != null;
+    }
+
+    /**
+     * Generate a hash key from the token bytes for cache storage.
+     *
+     * @param tokenString The LTPA token bytes
+     * @return Hash string with LOGOUT: prefix, or null if error
+     */
+    private String generateTokenHashKey(String tokenString) {
+        if (tc.isEntryEnabled()) Tr.entry(tc, "generateTokenHashKey()", tokenString);
+
+        if (tokenString == null || tokenString.isEmpty()) {
+            if (tc.isEntryEnabled()) Tr.exit(tc, "generateTokenHashKey()", "null or empty token");
+            return null;
+        }
+
+        if (messageDigest == null) {
+            try {
+                messageDigest = CryptoUtils.getMessageDigest();
+            } catch (NoSuchAlgorithmException e) {
+
+            }
+        }
+
+        String hashKey = null;
+        if (messageDigest != null) {
+            messageDigest.reset();
+            messageDigest.update(StringUtil.getBytes(tokenString));
+            byte[] hash = messageDigest.digest();
+
+            hashKey = LOGOUT_KEY_PREFIX + Base64Coder.base64Encode(StringUtil.toString(hash));
+        } else {
+            if (tc.isDebugEnabled()) Tr.debug(tc, "MessageDigest unavailable; token hash cannot be generated. Logout tracking is disabled.");
+        }
+
+        if (tc.isEntryEnabled()) Tr.exit(tc, "generateTokenHashKey()", hashKey);
+        return hashKey;
     }
 
     /**

--- a/dev/com.ibm.ws.webcontainer.security/src/com/ibm/ws/webcontainer/security/LoggedOutTokenCacheImpl.java
+++ b/dev/com.ibm.ws.webcontainer.security/src/com/ibm/ws/webcontainer/security/LoggedOutTokenCacheImpl.java
@@ -12,13 +12,9 @@
  *******************************************************************************/
 package com.ibm.ws.webcontainer.security;
 
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
 import java.util.Map;
 import java.util.Properties;
 
-import com.ibm.ws.common.crypto.CryptoUtils;
-import com.ibm.ws.webcontainer.security.internal.StringUtil;
 import org.osgi.framework.ServiceReference;
 import org.osgi.service.component.ComponentContext;
 
@@ -43,10 +39,6 @@ public class LoggedOutTokenCacheImpl implements LoggedOutTokenCache {
     private static final TraceComponent tc = Tr.register(LoggedOutTokenCacheImpl.class);
 
     private static final AtomicServiceReference<TokenManager> tokenManager = new AtomicServiceReference<TokenManager>("tokenManager");
-    
-    private static MessageDigest messageDigest = null;
-
-    private static final String LOGOUT_KEY_PREFIX = "LOGOUT:";
 
     private final InMemoryLoggedOutTokenCache inMemoryCookieCache = new InMemoryLoggedOutTokenCache();
 
@@ -80,7 +72,7 @@ public class LoggedOutTokenCacheImpl implements LoggedOutTokenCache {
         String keyStr = (String) key;
 
         LoggedOutCookieCache jCacheCookieCache = LoggedOutCookieCacheHelper.getLoggedOutCookieCacheService();
-        String hashedKeyStr = generateTokenHashKey(keyStr);
+        String hashedKeyStr = LoggedOutCookieCacheHelper.generateTokenHashKey(keyStr);
         if (jCacheCookieCache != null) {
             return jCacheCookieCache.contains(hashedKeyStr);
         } else {
@@ -125,7 +117,7 @@ public class LoggedOutTokenCacheImpl implements LoggedOutTokenCache {
          * Choose between using the in-memory logged out cookie cache, or the JCache logged out cookie cache.
          */
         LoggedOutCookieCache jCacheCookieCache = LoggedOutCookieCacheHelper.getLoggedOutCookieCacheService();
-        String hashedKeyStr = generateTokenHashKey(keyStr);
+        String hashedKeyStr = LoggedOutCookieCacheHelper.generateTokenHashKey(keyStr);
         if (jCacheCookieCache != null) {
             jCacheCookieCache.put(hashedKeyStr, value);
         } else {
@@ -139,43 +131,6 @@ public class LoggedOutTokenCacheImpl implements LoggedOutTokenCache {
          * Indicate we should always track tokens if LoggedOutCookieCacheService is available.
          */
         return LoggedOutCookieCacheHelper.getLoggedOutCookieCacheService() != null;
-    }
-
-    /**
-     * Generate a hash key from the token bytes for cache storage.
-     *
-     * @param tokenString The LTPA token bytes
-     * @return Hash string with LOGOUT: prefix, or null if error
-     */
-    private String generateTokenHashKey(String tokenString) {
-        if (tc.isEntryEnabled()) Tr.entry(tc, "generateTokenHashKey()", tokenString);
-
-        if (tokenString == null || tokenString.isEmpty()) {
-            if (tc.isEntryEnabled()) Tr.exit(tc, "generateTokenHashKey()", "null or empty token");
-            return null;
-        }
-
-        if (messageDigest == null) {
-            try {
-                messageDigest = CryptoUtils.getMessageDigest();
-            } catch (NoSuchAlgorithmException e) {
-
-            }
-        }
-
-        String hashKey = null;
-        if (messageDigest != null) {
-            messageDigest.reset();
-            messageDigest.update(StringUtil.getBytes(tokenString));
-            byte[] hash = messageDigest.digest();
-
-            hashKey = LOGOUT_KEY_PREFIX + Base64Coder.base64Encode(StringUtil.toString(hash));
-        } else {
-            if (tc.isDebugEnabled()) Tr.debug(tc, "MessageDigest unavailable; token hash cannot be generated. Logout tracking is disabled.");
-        }
-
-        if (tc.isEntryEnabled()) Tr.exit(tc, "generateTokenHashKey()", hashKey);
-        return hashKey;
     }
 
     /**

--- a/dev/com.ibm.ws.webcontainer.security/src/com/ibm/ws/webcontainer/security/WebAppSecurityCollaboratorImpl.java
+++ b/dev/com.ibm.ws.webcontainer.security/src/com/ibm/ws/webcontainer/security/WebAppSecurityCollaboratorImpl.java
@@ -30,6 +30,7 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import io.openliberty.checkpoint.spi.CheckpointPhase;
 import org.osgi.framework.ServiceReference;
 import org.osgi.service.component.ComponentContext;
 
@@ -338,10 +339,18 @@ public class WebAppSecurityCollaboratorImpl implements IWebAppSecurityCollaborat
     /**
      * Set the {@link CacheService} for the logged out cookie cache on this {@link WebAppSecurityCollaboratorImpl}.
      *
+     * When the CacheService is set, this method also triggers a one-time migration of any old
+     * logged-out tokens (stored without hashing) to the new hashed format. The migration is
+     * performed directly since the CacheService is ready when this setter is called by OSGi DS.
+     *
      * @param service the {@link CacheService}
      */
     protected void setLoggedOutCookieCacheService(CacheService service) {
-        LoggedOutCookieCacheHelper.setLoggedOutCookieCacheService(new JCacheLoggedOutCookieCache(service));
+        final JCacheLoggedOutCookieCache jCacheLoggedOutCookieCache = new JCacheLoggedOutCookieCache(service);
+        LoggedOutCookieCacheHelper.setLoggedOutCookieCacheService(jCacheLoggedOutCookieCache);
+
+        // Defer migration to restore phase 1, runs AFTER CachingProvider init(rank 0 checkpoint)
+        CheckpointPhase.onRestore(1, jCacheLoggedOutCookieCache::migrateOldTokensToHashedVersions);
     }
 
     /**

--- a/dev/com.ibm.ws.webcontainer.security/src/com/ibm/ws/webcontainer/security/internal/JCacheLoggedOutCookieCache.java
+++ b/dev/com.ibm.ws.webcontainer.security/src/com/ibm/ws/webcontainer/security/internal/JCacheLoggedOutCookieCache.java
@@ -79,7 +79,6 @@ public class JCacheLoggedOutCookieCache implements LoggedOutCookieCache {
 
             // Collect entries to migrate and build the batch update map
             Map<Object, Object> entriesToMigrate = new HashMap<>();
-            int skippedCount = 0;
 
             for (Cache.Entry<Object, Object> entry : cache) {
                 try {
@@ -110,10 +109,10 @@ public class JCacheLoggedOutCookieCache implements LoggedOutCookieCache {
                             migrationWarningPrinted = true;
                         }
                     } else {
-                        skippedCount++;
                         if (tc.isDebugEnabled()) {
-                            Tr.debug(tc, "Hashed token exists in cache: " + keyStr);
+                            Tr.debug(tc, "Exiting migration due to hashed token in cache: " + keyStr);
                         }
+                        break;
                     }
                 } catch (Exception e) {
                     // Log error and continue with next entry
@@ -133,7 +132,7 @@ public class JCacheLoggedOutCookieCache implements LoggedOutCookieCache {
             migrationCompleted = true;
 
             if (tc.isDebugEnabled()) {
-                Tr.debug(tc, "Token migration completed. Migrated: " + migratedCount + ", Skipped: " + skippedCount);
+                Tr.debug(tc, "Token migration completed. Migrated: " + migratedCount);
             }
 
         } catch (Exception e) {

--- a/dev/com.ibm.ws.webcontainer.security/src/com/ibm/ws/webcontainer/security/internal/JCacheLoggedOutCookieCache.java
+++ b/dev/com.ibm.ws.webcontainer.security/src/com/ibm/ws/webcontainer/security/internal/JCacheLoggedOutCookieCache.java
@@ -12,9 +12,17 @@
  *******************************************************************************/
 package com.ibm.ws.webcontainer.security.internal;
 
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+import javax.cache.Cache;
+
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.ws.common.encoder.Base64Coder;
 import com.ibm.ws.webcontainer.security.LoggedOutCookieCache;
+import com.ibm.ws.webcontainer.security.LoggedOutCookieCacheHelper;
 import com.ibm.ws.webcontainer.security.TraceConstants;
 
 import io.openliberty.jcache.CacheService;
@@ -26,9 +34,116 @@ public class JCacheLoggedOutCookieCache implements LoggedOutCookieCache {
 
     private static final TraceComponent tc = Tr.register(JCacheLoggedOutCookieCache.class, "LoggedOutCookieCache", TraceConstants.MESSAGE_BUNDLE);
     private final CacheService cacheService;
+    private volatile boolean migrationCompleted = false;
+    private volatile boolean migrationWarningPrinted = false;
 
     public JCacheLoggedOutCookieCache(CacheService cacheService) {
         this.cacheService = cacheService;
+    }
+
+    /**
+     * Migrate old logged-out tokens (without LOGOUT: prefix) to their hashed versions.
+     * This method should be called once during server startup after the JCache is ready.
+     *
+     * This migration ensures backward compatibility with older versions that stored
+     * tokens without hashing. The migrated entries will use the same global expiration
+     * policy as all other cache entries, since JCache doesn't support per-entry TTL
+     * through the standard API.
+     *
+     * Once all servers are upgraded, this migration can be removed.
+     */
+    public void migrateOldTokensToHashedVersions() {
+        if (migrationCompleted) {
+            if (tc.isDebugEnabled()) {
+                Tr.debug(tc, "Token migration already completed, skipping.");
+            }
+            return;
+        }
+
+        if (tc.isDebugEnabled()) {
+            Tr.debug(tc, "Starting migration of old logged-out tokens to hashed versions.");
+        }
+
+        try {
+            Cache<Object, Object> cache = cacheService.getCache();
+            if (cache == null) {
+                if (tc.isDebugEnabled()) {
+                    Tr.debug(tc, "Cache is not available, skipping migration.");
+                }
+                return;
+            }
+
+            // First pass: Collect all entries to avoid modifying cache during iteration
+            List<String> keysToMigrate = new ArrayList<>();
+            int skippedCount = 0;
+            
+            for (Cache.Entry<Object, Object> entry : cache) {
+                try {
+                    Object key = entry.getKey();
+                    String keyStr = (String) key;
+
+                    // Check if the key is NOT prefixed with "LOGOUT:"
+                    if (!keyStr.startsWith(LoggedOutCookieCacheHelper.LOGOUT_KEY_PREFIX)) {
+                        keysToMigrate.add(keyStr);
+                    } else {
+                        // this implies the migration logic is already being run in other nodes, skip migration logic above
+                        skippedCount++;
+                        if (tc.isDebugEnabled()) {
+                            Tr.debug(tc, "Hashed token exists in cache: " + keyStr);
+                        }
+                    }
+                } catch (Exception e) {
+                    // Log and continue with next entry
+                    if (tc.isDebugEnabled()) {
+                        Tr.debug(tc, "Error processing cache entry during migration", e);
+                    }
+                }
+            }
+
+            // Second pass: Migrate collected keys
+            int migratedCount = 0;
+            for (String keyStr : keysToMigrate) {
+                try {
+                    int SHA512_DIGEST_LENGTH = 64;
+                    String hashedKey;
+                    boolean isJWTLoggedOutToken = Base64Coder.base64DecodeString(keyStr).length <= SHA512_DIGEST_LENGTH;
+                    if (isJWTLoggedOutToken) {
+                        // For JWT LoggedOutTokens, we are hashing them already with sha512, so we just need to add the prefix
+                        hashedKey = LoggedOutCookieCacheHelper.LOGOUT_KEY_PREFIX + keyStr;
+                    } else {
+                        // Generate the hashed version of the key
+                        hashedKey = LoggedOutCookieCacheHelper.generateTokenHashKey(keyStr);
+                    }
+                    cache.put(hashedKey, "");
+                    migratedCount++;
+
+                    if (tc.isDebugEnabled()) {
+                        Tr.debug(tc, "Migrated old token to hashed version: " + keyStr.substring(0, 20) + " -> " + hashedKey);
+                    }
+                    if (!(migrationWarningPrinted)) {
+                        // Warn user that older version tokens exist in the JCache instance.
+                        Tr.warning(tc, "OLD_LOGOUT_TOKENS_MIGRATED_TO_HASHED", migratedCount);
+                        migrationWarningPrinted = true;
+                    }
+                } catch (Exception e) {
+                    // Log and continue with next entry
+                    if (tc.isDebugEnabled()) {
+                        Tr.debug(tc, "Error migrating cache entry", e);
+                    }
+                }
+            }
+
+            migrationCompleted = true;
+
+            if (tc.isDebugEnabled()) {
+                Tr.debug(tc, "Token migration completed. Migrated: " + migratedCount + ", Skipped: " + skippedCount);
+            }
+
+        } catch (Exception e) {
+            if (tc.isErrorEnabled()) {
+                Tr.error(tc, "JCACHE_MIGRATION_FAILURE", e);
+            }
+        }
     }
 
     @Override

--- a/dev/com.ibm.ws.webcontainer.security/src/com/ibm/ws/webcontainer/security/internal/JCacheLoggedOutCookieCache.java
+++ b/dev/com.ibm.ws.webcontainer.security/src/com/ibm/ws/webcontainer/security/internal/JCacheLoggedOutCookieCache.java
@@ -13,8 +13,10 @@
 package com.ibm.ws.webcontainer.security.internal;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 
 import javax.cache.Cache;
 
@@ -34,8 +36,10 @@ public class JCacheLoggedOutCookieCache implements LoggedOutCookieCache {
 
     private static final TraceComponent tc = Tr.register(JCacheLoggedOutCookieCache.class, "LoggedOutCookieCache", TraceConstants.MESSAGE_BUNDLE);
     private final CacheService cacheService;
+    private static final int SHA512_DIGEST_LENGTH = 64;
     private volatile boolean migrationCompleted = false;
     private volatile boolean migrationWarningPrinted = false;
+    private volatile boolean migrationErrorPrinted = false;
 
     public JCacheLoggedOutCookieCache(CacheService cacheService) {
         this.cacheService = cacheService;
@@ -73,64 +77,57 @@ public class JCacheLoggedOutCookieCache implements LoggedOutCookieCache {
                 return;
             }
 
-            // First pass: Collect all entries to avoid modifying cache during iteration
-            List<String> keysToMigrate = new ArrayList<>();
+            // Collect entries to migrate and build the batch update map
+            Map<Object, Object> entriesToMigrate = new HashMap<>();
             int skippedCount = 0;
-            
+
             for (Cache.Entry<Object, Object> entry : cache) {
                 try {
                     Object key = entry.getKey();
                     String keyStr = (String) key;
 
                     // Check if the key is NOT prefixed with "LOGOUT:"
-                    if (!keyStr.startsWith(LoggedOutCookieCacheHelper.LOGOUT_KEY_PREFIX)) {
-                        keysToMigrate.add(keyStr);
+                    if (!(keyStr.startsWith(LoggedOutCookieCacheHelper.LOGOUT_KEY_PREFIX))) {
+                        // Process(hash or append prefix) and add to migration map
+                        String hashedKey;
+                        boolean isJWTLoggedOutToken = Base64Coder.base64DecodeString(keyStr).length <= SHA512_DIGEST_LENGTH;
+                        if (isJWTLoggedOutToken) {
+                            // For JWT LoggedOutTokens, we are hashing them already with sha512, so we just need to add the prefix
+                            hashedKey = LoggedOutCookieCacheHelper.LOGOUT_KEY_PREFIX + keyStr;
+                        } else {
+                            // Generate the hashed version of the key
+                            hashedKey = LoggedOutCookieCacheHelper.generateTokenHashKey(keyStr);
+                        }
+                        
+                        entriesToMigrate.put(hashedKey, "");
+
+                        if (tc.isDebugEnabled()) {
+                            Tr.debug(tc, "Migrated old token to hashed version: " + keyStr.substring(0, 20) + "... -> " + hashedKey);
+                        }
+                        if (!(migrationWarningPrinted)) {
+                            // Warn user that older version tokens exist in the JCache instance.
+                            Tr.warning(tc, "OLD_LOGOUT_TOKENS_MIGRATED");
+                            migrationWarningPrinted = true;
+                        }
                     } else {
-                        // this implies the migration logic is already being run in other nodes, skip migration logic above
                         skippedCount++;
                         if (tc.isDebugEnabled()) {
                             Tr.debug(tc, "Hashed token exists in cache: " + keyStr);
                         }
                     }
                 } catch (Exception e) {
-                    // Log and continue with next entry
-                    if (tc.isDebugEnabled()) {
-                        Tr.debug(tc, "Error processing cache entry during migration", e);
+                    // Log error and continue with next entry
+                    if (!(migrationErrorPrinted)) {
+                        Tr.error(tc, "JCACHE_MIGRATION_FAILURE", e);
+                        migrationErrorPrinted = true;
                     }
                 }
             }
-
-            // Second pass: Migrate collected keys
-            int migratedCount = 0;
-            for (String keyStr : keysToMigrate) {
-                try {
-                    int SHA512_DIGEST_LENGTH = 64;
-                    String hashedKey;
-                    boolean isJWTLoggedOutToken = Base64Coder.base64DecodeString(keyStr).length <= SHA512_DIGEST_LENGTH;
-                    if (isJWTLoggedOutToken) {
-                        // For JWT LoggedOutTokens, we are hashing them already with sha512, so we just need to add the prefix
-                        hashedKey = LoggedOutCookieCacheHelper.LOGOUT_KEY_PREFIX + keyStr;
-                    } else {
-                        // Generate the hashed version of the key
-                        hashedKey = LoggedOutCookieCacheHelper.generateTokenHashKey(keyStr);
-                    }
-                    cache.put(hashedKey, "");
-                    migratedCount++;
-
-                    if (tc.isDebugEnabled()) {
-                        Tr.debug(tc, "Migrated old token to hashed version: " + keyStr.substring(0, 20) + " -> " + hashedKey);
-                    }
-                    if (!(migrationWarningPrinted)) {
-                        // Warn user that older version tokens exist in the JCache instance.
-                        Tr.warning(tc, "OLD_LOGOUT_TOKENS_MIGRATED", migratedCount);
-                        migrationWarningPrinted = true;
-                    }
-                } catch (Exception e) {
-                    // Log and continue with next entry
-                    if (tc.isDebugEnabled()) {
-                        Tr.debug(tc, "Error migrating cache entry", e);
-                    }
-                }
+            
+            // Batch insert all migrated entries
+            int migratedCount = entriesToMigrate.size();
+            if (!entriesToMigrate.isEmpty()) {
+                cache.putAll(entriesToMigrate);
             }
 
             migrationCompleted = true;
@@ -140,8 +137,9 @@ public class JCacheLoggedOutCookieCache implements LoggedOutCookieCache {
             }
 
         } catch (Exception e) {
-            if (tc.isErrorEnabled()) {
+            if (!(migrationErrorPrinted)) {
                 Tr.error(tc, "JCACHE_MIGRATION_FAILURE", e);
+                migrationErrorPrinted = true;
             }
         }
     }

--- a/dev/com.ibm.ws.webcontainer.security/src/com/ibm/ws/webcontainer/security/internal/JCacheLoggedOutCookieCache.java
+++ b/dev/com.ibm.ws.webcontainer.security/src/com/ibm/ws/webcontainer/security/internal/JCacheLoggedOutCookieCache.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2022 IBM Corporation and others.
+ * Copyright (c) 2021, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -122,7 +122,7 @@ public class JCacheLoggedOutCookieCache implements LoggedOutCookieCache {
                     }
                     if (!(migrationWarningPrinted)) {
                         // Warn user that older version tokens exist in the JCache instance.
-                        Tr.warning(tc, "OLD_LOGOUT_TOKENS_MIGRATED_TO_HASHED", migratedCount);
+                        Tr.warning(tc, "OLD_LOGOUT_TOKENS_MIGRATED", migratedCount);
                         migrationWarningPrinted = true;
                     }
                 } catch (Exception e) {

--- a/dev/com.ibm.ws.webcontainer.security/src/com/ibm/ws/webcontainer/security/internal/LoggedOutJwtSsoCookieCache.java
+++ b/dev/com.ibm.ws.webcontainer.security/src/com/ibm/ws/webcontainer/security/internal/LoggedOutJwtSsoCookieCache.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2025 IBM Corporation and others.
+ * Copyright (c) 2018, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -12,17 +12,11 @@
  *******************************************************************************/
 package com.ibm.ws.webcontainer.security.internal;
 
-import java.nio.charset.StandardCharsets;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
-
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.ConfigurationPolicy;
 
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
-import com.ibm.websphere.ras.annotation.Trivial;
-import com.ibm.ws.ffdc.annotation.FFDCIgnore;
 import com.ibm.ws.webcontainer.security.LoggedOutCookieCache;
 import com.ibm.ws.webcontainer.security.LoggedOutCookieCacheHelper;
 
@@ -35,24 +29,12 @@ import com.ibm.ws.webcontainer.security.LoggedOutCookieCacheHelper;
 public class LoggedOutJwtSsoCookieCache {
     private static final TraceComponent tc = Tr.register(LoggedOutJwtSsoCookieCache.class);
 
-    private static MessageDigest CLONEABLE_MESSAGE_DIGEST = null;
-    private static final String SHA_512 = "SHA-512";
-    private static final Object SYNC_OBJECT = new Object();
-
     // Only visible so unit tests can access the local cookie cache.
     static final LocalLoggedOutJwtSsoCookieCache localCookieCache = new LocalLoggedOutJwtSsoCookieCache();
 
-    // store as digests to save space
-    public static String toDigest(String input) {
-        MessageDigest md = getMessageDigest();
-        md.update(input.getBytes(StandardCharsets.UTF_8));
-        String result = com.ibm.ws.common.encoder.Base64Coder.base64EncodeToString(md.digest());
-        return result;
-    }
-
     public static boolean contains(String tokenString) {
         LoggedOutCookieCache service = LoggedOutCookieCacheHelper.getLoggedOutCookieCacheService();
-        String digest = toDigest(tokenString);
+        String digest = LoggedOutCookieCacheHelper.generateTokenHashKey(tokenString);
         if (service == null) {
             return localCookieCache.contains(digest);
         } else {
@@ -62,59 +44,11 @@ public class LoggedOutJwtSsoCookieCache {
 
     public static void put(String tokenString) {
         LoggedOutCookieCache service = LoggedOutCookieCacheHelper.getLoggedOutCookieCacheService();
-        String digest = toDigest(tokenString);
+        String digest = LoggedOutCookieCacheHelper.generateTokenHashKey(tokenString);
         if (service == null) {
             localCookieCache.put(digest);
         } else {
             service.put(digest, Boolean.TRUE);
-        }
-    }
-
-    /**
-     * Use clone() to get a new instance as its approximately 50% faster (as
-     * seen in empirical testing), if we can. Worst case scenario is we will
-     * create a new one each time.
-     *
-     * @return
-     */
-    @Trivial
-    @FFDCIgnore({ CloneNotSupportedException.class, NoSuchAlgorithmException.class })
-    private static MessageDigest getMessageDigest() {
-        /*
-         * If we've never been asked for a MessageDigest, create the parent of
-         * our clones.
-         */
-        if (CLONEABLE_MESSAGE_DIGEST == null) {
-            synchronized (SYNC_OBJECT) {
-                if (CLONEABLE_MESSAGE_DIGEST == null) {
-                    try {
-                        CLONEABLE_MESSAGE_DIGEST = MessageDigest.getInstance(SHA_512);
-                    } catch (NoSuchAlgorithmException nsae) {
-                        // Not possible. SHA-512 is required by all JREs.
-                    }
-                }
-            }
-        }
-
-        /*
-         * Try to clone the parent. If we can't, then we'll ignore the FFDC and create a
-         * new instance. If the clone fails, which is REALLY unlikely, as we
-         * know the SHA MessageDigest is cloneable on IBM and Sun JDKs
-         */
-        try {
-            return (MessageDigest) CLONEABLE_MESSAGE_DIGEST.clone();
-        } catch (CloneNotSupportedException cnse) {
-            if (tc.isDebugEnabled()) {
-                Tr.debug(tc, "CloneNotSupportedException caught while trying to clone MessageDigest with algorithm " + SHA_512
-                             + ". This is pretty unlikely, and we need to get details about the JDK which is in use.",
-                         cnse);
-            }
-            try {
-                return MessageDigest.getInstance(SHA_512);
-            } catch (NoSuchAlgorithmException nsae) {
-                // Not possible. SHA-512 is required by all JREs.
-                return null;
-            }
         }
     }
 }

--- a/dev/io.openliberty.checkpoint_fat_jcache_hazelcast/fat/src/io/openliberty/checkpoint/jcache/fat/BaseTestCase.java
+++ b/dev/io.openliberty.checkpoint_fat_jcache_hazelcast/fat/src/io/openliberty/checkpoint/jcache/fat/BaseTestCase.java
@@ -16,6 +16,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
+import com.ibm.ws.webcontainer.security.LoggedOutCookieCacheHelper;
 import org.junit.After;
 import org.junit.Assume;
 import org.junit.Before;
@@ -254,13 +255,14 @@ public abstract class BaseTestCase {
      * @throws Exception If the check failed for some unforeseen reason.
      */
     protected static void assertLtpaLoggedOutCookieCacheHit(boolean expectCacheHit, LibertyServer server, String cookie) throws Exception {
-        String encodedCookie = encodeForRegex(cookie);
+        String hashedCookie = LoggedOutCookieCacheHelper.generateTokenHashKey(cookie);
+        String encodedCookie = encodeForRegex(hashedCookie);
 
         if (expectCacheHit) {
-            assertFalse("Request should have resulted in an logged out cookie cache hit for LTPA (hashed) cookie " + cookie + ".",
+            assertFalse("Request should have resulted in an logged out cookie cache hit for LTPA (hashed) cookie " + hashedCookie + ".",
                         server.findStringsInLogsAndTraceUsingMark(JCACHE_HIT + encodedCookie).isEmpty());
         } else {
-            assertFalse("Request should have resulted in an logged out cookie cache miss for LTPA (hashed) cookie " + cookie + ".",
+            assertFalse("Request should have resulted in an logged out cookie cache miss for LTPA (hashed) cookie " + hashedCookie + ".",
                         server.findStringsInLogsAndTraceUsingMark(JCACHE_MISS + encodedCookie).isEmpty());
         }
     }

--- a/dev/io.openliberty.checkpoint_fat_jcache_hazelcast/fat/src/io/openliberty/checkpoint/jcache/fat/BaseTestCase.java
+++ b/dev/io.openliberty.checkpoint_fat_jcache_hazelcast/fat/src/io/openliberty/checkpoint/jcache/fat/BaseTestCase.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022, 2024 IBM Corporation and others.
+ * Copyright (c) 2022, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -16,6 +16,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
+import com.ibm.ws.security.common.crypto.HashUtils;
 import com.ibm.ws.webcontainer.security.LoggedOutCookieCacheHelper;
 import org.junit.After;
 import org.junit.Assume;
@@ -28,7 +29,6 @@ import com.gargoylesoftware.htmlunit.WebResponse;
 import com.gargoylesoftware.htmlunit.util.Cookie;
 import com.gargoylesoftware.htmlunit.util.NameValuePair;
 import com.ibm.websphere.simplicity.log.Log;
-import com.ibm.ws.security.common.crypto.HashUtils;
 
 import componenttest.topology.impl.LibertyServer;
 import io.openliberty.checkpoint.spi.CheckpointPhase;

--- a/dev/io.openliberty.jcache.internal_fat.hazelcast/fat/src/io/openliberty/jcache/internal/fat/BaseTestCase.java
+++ b/dev/io.openliberty.jcache.internal_fat.hazelcast/fat/src/io/openliberty/jcache/internal/fat/BaseTestCase.java
@@ -18,6 +18,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.util.Arrays;
 
+import com.ibm.ws.webcontainer.security.LoggedOutCookieCacheHelper;
 import org.junit.After;
 import org.junit.Assume;
 import org.junit.Before;
@@ -337,13 +338,14 @@ public abstract class BaseTestCase {
      * @throws Exception If the check failed for some unforeseen reason.
      */
     protected static void assertLtpaLoggedOutCookieCacheHit(boolean expectCacheHit, LibertyServer server, String cookie) throws Exception {
-        String encodedCookie = encodeForRegex(cookie);
+        String hashedCookie = LoggedOutCookieCacheHelper.generateTokenHashKey(cookie);
+        String encodedCookie = encodeForRegex(hashedCookie);
 
         if (expectCacheHit) {
-            assertFalse("Request should have resulted in an logged out cookie cache hit for LTPA (hashed) cookie " + cookie + ".",
+            assertFalse("Request should have resulted in an logged out cookie cache hit for LTPA (hashed) cookie " + hashedCookie + ".",
                         server.findStringsInLogsAndTraceUsingMark(JCACHE_HIT + encodedCookie).isEmpty());
         } else {
-            assertFalse("Request should have resulted in an logged out cookie cache miss for LTPA (hashed) cookie " + cookie + ".",
+            assertFalse("Request should have resulted in an logged out cookie cache miss for LTPA (hashed) cookie " + hashedCookie + ".",
                         server.findStringsInLogsAndTraceUsingMark(JCACHE_MISS + encodedCookie).isEmpty());
         }
     }

--- a/dev/io.openliberty.jcache.internal_fat.hazelcast/fat/src/io/openliberty/jcache/internal/fat/BaseTestCase.java
+++ b/dev/io.openliberty.jcache.internal_fat.hazelcast/fat/src/io/openliberty/jcache/internal/fat/BaseTestCase.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022, 2024 IBM Corporation and others.
+ * Copyright (c) 2022, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -359,7 +359,7 @@ public abstract class BaseTestCase {
      * @throws Exception If the check failed for some unforeseen reason.
      */
     protected static void assertJwtLoggedOutCookieCacheHit(boolean expectCacheHit, LibertyServer server, String cookie) throws Exception {
-        String hashedCookie = LoggedOutJwtSsoCookieCache.toDigest(cookie);
+        String hashedCookie = LoggedOutCookieCacheHelper.generateTokenHashKey(cookie);
         String encodedCookie = encodeForRegex(hashedCookie);
 
         if (expectCacheHit) {


### PR DESCRIPTION
IBM WebSphere Application Server Liberty is affected by a security bypass vulnerability (CVE-2026-5516)
Fixes https://github.com/OpenLiberty/open-liberty/issues/34922, #29131 
Fixes PH70798
