### PR TITLE
Looping when underflow is hit during decryption of encrypted bytes

### DIFF
--- a/dev/com.ibm.ws.channel.ssl/src/com/ibm/ws/channel/ssl/internal/SSLReadServiceContext.java
+++ b/dev/com.ibm.ws.channel.ssl/src/com/ibm/ws/channel/ssl/internal/SSLReadServiceContext.java
@@ -303,9 +303,9 @@ public class SSLReadServiceContext extends SSLBaseServiceContext implements TCPR
                     if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
                         Tr.debug(tc, "More data needs to be read, loop to another read");
                     }
-                    // if (0L == this.bytesRequested && encryptedBytesAvailable == 0) {
-                    //     break;
-                    // }
+                    if (0L == this.bytesRequested && encryptedBytesAvailable == 0) {
+                        break;
+                    }
                     getNetworkBuffer(this.bytesRequested - this.bytesProduced);
                     continue;
                 }

--- a/dev/com.ibm.ws.channel.ssl/src/com/ibm/ws/channel/ssl/internal/SSLReadServiceContext.java
+++ b/dev/com.ibm.ws.channel.ssl/src/com/ibm/ws/channel/ssl/internal/SSLReadServiceContext.java
@@ -303,9 +303,9 @@ public class SSLReadServiceContext extends SSLBaseServiceContext implements TCPR
                     if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
                         Tr.debug(tc, "More data needs to be read, loop to another read");
                     }
-                    if (0L == this.bytesRequested && encryptedBytesAvailable == 0) {
-                        break;
-                    }
+                    // if (0L == this.bytesRequested && encryptedBytesAvailable == 0) {
+                    //     break;
+                    // }
                     getNetworkBuffer(this.bytesRequested - this.bytesProduced);
                     continue;
                 }

--- a/dev/com.ibm.ws.channel.ssl/src/com/ibm/ws/channel/ssl/internal/SSLReadServiceContext.java
+++ b/dev/com.ibm.ws.channel.ssl/src/com/ibm/ws/channel/ssl/internal/SSLReadServiceContext.java
@@ -303,7 +303,7 @@ public class SSLReadServiceContext extends SSLBaseServiceContext implements TCPR
                     if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
                         Tr.debug(tc, "More data needs to be read, loop to another read");
                     }
-                    if (0L == this.bytesRequested) {
+                    if (0L == this.bytesRequested && encryptedBytesAvailable == 0) {
                         break;
                     }
                     getNetworkBuffer(this.bytesRequested - this.bytesProduced);


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
resolves #34647 
