### PR TITLE
Add Timer C to sipcontainer

### DIFF
--- a/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/container/tu/TransactionUserImpl.java
+++ b/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/container/tu/TransactionUserImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2003, 2021 IBM Corporation and others.
+ * Copyright (c) 2003, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -3192,7 +3192,7 @@ public class TransactionUserImpl  extends ReplicatableImpl {
 			c_logger.traceEntry(this, " processTimeout", params);
 		}
 		if( isInitialState(_tuWrapper.getState()) && SipUtil.isDialogInitialRequest(req.getMethod())){
-			//        	If the request that was timedOut is on the dialog that is in initial 
+			//        	If the request that was timedOut is on the dialog that is in initial
 			//        	state it should be removed from transactionUsers table.
 			SipTransactionUserTable.getInstance().removeTransactionUserForOutgoingRequest(req);
 		}
@@ -3201,6 +3201,7 @@ public class TransactionUserImpl  extends ReplicatableImpl {
 
 		_tuWrapper.logToContext(SipSessionSeqLog.PROCESS_TIMEOUT, req.getCallId(), req);
 
+		// Generate and send 408 response
 		IncomingSipServletResponse response = null;
 		try {
 			response = SipUtil.createResponse(SipServletResponse.SC_REQUEST_TIMEOUT, req);

--- a/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/properties/StackProperties.java
+++ b/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/properties/StackProperties.java
@@ -194,6 +194,10 @@ public class StackProperties {
 	public static final String TIMER_B_DEPRECATED = "javax.sip.transaction.timerb";
 	public static final int TIMER_B_DEFAULT = 64*TIMER_T1_DEFAULT;
 	
+	/** Timer C - INVITE client transaction timeout timer */
+	public static final String TIMER_C = "javax.sip.transaction.timer.c";
+	public static final int TIMER_C_DEFAULT = 180000;
+	
 	/** Timer D - Wait time for INVITE response retransmits */
 	public static final String TIMER_D = "timerD";
 	public static final int TIMER_D_DEFAULT = 32000;

--- a/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/stack/transaction/SIPStackConfiguration.java
+++ b/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/stack/transaction/SIPStackConfiguration.java
@@ -116,6 +116,9 @@ public class SIPStackConfiguration
 	/** Timer B - INVITE client transaction timeout timer */
 	private int m_timerB;
 
+	/** Timer C - INVITE client transaction timeout timer */
+	private int m_timerC;
+
 	/** Timer D - Wait time for INVITE response retransmits */
 	private int m_timerD;
 
@@ -335,6 +338,16 @@ public class SIPStackConfiguration
 		}else{
 			if (s_logger.isInfoEnabled()) {
 				Object[] params = { "Timer B", Integer.valueOf(m_timerB) };
+				s_logger.info("info.sip.stack.timer", Situation.SITUATION_CONFIGURE, params);
+			}
+		}
+		m_timerC = ApplicationProperties.getProperties().getDuration(StackProperties.TIMER_C);
+		if (m_timerC == -1) {
+			m_timerC = StackProperties.TIMER_C_DEFAULT;
+		}
+		if (m_timerC != StackProperties.TIMER_C_DEFAULT) {
+			if (s_logger.isInfoEnabled()) {
+				Object[] params = { "Timer C", Integer.valueOf(m_timerC) };
 				s_logger.info("info.sip.stack.timer", Situation.SITUATION_CONFIGURE, params);
 			}
 		}
@@ -672,6 +685,10 @@ public class SIPStackConfiguration
 		return m_timerB;
 	}
 
+	/** @return Timer C - INVITE client transaction timeout timer */
+	public int getTimerC() {
+		return m_timerC;
+	}
 	/** @return Timer D - Wait time for INVITE response retransmits */
 	public int getTimerD() {
 		return m_timerD;

--- a/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/stack/transaction/SIPStackConfiguration.java
+++ b/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/stack/transaction/SIPStackConfiguration.java
@@ -689,6 +689,7 @@ public class SIPStackConfiguration
 	public int getTimerC() {
 		return m_timerC;
 	}
+
 	/** @return Timer D - Wait time for INVITE response retransmits */
 	public int getTimerD() {
 		return m_timerD;

--- a/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/stack/transaction/transactions/ct/SIPInviteClientTransactionImpl.java
+++ b/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/stack/transaction/transactions/ct/SIPInviteClientTransactionImpl.java
@@ -27,6 +27,7 @@ import com.ibm.ws.sip.stack.transaction.transactions.SIPTransactionHelper;
 import com.ibm.ws.sip.stack.transaction.transport.SIPTransportException;
 import com.ibm.ws.sip.stack.transaction.util.ApplicationProperties;
 import com.ibm.ws.sip.stack.util.SipStackUtil;
+import com.ibm.ws.sip.container.tu.TransactionUserImpl;
 
 import jain.protocol.ip.sip.SipParseException;
 import jain.protocol.ip.sip.SipProvider;
@@ -53,6 +54,11 @@ public class SIPInviteClientTransactionImpl
 	private TimerB m_timerB;
 	
 	/**
+	 * Timer C for all transport types, controls client INVITE transaction timeouts
+	 */
+	private TimerC m_timerC;
+
+	/**
 	 * Timer D reflects the amount of time that the server transaction can remain in the "Completed" 
 	 * state when unreliable transports are used
 	 */
@@ -63,6 +69,9 @@ public class SIPInviteClientTransactionImpl
 	
 	/** value of timer B for this transaction, in milliseconds */
 	private final int m_timerBvalue;
+	
+	/** value of timer C for this transaction, in milliseconds */
+	private final int m_timerCvalue;
 	
 	/**
 	 * the last response that was receives ( could be provisionning like RINGING )
@@ -103,6 +112,7 @@ public class SIPInviteClientTransactionImpl
 		super(transactionStack, provider, req, key, transactionId);
 		m_timerAvalue = getTimerA(req);
 		m_timerBvalue = getTimerB(req);
+		m_timerCvalue = getTimerC(req);
 		SIPNonInviteClientTransactionImpl.getTimerT2(req); // just remove this header if it exists
 
 		try {
@@ -147,6 +157,9 @@ public class SIPInviteClientTransactionImpl
 							
 							m_timerB = new TimerB(this, getCallId());
 							addTimerTask(m_timerB, m_timerBvalue);
+							
+							m_timerC = new TimerC(this, getCallId());
+							addTimerTask(m_timerC, m_timerCvalue);
 							break;
 		
 					case STATE_CALLING:					
@@ -210,6 +223,7 @@ public class SIPInviteClientTransactionImpl
 							setFinalResponse(sipResponse);
 							sendAutomaticAckRequest();
 							notCalling();
+							cancelTimerC();
 							setCompletedState();
 							sendResponseToUA( sipResponse );				
 						}												
@@ -346,6 +360,20 @@ public class SIPInviteClientTransactionImpl
 	}
 
 	/**
+	 * gets the value of timer C for the given message:
+	 *
+	 * If a timer value is specified in configuration, its value is used, otherwise..
+	 * The default timer value is used.
+	 *
+	 * @param request the request to send
+	 * @return the value of timer C to use in this transaction
+	 */
+	private static int getTimerC(Request request) {
+		SIPStackConfiguration config = SIPTransactionStack.instance().getConfiguration();
+		return config.getTimerC();
+	}
+
+	/**
 	 * timer A fired , try to send again
 	 */
 	synchronized void timerAfired()
@@ -401,6 +429,26 @@ public class SIPInviteClientTransactionImpl
 		}
 	}
 
+	/**
+	 * called when TimerC fires
+	 */
+	void timerCfired() {
+		if (c_logger.isTraceDebugEnabled()) {
+			c_logger.traceDebug(this, "timerCfired",
+				"Timer C fired on transaction " + toString());
+		}
+		updateSipTimersInvocationsPMICounter();
+		if (getState() == STATE_CALLING) {
+			notifyTransactionTimeoutToUA();
+			destroyTransaction();
+		}
+		if (getState() == STATE_PROCEEDING) {
+			//terminateUndelyingClientTransactions();
+                        notifyTransactionTimeoutToUA();
+                        destroyTransaction();
+                }
+	}
+	
 	/**
 	 * called when TimerD fires
 	 */
@@ -472,6 +520,33 @@ public class SIPInviteClientTransactionImpl
 					return super.cancel();
 				}
 			}	
+			
+			/**
+			 *  timer C for this transaction
+			 */
+			static class TimerC extends TimerEvent
+			{
+				SIPInviteClientTransactionImpl m_ct;
+				
+				TimerC(SIPInviteClientTransactionImpl ct, String callId)
+				{
+					super(callId);
+					m_ct = ct;
+				}
+				
+				public void onExecute()
+				{
+					//timer C
+					if (m_ct != null) {
+						m_ct.timerCfired();
+					}
+				}
+				
+				public boolean cancel()
+				{
+					return super.cancel();
+				}
+			}
 			
 			/**
 			 *  timer D for this transaction
@@ -624,6 +699,10 @@ public class SIPInviteClientTransactionImpl
 		{
 			m_timerB.cancel();
 		}
+		if( m_timerC!=null)
+		{
+			m_timerC.cancel();
+		}
 		if( m_timerD!=null)
 		{
 			m_timerD.cancel();
@@ -644,6 +723,15 @@ public class SIPInviteClientTransactionImpl
 			m_timerB.cancel();
 		}
 	}
+
+    /** cancel timerC  */
+	private void cancelTimerC() {
+    	if (m_timerC != null) {
+			m_timerC.cancel();
+		}
+
+	}
+
 
 	/** return the most recent response */
 	public Response getMostRecentResponse()

--- a/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/stack/transaction/transactions/ct/SIPInviteClientTransactionImpl.java
+++ b/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/stack/transaction/transactions/ct/SIPInviteClientTransactionImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2021 IBM Corporation and others.
+ * Copyright (c) 2008, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -27,7 +27,6 @@ import com.ibm.ws.sip.stack.transaction.transactions.SIPTransactionHelper;
 import com.ibm.ws.sip.stack.transaction.transport.SIPTransportException;
 import com.ibm.ws.sip.stack.transaction.util.ApplicationProperties;
 import com.ibm.ws.sip.stack.util.SipStackUtil;
-import com.ibm.ws.sip.container.tu.TransactionUserImpl;
 
 import jain.protocol.ip.sip.SipParseException;
 import jain.protocol.ip.sip.SipProvider;
@@ -438,15 +437,10 @@ public class SIPInviteClientTransactionImpl
 				"Timer C fired on transaction " + toString());
 		}
 		updateSipTimersInvocationsPMICounter();
-		if (getState() == STATE_CALLING) {
+		if (getState() == STATE_PROCEEDING) {
 			notifyTransactionTimeoutToUA();
 			destroyTransaction();
 		}
-		if (getState() == STATE_PROCEEDING) {
-			//terminateUndelyingClientTransactions();
-                        notifyTransactionTimeoutToUA();
-                        destroyTransaction();
-                }
 	}
 	
 	/**


### PR DESCRIPTION
Add Timer C to the sipcontainer code. Timer C is started when a Client INVITE is created and is cancelled when a final response was received. In case Timer C fires before a final response arrives the Client INVITE transaction will be cancelled.


- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

Resolves #34938 
