### PR TITLE
Revert com.ibm.ws.concurrent_fat_db back to Derby

### DIFF
--- a/dev/com.ibm.ws.concurrent_fat_db/build.gradle
+++ b/dev/com.ibm.ws.concurrent_fat_db/build.gradle
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2026 IBM Corporation and others.
+ * Copyright (c) 2017, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -11,4 +11,4 @@
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 
-addRequiredLibraries.dependsOn addH2Java8
+addRequiredLibraries.dependsOn addDerby

--- a/dev/com.ibm.ws.concurrent_fat_db/cognitiveMetadata.yml
+++ b/dev/com.ibm.ws.concurrent_fat_db/cognitiveMetadata.yml
@@ -1,6 +1,6 @@
 ---
 # YML metadata file made use of by the Cognitive Ecosystem.
 # Reference Cognitive Metadata is available at: https://github.com/OpenLiberty/open-liberty/tree/integration/dev/build.example_fat/cognitiveMetadata.yml
-# description: Uncomment this field and add a description to give some notes about this bucket.
+description: This bucket cannot be migrated from Derby to H2 since H2 does not support suspending local transactions.
 # triageNotes: Uncomment this field if there are some short notes you would like Pipeline Monitors to see when triaging this bucket.
 functionalArea: EE / MP Concurrency

--- a/dev/com.ibm.ws.concurrent_fat_db/publish/servers/concurrent_fat_db/server.xml
+++ b/dev/com.ibm.ws.concurrent_fat_db/publish/servers/concurrent_fat_db/server.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2017,2026 IBM Corporation and others.
+    Copyright (c) 2017,2020 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -23,20 +23,20 @@
 
     <dataSource id="CPDataSource" jndiName="jdbc/CPDataSource" type="javax.sql.ConnectionPoolDataSource">
         <connectionManager autoCloseConnections="false"/>
-        <jdbcDriver libraryRef="H2Lib"/>
-        <properties.h2 URL="jdbc:h2:mem:concurrent_fat_db;DB_CLOSE_DELAY=-1"/>
+        <jdbcDriver libraryRef="DerbyLib"/>
+        <properties.derby.embedded createDatabase="create" databaseName="memory:concurrent_fat_db"/>
     </dataSource>
 
     <dataSource id="DefaultDataSource"> <!-- an XADataSource -->
         <connectionManager autoCloseConnections="true"/>
-        <jdbcDriver libraryRef="H2Lib"/>
-        <properties.h2 URL="jdbc:h2:mem:concurrent_fat_db;DB_CLOSE_DELAY=-1"/>
+        <jdbcDriver libraryRef="DerbyLib"/>
+        <properties.derby.embedded createDatabase="create" databaseName="memory:concurrent_fat_db"/>
     </dataSource>
 
-    <library id="H2Lib">
-        <fileset dir="${shared.resource.dir}/h2Java8" includes="h2.jar"/>
+    <library id="DerbyLib">
+        <fileset dir="${shared.resource.dir}/derby" includes="derby.jar"/>
     </library>
 
-    <!-- permissions for H2 -->
-    <javaPermission codebase="${shared.resource.dir}/h2Java8/h2.jar" className="java.security.AllPermission"/>
+    <!-- permissions for Derby -->
+    <javaPermission codebase="${shared.resource.dir}/derby/derby.jar" className="java.security.AllPermission"/>
 </server>

--- a/dev/com.ibm.ws.concurrent_fat_db/test-applications/concurrentdbtest/src/concurrent/fat/db/web/ConcurrentDBTestServlet.java
+++ b/dev/com.ibm.ws.concurrent_fat_db/test-applications/concurrentdbtest/src/concurrent/fat/db/web/ConcurrentDBTestServlet.java
@@ -284,7 +284,6 @@ public class ConcurrentDBTestServlet extends FATDatabaseServlet {
      * Have a task run in the transaction that is already on the thread of execution. Roll it back.
      */
     @Test
-    @Ignore("https://github.com/OpenLiberty/open-liberty/issues/33035") //TODO this test currently fails now that an XA datasource is actually being used.
     public void testLTCOfExecutionThread() throws Exception {
         Connection con = dataSource.getConnection();
         try {
@@ -330,7 +329,6 @@ public class ConcurrentDBTestServlet extends FATDatabaseServlet {
      * Schedule a task that does work in an LTC, rolls it back, and then starts a global transaction.
      */
     @Test
-    @Ignore("https://github.com/OpenLiberty/open-liberty/issues/33035") //TODO this test currently fails now that an XA datasource is actually being used.
     public void testLTCRollbackAndStartGlobalTran() throws Exception {
         Future<Integer> future = scheduledExecutor.schedule(new Callable<Integer>() {
             @Override

--- a/dev/com.ibm.ws.concurrent_fat_db/test-applications/concurrentdbtest/src/concurrent/fat/db/web/ConcurrentDBTestServlet.java
+++ b/dev/com.ibm.ws.concurrent_fat_db/test-applications/concurrentdbtest/src/concurrent/fat/db/web/ConcurrentDBTestServlet.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2026 IBM Corporation and others.
+ * Copyright (c) 2017,2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- *
+ * 
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -44,7 +44,6 @@ import jakarta.transaction.UserTransaction;
 
 import javax.sql.DataSource;
 
-import org.junit.Ignore;
 import org.junit.Test;
 
 import componenttest.app.FATDatabaseServlet;
@@ -368,7 +367,6 @@ public class ConcurrentDBTestServlet extends FATDatabaseServlet {
      * Run a task on the same thread in the middle of an LTC. The LTC should be temporarily suspended, and afterwards resumed.
      */
     @Test
-    @Ignore("https://github.com/OpenLiberty/open-liberty/issues/33035") //TODO this test currently fails now that an XA datasource is actually being used.
     public void testLTCSuspendAndResume() throws Exception {
         Connection con = dataSource.getConnection();
         try {
@@ -408,7 +406,7 @@ public class ConcurrentDBTestServlet extends FATDatabaseServlet {
         try {
             ResultSet result = con.createStatement().executeQuery("SELECT MYVALUE FROM MYTABLE WHERE MYKEY = 'testLTCSuspendAndResume'");
             if (result.next())
-                throw new Exception("Updates should have been rolled back, value was: " + result.getObject("MYVALUE"));
+                throw new Exception("Updates should have been rolled back");
         } finally {
             con.commit();
             con.close();
@@ -420,7 +418,6 @@ public class ConcurrentDBTestServlet extends FATDatabaseServlet {
      * the one from Jakarta Concurrency must take precedence when Jakarta Concurrency is enabled.
      */
     @Test
-    @Ignore("https://github.com/OpenLiberty/open-liberty/issues/33035") //TODO this test currently fails now that an XA datasource is actually being used.
     public void testPrecedenceOfTransactionConstant() throws Exception {
         Map<String, String> execProps = new TreeMap<String, String>();
         execProps.put(ManagedTask.TRANSACTION.replace("jakarta", "javax"), ManagedTask.SUSPEND);


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

Fix #34816 
