### PR TITLE
QueryOptions with entityGraph

### DIFF
--- a/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/EntityInfo.java
+++ b/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/EntityInfo.java
@@ -75,7 +75,7 @@ public class EntityInfo {
     final Class<?> idType; // type of the id, which could be a JPA IdClass for composite ids
     final SortedMap<String, Member> idClassAttributeAccessors; // null if no IdClass
     final boolean inheritance;
-    final boolean isHibernate;
+    public final boolean isHibernate;
     final String name; // entity name to use in query language. If a record, the name will be [RecordName]Entity.
     final Class<?> recordClass; // null if not a record
     final String versionAttributeName; // null if unversioned

--- a/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/QueryInfo.java
+++ b/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/QueryInfo.java
@@ -338,7 +338,7 @@ public abstract class QueryInfo {
     /**
      * Categorization of query type.
      */
-    QueryType type;
+    protected QueryType type;
 
     /**
      * Indicates whether or not to validate method parameters, if Jakarta Validation is available.
@@ -1098,7 +1098,7 @@ public abstract class QueryInfo {
                         : this;
 
         jakarta.persistence.Query query = typeOfTypedQuery == null //
-                        ? ehCreateQuery(entityHandler, queryInfo.jpql) //
+                        ? ehCreateStatement(entityHandler, queryInfo.jpql) //
                         : ehCreateTypedQuery(entityHandler,
                                              queryInfo.jpql,
                                              typeOfTypedQuery);
@@ -1152,8 +1152,8 @@ public abstract class QueryInfo {
             } else if (entityInfo.entityClass.isInstance(result)) {
                 ehDelete(entityHandler, result);
             } else if (entityInfo.idClassAttributeAccessors != null) {
-                jakarta.persistence.Query delete = ehCreateQuery(entityHandler,
-                                                                 jpqlDelete);
+                jakarta.persistence.Query delete = ehCreateStatement(entityHandler,
+                                                                     jpqlDelete);
                 int numParams = 0;
                 for (Member accessor : entityInfo.idClassAttributeAccessors.values()) {
                     Object value = accessor instanceof Method //
@@ -1188,8 +1188,8 @@ public abstract class QueryInfo {
                         throw Fail.returnTypeInvalidForDelete(this);
                 }
 
-                jakarta.persistence.Query delete = ehCreateQuery(entityHandler,
-                                                                 jpqlDelete);
+                jakarta.persistence.Query delete = ehCreateStatement(entityHandler,
+                                                                     jpqlDelete);
                 if (trace && tc.isDebugEnabled())
                     Tr.debug(this, tc, jpqlDelete,
                              "set ?1 " + loggable(value));
@@ -1300,7 +1300,7 @@ public abstract class QueryInfo {
             && jpql != this.jpql)
             Tr.debug(this, tc, "JPQL adjusted for NULL id or version", jpql);
 
-        jakarta.persistence.Query delete = ehCreateQuery(entityHandler, jpql);
+        jakarta.persistence.Query delete = ehCreateStatement(entityHandler, jpql);
 
         if (entityInfo.idClassAttributeAccessors == null) {
             int p = 1;
@@ -1376,16 +1376,15 @@ public abstract class QueryInfo {
 
     /**
      * Delegates to the EntityAgent or EntityManager to create a
-     * Jakarta Persistence Query, typically used for DELETE and
-     * UPDATE.
+     * Jakarta Persistence Query that peforms a DELETE or UPDATE.
      *
      * @param entityHandler EntityAgent or EntityManager
-     * @param jpql          the query represented as JPQL
+     * @param jpql          a JPQL DELETE or UPDATE statement
      * @return the query, ready to execute
      */
     protected abstract jakarta.persistence.Query //
-                    ehCreateQuery(AutoCloseable entityHandler,
-                                  String jpql);
+                    ehCreateStatement(AutoCloseable entityHandler,
+                                      String jpql);
 
     /**
      * Delegates to the EntityAgent or EntityManager to create a TypedQuery.
@@ -6009,7 +6008,7 @@ public abstract class QueryInfo {
         if (TraceComponent.isAnyTracingEnabled() && jpql != this.jpql)
             Tr.debug(this, tc, "JPQL adjusted for NULL id", jpql);
 
-        jakarta.persistence.Query update = ehCreateQuery(entityHandler, jpql);
+        jakarta.persistence.Query update = ehCreateStatement(entityHandler, jpql);
 
         // parameters for entity attributes to update:
         int p = 1;

--- a/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/QueryType.java
+++ b/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/QueryType.java
@@ -33,7 +33,8 @@ public enum QueryType {
           !Require.AUTO_START_TX, //
           !Require.DETACH_ENTITIES, //
           !Require.RETURN_HIDDEN, //
-          null), // stateful or stateless
+          null, // stateful or stateless
+          Supports.QUERY_OPTIONS),
 
     // stateful repository life cycle method @Detach
     DETACH("Detach", //
@@ -41,7 +42,8 @@ public enum QueryType {
            !Require.AUTO_START_TX, //
            Require.DETACH_ENTITIES, //
            !Require.RETURN_HIDDEN, //
-           Require.STATEFUL),
+           Require.STATEFUL, //
+           !Supports.QUERY_OPTIONS),
 
     // repository query method exists
     EXISTS(null, //
@@ -49,7 +51,8 @@ public enum QueryType {
            !Require.AUTO_START_TX, //
            !Require.DETACH_ENTITIES, //
            !Require.RETURN_HIDDEN, //
-           null), // stateful or stateless
+           null, // stateful or stateless
+           Supports.QUERY_OPTIONS),
 
     // repository query method find/@Find/@Query(SELECT/FROM/WHERE)
     FIND(Find.class.getSimpleName(), //
@@ -57,7 +60,8 @@ public enum QueryType {
          !Require.AUTO_START_TX, //
          null, // detach depends on stateless vs stateful repository
          Require.RETURN_HIDDEN, //
-         null), // stateful or stateless
+         null, // stateful or stateless
+         Supports.QUERY_OPTIONS),
 
     // stateless repository query method delete/@Delete with entity result
     FIND_AND_DELETE(Delete.class.getSimpleName(), //
@@ -65,7 +69,8 @@ public enum QueryType {
                     Require.AUTO_START_TX, //
                     Require.DETACH_ENTITIES, //
                     Require.RETURN_HIDDEN, //
-                    Require.STATELESS),
+                    Require.STATELESS, //
+                    Supports.QUERY_OPTIONS),
 
     // stateless repository life cycle method @Insert
     INSERT(Insert.class.getSimpleName(), //
@@ -73,7 +78,8 @@ public enum QueryType {
            Require.AUTO_START_TX, //
            Require.DETACH_ENTITIES, //
            Require.RETURN_HIDDEN, //
-           Require.STATELESS),
+           Require.STATELESS, //
+           !Supports.QUERY_OPTIONS),
 
     // stateless repository life cycle method @Delete
     LC_DELETE(Delete.class.getSimpleName(), //
@@ -81,7 +87,8 @@ public enum QueryType {
               Require.AUTO_START_TX, //
               !Require.DETACH_ENTITIES, //
               !Require.RETURN_HIDDEN, //
-              Require.STATELESS),
+              Require.STATELESS, //
+              !Supports.QUERY_OPTIONS),
 
     // stateless repository life cycle method @Update
     LC_UPDATE(Update.class.getSimpleName(), //
@@ -89,7 +96,8 @@ public enum QueryType {
               Require.AUTO_START_TX, //
               !Require.DETACH_ENTITIES, //
               !Require.RETURN_HIDDEN, //
-              Require.STATELESS),
+              Require.STATELESS, //
+              !Supports.QUERY_OPTIONS),
 
     // stateless repository life cycle method @Update with entity result (find & merge)
     LC_UPDATE_MERGE(Update.class.getSimpleName(), //
@@ -97,7 +105,8 @@ public enum QueryType {
                     Require.AUTO_START_TX, //
                     Require.DETACH_ENTITIES, //
                     Require.RETURN_HIDDEN, //
-                    Require.STATELESS),
+                    Require.STATELESS, //
+                    !Supports.QUERY_OPTIONS),
 
     // stateful repository life cycle method @Merge
     MERGE("Merge", //
@@ -105,7 +114,8 @@ public enum QueryType {
           !Require.AUTO_START_TX, //
           !Require.DETACH_ENTITIES, //
           Require.RETURN_HIDDEN, //
-          Require.STATEFUL),
+          Require.STATEFUL, //
+          !Supports.QUERY_OPTIONS),
 
     // stateful repository life cycle method @Persist
     PERSIST("Persist", //
@@ -113,7 +123,8 @@ public enum QueryType {
             Require.AUTO_START_TX, //
             !Require.DETACH_ENTITIES, //
             !Require.RETURN_HIDDEN, //
-            Require.STATEFUL),
+            Require.STATEFUL, //
+            !Supports.QUERY_OPTIONS),
 
     // stateless repository query method delete/@Delete/@Query(DELETE)
     QM_DELETE(Delete.class.getSimpleName(), //
@@ -121,7 +132,8 @@ public enum QueryType {
               Require.AUTO_START_TX, //
               !Require.DETACH_ENTITIES, //
               !Require.RETURN_HIDDEN, //
-              Require.STATELESS),
+              Require.STATELESS, //
+              Supports.QUERY_OPTIONS),
 
     // stateless repository query method update/@Update/@Query(UPDATE)
     QM_UPDATE(Update.class.getSimpleName(), //
@@ -129,7 +141,8 @@ public enum QueryType {
               Require.AUTO_START_TX, //
               !Require.DETACH_ENTITIES, //
               !Require.RETURN_HIDDEN, //
-              Require.STATELESS),
+              Require.STATELESS, //
+              Supports.QUERY_OPTIONS),
 
     // stateful repository life cycle method @Refresh
     REFRESH("Refresh", //
@@ -137,7 +150,8 @@ public enum QueryType {
             !Require.AUTO_START_TX, //
             !Require.DETACH_ENTITIES, //
             !Require.RETURN_HIDDEN, //
-            Require.STATEFUL),
+            Require.STATEFUL, //
+            !Supports.QUERY_OPTIONS),
 
     // stateful repository life cycle method @Remove
     REMOVE("Remove", //
@@ -145,7 +159,8 @@ public enum QueryType {
            Require.AUTO_START_TX, //
            !Require.DETACH_ENTITIES, //
            !Require.RETURN_HIDDEN, //
-           Require.STATEFUL),
+           Require.STATEFUL, //
+           !Supports.QUERY_OPTIONS),
 
     // resource accessor method
     RESOURCE_ACCESS(null, //
@@ -153,7 +168,8 @@ public enum QueryType {
                     !Require.AUTO_START_TX, //
                     !Require.DETACH_ENTITIES, //
                     !Require.RETURN_HIDDEN, //
-                    null), // stateful or stateless
+                    null, // stateful or stateless
+                    !Supports.QUERY_OPTIONS),
 
     // stateless repository life cycle method @Save
     SAVE(Save.class.getSimpleName(), //
@@ -161,7 +177,8 @@ public enum QueryType {
          Require.AUTO_START_TX, //
          Require.DETACH_ENTITIES, //
          Require.RETURN_HIDDEN, //
-         Require.STATELESS);
+         Require.STATELESS, //
+         !Supports.QUERY_OPTIONS);
 
     private final static TraceComponent tc = Tr.register(QueryType.class);
 
@@ -208,6 +225,12 @@ public enum QueryType {
     private final Boolean stateful;
 
     /**
+     * Indicates whether the jakarta.persistence.QueryOptions annotation
+     * is supported on the type of repository method for Persistence 4.0+.
+     */
+    public final boolean supportsQueryOptions;
+
+    /**
      * Internal constructor for enumeration values.
      *
      * @param annoName             Simple name of the equivalent repository method
@@ -231,13 +254,15 @@ public enum QueryType {
                       boolean autoStartTransaction,
                       Boolean detachEntities,
                       boolean hideReturnValue,
-                      Boolean stateful) {
+                      Boolean stateful,
+                      boolean supportsQueryOptions) {
         this.autoStartTransaction = autoStartTransaction;
         this.detachEntities = detachEntities;
         this.hideReturnValue = hideReturnValue;
         this.isLifeCycleMethod = isLifeCycleMethod;
         this.operationName = annoName == null ? name() : annoName;
         this.stateful = stateful;
+        this.supportsQueryOptions = supportsQueryOptions;
     }
 
     /**
@@ -284,4 +309,15 @@ public enum QueryType {
         static final boolean STATEFUL = true;
         static final boolean STATELESS = false;
     }
+
+    /**
+     * Constants used internally by the enumeration.
+     * The constants cannot be declared directly on the enumeration because the
+     * enumerated values need access to them and cannot access fields that are
+     * declared later in the file.
+     */
+    private static final class Supports {
+        static final boolean QUERY_OPTIONS = true;
+    }
+
 }

--- a/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/v1_0/QueryInfo_1_0.java
+++ b/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/v1_0/QueryInfo_1_0.java
@@ -130,8 +130,8 @@ public class QueryInfo_1_0 extends QueryInfo {
 
     @Override
     @Trivial
-    protected jakarta.persistence.Query ehCreateQuery(AutoCloseable entityHandler,
-                                                      String jpql) {
+    protected jakarta.persistence.Query ehCreateStatement(AutoCloseable entityHandler,
+                                                          String jpql) {
         return ((EntityManager) entityHandler).createQuery(jpql);
     }
 

--- a/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/v1_1/QueryInfo_1_1.java
+++ b/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/v1_1/QueryInfo_1_1.java
@@ -85,6 +85,7 @@ import jakarta.data.repository.Is;
 import jakarta.data.repository.JakartaQuery;
 import jakarta.data.repository.OrderBy;
 import jakarta.data.repository.Query;
+import jakarta.data.repository.QueryOptions;
 import jakarta.data.repository.Save;
 import jakarta.data.repository.Update;
 import jakarta.data.repository.stateful.Detach;
@@ -105,7 +106,10 @@ import jakarta.data.spi.expression.function.TextFunctionExpression;
 import jakarta.data.spi.expression.literal.Literal;
 import jakarta.data.spi.expression.path.NavigablePath;
 import jakarta.data.spi.expression.path.Path;
+import jakarta.persistence.EntityGraph;
 import jakarta.persistence.EntityManager;
+import jakarta.persistence.FlushModeType;
+import jakarta.persistence.QueryHint;
 import jakarta.persistence.TypedQuery;
 
 /**
@@ -368,16 +372,24 @@ public class QueryInfo_1_1 extends QueryInfo {
 
     @Override
     @Trivial
-    protected jakarta.persistence.Query ehCreateQuery(AutoCloseable entityHandler,
-                                                      String jpql) {
+    protected jakarta.persistence.Query ehCreateStatement(AutoCloseable entityHandler,
+                                                          String jpql) {
+        QueryOptions options = type.supportsQueryOptions //
+                        ? method.getAnnotation(QueryOptions.class) //
+                        : null;
+
         // TODO Persistence 4.0 API
         //return entityHandler instanceof EntityHandler handler //
-        //                ? handler.createQuery(jpql) //
-        //                : super.ehCreateQuery(entityHandler, jpql);
+        //                ? handler.createStatement(jpql) //
+        //                : ((EntityManager) entityHandler).createQuery(jpql);
         try {
-            return (jakarta.persistence.Query) entityHandler.getClass() //
-                            .getMethod("createQuery", String.class) //
-                            .invoke(entityHandler, jpql);
+            jakarta.persistence.Query query = //
+                            (jakarta.persistence.Query) entityHandler.getClass() //
+                                            .getMethod("createQuery", String.class) //
+                                            .invoke(entityHandler, jpql);
+            if (options != null)
+                setWriteOptions(options, query);
+            return query;
         } catch (IllegalAccessException | NoSuchMethodException x) {
             throw new RuntimeException(x); // should be impossible
         } catch (InvocationTargetException x) {
@@ -388,19 +400,27 @@ public class QueryInfo_1_1 extends QueryInfo {
     }
 
     @Override
-    @SuppressWarnings("unchecked")
     @Trivial
     protected <T> TypedQuery<T> ehCreateTypedQuery(AutoCloseable entityHandler,
                                                    String jpql,
                                                    Class<?> resultType) {
+        QueryOptions options = type.supportsQueryOptions //
+                        ? method.getAnnotation(QueryOptions.class) //
+                        : null;
+
         // TODO Persistence 4.0 API
-        //return entityHandler instanceof EntityHandler handler //
+        //TypedQuery<T> query = entityHandler instanceof EntityHandler handler //
         //                ? handler.createQuery(jpql, resultType) //
-        //                : super.ehCreateQuery(entityHandler, jpql, resultType);
+        //                : ((EntityManager) entityHandler) //
+        //                        .createQuery(jpql, resultType)
         try {
-            return (TypedQuery<T>) entityHandler.getClass() //
+            @SuppressWarnings("unchecked")
+            TypedQuery<T> query = (TypedQuery<T>) entityHandler.getClass() //
                             .getMethod("createQuery", String.class, Class.class) //
                             .invoke(entityHandler, jpql, resultType);
+            if (options != null)
+                setReadOptions(options, query, entityHandler);
+            return query;
         } catch (IllegalAccessException | NoSuchMethodException x) {
             throw new RuntimeException(x); // should be impossible
         } catch (InvocationTargetException x) {
@@ -1072,6 +1092,89 @@ public class QueryInfo_1_1 extends QueryInfo {
         }
 
         return numJPQLParams;
+    }
+
+    /**
+     * Configures the query options that are intended for JPQL find/select queries.
+     *
+     * @param options       configurable query options
+     * @param query         the query upon which to configure the options
+     * @param entityHandler EntityAgent or EntityManager
+     */
+    private <T> void setReadOptions(QueryOptions options,
+                                    TypedQuery<T> query,
+                                    AutoCloseable entityHandler) //
+                    throws // TODO remove once using Persistence 4.0 API
+                    IllegalAccessException, //
+                    InvocationTargetException, //
+                    NoSuchMethodException {
+        // QueryOptions specified via Hints:
+        for (QueryHint hint : options.hints())
+            query.setHint(hint.name(),
+                          hint);
+        if (options.entityGraph().length() > 0) {
+            // TODO Persistence 4.0: entityHandler.getEntityGraph(options.entityGraph());
+            EntityGraph<?> loadGraph = (EntityGraph<?>) entityHandler.getClass() //
+                            .getMethod("getEntityGraph", String.class) //
+                            .invoke(entityHandler, options.entityGraph());
+            query.setHint("jakarta.persistence.loadgraph",
+                          loadGraph);
+        }
+
+        query.setHint("jakarta.persistence.lock.scope",
+                      options.lockScope());
+
+        // QueryOptions specified via dedicated API methods:
+        if (!entityInfo.isHibernate) {
+            // TODO enable for Hibernate once its NullPointerException is fixed
+            query.setCacheStoreMode(options.cacheStoreMode());
+            query.setCacheRetrieveMode(options.cacheRetrieveMode());
+        }
+        // TODO Persistence 4.0 directly delegate to setQueryFlushMode
+        switch (options.flush()) {
+            case DEFAULT:
+                break;
+            case FLUSH:
+                query.setFlushMode(FlushModeType.AUTO);
+                break;
+            case NO_FLUSH:
+                // TODO query.setQueryFlushMode(NO_FLUSH);
+                throw new UnsupportedOperationException("QueryFlushMode.NO_FLUSH");
+        }
+        query.setLockMode(options.lockMode());
+        // TODO the correct value is null, but Hibernate and EclipseLink do not handle it correctly
+        query.setTimeout(options.timeout() == -1 ? 0 : options.timeout());
+    }
+
+    /**
+     * Configures the query options that are intended for JPQL DELETE and UPDATE
+     * statements.
+     *
+     * @param options   configurable query options
+     * @param statement the jakarta.persistence.Statement upon which to configure
+     *                      the options
+     */
+    private static void setWriteOptions(QueryOptions options,
+                                        jakarta.persistence.Query statement) {
+        // QueryOptions specified via Hints:
+        for (QueryHint hint : options.hints())
+            statement.setHint(hint.name(),
+                              hint.value());
+
+        // QueryOptions specified via dedicated API methods:
+        // TODO Persistence 4.0 directly delegate to setQueryFlushMode
+        switch (options.flush()) {
+            case DEFAULT:
+                break;
+            case FLUSH:
+                statement.setFlushMode(FlushModeType.AUTO);
+                break;
+            case NO_FLUSH:
+                // TODO query.setQueryFlushMode(NO_FLUSH);
+                throw new UnsupportedOperationException("QueryFlushMode.NO_FLUSH");
+        }
+
+        statement.setTimeout(options.timeout() == -1 ? null : options.timeout());
     }
 
     /**

--- a/dev/io.openliberty.data.internal_fat_1_1/test-applications/Data_1_1_App/src/test/jakarta/data/v1_1/web/Data_1_1_Servlet.java
+++ b/dev/io.openliberty.data.internal_fat_1_1/test-applications/Data_1_1_App/src/test/jakarta/data/v1_1/web/Data_1_1_Servlet.java
@@ -489,6 +489,29 @@ public class Data_1_1_Servlet extends FATServlet {
     }
 
     /**
+     * Use the QueryOptions annotation on a Find method to supply a load graph
+     * that overrides loading of an ElementCollection to make it eager rather
+     * than lazily loaded.
+     */
+    @Test
+    public void testEntityGraphAsQueryOption() {
+        assertEquals(List.of(BigDecimal.valueOf(300, 3), // nearest tenth
+                             BigDecimal.valueOf(310, 3), // nearest hundreth
+                             BigDecimal.valueOf(313, 3)), // nearest thousandth
+                     fractions.of(5, 16).orElseThrow().rounded);
+
+        assertEquals(List.of(BigDecimal.valueOf(900, 3), // nearest tenth
+                             BigDecimal.valueOf(860, 3), // nearest hundreth
+                             BigDecimal.valueOf(857, 3)), // nearest thousandth
+                     fractions.of(6, 7).orElseThrow().rounded);
+
+        assertEquals(List.of(BigDecimal.valueOf(600, 3), // nearest tenth
+                             BigDecimal.valueOf(620, 3), // nearest hundreth
+                             BigDecimal.valueOf(615, 3)), // nearest thousandth
+                     fractions.of(8, 13).orElseThrow().rounded);
+    }
+
+    /**
      * Tests a Find method with the First annotation specifying a value
      * larger than 1.
      */

--- a/dev/io.openliberty.data.internal_fat_1_1/test-applications/Data_1_1_App/src/test/jakarta/data/v1_1/web/Fraction.java
+++ b/dev/io.openliberty.data.internal_fat_1_1/test-applications/Data_1_1_App/src/test/jakarta/data/v1_1/web/Fraction.java
@@ -26,6 +26,8 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.ForeignKey;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
+import jakarta.persistence.NamedAttributeNode;
+import jakarta.persistence.NamedEntityGraph;
 
 /**
  * Entity for representing fractions less than 1, such as 3/4 or 5/6.
@@ -33,6 +35,8 @@ import jakarta.persistence.JoinColumn;
  * and various other attribute types that we will want test coverage for.
  */
 @Entity
+@NamedEntityGraph(name = "EagerlyLoadRoundedValues",
+                  attributeNodes = @NamedAttributeNode("rounded"))
 public class Fraction {
 
     @Embedded

--- a/dev/io.openliberty.data.internal_fat_1_1/test-applications/Data_1_1_App/src/test/jakarta/data/v1_1/web/Fraction.java
+++ b/dev/io.openliberty.data.internal_fat_1_1/test-applications/Data_1_1_App/src/test/jakarta/data/v1_1/web/Fraction.java
@@ -13,13 +13,19 @@
 package test.jakarta.data.v1_1.web;
 
 import java.math.BigDecimal;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 
+import jakarta.persistence.CollectionTable;
 import jakarta.persistence.Column;
+import jakarta.persistence.ElementCollection;
 import jakarta.persistence.Embeddable;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
+import jakarta.persistence.ForeignKey;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
 
 /**
  * Entity for representing fractions less than 1, such as 3/4 or 5/6.
@@ -44,6 +50,18 @@ public class Fraction {
 
     @Column(nullable = false)
     boolean reduced;
+
+    @ElementCollection
+    @CollectionTable //
+    (name = "Fraction_rounded",
+     joinColumns = @JoinColumn//
+     (name = "Fraction_name",
+      foreignKey = @ForeignKey//
+      (name = "FK_Fraction_rounded",
+       foreignKeyDefinition = //
+       "FOREIGN KEY (Fraction_name) REFERENCES Fraction(name) ON DELETE CASCADE")))
+    @Column(precision = 10, scale = 3)
+    List<BigDecimal> rounded;
 
     @Embeddable
     public static record Decimal(
@@ -221,6 +239,16 @@ public class Fraction {
             if (numerator % i == 0 &&
                 denominator % i == 0)
                 f.reduced = false;
+
+        // rounded to nearest tenth, hundreth, and thousandth:
+        long halfUp = denominator / 2;
+        f.rounded = new ArrayList<>(3);
+        f.rounded.add(BigDecimal //
+                        .valueOf((numerator * 10 + halfUp) / denominator, 1));
+        f.rounded.add(BigDecimal //
+                        .valueOf((numerator * 100 + halfUp) / denominator, 2));
+        f.rounded.add(BigDecimal //
+                        .valueOf((numerator * 1000 + halfUp) / denominator, 3));
 
         return f;
     }

--- a/dev/io.openliberty.data.internal_fat_1_1/test-applications/Data_1_1_App/src/test/jakarta/data/v1_1/web/Fractions.java
+++ b/dev/io.openliberty.data.internal_fat_1_1/test-applications/Data_1_1_App/src/test/jakarta/data/v1_1/web/Fractions.java
@@ -42,6 +42,7 @@ import jakarta.data.repository.Is;
 import jakarta.data.repository.JakartaQuery; // TODO replace with Persistence 4.0 anno once available
 import jakarta.data.repository.OrderBy;
 import jakarta.data.repository.Query;
+import jakarta.data.repository.QueryOptions; // TODO replace with Persistence 4.0 anno once available
 import jakarta.data.repository.Repository;
 import jakarta.data.repository.Select;
 import jakarta.data.restrict.Restriction;
@@ -103,6 +104,10 @@ public interface Fractions {
     List<String> named(@By(_Fraction.NAME) Like pattern,
                        Order<Fraction> order,
                        Limit limit);
+
+    @Find
+    @QueryOptions(entityGraph = "EagerlyLoadRoundedValues")
+    Optional<Fraction> of(int numerator, int denominator);
 
     @Query("SELECT numerator, denominator - numerator" +
            " ORDER BY denominator - numerator DESC, numerator ASC")


### PR DESCRIPTION
Implement and test `entityGraph` field of `@QueryOptions` for a repository Find method.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
