### PR TITLE
Fix-OL-Issue-34944-JAX-RS client hostname verification bypass on Windows by clearing cached TLSClientParameters 

### DIFF
--- a/dev/com.ibm.ws.jaxrs.2.0.client/src/com/ibm/ws/jaxrs20/client/security/LibertyJaxRsClientSSLOutInterceptor.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.client/src/com/ibm/ws/jaxrs20/client/security/LibertyJaxRsClientSSLOutInterceptor.java
@@ -129,12 +129,15 @@ public class LibertyJaxRsClientSSLOutInterceptor extends AbstractPhaseIntercepto
             }
             //let's use liberty SSL configuration
             tlsClientParams.setSSLSocketFactory(sslSocketFactory);
-            // Only set disableCNCheck when BOTH property is set to "true" AND boolean is true
-            // Avoid setting it when null or "false" to prevent Windows-specific(only on Hotspot JVM) CXF behavior
+            // Always set disableCNCheck explicitly to prevent Windows-specific CXF caching issues
+            // where TLSClientParameters objects persist between requests with stale hostname verifiers
             Object disableCNCheckObj = message.get(JAXRSClientConstants.DISABLE_CN_CHECK);
             
             if ("true".equalsIgnoreCase(String.valueOf(disableCNCheckObj))) {
                 tlsClientParams.setDisableCNCheck(disableCNCheck);
+            } else {
+                // Explicitly set to false to clear any cached AllowAllHostnameVerifier
+                tlsClientParams.setDisableCNCheck(false);
             }
 
         } else if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

Fixes https://github.com/OpenLiberty/open-liberty/issues/34944

FIX: Explicitly set disableCNCheck to false to clear the cache
