### PR TITLE
Make suspendedUOW thread local.

### DIFF
--- a/dev/com.ibm.ws.transaction.context/src/com/ibm/ws/transaction/context/internal/TransactionContextImpl.java
+++ b/dev/com.ibm.ws.transaction.context/src/com/ibm/ws/transaction/context/internal/TransactionContextImpl.java
@@ -87,6 +87,12 @@ public class TransactionContextImpl implements ThreadContext {
     public ThreadContext clone() {
         try {
             TransactionContextImpl copy = (TransactionContextImpl) super.clone();
+            // Copy the ThreadLocal value to the cloned instance
+            copy.suspendedUOW = new ThreadLocal<UOWToken>();
+            UOWToken currentValue = this.suspendedUOW.get();
+            if (currentValue != null) {
+                copy.suspendedUOW.set(currentValue);
+            }
             return copy;
         } catch (CloneNotSupportedException x) {
             throw new RuntimeException(x);

--- a/dev/com.ibm.ws.transaction.context/src/com/ibm/ws/transaction/context/internal/TransactionContextImpl.java
+++ b/dev/com.ibm.ws.transaction.context/src/com/ibm/ws/transaction/context/internal/TransactionContextImpl.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -67,7 +67,7 @@ public class TransactionContextImpl implements ThreadContext {
     /**
      * Unit of work that was on the thread of execution prior to invoking the contextual task.
      */
-    private transient UOWToken suspendedUOW;
+    private transient ThreadLocal<UOWToken> suspendedUOW = new ThreadLocal<UOWToken>();
 
     /**
      * Indicates that prior to invoking a task, any transaction that is present on the thread of execution
@@ -104,7 +104,8 @@ public class TransactionContextImpl implements ThreadContext {
             // Suspend whatever is currently on the thread.
             try {
                 UOWManager uowManager = UOWManagerFactory.getUOWManager();
-                suspendedUOW = uowManager.suspend();
+                UOWToken localuSpendedUOW = uowManager.suspend();
+                suspendedUOW.set(localuSpendedUOW);
             } catch (com.ibm.ws.uow.embeddable.SystemException e) {
             }
 
@@ -156,10 +157,11 @@ public class TransactionContextImpl implements ThreadContext {
 
             // Resume the original transaction.
             try {
-                if (suspendedUOW != null) {
+                UOWToken localSuspendedUOW = suspendedUOW.get();
+                if (localSuspendedUOW != null) {
                     UOWManager uowManager = UOWManagerFactory.getUOWManager();
-                    uowManager.resume(suspendedUOW);
-                    suspendedUOW = null;
+                    uowManager.resume(localSuspendedUOW);
+                    suspendedUOW.remove();
                 }
             } catch (Throwable e) {
                 exception = e;

--- a/dev/com.ibm.ws.transaction.context/src/com/ibm/ws/transaction/context/internal/TransactionContextImpl.java
+++ b/dev/com.ibm.ws.transaction.context/src/com/ibm/ws/transaction/context/internal/TransactionContextImpl.java
@@ -187,6 +187,8 @@ public class TransactionContextImpl implements ThreadContext {
      * @throws ClassNotFoundException
      */
     private void readObject(java.io.ObjectInputStream in) throws IOException, ClassNotFoundException {
+        suspendedUOW = new ThreadLocal<UOWToken>();//Reinitialize transient field.
+
         GetField fields = in.readFields();
 
         Object type = fields.get(TYPE, null);

--- a/dev/com.ibm.ws.transaction.context/src/com/ibm/ws/transaction/context/internal/TransactionContextImpl.java
+++ b/dev/com.ibm.ws.transaction.context/src/com/ibm/ws/transaction/context/internal/TransactionContextImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2022 IBM Corporation and others.
+ * Copyright (c) 2012, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -7,8 +7,6 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package com.ibm.ws.transaction.context.internal;
 


### PR DESCRIPTION
I have been seeing an IllegalStateException which is only possible if suspendedUOW is not null, on a thread where that value is never populated. 

While I couldn't recreate this issue myself, I am suspicious that the path it is taking comes from: `ThreadContextDescriptorImpl line 428` calling `clone()` on all `ThreadContextProvider` as `TransactionContextImpl` implements `ThreadContext`.

Making suspendedUOW a ThreadLocal fixes this as a reference to a ThreadLocal can be passed across threads without its contents following. The fact `suspendedUOW` is also `transient` suggests to me that this is not supposed to be transferred around. 

resolves #35037