### PR TITLE
Fix illegal state exception in websocket cdi integration for non-bean endpoints

### DIFF
--- a/dev/com.ibm.ws.cdi.jee_fat/fat/src/com/ibm/ws/cdi/jee/FATSuite.java
+++ b/dev/com.ibm.ws.cdi.jee_fat/fat/src/com/ibm/ws/cdi/jee/FATSuite.java
@@ -22,6 +22,7 @@ import com.ibm.ws.cdi.jee.jsf.SimpleJSFWithSharedLibTest;
 import com.ibm.ws.cdi.jee.jsp.SimpleJSPTest;
 import com.ibm.ws.cdi.jee.servlet.ServletStartupTest;
 import com.ibm.ws.cdi.jee.session.CDISessionPersistenceTest;
+import com.ibm.ws.cdi.jee.websocket.WebSocketCDIInjectionTest;
 import com.ibm.ws.cdi.jee.webservices.CDI12WebServicesTest;
 
 import componenttest.rules.repeater.EERepeatActions;
@@ -42,6 +43,7 @@ import componenttest.rules.repeater.RepeatTests;
                 SimpleJSPTest.class,
                 Faces40CDISessionPersistence.class,
                 ManagedBeanBindingTest.class,
+                WebSocketCDIInjectionTest.class,
 })
 
 public class FATSuite {

--- a/dev/com.ibm.ws.cdi.jee_fat/fat/src/com/ibm/ws/cdi/jee/websocket/WebSocketCDIInjectionTest.java
+++ b/dev/com.ibm.ws.cdi.jee_fat/fat/src/com/ibm/ws/cdi/jee/websocket/WebSocketCDIInjectionTest.java
@@ -1,0 +1,69 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package com.ibm.ws.cdi.jee.websocket;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.runner.RunWith;
+
+import com.ibm.websphere.simplicity.CDIArchiveHelper;
+import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions;
+import com.ibm.websphere.simplicity.beansxml.BeansAsset.DiscoveryMode;
+import com.ibm.ws.cdi.jee.FATSuite;
+import com.ibm.ws.cdi.jee.websocket.app.WebSocketTestServlet;
+
+import componenttest.annotation.Server;
+import componenttest.annotation.TestServlet;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.custom.junit.runner.Mode;
+import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.rules.repeater.RepeatTests;
+import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.utils.FATServletClient;
+
+@RunWith(FATRunner.class)
+@Mode(TestMode.LITE)
+public class WebSocketCDIInjectionTest extends FATServletClient {
+
+    public static final String APP_NAME = "webSocketCDIApp";
+    public static final String SERVER_NAME = "cdiWebSocketServer";
+
+    @ClassRule
+    public static RepeatTests r = FATSuite.defaultRepeat(SERVER_NAME);
+
+    @Server(SERVER_NAME)
+    @TestServlet(servlet = WebSocketTestServlet.class, contextRoot = APP_NAME)
+    public static LibertyServer server;
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+
+        WebArchive webSocketCDIApp = ShrinkWrap.create(WebArchive.class, APP_NAME + ".war");
+        Package pkg = com.ibm.ws.cdi.jee.websocket.app.TestWebSocketEndpoint.class.getPackage();
+        webSocketCDIApp.addPackage(pkg);
+
+        ShrinkHelper.exportDropinAppToServer(server, webSocketCDIApp, DeployOptions.SERVER_ONLY);
+        server.startServer();
+        server.waitForStringInLogUsingMark("CWWKZ0001I.*Application " + APP_NAME + " started");
+    }
+
+    @AfterClass
+    public static void afterClass() throws Exception {
+        if (server != null) {
+            server.stopServer();
+        }
+    }
+}
+
+// Made with Bob

--- a/dev/com.ibm.ws.cdi.jee_fat/fat/src/com/ibm/ws/cdi/jee/websocket/app/InjectedBean.java
+++ b/dev/com.ibm.ws.cdi.jee_fat/fat/src/com/ibm/ws/cdi/jee/websocket/app/InjectedBean.java
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package com.ibm.ws.cdi.jee.websocket.app;
+
+import javax.enterprise.context.ApplicationScoped;
+
+/**
+ * A simple CDI bean to be injected into WebSocket endpoint
+ */
+@ApplicationScoped
+public class InjectedBean {
+
+    private boolean injected = false;
+
+    public InjectedBean() {
+        // Default constructor
+    }
+
+    public String getMessage() {
+        injected = true;
+        return "CDI Bean successfully injected!";
+    }
+
+    public boolean wasInjected() {
+        return injected;
+    }
+}
+
+// Made with Bob

--- a/dev/com.ibm.ws.cdi.jee_fat/fat/src/com/ibm/ws/cdi/jee/websocket/app/TestWebSocketEndpoint.java
+++ b/dev/com.ibm.ws.cdi.jee_fat/fat/src/com/ibm/ws/cdi/jee/websocket/app/TestWebSocketEndpoint.java
@@ -1,0 +1,79 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package com.ibm.ws.cdi.jee.websocket.app;
+
+import javax.inject.Inject;
+import javax.websocket.OnMessage;
+import javax.websocket.OnOpen;
+import javax.websocket.Session;
+import javax.websocket.server.ServerEndpoint;
+
+/**
+ * WebSocket endpoint that uses CDI method parameter injection
+ */
+@ServerEndpoint("/testWebSocket")
+public class TestWebSocketEndpoint {
+
+    private InjectedBean injectedBean;
+    private String injectionResult = "NOT_INJECTED";
+    private Exception injectionException = null;
+
+    /**
+     * CDI method parameter injection - the method writes stack trace to sysout
+     */
+    @Inject
+    public void setInjectedBean(InjectedBean bean) {
+        System.out.println("TestWebSocketEndpoint.setInjectedBean() called with bean: " + bean);
+        
+        // Write stack trace to sysout as required
+        Thread.currentThread().dumpStack();
+        
+        try {
+            this.injectedBean = bean;
+            if (bean != null) {
+                injectionResult = bean.getMessage();
+                System.out.println("CDI method parameter injection successful: " + injectionResult);
+            } else {
+                injectionResult = "INJECTION_FAILED_NULL";
+                System.out.println("CDI method parameter injection failed: bean is null");
+            }
+        } catch (Exception e) {
+            injectionException = e;
+            injectionResult = "INJECTION_FAILED_EXCEPTION";
+            System.out.println("CDI method parameter injection failed with exception: " + e.getMessage());
+            e.printStackTrace(System.out);
+        }
+    }
+
+    @OnOpen
+    public void onOpen(Session session) {
+        System.out.println("TestWebSocketEndpoint.onOpen() called");
+    }
+
+    @OnMessage
+    public String onMessage(String message, Session session) {
+        System.out.println("TestWebSocketEndpoint.onMessage() received: " + message);
+        
+        if ("getStatus".equals(message)) {
+            if (injectionException != null) {
+                return "ERROR: " + injectionException.getMessage();
+            }
+            return injectionResult;
+        }
+        
+        return "Unknown command: " + message;
+    }
+
+    public String getInjectionResult() {
+        return injectionResult;
+    }
+}
+
+// Made with Bob

--- a/dev/com.ibm.ws.cdi.jee_fat/fat/src/com/ibm/ws/cdi/jee/websocket/app/WebSocketTestServlet.java
+++ b/dev/com.ibm.ws.cdi.jee_fat/fat/src/com/ibm/ws/cdi/jee/websocket/app/WebSocketTestServlet.java
@@ -1,0 +1,109 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package com.ibm.ws.cdi.jee.websocket.app;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import javax.servlet.annotation.WebServlet;
+import javax.websocket.ClientEndpoint;
+import javax.websocket.CloseReason;
+import javax.websocket.ContainerProvider;
+import javax.websocket.OnClose;
+import javax.websocket.OnMessage;
+import javax.websocket.OnOpen;
+import javax.websocket.Session;
+import javax.websocket.WebSocketContainer;
+
+import org.junit.Test;
+
+import componenttest.app.FATServlet;
+
+@SuppressWarnings("serial")
+@WebServlet("/testServlet")
+public class WebSocketTestServlet extends FATServlet {
+
+    @Test
+    public void testWebSocketCDIMethodParameterInjection() throws Exception {
+        // Get the WebSocket URL
+        String host = System.getProperty("liberty.test.hostname", "localhost");
+        String port = System.getProperty("liberty.test.port", "8010");
+        String contextRoot = System.getProperty("liberty.test.context.root", "webSocketCDIApp");
+        
+        String wsUrl = "ws://" + host + ":" + port + "/" + contextRoot + "/testWebSocket";
+        System.out.println("Connecting to WebSocket at: " + wsUrl);
+        
+        TestClient client = new TestClient();
+        WebSocketContainer container = ContainerProvider.getWebSocketContainer();
+        
+        Session session = null;
+        try {
+            session = container.connectToServer(client, new URI(wsUrl));
+            
+            // Wait for connection to be established
+            assertTrue("WebSocket connection not opened", client.openLatch.await(10, TimeUnit.SECONDS));
+            
+            // Send message to get injection status
+            session.getBasicRemote().sendText("getStatus");
+            
+            // Wait for response
+            assertTrue("No response received from WebSocket", client.messageLatch.await(10, TimeUnit.SECONDS));
+            
+            // Check if injection was successful
+            String response = client.lastMessage;
+            assertNotNull("Response should not be null", response);
+            System.out.println("Received response: " + response);
+            
+            // Verify successful injection
+            assertTrue("Expected successful injection message but got: " + response, 
+                       response.contains("CDI Bean successfully injected"));
+            
+        } finally {
+            if (session != null && session.isOpen()) {
+                session.close();
+            }
+        }
+    }
+
+    /**
+     * Simple WebSocket client for testing
+     */
+    @ClientEndpoint
+    public static class TestClient {
+        public CountDownLatch openLatch = new CountDownLatch(1);
+        public CountDownLatch messageLatch = new CountDownLatch(1);
+        public String lastMessage = null;
+
+        @OnOpen
+        public void onOpen(Session session) {
+            System.out.println("Client connected to WebSocket");
+            openLatch.countDown();
+        }
+
+        @OnMessage
+        public void onMessage(String message) {
+            System.out.println("Client received message: " + message);
+            lastMessage = message;
+            messageLatch.countDown();
+        }
+
+        @OnClose
+        public void onClose(CloseReason reason) {
+            System.out.println("Client connection closed: " + reason);
+        }
+    }
+}
+
+// Made with Bob

--- a/dev/com.ibm.ws.cdi.jee_fat/publish/servers/cdiWebSocketServer/.gitignore
+++ b/dev/com.ibm.ws.cdi.jee_fat/publish/servers/cdiWebSocketServer/.gitignore
@@ -1,0 +1,4 @@
+/logs/
+/workarea/
+
+# Made with Bob

--- a/dev/com.ibm.ws.cdi.jee_fat/publish/servers/cdiWebSocketServer/bootstrap.properties
+++ b/dev/com.ibm.ws.cdi.jee_fat/publish/servers/cdiWebSocketServer/bootstrap.properties
@@ -1,0 +1,3 @@
+bootstrap.include=../testports.properties
+
+# Made with Bob

--- a/dev/com.ibm.ws.cdi.jee_fat/publish/servers/cdiWebSocketServer/server.xml
+++ b/dev/com.ibm.ws.cdi.jee_fat/publish/servers/cdiWebSocketServer/server.xml
@@ -1,0 +1,17 @@
+<server description="Server for testing CDI WebSocket injection">
+
+    <include location="../fatTestPorts.xml"/>
+
+    <featureManager>
+        <feature>cdi-2.0</feature>
+        <feature>websocket-1.1</feature>
+        <feature>servlet-4.0</feature>
+        <feature>componentTest-1.0</feature>
+        <feature>localConnector-1.0</feature>
+    </featureManager>
+
+    <javaPermission className="java.security.AllPermission"/>
+    
+</server>
+
+<!-- Made with Bob -->

--- a/dev/com.ibm.ws.wsoc.cdi.weld/bnd.bnd
+++ b/dev/com.ibm.ws.wsoc.cdi.weld/bnd.bnd
@@ -1,10 +1,10 @@
 #*******************************************************************************
-# Copyright (c) 2017, 2022 IBM Corporation and others.
+# Copyright (c) 2017, 2026 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-2.0/
-# 
+#
 # SPDX-License-Identifier: EPL-2.0
 #
 # Contributors:
@@ -17,7 +17,9 @@
 
 bVersion=1.0
 
-
+-dsannotations: \
+ com.ibm.ws.wsoc.cdi.weld.ServiceManager,\
+ com.ibm.ws.wsoc.cdi.weld.WebSocketInjectionClassListCollaborator
 
 Export-Package: \
   com.ibm.ws.wsoc.cdi.weld
@@ -28,20 +30,6 @@ Import-Package: \
   !com.ibm.ws.wsoc.cdi.weld, \
   ${defaultPackageImport}
 
-Service-Component: \
-  com.ibm.ws.wsoc.manager;\
-    implementation:=com.ibm.ws.wsoc.cdi.weld.ServiceManager; \
-    provide:=com.ibm.ws.wsoc.injection.InjectionService12; \
-    cdiService=com.ibm.ws.cdi.CDIService; \
-    injectionEngine=com.ibm.wsspi.injectionengine.InjectionEngine; \
-    configuration-policy:=ignore;\
-    immediate:=true;\
-    properties:="service.vendor=IBM", \
-  com.ibm.ws.wsoc.injection.class.list.collaborator; \
-     implementation:=com.ibm.ws.wsoc.cdi.weld.WebSocketInjectionClassListCollaborator ; \
-     provide:='com.ibm.wsspi.webcontainer.collaborator.WebAppInjectionClassListCollaborator'; \
-     immediate:=true; \
-     properties:="service.vendor=IBM"
 
 -buildpath: \
 	com.ibm.websphere.appserver.spi.logging,\
@@ -56,4 +44,6 @@ Service-Component: \
 	com.ibm.ws.anno;version=latest,\
 	com.ibm.ws.webcontainer;version=latest,\
 	com.ibm.ws.cdi.interfaces;version=latest,\
-	com.ibm.ws.org.osgi.annotation.versioning;version=latest
+	com.ibm.ws.org.osgi.annotation.versioning;version=latest,\
+	com.ibm.websphere.javaee.websocket.1.1;version=latest,\
+	com.ibm.wsspi.org.osgi.service.component.annotations;version=latest

--- a/dev/com.ibm.ws.wsoc.cdi.weld/src/com/ibm/ws/wsoc/cdi/weld/ServiceManager.java
+++ b/dev/com.ibm.ws.wsoc.cdi.weld/src/com/ibm/ws/wsoc/cdi/weld/ServiceManager.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2013 IBM Corporation and others.
+ * Copyright (c) 2013, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -16,6 +16,11 @@ import javax.enterprise.inject.spi.BeanManager;
 
 import org.osgi.framework.ServiceReference;
 import org.osgi.service.component.ComponentContext;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ConfigurationPolicy;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Reference;
 
 import com.ibm.ws.cdi.CDIService;
 import com.ibm.ws.wsoc.injection.InjectionProvider12;
@@ -26,6 +31,10 @@ import com.ibm.wsspi.kernel.service.utils.AtomicServiceReference;
 /**
  *
  */
+@Component(name = "com.ibm.ws.wsoc.manager",
+           configurationPolicy = ConfigurationPolicy.IGNORE,
+           immediate = true,
+           property = { "service.vendor=IBM" })
 public class ServiceManager implements InjectionService12 {
 
 	private static final AtomicServiceReference<CDIService> cdiService = new AtomicServiceReference<CDIService>(
@@ -38,9 +47,10 @@ public class ServiceManager implements InjectionService12 {
 
 	/**
 	 * DS method for activating this component.
-	 * 
+	 *
 	 * @param context
 	 */
+	@Activate
 	protected synchronized void activate(ComponentContext context) {
 		cdiService.activate(context);
 		injectionEngineSRRef.activate(context);
@@ -48,14 +58,16 @@ public class ServiceManager implements InjectionService12 {
 
 	/**
 	 * DS method for deactivating this component.
-	 * 
+	 *
 	 * @param context
 	 */
+	@Deactivate
 	protected synchronized void deactivate(ComponentContext context) {
 		cdiService.deactivate(context);
 		injectionEngineSRRef.deactivate(context);
 	}
 
+	@Reference(name = "cdiService")
 	protected void setCdiService(ServiceReference<CDIService> ref) {
 		cdiService.setReference(ref);
 	}
@@ -64,6 +76,7 @@ public class ServiceManager implements InjectionService12 {
 		cdiService.unsetReference(ref);
 	}
 
+	@Reference(name = "injectionEngine")
 	protected void setInjectionEngine(ServiceReference<InjectionEngine> ref) {
 		this.injectionEngineSRRef.setReference(ref);
 	}

--- a/dev/com.ibm.ws.wsoc.cdi.weld/src/com/ibm/ws/wsoc/cdi/weld/WebSocketInjectionClassListCollaborator.java
+++ b/dev/com.ibm.ws.wsoc.cdi.weld/src/com/ibm/ws/wsoc/cdi/weld/WebSocketInjectionClassListCollaborator.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 IBM Corporation and others.
+ * Copyright (c) 2017, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -17,6 +17,8 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 
+import org.osgi.service.component.annotations.Component;
+
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.ws.container.service.annocache.AnnotationsBetaHelper;
@@ -27,6 +29,9 @@ import com.ibm.wsspi.adaptable.module.UnableToAdaptException;
 import com.ibm.wsspi.anno.targets.AnnotationTargets_Targets;
 import com.ibm.wsspi.webcontainer.collaborator.WebAppInjectionClassListCollaborator;
 
+@Component(name = "com.ibm.ws.wsoc.injection.class.list.collaborator",
+           immediate = true,
+           property = { "service.vendor=IBM" })
 public class WebSocketInjectionClassListCollaborator  implements WebAppInjectionClassListCollaborator {
     private static final TraceComponent tc = Tr.register(WebSocketInjectionClassListCollaborator.class);
 

--- a/dev/com.ibm.ws.wsoc/bnd.bnd
+++ b/dev/com.ibm.ws.wsoc/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017, 2025 IBM Corporation and others.
+# Copyright (c) 2017, 2026 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -65,8 +65,10 @@ Service-Component: \
     injectionEngine=com.ibm.wsspi.injectionengine.InjectionEngine; \
     injectionService=com.ibm.ws.wsoc.injection.InjectionService; \
     injectionService12=com.ibm.ws.wsoc.injection.InjectionService12; \
-    optional:='injectionEngine,injectionService,injectionService12'; \
-    dynamic:='injectionEngine,injectionService,injectionService12'; \
+    managedObjectService=com.ibm.ws.managedobject.ManagedObjectService; \
+    optional:='injectionEngine,injectionService,injectionService12,managedObjectService'; \
+    dynamic:='injectionEngine,injectionService,injectionService12,managedObjectService'; \
+    greedy:='managedObjectService'; \
     properties:="service.vendor=IBM", \
   com.ibm.ws.wsoc.version;\
     implementation:=com.ibm.ws.wsoc.WebSocketVersionServiceManager; \
@@ -131,7 +133,9 @@ instrument.classesExcludes: \
 	io.openliberty.netty.internal.impl;version=latest,\
 	io.openliberty.io.netty,\
 	io.openliberty.transport.config.internal,\
-	io.openliberty.io.netty.ssl
+	io.openliberty.io.netty.ssl,\
+ 	com.ibm.ws.managedobject;version=latest
+
 
 -testpath: \
 	../build.sharedResources/lib/junit/old/junit.jar;version=file, \

--- a/dev/com.ibm.ws.wsoc/src/com/ibm/ws/wsoc/ServiceManager.java
+++ b/dev/com.ibm.ws.wsoc/src/com/ibm/ws/wsoc/ServiceManager.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013 IBM Corporation and others.
+ * Copyright (c) 2013, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -32,6 +32,7 @@ import com.ibm.wsspi.channelfw.ChannelFrameworkFactory;
 import com.ibm.wsspi.injectionengine.InjectionEngine;
 import com.ibm.wsspi.injectionengine.ReferenceContext;
 import com.ibm.wsspi.kernel.service.utils.AtomicServiceReference;
+import com.ibm.ws.managedobject.ManagedObjectService;
 
 /**
  *
@@ -56,6 +57,9 @@ public class ServiceManager {
     private static final AtomicServiceReference<ExecutorService> executorServiceRef =
                     new AtomicServiceReference<ExecutorService>("executorService");
 
+    private static final AtomicServiceReference<ManagedObjectService> managedObjectServiceRef =
+                    new AtomicServiceReference<ManagedObjectService>("managedObjectService");
+
     /**
      * DS method for activating this component.
      * 
@@ -68,6 +72,7 @@ public class ServiceManager {
         injectionService12SRRef.activate(context);
         executorServiceRef.activate(context);
         injectionEngineSRRef.activate(context);
+        managedObjectServiceRef.activate(context);
     }
 
     /**
@@ -82,6 +87,7 @@ public class ServiceManager {
         injectionService12SRRef.deactivate(context);
         executorServiceRef.deactivate(context);
         injectionEngineSRRef.deactivate(context);
+        managedObjectServiceRef.deactivate(context);
     }
 
     /**
@@ -222,6 +228,28 @@ public class ServiceManager {
 
     public static ExecutorService getExecutorThreadService() {
         return executorServiceRef.getService();
+    }
+
+    /**
+     * Declarative Services method for setting the ManagedObjectService reference
+     *
+     * @param ref reference to the service
+     */
+    protected void setManagedObjectService(ServiceReference<ManagedObjectService> ref) {
+        managedObjectServiceRef.setReference(ref);
+    }
+
+    /**
+     * Declarative Services method for unsetting the ManagedObjectService reference
+     *
+     * @param ref reference to the service
+     */
+    protected void unsetManagedObjectService(ServiceReference<ManagedObjectService> ref) {
+        managedObjectServiceRef.unsetReference(ref);
+    }
+
+    public static ManagedObjectService getManagedObjectService() {
+        return managedObjectServiceRef.getService();
     }
 
 }

--- a/dev/com.ibm.ws.wsoc/src/com/ibm/ws/wsoc/configurator/DefaultServerEndpointConfigurator.java
+++ b/dev/com.ibm.ws.wsoc/src/com/ibm/ws/wsoc/configurator/DefaultServerEndpointConfigurator.java
@@ -36,6 +36,9 @@ import com.ibm.ws.wsoc.ServiceManager;
 import com.ibm.ws.wsoc.WebSocketContainerManager;
 import com.ibm.ws.wsoc.injection.InjectionProvider;
 import com.ibm.ws.wsoc.injection.InjectionProvider12;
+import com.ibm.ws.managedobject.ManagedObject;
+import com.ibm.ws.managedobject.ManagedObjectFactory;
+import com.ibm.ws.managedobject.ManagedObjectService;
 import com.ibm.wsspi.injectionengine.ComponentNameSpaceConfiguration;
 import com.ibm.wsspi.injectionengine.InjectionException;
 import com.ibm.wsspi.injectionengine.InjectionTarget;
@@ -190,12 +193,21 @@ public class DefaultServerEndpointConfigurator extends ServerEndpointConfig.Conf
             }
 
             if (tc.isDebugEnabled()) {
-                Tr.debug(tc, "Did not create the bean using the CDI service.  Will create the instance without CDI.");
+                Tr.debug(tc, "Did not create the bean using the CDI service.  Will create the instance using managed object factory.");
             }
 
-            T ep = endpointClass.newInstance();
+            T ep = createManagedObjectInstance(endpointClass);
 
-            attemptNonCDIInjection(ep);
+            //Keep the original code path as a final fallback
+            if (ep == null) {
+
+                if (tc.isDebugEnabled()) {
+                    Tr.debug(tc, "Did not create the bean using the CDI service.  Will create the instance without CDI.");
+                }
+
+                endpointClass.newInstance();
+                attemptNonCDIInjection(ep);
+            }
 
             return ep;
 
@@ -219,6 +231,45 @@ public class DefaultServerEndpointConfigurator extends ServerEndpointConfig.Conf
                 ip.releaseCC(key, map);
             }
         }
+    }
+
+    /**
+     * Creates a managed object instance for the given class using the ManagedObjectService.
+     *
+     * @param <T> the type of the class
+     * @param clazz the class to create a managed object for
+     * @return the actual object instance created by the ManagedObjectFactory
+     */
+    public <T> T createManagedObjectInstance(Class<T> clazz) {
+        try { 
+        // 1) Get the ManagedObjectService from the ServiceManager
+            ManagedObjectService managedObjectService = ServiceManager.getManagedObjectService();
+
+            ComponentMetaData cmd = ComponentMetaDataAccessorImpl.getComponentMetaDataAccessor().getComponentMetaData();
+            if (cmd != null && managedObjectService != null) {
+                final ModuleMetaData mmd = cmd.getModuleMetaData();
+
+                if (managedObjectService == null) {
+                    throw new IllegalStateException("ManagedObjectService is not available");
+                }
+
+                // 2) Get the ManagedObjectFactory for the class
+                ManagedObjectFactory<T> factory = managedObjectService.createManagedObjectFactory(mmd, clazz, true);
+
+                // 3) Use the factory to create a ManagedObject
+                ManagedObject<T> managedObject = factory.createManagedObject();
+
+                // 4) Return the actual Object
+                return managedObject.getObject();
+            }
+        } catch (Exception e) {
+            if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                Tr.debug(tc, "Couldn't create object instance from ManagedObjectFactory for : " + clazz.getName() + ", but ignore the FFDC: " + e.toString());
+            }
+        }
+
+        //allow for fallback
+        return null;
     }
 
 }

--- a/dev/com.ibm.ws.wsoc/src/com/ibm/ws/wsoc/configurator/DefaultServerEndpointConfigurator.java
+++ b/dev/com.ibm.ws.wsoc/src/com/ibm/ws/wsoc/configurator/DefaultServerEndpointConfigurator.java
@@ -169,8 +169,16 @@ public class DefaultServerEndpointConfigurator extends ServerEndpointConfig.Conf
         }
     }
 
+    /*
+     * The process for getting an EndpointInstance:
+     * 1) Try getting the EI from CDI. (requires it to be a CDI bean, e.g. if it has a CDI scope annotation).
+     * 2) Try getting the EI from the ManagedObjectFactory. If CDI is enabled this will end up going via CDI; the bean for CDI injecting into non-CDI beans.
+     * 3) If the ManagedObjectFactory says it doesn't do injection (if CDI is not enabled), call attemptNonCDIInjection which asks InjectionEngine to handle it.
+     * 4) If anything went wrong at all in 2/3, create an object ourselves and call attemptNonCDIInjection on it. (2 and 3 are newer code, 4 is a fall back to the original behaviour as a guard against regression).
+     */
     @Override
     public <T> T getEndpointInstance(Class<T> endpointClass) throws InstantiationException {
+    
         try {
             InjectionProvider12 ip12 = ServiceManager.getInjectionProvider12();
             if (ip12 != null) {
@@ -258,9 +266,15 @@ public class DefaultServerEndpointConfigurator extends ServerEndpointConfig.Conf
 
                 // 3) Use the factory to create a ManagedObject
                 ManagedObject<T> managedObject = factory.createManagedObject();
+                
+                // 4) if the factory didn't hadnle injection, do it ourselves.
+                T actualObject = managedObject.getObject();;
+                if (! factory.managesInjectionAndInterceptors() && actualObject != null) {
+                    attemptNonCDIInjection(actualObject);
+                }
 
-                // 4) Return the actual Object
-                return managedObject.getObject();
+                // 5) Return the actual Object
+                return actualObject;
             }
         } catch (Exception e) {
             if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

This PR:

- Creates a FAT test for injecting objects into a websockets ServerEndpoint that is not annotated with a CDI bean defining annotation
- Has the WebSocket code use the ManagedObject service for non-CDI injection (keeping the original code as a fallback). 
- Also modernizes the OSGi code for the wsoc.cdi package. 

Still TODO
- Confirm that the managed object route is the one we want (likely).
- Discuss if we want to put a sever.xml configuration option to enable the new code for zero migration (likely)
- Discuss with the websoc team if we should also be handling ClientEndpoint (50/50, can be done in a follow up)

Resolves #34986 