### PR TITLE
Require Java 21 to build liberty instead of 17

### DIFF
--- a/dev/gradle.properties
+++ b/dev/gradle.properties
@@ -54,7 +54,3 @@ systemProp.org.gradle.internal.http.connectionTimeout=180000
 systemProp.org.gradle.internal.http.socketTimeout=180000
 systemProp.org.gradle.internal.repository.max.tentatives=11
 systemProp.org.gradle.internal.repository.initial.backoff=125
-
-# Env variable to compile with Java 21
-org.gradle.java.installations.auto-download=false
-org.gradle.java.installations.fromEnv=JAVA_21_HOME

--- a/dev/settings.gradle
+++ b/dev/settings.gradle
@@ -177,29 +177,18 @@ pluginManagement {
   }
 }
 
-// Require Java 17
+// Require Java 21
 int javaVersion = Integer.parseInt(JavaVersion.current().getMajorVersion())
 
-if (javaVersion < 17) {
-  println "ERROR: Building this repository requires Java 17. To use Java 17 follow these steps:\n" + 
-                            "  1) You can download a copy for your OS here if you don't already have it: " + 
-                            "http://ibm.biz/GetSemeru\n" + 
-                            "  2) run 'export JAVA_HOME=/path/to/your/java17' in the shell, or set in ~/.bashrc\n" + 
-                            "  3) [MACOS ONLY] Set 'ulimit -Sn 1024' in your ~/.bashrc\n" + 
-                            "  4) Restart your gradle daemon with './gradlew --stop'\n";
-        throw new GradleException('Current Java version is not 17 or higher.')
-
-}
-
 if (javaVersion < 21) {
-  if (System.getenv("JAVA_21_HOME") == null) {
-    print "ERROR: Building this repository requires JAVA_21_HOME to be set to a path for a Java 21 SDK.  Please follow these steps:\n" +
-      "  1) You can download a copy for your OS here if you don't already have it: " + 
-      "https://jdk.java.net/21/\n" +
-      "  2) export 'JAVA_21_HOME=/path/to/your/java21' in the shell or set in your ~/.bashrc\n" +
-      "  3) Restart your gradle daemon with './gradlew --stop'\n";
-    throw new GradleException('JAVA_21_HOME is not set.')
-  }
+  println "ERROR: Building this repository requires Java 21. To use Java 21 follow these steps:\n" +
+                            "  1) You can download a copy for your OS here if you don't already have it: " + 
+                            "http://ibm.biz/GetSemeru\n" +
+                            "  2) run 'export JAVA_HOME=/path/to/your/java21' in the shell, or set in ~/.bashrc\n" +
+                            "  3) [MACOS ONLY] Set 'ulimit -Sn 1024' in your ~/.bashrc\n" +
+                            "  4) Restart your gradle daemon with './gradlew --stop'\n";
+        throw new GradleException('Current Java version is not 21 or higher.')
+
 }
 
 // Require cnf:initialize on clean workspace for tasks that need it.

--- a/dev/wlp-gradle/java.gradle
+++ b/dev/wlp-gradle/java.gradle
@@ -95,13 +95,6 @@ subprojects {
 
   
   tasks.withType(JavaCompile).configureEach({
-      int javaVersionNumVal = Integer.parseInt(JavaVersion.current().getMajorVersion())
-      if (javaVersionNumVal < 21 && '21'.equals(sourceCompatibility)) {
-          javaCompiler = javaToolchains.compilerFor {
-              languageVersion = JavaLanguageVersion.of(21)
-          }
-      }
-
       // Set the --release compiler flag to keep bootclasspath in sync 
       if(!'off'.equals(bnd.get('javac.args.release'))) {
         def release = sourceCompatibility

--- a/dev/wlp-gradle/subprojects/tasks.gradle
+++ b/dev/wlp-gradle/subprojects/tasks.gradle
@@ -182,16 +182,6 @@ compileTestJava {
   classpath = files(sourceSets.main.output.classesDirs) + classpath
 }
 
-
-tasks.withType(Test) configureEach {
-    int javaVersionNumVal = Integer.parseInt(JavaVersion.current().getMajorVersion())
-    if (javaVersionNumVal < 21 && '21'.equals(bnd.get('javac.source'))) {
-        javaLauncher = javaToolchains.launcherFor {
-            languageVersion = JavaLanguageVersion.of(21)
-        }
-    }
-}
-
 test {
   dependsOn ':cnf:copyMavenLibs'
   def testports = fileTree(dir: compileTestJava.destinationDirectory.getAsFile().get(), include: 'unittestports.properties')
@@ -258,17 +248,10 @@ if (bnd.get('publish.wlp.jar.suffix', 'lib').contains('api/ibm') || bnd.get('pub
       !new File(buildDir, "javadoc").exists()
     }
 
-    int javaVersionNumVal = Integer.parseInt(JavaVersion.current().getMajorVersion())
     def release = bnd.get('javac.source')
 
     if(release.startsWith('1.')) {
       release = release.substring(2);
-    }
-
-    if (javaVersionNumVal < 21 && '21'.equals(release)) {
-      javadocTool = javaToolchains.javadocToolFor {
-        languageVersion = JavaLanguageVersion.of(21)
-      }
     }
 
     def sp = files(bndWorkspace.getProject(project.name).getSourcePath())
@@ -300,9 +283,7 @@ if (bnd.get('publish.wlp.jar.suffix', 'lib').contains('api/ibm') || bnd.get('pub
     options.noIndex true
     options.use true
     options.addStringOption('-release', release)
-    if (javaVersionNumVal > 11) {
-      options.addStringOption('-legal-notices', 'none')
-    }
+    options.addStringOption('-legal-notices', 'none')
     options.addBooleanOption('Xdoclint:none', true)
   }
 


### PR DESCRIPTION
- Jakarta EE 12 requires Java 21 minimum Java so we should have liberty's minimum Java set to Java 21 as well now that we no longer depend on Java 7 byte code being generated as part of the build.
- We already test with Java 21 in the builds, but locally we would be testing with Java 17 if people have their Java configured as such.  This will cause people to test Jakarta 11 instead of 12 which does not help their development and requires them to do extra work

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [ ] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
