### PR TITLE
Update to use server Java when making Java level decisions for FATs

### DIFF
--- a/dev/com.ibm.ws.security.oauth.oidc_fat.common/src/com/ibm/ws/security/oauth_oidc/fat/commonTest/CommonTest.java
+++ b/dev/com.ibm.ws.security.oauth.oidc_fat.common/src/com/ibm/ws/security/oauth_oidc/fat/commonTest/CommonTest.java
@@ -1,14 +1,11 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2025 IBM Corporation and others.
+ * Copyright (c) 2020, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- * IBM Corporation - initial API and implementation
  *******************************************************************************/
 package com.ibm.ws.security.oauth_oidc.fat.commonTest;
 
@@ -373,12 +370,7 @@ public class CommonTest extends com.ibm.ws.security.fat.common.CommonTest {
                 }
             }
 
-            boolean overrideForConsul = false;
-            if (!useDerby && useMongo && JavaInfo.JAVA_VERSION == 7) { // Added Java 7 back in, need to do this to connect to Consul for MongoDB
-                overrideForConsul = true;
-            }
-
-            setupSSLClient(overrideForConsul);
+            setupSSLClient();
 
             /*
              * reconfigExpectations = new FATDataHelpers().addExpectation(null,
@@ -528,7 +520,7 @@ public class CommonTest extends com.ibm.ws.security.fat.common.CommonTest {
      * Perform setup for testing with SSL connections: TrustManager, hostname
      * verifier, ...
      */
-    private static void setupSSLClient(boolean overrideForConsul) {
+    private static void setupSSLClient() {
 
         String thisMethod = "setupSSLCLient";
 

--- a/dev/fattest.simplicity/src/componenttest/annotation/processor/TestServletProcessor.java
+++ b/dev/fattest.simplicity/src/componenttest/annotation/processor/TestServletProcessor.java
@@ -1,14 +1,11 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2025 IBM Corporation and others.
+ * Copyright (c) 2017, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package componenttest.annotation.processor;
 
@@ -71,9 +68,9 @@ public class TestServletProcessor {
 
             // For each @TestServlet for this server, add all @Test methods
             for (TestServlet anno : testServlets) {
-                if (JavaInfo.JAVA_VERSION < anno.minJavaLevel()) {
+                if (JavaInfo.BOOTSTRAP_JAVA_VERSION < anno.minJavaLevel()) {
                     Log.info(c, m, "Skipping scan of TestServlet " + anno.servlet()
-                                   + " because the current java level " + JavaInfo.JAVA_VERSION
+                                   + " because the current java level " + JavaInfo.BOOTSTRAP_JAVA_VERSION
                                    + " did not meet the configured minimum " + anno.minJavaLevel());
                     continue;
                 }

--- a/dev/fattest.simplicity/src/componenttest/custom/junit/runner/JavaLevelFilter.java
+++ b/dev/fattest.simplicity/src/componenttest/custom/junit/runner/JavaLevelFilter.java
@@ -1,14 +1,11 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2025 IBM Corporation and others.
+ * Copyright (c) 2017, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package componenttest.custom.junit.runner;
 
@@ -50,10 +47,10 @@ public class JavaLevelFilter extends Filter {
             maximumJavaLevelAnnotation = FilterUtils.getTestClass(desc, getMyClass()).getAnnotation(MaximumJavaLevel.class);
         }
         if (maximumJavaLevelAnnotation != null) {
-            if (JavaInfo.JAVA_VERSION > maximumJavaLevelAnnotation.javaLevel()) {
+            if (JavaInfo.BOOTSTRAP_JAVA_VERSION > maximumJavaLevelAnnotation.javaLevel()) {
                 Log.debug(getMyClass(), "Removing test " + desc.getMethodName()
                                         + " from list to run, because its maximum java level is " + maximumJavaLevelAnnotation.javaLevel()
-                                        + " and we are running with " + JavaInfo.JAVA_VERSION);
+                                        + " and we are running with " + JavaInfo.BOOTSTRAP_JAVA_VERSION);
                 return false;
             }
         }
@@ -69,11 +66,11 @@ public class JavaLevelFilter extends Filter {
         }
 
         // If there's a minimum java level annotaton, that sets a global minimum level, so if we don't meet that, don't run tests
-        boolean javaLevelTooLowForAllFeatures = minimumJavaLevelAnnotation != null && JavaInfo.JAVA_VERSION < minimumJavaLevelAnnotation.javaLevel();
+        boolean javaLevelTooLowForAllFeatures = minimumJavaLevelAnnotation != null && JavaInfo.BOOTSTRAP_JAVA_VERSION < minimumJavaLevelAnnotation.javaLevel();
         if (javaLevelTooLowForAllFeatures) {
             Log.debug(getMyClass(), "Removing test " + desc.getMethodName() + " with minimum java level " + minimumJavaLevelAnnotation.javaLevel()
                                     + " from list to run, because it is too high for current java level "
-                                    + JavaInfo.JAVA_VERSION);
+                                    + JavaInfo.BOOTSTRAP_JAVA_VERSION);
             return false;
         }
 

--- a/dev/fattest.simplicity/src/componenttest/rules/repeater/EmptyAction.java
+++ b/dev/fattest.simplicity/src/componenttest/rules/repeater/EmptyAction.java
@@ -28,9 +28,9 @@ public class EmptyAction implements RepeatTestAction {
     private TestMode testRunMode = TestMode.LITE;
     private boolean liteFATOnly = false;
 
-    public static final Predicate<EmptyAction> GREATER_THAN_OR_EQUAL_JAVA_11 = (action) -> JavaInfo.JAVA_VERSION >= 11;
-    public static final Predicate<EmptyAction> GREATER_THAN_OR_EQUAL_JAVA_17 = (action) -> JavaInfo.JAVA_VERSION >= 17;
-    public static final Predicate<EmptyAction> GREATER_THAN_OR_EQUAL_JAVA_21 = (action) -> JavaInfo.JAVA_VERSION >= 21;
+    public static final Predicate<EmptyAction> GREATER_THAN_OR_EQUAL_JAVA_11 = (action) -> JavaInfo.BOOTSTRAP_JAVA_VERSION >= 11;
+    public static final Predicate<EmptyAction> GREATER_THAN_OR_EQUAL_JAVA_17 = (action) -> JavaInfo.BOOTSTRAP_JAVA_VERSION >= 17;
+    public static final Predicate<EmptyAction> GREATER_THAN_OR_EQUAL_JAVA_21 = (action) -> JavaInfo.BOOTSTRAP_JAVA_VERSION >= 21;
 
     @Override
     public void setup() {}

--- a/dev/fattest.simplicity/src/componenttest/rules/repeater/FeatureReplacementAction.java
+++ b/dev/fattest.simplicity/src/componenttest/rules/repeater/FeatureReplacementAction.java
@@ -1,14 +1,11 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2025 IBM Corporation and others.
+ * Copyright (c) 2017, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package componenttest.rules.repeater;
 
@@ -106,9 +103,9 @@ public class FeatureReplacementAction implements RepeatTestAction {
         featuresWithNameChangeOnEE9 = Collections.unmodifiableMap(featureNameMapping);
     }
 
-    public static final Predicate<FeatureReplacementAction> GREATER_THAN_OR_EQUAL_JAVA_11 = (action) -> JavaInfo.JAVA_VERSION >= 11;
-    public static final Predicate<FeatureReplacementAction> GREATER_THAN_OR_EQUAL_JAVA_17 = (action) -> JavaInfo.JAVA_VERSION >= 17;
-    public static final Predicate<FeatureReplacementAction> GREATER_THAN_OR_EQUAL_JAVA_21 = (action) -> JavaInfo.JAVA_VERSION >= 21;
+    public static final Predicate<FeatureReplacementAction> GREATER_THAN_OR_EQUAL_JAVA_11 = (action) -> JavaInfo.BOOTSTRAP_JAVA_VERSION >= 11;
+    public static final Predicate<FeatureReplacementAction> GREATER_THAN_OR_EQUAL_JAVA_17 = (action) -> JavaInfo.BOOTSTRAP_JAVA_VERSION >= 17;
+    public static final Predicate<FeatureReplacementAction> GREATER_THAN_OR_EQUAL_JAVA_21 = (action) -> JavaInfo.BOOTSTRAP_JAVA_VERSION >= 21;
 
     public static EmptyAction NO_REPLACEMENT() {
         return new EmptyAction();
@@ -514,11 +511,11 @@ public class FeatureReplacementAction implements RepeatTestAction {
     }
 
     public boolean checkEnabled() {
-        if (JavaInfo.forCurrentVM().majorVersion() < minJavaLevel.majorVersion()) {
+        if (JavaInfo.BOOTSTRAP_JAVA_VERSION < minJavaLevel.majorVersion()) {
             Log.info(c, "isEnabled", "Skipping action '" + toString() + "' because the java level is too low.");
             return false;
         }
-        if (maxJavaLevel != null && JavaInfo.forCurrentVM().majorVersion() > maxJavaLevel.majorVersion()) {
+        if (maxJavaLevel != null && JavaInfo.BOOTSTRAP_JAVA_VERSION > maxJavaLevel.majorVersion()) {
             Log.info(c, "isEnabled", "Skipping action '" + toString() + "' because the java level is too high.");
             return false;
         }

--- a/dev/fattest.simplicity/src/componenttest/rules/repeater/RepeatActions.java
+++ b/dev/fattest.simplicity/src/componenttest/rules/repeater/RepeatActions.java
@@ -1,14 +1,11 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2024 IBM Corporation and others.
+ * Copyright (c) 2020, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package componenttest.rules.repeater;
 
@@ -165,7 +162,7 @@ public class RepeatActions {
         List<FeatureSet> actualOtherFeatureSets = new ArrayList<>(otherFeatureSets);
 
         // If the firstFeatureSet requires a Java level higher than the one we're running, try to find a suitable replacement so we don't end up not running the test at all in LITE mode
-        int currentJavaLevel = JavaInfo.forCurrentVM().majorVersion();
+        int currentJavaLevel = JavaInfo.BOOTSTRAP_JAVA_VERSION;
         if (currentJavaLevel < firstFeatureSet.getMinJavaLevel().majorVersion()) {
 
             // Find the newest feature set that's in otherFeatureSets and is compatible with the current java version

--- a/dev/fattest.simplicity/src/componenttest/topology/impl/JavaInfo.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/impl/JavaInfo.java
@@ -1,14 +1,11 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2025 IBM Corporation and others.
+ * Copyright (c) 2017, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package componenttest.topology.impl;
 
@@ -29,6 +26,8 @@ import java.util.concurrent.ConcurrentHashMap;
 import com.ibm.websphere.simplicity.log.Log;
 import com.ibm.ws.ffdc.annotation.FFDCIgnore;
 
+import componenttest.common.apiservices.Bootstrap;
+
 /**
  * A class used for identifying properties of a JDK other
  * than the one that is currently being run.
@@ -37,7 +36,19 @@ public class JavaInfo {
     private static Class<?> c = JavaInfo.class;
     private static Map<String, JavaInfo> cache = new HashMap<String, JavaInfo>();
 
-    public static int JAVA_VERSION = JavaInfo.forCurrentVM().majorVersion();
+    public final static int JAVA_VERSION = JavaInfo.forCurrentVM().majorVersion();
+
+    public final static int BOOTSTRAP_JAVA_VERSION;
+    static {
+        try {
+            BOOTSTRAP_JAVA_VERSION = JavaInfo.forBootstrap(Bootstrap.getInstance()).majorVersion();
+        } catch (Exception ex) {
+            if (ex instanceof RuntimeException) {
+                throw (RuntimeException) ex;
+            }
+            throw new RuntimeException(ex);
+        }
+    }
 
     public static JavaInfo forCurrentVM() {
         String javaHome = System.getProperty("java.home");
@@ -67,6 +78,19 @@ public class JavaInfo {
         cache.put(jdkPath, info);
         if (jdkPath.contains("\\"))
             cache.put(jdkPath.replace("\\", "/"), info);
+    }
+
+    /**
+     * Get the JavaInfo for the JDK that will be used for LibertyServer and LibertyClient
+     * from the Bootstrap that is fed to those classes. The Java used to run the tests
+     * can be different than the one to run the client and server when using the
+     * supports.framework.java variable.
+     * </ol>
+     */
+    public static JavaInfo forBootstrap(Bootstrap bootstrap) throws IOException {
+        String bootstrapHostName = bootstrap.getValue("hostName");
+        String bootstrapJava = bootstrap.getValue(bootstrapHostName + ".JavaHome");
+        return fromPath(bootstrapJava);
     }
 
     /**

--- a/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyClient.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyClient.java
@@ -6,9 +6,6 @@
  * http://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package componenttest.topology.impl;
 
@@ -92,7 +89,6 @@ public class LibertyClient {
     public static boolean VALIDATE_APPS = DEFAULT_VALIDATE_APPS;
 
     protected static final JavaInfo javaInfo = JavaInfo.forCurrentVM();
-    protected static final boolean J9_JVM_RUN = javaInfo.vendor() == Vendor.IBM;
 
     protected static final boolean FAT_TEST_LOCALRUN = Boolean.getBoolean("fat.test.localrun");
     protected static final String MAC_RUN = PrivHelper.getProperty("fat.on.mac");
@@ -616,7 +612,7 @@ public class LibertyClient {
         JVM_ARGS += " -Djava.io.tmpdir=" + TMP_DIR;
 
         //FIPS 140-3
-        JavaInfo javaInfo = JavaInfo.forClient(this);
+        JavaInfo clientJavaInfo = JavaInfo.forClient(this);
 
         // Add JaCoCo java agent to generate code coverage for FAT test run
         if (DO_COVERAGE) {
@@ -670,11 +666,11 @@ public class LibertyClient {
             startedWithJavaSecurity = bootstrapHasJava2SecProps;
 
             if (bootstrapHasJava2SecProps) {
-                if (javaInfo.majorVersion() >= 24) {
+                if (clientJavaInfo.majorVersion() >= 24) {
                     // Security manager is permanently disabled starting in Java 24
                     LOG.severe("The build is configured to run FAT tests with Java 2 security enabled, but the security manager is permanently disabled in Java versions 24 and later.  The security manager cannot be set!");
                     throw new RuntimeException("The security manager is permanently disabled in Java versions 24 and later.  When running FATs, use @MaximumJavaLevel(javaLevel = 23) or disable Java 2 security to prevent this test from failing running in Java 24 or later.");
-                } else if (javaInfo.majorVersion() >= 18) {
+                } else if (clientJavaInfo.majorVersion() >= 18) {
                     // If we are running on Java 18 through 23, then we need to explicitly enable the security manager
                     Log.info(c, method, "Java 18 + Java2Sec requested, setting -Djava.security.manager=allow");
                     JVM_ARGS += " -Djava.security.manager=allow";
@@ -684,7 +680,7 @@ public class LibertyClient {
 
         //FIPS 140-3
         // if we have FIPS 140-3 enabled, and the matched java/platform, add JVM arg
-        if (isFIPS140_3EnabledAndSupported()) {
+        if (isFIPS140_3EnabledAndSupported(clientJavaInfo)) {
             if (GLOBAL_ENHANCED_ALGO) {
                 JVM_ARGS += " -Duse.enhanced.security.algorithms=true";
                 JVM_ARGS += " -Dcom.ibm.ws.beta.edition=true";
@@ -697,11 +693,11 @@ public class LibertyClient {
                     || opts.containsKey("-Dsemeru.fips")) {
                     Log.info(c, method, "Test has defined its own settings for FIPS140-3");
                 } else {
-                    Log.info(c, "startClientWithArgs", "The JDK version: " + javaInfo.majorVersion() + " and vendor: " + JavaInfo.Vendor.IBM);
+                    Log.info(c, "startClientWithArgs", "The JDK version: " + clientJavaInfo.majorVersion() + " and vendor: " + JavaInfo.Vendor.IBM);
 
-                    if (javaInfo.majorVersion() >= 11) {
+                    if (clientJavaInfo.majorVersion() >= 11) {
                         Log.info(c, "startClientWithArgs", "FIPS 140-3 global build properties is set for Client " + getClientName()
-                                                           + " with IBM Java " + javaInfo.majorVersion() + ", adding required JVM arguments to run with FIPS 140-3 enabled");
+                                                           + " with IBM Java " + clientJavaInfo.majorVersion() + ", adding required JVM arguments to run with FIPS 140-3 enabled");
 
                         JVM_ARGS += " -Dsemeru.fips=true";
                         JVM_ARGS += " -Dsemeru.customprofile=OpenJCEPlusFIPS.FIPS140-3-Custom";
@@ -709,7 +705,7 @@ public class LibertyClient {
                                     + getSemeruFips140_3CustomProfileLocationAndPrintFileContents();
                         JVM_ARGS += " -Dcom.ibm.fips.mode=140-3";
                         // JVM_ARGS += " -Djavax.net.debug=all";  // Uncomment as needed for additional debugging
-                    } else if (javaInfo.majorVersion() == 8) {
+                    } else if (clientJavaInfo.majorVersion() == 8) {
                         Log.info(c, "startClientWithArgs", "FIPS 140-3 global build properties is set for Client " + getClientName()
                                                            + " with IBM Java 8, adding JVM arguments -Xenablefips140-3, ...,  to run with FIPS 140-3 enabled");
 
@@ -796,7 +792,7 @@ public class LibertyClient {
 
         Log.info(c, method, "Starting Client with command: " + cmd);
 
-        if (isFIPS140_3EnabledAndSupported()) {
+        if (isFIPS140_3EnabledAndSupported(clientJavaInfo)) {
             String clientSecurityDir = clientRoot + File.separator + "resources" + File.separator + "security";
             File ltpaFIPSKeys = new File(clientSecurityDir, "ltpaFIPS.keys");
             File ltpaKeys = new File(clientSecurityDir, "ltpa.keys");
@@ -2812,13 +2808,12 @@ public class LibertyClient {
         RemoteFile remoteLogFile = machine.getFile(logFile);
         return findStringsInLogs(regexp, remoteLogFile);
     }
+
     public List<String> findStringsInCopiedTraceLogs(String regexp, String filePath) throws Exception {
         String logFile = pathToAutoFVTOutputClientsFolder + "/" + clientToUse + "-" + logStamp + "/" + filePath;
         RemoteFile remoteLogFile = machine.getFile(logFile);
         return findStringsInLogs(regexp, remoteLogFile);
     }
-
-    
 
     /**
      * This method will search the output and trace files for this client
@@ -4067,6 +4062,10 @@ public class LibertyClient {
 
     //FIPS 140-3
     public boolean isFIPS140_3EnabledAndSupported() throws Exception {
+        return isFIPS140_3EnabledAndSupported(JavaInfo.forClient(this));
+    }
+
+    private boolean isFIPS140_3EnabledAndSupported(JavaInfo clientJavaInfo) throws Exception {
         String methodName = "isFIPS140_3EnabledAndSupported";
 
         // short circuit this function so that it returns true if GLOBAL_ENHANCED_ALGO is true, this way the tests behave as though FIPS is enabled.
@@ -4075,16 +4074,16 @@ public class LibertyClient {
             return true;
         }
 
-        boolean isIBMJVM8 = (javaInfo.majorVersion() == 8) && (javaInfo.VENDOR == Vendor.IBM);
-        boolean isIBMJVMGreaterOrEqualTo11 = (javaInfo.majorVersion() >= 11) && (javaInfo.VENDOR == Vendor.IBM);
+        boolean isIBMJVM8 = (clientJavaInfo.majorVersion() == 8) && (clientJavaInfo.VENDOR == Vendor.IBM);
+        boolean isIBMJVMGreaterOrEqualTo11 = (clientJavaInfo.majorVersion() >= 11) && (clientJavaInfo.VENDOR == Vendor.IBM);
         if (GLOBAL_CLIENT_FIPS_140_3) {
-            Log.info(c, methodName, "Liberty client is running JDK version: " + javaInfo.majorVersion() + " and vendor: " + javaInfo.VENDOR);
+            Log.info(c, methodName, "Liberty client is running JDK version: " + clientJavaInfo.majorVersion() + " and vendor: " + clientJavaInfo.VENDOR);
             if (isIBMJVM8) {
                 Log.info(c, methodName, "global build properties FIPS_140_3 is set for client " + getClientName() +
                                         " and IBM java 8 is available to run with FIPS 140-3 enabled.");
             } else if (isIBMJVMGreaterOrEqualTo11) {
                 Log.info(c, methodName, "global build properties FIPS_140_3 is set for client " + getClientName() +
-                                        " and IBM java " + javaInfo.majorVersion() + " is available to run with FIPS 140-3 enabled.");
+                                        " and IBM java " + clientJavaInfo.majorVersion() + " is available to run with FIPS 140-3 enabled.");
             } else {
                 throw new RuntimeException("The global build properties FIPS_140_3 is set for client " + getClientName() +
                                            ",  but no IBM java on liberty client to run with FIPS 140-3 enabled.");

--- a/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyServer.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyServer.java
@@ -7950,16 +7950,6 @@ public class LibertyServer implements LogMonitorClient {
         updateServerConfiguration(config);
     }
 
-    @SuppressWarnings("deprecation")
-    public boolean isIBMJVM() {
-        return javaInfo.vendor() == JavaInfo.Vendor.IBM;
-    }
-
-    @SuppressWarnings("deprecation")
-    public boolean isOracleJVM() {
-        return javaInfo.vendor() == JavaInfo.Vendor.SUN_ORACLE;
-    }
-
     public void useSecondaryHTTPPort() {
         setHttpDefaultPort(getHttpSecondaryPort());
         setHttpDefaultSecurePort(getHttpSecondarySecurePort());


### PR DESCRIPTION
- Switch from using the JUnit side Java to determine the Java version used for a test since you can use Java 21 to run the test case, and a different Java level to run the Liberty server or client
- Remove some Java 7 and vendor code that isn't valid any longer


- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
