### PR TITLE
fix: hibernate issues with database rotation #34902

### DIFF
--- a/dev/fattest.simplicity/src/componenttest/topology/database/container/DatabaseContainerFactory.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/database/container/DatabaseContainerFactory.java
@@ -170,9 +170,12 @@ public class DatabaseContainerFactory {
     }
 
     public static JdbcDatabaseContainer<?> createType(DatabaseContainerType type) throws IllegalArgumentException {
-        Log.info(c, "createType", "Database Container Type is " + type);
+        return createType(type, Optional.empty());
+    }
 
-        return initContainer(type, Optional.empty());
+    public static JdbcDatabaseContainer<?> createType(DatabaseContainerType type, Optional<H2Database> h2Database) throws IllegalArgumentException {
+        Log.info(c, "createType", "Database Container Type is " + type);
+        return initContainer(type, h2Database);
     }
 
     //Private Method: used to initialize test container.

--- a/dev/io.openliberty.data.internal_fat_jpa/cognitiveMetadata.yml
+++ b/dev/io.openliberty.data.internal_fat_jpa/cognitiveMetadata.yml
@@ -3,4 +3,4 @@
 # Reference Cognitive Metadata is available at: https://github.com/OpenLiberty/open-liberty/tree/integration/dev/build.example_fat/cognitiveMetadata.yml
 description: Migrated from derby to h2
 triageNotes: Route defects to InstantOn for failures in class DataJPATestCheckpoint for initial triage.
-functionalArea: JPA
+functionalArea: Jakarta Data

--- a/dev/io.openliberty.data.internal_fat_jpa/fat/src/test/jakarta/data/jpa/DataJPATestHibernate.java
+++ b/dev/io.openliberty.data.internal_fat_jpa/fat/src/test/jakarta/data/jpa/DataJPATestHibernate.java
@@ -31,6 +31,7 @@ import componenttest.annotation.TestServlets;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.database.H2Database;
 import componenttest.topology.database.container.DatabaseContainerFactory;
+import componenttest.topology.database.container.DatabaseContainerType;
 import componenttest.topology.database.container.DatabaseContainerUtil;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
@@ -72,8 +73,12 @@ public class DataJPATestHibernate extends FATServletClient {
     private static final H2Database h2Database = H2Database.create("dbuser1", "dbpwd1")
                     .withDatabaseName("testdb");
 
+    // TODO enable database rotation to verify Hibernate behavior against other databases.
+//    @ClassRule
+//    public static final JdbcDatabaseContainer<?> testContainer = DatabaseContainerFactory.createLatestH2(Optional.of(h2Database));
+
     @ClassRule
-    public static final JdbcDatabaseContainer<?> testContainer = DatabaseContainerFactory.createH2(Optional.of(h2Database));
+    public static final JdbcDatabaseContainer<?> testContainer = DatabaseContainerFactory.createType(DatabaseContainerType.H2Java11Plus, Optional.of(h2Database));
 
     @Server("io.openliberty.data.internal.fat.jpa.hibernate")
     @TestServlets({


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

- The io.openliberty.data.internal_fat_jpa bucket was switched to be included in Database Rotation before we had a chance to do internal testing to verify there were no failures. 
- Switching this back to not use database rotation, and reporting errors to the JPA team that were found.
