### PR TITLE
JAX-WS: Service name is corrected for the test

### DIFF
--- a/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat_extended/fat/src/com/ibm/ws/jaxws/fat/ColocatedDynamicPolicyAttachmentsTest.java
+++ b/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat_extended/fat/src/com/ibm/ws/jaxws/fat/ColocatedDynamicPolicyAttachmentsTest.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -247,7 +247,7 @@ public class ColocatedDynamicPolicyAttachmentsTest {
     @ExpectedFFDC("jakarta.xml.ws.soap.SOAPFaultException")
     public void testPolicyAttachments_serviceURI_Non_AnnonResponses_JakartaFailure() throws Exception {
         server.setMarkToEndOfLog(server.getDefaultLogFile());
-        commonTest(clientApp1, ClientServlet1, service3, "helloWithPolicy", failureResult);
+        commonTest(clientApp1, ClientServlet1, service4, "helloWithPolicy", failureResult);
 
         assertNotNull("Expected to find " + failureNonAnonymous + " but error not found in logs", server.findStringsInLogsAndTraceUsingMark(failureNonAnonymous));
     }


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

Problem: Found non-anonymous address but only anonymous supported
Solution: Service name is corrected. HelloService3 was anonymous client. It's replaced by  HelloService4 which is nonanonymous.