### PR TITLE
Recreate EclipseLink CASE expression parsing issue #33842

### DIFF
--- a/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartadata/src/io/openliberty/jpa/data/tests/web/JakartaDataRecreateServlet.java
+++ b/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartadata/src/io/openliberty/jpa/data/tests/web/JakartaDataRecreateServlet.java
@@ -2681,4 +2681,73 @@ public class JakartaDataRecreateServlet extends FATServlet {
         tx.commit();
     }
 
+    @Test
+    @Ignore("Reference issue: https://github.com/OpenLiberty/open-liberty/issues/33842")
+    public void testOLGH33842() throws Exception {
+        // Setup test data
+        Prime prime2 = Prime.of(2, "II", "two");
+        Prime prime3 = Prime.of(3, "III", "three");
+        Prime prime5 = Prime.of(5, "V", "five");
+        Prime prime7 = Prime.of(7, "VII", "seven");
+
+        List<Object[]> results;
+
+        tx.begin();
+        try {
+            // Persist test entities
+            em.persist(prime2);
+            em.persist(prime3);
+            em.persist(prime5);
+            em.persist(prime7);
+
+            // Execute the problematic JPQL query
+            results = em.createQuery(
+                "SELECT numberId, CASE WHEN even = TRUE THEN 'even' ELSE 'odd' END " +
+                "FROM Prime " +
+                "WHERE numberId BETWEEN ?1 AND ?2 " +
+                "ORDER BY numberId ASC",
+                Object[].class)
+                .setParameter(1, 2L)
+                .setParameter(2, 7L)
+                .getResultList();
+
+            tx.commit();
+        } catch (Exception e) {
+            tx.rollback();
+
+            /*
+            * Recreated from issue #33842
+            * Exception [EclipseLink-0] (Eclipse Persistence Services - 5.0.0-B11):
+            * org.eclipse.persistence.exceptions.JPQLException
+            * Exception Description: Problem compiling [SELECT numberId, 
+            * CASE WHEN even = TRUE THEN 'even' ELSE 'odd' END
+            * FROM Prime
+            * WHERE numberId BETWEEN ?1 and ?2
+            * ORDER BY numberId ASC].
+            * [27, 31] 'even' cannot be resolved to a type.
+            */
+            throw e;
+        }
+
+        // Verify results
+        assertNotNull(results);
+        assertEquals(4, results.size());
+
+        // Verify first result (2 is even)
+        assertEquals(2L, results.get(0)[0]);
+        assertEquals("even", results.get(0)[1]);
+
+        // Verify second result (3 is odd)
+        assertEquals(3L, results.get(1)[0]);
+        assertEquals("odd", results.get(1)[1]);
+
+        // Verify third result (5 is odd)
+        assertEquals(5L, results.get(2)[0]);
+        assertEquals("odd", results.get(2)[1]);
+
+        // Verify fourth result (7 is odd)
+        assertEquals(7L, results.get(3)[0]);
+        assertEquals("odd", results.get(3)[1]);
+    }
+
 }


### PR DESCRIPTION

### Description

Adds a test case to reproduce the EclipseLink JPQL parsing bug where CASE expressions fail when boolean field references omit the entity identifier variable.

### Changes

- Added `testOLGH33842()` method to `JakartaDataRecreateServlet.java`
- Test reproduces EclipseLink bug where it incorrectly interprets `even` as a type rather than a field reference in CASE WHEN clauses
- Test is marked with `@Ignore` as it demonstrates a known EclipseLink limitation
- Uses existing `Prime` entity with boolean `even` field and long `numberId` ID

### Problematic JPQL Query

```sql
SELECT numberId, CASE WHEN even = TRUE THEN 'even' ELSE 'odd' END
FROM Prime
WHERE numberId BETWEEN ?1 AND ?2
ORDER BY numberId ASC
```

### Expected Error (EclipseLink)

```
Exception [EclipseLink-0]: org.eclipse.persistence.exceptions.JPQLException
Exception Description: Problem compiling [SELECT numberId, CASE WHEN even = TRUE THEN 'even' ELSE 'odd' END FROM Prime WHERE numberId BETWEEN ?1 and ?2 ORDER BY numberId ASC].
[27, 31] 'even' cannot be resolved to a type.
```

### Workaround

Use explicit entity alias: `CASE WHEN p.even = TRUE THEN 'even' ELSE 'odd' END FROM Prime p`

### Testing

- Test successfully reproduces the issue on EclipseLink
- Test passes on Hibernate (which correctly parses the query)
- Can be enabled once EclipseLink fixes the parsing bug



- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".


