### PR TITLE
JakartaQuery method with multiple QueryOptions

### DIFF
--- a/dev/io.openliberty.data.internal_fat_1_1/fat/src/test/jakarta/data/v1_1/Data_1_1_HibernateTest.java
+++ b/dev/io.openliberty.data.internal_fat_1_1/fat/src/test/jakarta/data/v1_1/Data_1_1_HibernateTest.java
@@ -46,6 +46,9 @@ public class Data_1_1_HibernateTest extends FATServletClient {
                     new String[] {
                                    "CWWKD1054E.*findByIsControlTrueAndNumericValueBetween",
                                    "CWWKD1091E.*countBySurgePriceGreaterThanEqual",
+                                   "DSRA0302E.*XA_RBTIMEOUT", // query timeout
+                                   "DSRA0304E.*", // query timeout
+                                   "J2CA0027E.*" // query timeout
                     };
 
     @ClassRule

--- a/dev/io.openliberty.data.internal_fat_1_1/fat/src/test/jakarta/data/v1_1/Data_1_1_Test.java
+++ b/dev/io.openliberty.data.internal_fat_1_1/fat/src/test/jakarta/data/v1_1/Data_1_1_Test.java
@@ -44,6 +44,9 @@ public class Data_1_1_Test extends FATServletClient {
                     new String[] {
                                    "CWWKD1054E.*findByIsControlTrueAndNumericValueBetween",
                                    "CWWKD1091E.*countBySurgePriceGreaterThanEqual",
+                                   "DSRA0302E.*XA_RBTIMEOUT", // query timeout
+                                   "DSRA0304E.*", // query timeout
+                                   "J2CA0027E.*" // query timeout
                     };
 
     @ClassRule
@@ -67,7 +70,6 @@ public class Data_1_1_Test extends FATServletClient {
 
         WebArchive war = ShrinkHelper
                         .buildDefaultApp("Data_1_1_App",
-                                         "test.jakarta.data.v1_1.eclipselink",
                                          "test.jakarta.data.v1_1.web");
         ShrinkHelper.exportAppToServer(server, war);
         server.startServer();

--- a/dev/io.openliberty.data.internal_fat_1_1/test-applications/Data_1_1_App/src/test/jakarta/data/v1_1/web/Data_1_1_Servlet.java
+++ b/dev/io.openliberty.data.internal_fat_1_1/test-applications/Data_1_1_App/src/test/jakarta/data/v1_1/web/Data_1_1_Servlet.java
@@ -107,6 +107,16 @@ public class Data_1_1_Servlet extends FATServlet {
     }
 
     /**
+     * Indicates if testing with the Derby database.
+     *
+     * @return true if testing with the Derby database.
+     */
+    static final boolean isDerby() {
+        String jdbcJarName = System.getenv().getOrDefault("DB_DRIVER", "UNKNOWN");
+        return jdbcJarName.startsWith("derby");
+    }
+
+    /**
      * Indicates if testing with the Hibernate Persistence provider
      * rather than EclipseLink.
      *
@@ -1077,6 +1087,14 @@ public class Data_1_1_Servlet extends FATServlet {
         });
         try {
             assertEquals(true, locked.await(TIMEOUT_S, TimeUnit.SECONDS));
+            // Derby ignores query timeout and the lock timeout ends up applying
+            // instead. Work around this by also setting the lock timeout when
+            // running on Derby:
+            if (isDerby())
+                if (isHibernatePersistence())
+                    statefulFractions.setLockTimeout(5);
+                else
+                    fractions.setLockTimeout(5);
             tx.begin();
             try {
                 Optional<Fraction> found = //
@@ -1104,6 +1122,11 @@ public class Data_1_1_Servlet extends FATServlet {
             fractions.discard(AtLeast.min(23),
                               AtMost.max(Integer.MAX_VALUE),
                               Restrict.unrestricted());
+            if (isDerby())
+                if (isHibernatePersistence())
+                    statefulFractions.setLockTimeout(60);
+                else
+                    fractions.setLockTimeout(60);
         }
     }
 

--- a/dev/io.openliberty.data.internal_fat_1_1/test-applications/Data_1_1_App/src/test/jakarta/data/v1_1/web/Data_1_1_Servlet.java
+++ b/dev/io.openliberty.data.internal_fat_1_1/test-applications/Data_1_1_App/src/test/jakarta/data/v1_1/web/Data_1_1_Servlet.java
@@ -24,9 +24,11 @@ import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
@@ -41,6 +43,7 @@ import jakarta.data.constraint.In;
 import jakarta.data.constraint.Like;
 import jakarta.data.constraint.NotBetween;
 import jakarta.data.constraint.NotNull;
+import jakarta.data.exceptions.DataException;
 import jakarta.data.expression.TextExpression;
 import jakarta.data.page.CursoredPage;
 import jakarta.data.page.Page;
@@ -58,6 +61,7 @@ import jakarta.transaction.UserTransaction;
 
 import org.junit.Test;
 
+import componenttest.annotation.AllowedFFDC;
 import componenttest.app.FATServlet;
 import test.jakarta.data.v1_1.web.Fraction.Decimal;
 
@@ -1038,6 +1042,69 @@ public class Data_1_1_Servlet extends FATServlet {
                      fractions.named(Like.pattern("T% _i_ths"),
                                      Order.by(Sort.desc(_Fraction.NAME)),
                                      Limit.of(4)));
+    }
+
+    /**
+     * Use the QueryOptions annotation to establish pessimistic locking and
+     * a query timeout on a repository method annotated JakartaQuery.
+     */
+    @AllowedFFDC("javax.transaction.xa.XAException") // due to query timeout
+    @Test
+    public void testLockModeAndQueryTimeoutAsQueryOptions() throws Exception {
+        // Populate with 18/23.
+        // Ensure deletion in the finally block.
+        fractions.supply(List.of(Fraction.of(18, 23)));
+
+        CountDownLatch locked = new CountDownLatch(1);
+        CountDownLatch blocked = new CountDownLatch(1);
+        CompletableFuture<Fraction> lockDB = CompletableFuture.supplyAsync(() -> {
+            try {
+                tx.setTransactionTimeout((int) TIMEOUT_S * 3);
+                tx.begin();
+                Optional<Fraction> found = //
+                                fractions.withWriteLock("Eighteen Twenty-thirds");
+                System.out.println("Obtained lock on 18/23");
+                locked.countDown();
+                blocked.await(TIMEOUT_S * 2, TimeUnit.SECONDS);
+                System.out.println("Release lock on 18/23");
+                tx.commit();
+                return found.orElseThrow();
+            } catch (RuntimeException x) {
+                throw x;
+            } catch (Exception x) {
+                throw new CompletionException(x);
+            }
+        });
+        try {
+            assertEquals(true, locked.await(TIMEOUT_S, TimeUnit.SECONDS));
+            tx.begin();
+            try {
+                Optional<Fraction> found = //
+                                fractions.withWriteLock("Eighteen Twenty-thirds");
+                fail("Query timeout on QueryOptions should have caused the" +
+                     " query to time out. Instead found " + found);
+            } catch (DataException x) {
+                // expected for query timeout
+            } finally {
+                tx.rollback();
+            }
+
+            blocked.countDown();
+            tx.begin();
+            Fraction f18_23 = fractions.withWriteLock("Eighteen Twenty-thirds")
+                            .orElseThrow();
+            assertEquals(0.7826,
+                         f18_23.decimal.value(),
+                         0.0001);
+            tx.commit();
+        } finally {
+            locked.countDown();
+            blocked.countDown();
+            // Ensure no fractions with denominator of 23 or more are left around
+            fractions.discard(AtLeast.min(23),
+                              AtMost.max(Integer.MAX_VALUE),
+                              Restrict.unrestricted());
+        }
     }
 
     /**

--- a/dev/io.openliberty.data.internal_fat_1_1/test-applications/Data_1_1_App/src/test/jakarta/data/v1_1/web/Fractions.java
+++ b/dev/io.openliberty.data.internal_fat_1_1/test-applications/Data_1_1_App/src/test/jakarta/data/v1_1/web/Fractions.java
@@ -12,6 +12,9 @@
  *******************************************************************************/
 package test.jakarta.data.v1_1.web;
 
+import java.sql.CallableStatement;
+import java.sql.Connection;
+import java.sql.SQLException;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
@@ -61,6 +64,8 @@ public interface Fractions {
                                      Restriction<Fraction> filter,
                                      Order<Fraction> sortBy);
 
+    Connection connect();
+
     Long count(Restriction<Fraction> filter);
 
     long countByDenominatorBetween(int min,
@@ -107,6 +112,13 @@ public interface Fractions {
                        Limit limit);
 
     @Find
+    @OrderBy(_Fraction.DENOMINATOR)
+    CursoredPage<Fraction> namedLike //
+    (@By(_Fraction.NAME) @Is(Like.class) String pattern,
+     Order<Fraction> additionalSorting,
+     PageRequest pageReq);
+
+    @Find
     @QueryOptions(entityGraph = "EagerlyLoadRoundedValues")
     Optional<Fraction> of(int numerator, int denominator);
 
@@ -117,6 +129,23 @@ public interface Fractions {
     @Delete
     List<Fraction> remove(Like name,
                           Restriction<Fraction> filter);
+
+    /**
+     * This is a workaround for Derby, which ignores query timeout
+     * and eventually the lock timeout (default 60s) applies instead.
+     * Tests can use this method to set the lock timeout to the desired
+     * query timeout value to make a query that involves a lock appear
+     * to time out as expected if the query timeout were honored.
+     */
+    default void setLockTimeout(int seconds) throws SQLException {
+        String sql = "CALL SYSCS_UTIL.SYSCS_SET_DATABASE_PROPERTY(?, ?)";
+        try (Connection con = connect()) {
+            CallableStatement cs = con.prepareCall(sql);
+            cs.setString(1, "derby.locks.waitTimeout");
+            cs.setInt(2, seconds);
+            cs.execute();
+        }
+    }
 
     @Query("SELECT NEW test.jakarta.data.v1_1.web.Ratio(" +
            "\t\tnumerator, denominator - numerator)" +
@@ -134,13 +163,6 @@ public interface Fractions {
 
     @Query("SELECT numerator, denominator - numerator")
     Stream<Ratio> streamOfRatios();
-
-    @Find
-    @OrderBy(_Fraction.DENOMINATOR)
-    CursoredPage<Fraction> namedLike //
-    (@By(_Fraction.NAME) @Is(Like.class) String pattern,
-     Order<Fraction> additionalSorting,
-     PageRequest pageReq);
 
     @Insert
     void supply(Collection<Fraction> list);

--- a/dev/io.openliberty.data.internal_fat_1_1/test-applications/Data_1_1_App/src/test/jakarta/data/v1_1/web/Fractions.java
+++ b/dev/io.openliberty.data.internal_fat_1_1/test-applications/Data_1_1_App/src/test/jakarta/data/v1_1/web/Fractions.java
@@ -46,6 +46,7 @@ import jakarta.data.repository.QueryOptions; // TODO replace with Persistence 4.
 import jakarta.data.repository.Repository;
 import jakarta.data.repository.Select;
 import jakarta.data.restrict.Restriction;
+import jakarta.persistence.LockModeType;
 
 /**
  * Repository for the Fraction entity
@@ -176,4 +177,10 @@ public interface Fractions {
     (@By(_Fraction.NUMERATOR) In<Integer> numerators,
      @Is int denominator,
      Sort<Fraction> sort);
+
+    @JakartaQuery("WHERE name = :name")
+    @QueryOptions(lockMode = LockModeType.PESSIMISTIC_WRITE,
+                  timeout = 10000) // query timeout = 10 seconds
+    Optional<Fraction> withWriteLock(String name);
+
 }

--- a/dev/io.openliberty.data.internal_fat_1_1/test-applications/Data_1_1_App/src/test/jakarta/data/v1_1/web/StatefulFractions.java
+++ b/dev/io.openliberty.data.internal_fat_1_1/test-applications/Data_1_1_App/src/test/jakarta/data/v1_1/web/StatefulFractions.java
@@ -12,6 +12,9 @@
  *******************************************************************************/
 package test.jakarta.data.v1_1.web;
 
+import java.sql.CallableStatement;
+import java.sql.Connection;
+import java.sql.SQLException;
 import java.util.Optional;
 
 import jakarta.data.constraint.EqualTo;
@@ -21,6 +24,7 @@ import jakarta.data.repository.Is;
 import jakarta.data.repository.Repository;
 import jakarta.data.repository.stateful.Detach;
 import jakarta.persistence.EntityManager;
+import jakarta.transaction.Transactional;
 
 /**
  * Stateful repository for the Fraction entity
@@ -41,4 +45,27 @@ public interface StatefulFractions {
     }
 
     EntityManager manager();
+
+    /**
+     * This is a workaround for Derby, which ignores query timeout
+     * and eventually the lock timeout (default 60s) applies instead.
+     * Tests can use this method to set the lock timeout to the desired
+     * query timeout value to make a query that involves a lock appear
+     * to time out as expected if the query timeout were honored.
+     */
+    @Transactional
+    default void setLockTimeout(int seconds) throws SQLException {
+        String sql = "CALL SYSCS_UTIL.SYSCS_SET_DATABASE_PROPERTY(?, ?)";
+        EntityManager em = manager();
+        em.runWithConnection((Connection con) -> {
+            try {
+                CallableStatement cs = con.prepareCall(sql);
+                cs.setString(1, "derby.locks.waitTimeout");
+                cs.setInt(2, seconds);
+                cs.execute();
+            } catch (SQLException x) {
+                throw new RuntimeException(x);
+            }
+        });
+    }
 }


### PR DESCRIPTION
Repository method annotated `@JakartaQuery` and `@QueryOptions` where multiple non-default QueryOptions values are set: the lockMode and timeout.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
