### PR TITLE
Ensure testServerWithIncludeSuccess cleans up included.xml after test finishes

### DIFF
--- a/dev/com.ibm.ws.install.featureUtility_fat/fat/src/com/ibm/ws/install/featureUtility/fat/FeatureUtilityToolTest.java
+++ b/dev/com.ibm.ws.install.featureUtility_fat/fat/src/com/ibm/ws/install/featureUtility/fat/FeatureUtilityToolTest.java
@@ -185,6 +185,10 @@ public abstract class FeatureUtilityToolTest {
     public static void copyFileToMinifiedRoot(String extendedPath, String fileName) throws Exception {
 	LibertyFileManager.copyFileIntoLiberty(server.getMachine(), minifiedRoot + "/" + extendedPath, fileName);
     }
+
+    public static void deleteFileFromMinifiedRoot(String fileName) throws Exception {
+        LibertyFileManager.deleteLibertyFile(server.getMachine(), minifiedRoot + "/" + fileName);
+    }
     
 
     public static void writeToProps(String remoteFileName, String property, String value) throws Exception {

--- a/dev/com.ibm.ws.install.featureUtility_fat/fat/src/com/ibm/ws/install/featureUtility/fat/InstallServerTest.java
+++ b/dev/com.ibm.ws.install.featureUtility_fat/fat/src/com/ibm/ws/install/featureUtility/fat/InstallServerTest.java
@@ -155,6 +155,7 @@ public class InstallServerTest extends FeatureUtilityToolTest {
 		String output = po.getStdout();
 
 		checkCommandOutput(po, 0, null, null);
+		deleteFileFromMinifiedRoot("usr/servers/serverX/included.xml");
 
 		Log.exiting(c, METHOD_NAME);
 	}


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".