### PR TITLE
Use host/port-aware cache key for dynamic JAX-RS outbound SSL

### DIFF
--- a/dev/com.ibm.ws.jaxrs.2.0.security/src/com/ibm/ws/jaxrs20/appsecurity/security/JaxRsSSLManager.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.security/src/com/ibm/ws/jaxrs20/appsecurity/security/JaxRsSSLManager.java
@@ -50,27 +50,89 @@ public class JaxRsSSLManager {
 
         try {
             Map<String, Object> connectionInfo = getConnectionInfo(host, port);
+            String cacheKey = getCacheKey(sslRef, host, port);
+            if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                Tr.debug(tc, "JaxRsSSLManager.getSSLSocketFactoryBySSLRef entry"
+                             + ", inputSslRef=" + sslRef
+                             + ", host=" + host
+                             + ", port=" + port
+                             + ", cacheKey=" + cacheKey
+                             + ", connectionInfo=" + connectionInfo,
+                         new Throwable("JaxRsSSLManager.getSSLSocketFactoryBySSLRef entry stack"));
+            }
+
             SSLContext sslContext = getSSLContext(sslRef, connectionInfo);
 
+            if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                Tr.debug(tc, "JaxRsSSLManager.getSSLSocketFactoryBySSLRef after getSSLContext"
+                             + ", inputSslRef=" + sslRef
+                             + ", host=" + host
+                             + ", port=" + port
+                             + ", cacheKey=" + cacheKey
+                             + ", sslContextIdentity=" + (sslContext == null ? "null" : Integer.toHexString(System.identityHashCode(sslContext)))
+                             + ", sslContextClass=" + (sslContext == null ? "null" : sslContext.getClass().getName()));
+            }
+
             if (sslContext == null) {
+                if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                    Tr.debug(tc, "JaxRsSSLManager.getSSLSocketFactoryBySSLRef returning null because sslContext is null"
+                                 + ", inputSslRef=" + sslRef
+                                 + ", host=" + host
+                                 + ", port=" + port
+                                 + ", cacheKey=" + cacheKey);
+                }
                 return null;
             }
 
             boolean recache = false;
             synchronized (sslContexts) {
-                SSLContext cachedSslContext = sslContexts.get(sslRef);
+                SSLContext cachedSslContext = sslContexts.get(cacheKey);
+                if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                    Tr.debug(tc, "JaxRsSSLManager.sslContexts lookup"
+                                 + ", cacheKey=" + cacheKey
+                                 + ", host=" + host
+                                 + ", port=" + port
+                                 + ", requestedSslContextIdentity=" + Integer.toHexString(System.identityHashCode(sslContext))
+                                 + ", cachedSslContextIdentity=" + (cachedSslContext == null ? "null" : Integer.toHexString(System.identityHashCode(cachedSslContext)))
+                                 + ", cacheHit=" + (cachedSslContext != null));
+                }
                 if (sslContext == null || !sslContext.equals(cachedSslContext)) {
                     // first request or SSL config has changed, re-cache the SSLContext and SSLSocketFactory
-                    sslContexts.put(sslRef, sslContext);
+                    sslContexts.put(cacheKey, sslContext);
                     recache = true;
+                    if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                        Tr.debug(tc, "JaxRsSSLManager.sslContexts put"
+                                     + ", cacheKey=" + cacheKey
+                                     + ", host=" + host
+                                     + ", port=" + port
+                                     + ", storedSslContextIdentity=" + Integer.toHexString(System.identityHashCode(sslContext))
+                                     + ", recache=true");
+                    }
                 }
             }
 
             synchronized (socketFactories) {
-                sslSocketFactory = socketFactories.get(sslRef);
+                sslSocketFactory = socketFactories.get(cacheKey);
+                if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                    Tr.debug(tc, "JaxRsSSLManager.socketFactories lookup"
+                                 + ", cacheKey=" + cacheKey
+                                 + ", host=" + host
+                                 + ", port=" + port
+                                 + ", cachedSocketFactoryIdentity=" + (sslSocketFactory == null ? "null" : Integer.toHexString(System.identityHashCode(sslSocketFactory)))
+                                 + ", cacheHit=" + (sslSocketFactory != null)
+                                 + ", recache=" + recache);
+                }
                 if (sslSocketFactory == null || recache) {
                     sslSocketFactory = sslContext.getSocketFactory();
-                    socketFactories.put(sslRef, sslSocketFactory);
+                    socketFactories.put(cacheKey, sslSocketFactory);
+                    if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                        Tr.debug(tc, "JaxRsSSLManager.socketFactories put"
+                                     + ", cacheKey=" + cacheKey
+                                     + ", host=" + host
+                                     + ", port=" + port
+                                     + ", storedSocketFactoryIdentity=" + Integer.toHexString(System.identityHashCode(sslSocketFactory))
+                                     + ", sslContextIdentity=" + Integer.toHexString(System.identityHashCode(sslContext)));
+                    }
                 }
             }
         } catch (com.ibm.websphere.ssl.SSLException e) {
@@ -79,7 +141,23 @@ public class JaxRsSSLManager {
             }
             return null;
         }
+        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+            Tr.debug(tc, "JaxRsSSLManager.getSSLSocketFactoryBySSLRef return"
+                         + ", inputSslRef=" + sslRef
+                         + ", host=" + host
+                         + ", port=" + port
+                         + ", cacheKey=" + getCacheKey(sslRef, host, port)
+                         + ", returnedSocketFactoryIdentity=" + (sslSocketFactory == null ? "null" : Integer.toHexString(System.identityHashCode(sslSocketFactory)))
+                         + ", returnedSocketFactoryClass=" + (sslSocketFactory == null ? "null" : sslSocketFactory.getClass().getName()));
+        }
         return sslSocketFactory;
+    }
+
+    private static String getCacheKey(String sslRef, String host, String port) {
+        if (sslRef != null) {
+            return sslRef;
+        }
+        return "dynamic:" + host + ":" + port;
     }
 
     private static Map<String, Object> getConnectionInfo(String host, String port) {
@@ -93,6 +171,12 @@ public class JaxRsSSLManager {
     private static Properties getSSLProperties(String sslRef, Map<String, Object> connectionInfo) throws SSLException {
         Properties sslProps;
         try {
+            if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                Tr.debug(tc, "JaxRsSSLManager.getSSLProperties before jsseHelper.getProperties"
+                             + ", inputSslRef=" + sslRef
+                             + ", connectionInfo=" + connectionInfo,
+                         new Throwable("JaxRsSSLManager.getSSLProperties before stack"));
+            }
             sslProps = AccessController.doPrivileged(new PrivilegedExceptionAction<Properties>() {
                 @Override
                 public Properties run() throws SSLException {
@@ -105,11 +189,27 @@ public class JaxRsSSLManager {
             throw (SSLException) cause;
         }
 
+        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+            Tr.debug(tc, "JaxRsSSLManager.getSSLProperties after jsseHelper.getProperties"
+                         + ", inputSslRef=" + sslRef
+                         + ", connectionInfo=" + connectionInfo
+                         + ", resolvedAlias=" + (sslProps == null ? "null" : sslProps.getProperty(Constants.SSLPROP_ALIAS))
+                         + ", resolvedTrustStore=" + (sslProps == null ? "null" : sslProps.getProperty(Constants.SSLPROP_TRUST_STORE))
+                         + ", propertiesIdentity=" + (sslProps == null ? "null" : Integer.toHexString(System.identityHashCode(sslProps))),
+                     new Throwable("JaxRsSSLManager.getSSLProperties after stack"));
+        }
+
         return sslProps;
     }
 
     private static SSLContext getSSLContext(String sslRef, Map<String, Object> connectionInfo) throws SSLException {
         Boolean sslCfgExists = null;
+        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+            Tr.debug(tc, "JaxRsSSLManager.getSSLContext entry"
+                         + ", inputSslRef=" + sslRef
+                         + ", connectionInfo=" + connectionInfo,
+                     new Throwable("JaxRsSSLManager.getSSLContext entry stack"));
+        }
         if (sslRef != null) {
             try {
                 sslCfgExists = AccessController.doPrivileged(new PrivilegedExceptionAction<Boolean>() {
@@ -124,6 +224,12 @@ public class JaxRsSSLManager {
                 throw (SSLException) cause;
             }
 
+            if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                Tr.debug(tc, "JaxRsSSLManager.getSSLContext explicit sslRef existence check"
+                             + ", inputSslRef=" + sslRef
+                             + ", sslCfgExists=" + sslCfgExists);
+            }
+
             if (!sslCfgExists.booleanValue())
                 return null;
         }
@@ -133,10 +239,40 @@ public class JaxRsSSLManager {
                 @Override
                 public SSLContext run() throws SSLConfigurationNotAvailableException, SSLException {
                     if (sslRef != null) {
-                        return jsseHelper.getSSLContext(sslRef, connectionInfo, null, false);
+                        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                            Tr.debug(tc, "JaxRsSSLManager.getSSLContext using explicit sslRef path"
+                                         + ", inputSslRef=" + sslRef
+                                         + ", connectionInfo=" + connectionInfo);
+                        }
+                        SSLContext sslContext = jsseHelper.getSSLContext(sslRef, connectionInfo, null, false);
+                        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                            Tr.debug(tc, "JaxRsSSLManager.getSSLContext explicit sslRef path result"
+                                         + ", inputSslRef=" + sslRef
+                                         + ", sslContextIdentity=" + (sslContext == null ? "null" : Integer.toHexString(System.identityHashCode(sslContext)))
+                                         + ", sslContextClass=" + (sslContext == null ? "null" : sslContext.getClass().getName()));
+                        }
+                        return sslContext;
                     } else {
                         // get the default ssl context with possible dynamic outbound mapping
-                        return jsseHelper.getSSLContext(connectionInfo, getSSLProperties(sslRef, connectionInfo));
+                        Properties resolvedProps = getSSLProperties(sslRef, connectionInfo);
+                        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                            Tr.debug(tc, "JaxRsSSLManager.getSSLContext dynamic path resolved properties"
+                                         + ", inputSslRef=" + sslRef
+                                         + ", connectionInfo=" + connectionInfo
+                                         + ", resolvedAlias=" + (resolvedProps == null ? "null" : resolvedProps.getProperty(Constants.SSLPROP_ALIAS))
+                                         + ", resolvedTrustStore=" + (resolvedProps == null ? "null" : resolvedProps.getProperty(Constants.SSLPROP_TRUST_STORE))
+                                         + ", propertiesIdentity=" + (resolvedProps == null ? "null" : Integer.toHexString(System.identityHashCode(resolvedProps))));
+                        }
+                        SSLContext sslContext = jsseHelper.getSSLContext(connectionInfo, resolvedProps);
+                        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                            Tr.debug(tc, "JaxRsSSLManager.getSSLContext dynamic path result"
+                                         + ", inputSslRef=" + sslRef
+                                         + ", connectionInfo=" + connectionInfo
+                                         + ", resolvedAlias=" + (resolvedProps == null ? "null" : resolvedProps.getProperty(Constants.SSLPROP_ALIAS))
+                                         + ", sslContextIdentity=" + (sslContext == null ? "null" : Integer.toHexString(System.identityHashCode(sslContext)))
+                                         + ", sslContextClass=" + (sslContext == null ? "null" : sslContext.getClass().getName()));
+                        }
+                        return sslContext;
                     }
                 }
             });

--- a/dev/com.ibm.ws.jaxrs.2.0.security/src/com/ibm/ws/jaxrs20/appsecurity/security/JaxRsSSLManager.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.security/src/com/ibm/ws/jaxrs20/appsecurity/security/JaxRsSSLManager.java
@@ -1,4 +1,4 @@
-﻿/*******************************************************************************
+/*******************************************************************************
  * Copyright (c) 2017, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0

--- a/dev/com.ibm.ws.jaxrs.2.0.security/src/com/ibm/ws/jaxrs20/appsecurity/security/JaxRsSSLManager.java
+++ b/dev/com.ibm.ws.jaxrs.2.0.security/src/com/ibm/ws/jaxrs20/appsecurity/security/JaxRsSSLManager.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+﻿/*******************************************************************************
  * Copyright (c) 2017, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -52,34 +52,14 @@ public class JaxRsSSLManager {
             Map<String, Object> connectionInfo = getConnectionInfo(host, port);
             String cacheKey = getCacheKey(sslRef, host, port);
             if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-                Tr.debug(tc, "JaxRsSSLManager.getSSLSocketFactoryBySSLRef entry"
-                             + ", inputSslRef=" + sslRef
-                             + ", host=" + host
-                             + ", port=" + port
-                             + ", cacheKey=" + cacheKey
-                             + ", connectionInfo=" + connectionInfo,
-                         new Throwable("JaxRsSSLManager.getSSLSocketFactoryBySSLRef entry stack"));
+                Tr.debug(tc, "getSSLSocketFactoryBySSLRef: sslRef=" + sslRef + ", host=" + host + ", port=" + port + ", cacheKey=" + cacheKey);
             }
 
             SSLContext sslContext = getSSLContext(sslRef, connectionInfo);
 
-            if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-                Tr.debug(tc, "JaxRsSSLManager.getSSLSocketFactoryBySSLRef after getSSLContext"
-                             + ", inputSslRef=" + sslRef
-                             + ", host=" + host
-                             + ", port=" + port
-                             + ", cacheKey=" + cacheKey
-                             + ", sslContextIdentity=" + (sslContext == null ? "null" : Integer.toHexString(System.identityHashCode(sslContext)))
-                             + ", sslContextClass=" + (sslContext == null ? "null" : sslContext.getClass().getName()));
-            }
-
             if (sslContext == null) {
                 if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-                    Tr.debug(tc, "JaxRsSSLManager.getSSLSocketFactoryBySSLRef returning null because sslContext is null"
-                                 + ", inputSslRef=" + sslRef
-                                 + ", host=" + host
-                                 + ", port=" + port
-                                 + ", cacheKey=" + cacheKey);
+                    Tr.debug(tc, "getSSLSocketFactoryBySSLRef: returning null, sslContext is null");
                 }
                 return null;
             }
@@ -87,52 +67,18 @@ public class JaxRsSSLManager {
             boolean recache = false;
             synchronized (sslContexts) {
                 SSLContext cachedSslContext = sslContexts.get(cacheKey);
-                if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-                    Tr.debug(tc, "JaxRsSSLManager.sslContexts lookup"
-                                 + ", cacheKey=" + cacheKey
-                                 + ", host=" + host
-                                 + ", port=" + port
-                                 + ", requestedSslContextIdentity=" + Integer.toHexString(System.identityHashCode(sslContext))
-                                 + ", cachedSslContextIdentity=" + (cachedSslContext == null ? "null" : Integer.toHexString(System.identityHashCode(cachedSslContext)))
-                                 + ", cacheHit=" + (cachedSslContext != null));
-                }
                 if (sslContext == null || !sslContext.equals(cachedSslContext)) {
                     // first request or SSL config has changed, re-cache the SSLContext and SSLSocketFactory
                     sslContexts.put(cacheKey, sslContext);
                     recache = true;
-                    if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-                        Tr.debug(tc, "JaxRsSSLManager.sslContexts put"
-                                     + ", cacheKey=" + cacheKey
-                                     + ", host=" + host
-                                     + ", port=" + port
-                                     + ", storedSslContextIdentity=" + Integer.toHexString(System.identityHashCode(sslContext))
-                                     + ", recache=true");
-                    }
                 }
             }
 
             synchronized (socketFactories) {
                 sslSocketFactory = socketFactories.get(cacheKey);
-                if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-                    Tr.debug(tc, "JaxRsSSLManager.socketFactories lookup"
-                                 + ", cacheKey=" + cacheKey
-                                 + ", host=" + host
-                                 + ", port=" + port
-                                 + ", cachedSocketFactoryIdentity=" + (sslSocketFactory == null ? "null" : Integer.toHexString(System.identityHashCode(sslSocketFactory)))
-                                 + ", cacheHit=" + (sslSocketFactory != null)
-                                 + ", recache=" + recache);
-                }
                 if (sslSocketFactory == null || recache) {
                     sslSocketFactory = sslContext.getSocketFactory();
                     socketFactories.put(cacheKey, sslSocketFactory);
-                    if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-                        Tr.debug(tc, "JaxRsSSLManager.socketFactories put"
-                                     + ", cacheKey=" + cacheKey
-                                     + ", host=" + host
-                                     + ", port=" + port
-                                     + ", storedSocketFactoryIdentity=" + Integer.toHexString(System.identityHashCode(sslSocketFactory))
-                                     + ", sslContextIdentity=" + Integer.toHexString(System.identityHashCode(sslContext)));
-                    }
                 }
             }
         } catch (com.ibm.websphere.ssl.SSLException e) {
@@ -140,15 +86,6 @@ public class JaxRsSSLManager {
                 Tr.debug(tc, "configClientSSL failed to get the SSLSocketFactory with exception: " + e.toString());
             }
             return null;
-        }
-        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-            Tr.debug(tc, "JaxRsSSLManager.getSSLSocketFactoryBySSLRef return"
-                         + ", inputSslRef=" + sslRef
-                         + ", host=" + host
-                         + ", port=" + port
-                         + ", cacheKey=" + getCacheKey(sslRef, host, port)
-                         + ", returnedSocketFactoryIdentity=" + (sslSocketFactory == null ? "null" : Integer.toHexString(System.identityHashCode(sslSocketFactory)))
-                         + ", returnedSocketFactoryClass=" + (sslSocketFactory == null ? "null" : sslSocketFactory.getClass().getName()));
         }
         return sslSocketFactory;
     }
@@ -171,12 +108,6 @@ public class JaxRsSSLManager {
     private static Properties getSSLProperties(String sslRef, Map<String, Object> connectionInfo) throws SSLException {
         Properties sslProps;
         try {
-            if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-                Tr.debug(tc, "JaxRsSSLManager.getSSLProperties before jsseHelper.getProperties"
-                             + ", inputSslRef=" + sslRef
-                             + ", connectionInfo=" + connectionInfo,
-                         new Throwable("JaxRsSSLManager.getSSLProperties before stack"));
-            }
             sslProps = AccessController.doPrivileged(new PrivilegedExceptionAction<Properties>() {
                 @Override
                 public Properties run() throws SSLException {
@@ -189,27 +120,11 @@ public class JaxRsSSLManager {
             throw (SSLException) cause;
         }
 
-        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-            Tr.debug(tc, "JaxRsSSLManager.getSSLProperties after jsseHelper.getProperties"
-                         + ", inputSslRef=" + sslRef
-                         + ", connectionInfo=" + connectionInfo
-                         + ", resolvedAlias=" + (sslProps == null ? "null" : sslProps.getProperty(Constants.SSLPROP_ALIAS))
-                         + ", resolvedTrustStore=" + (sslProps == null ? "null" : sslProps.getProperty(Constants.SSLPROP_TRUST_STORE))
-                         + ", propertiesIdentity=" + (sslProps == null ? "null" : Integer.toHexString(System.identityHashCode(sslProps))),
-                     new Throwable("JaxRsSSLManager.getSSLProperties after stack"));
-        }
-
         return sslProps;
     }
 
     private static SSLContext getSSLContext(String sslRef, Map<String, Object> connectionInfo) throws SSLException {
         Boolean sslCfgExists = null;
-        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-            Tr.debug(tc, "JaxRsSSLManager.getSSLContext entry"
-                         + ", inputSslRef=" + sslRef
-                         + ", connectionInfo=" + connectionInfo,
-                     new Throwable("JaxRsSSLManager.getSSLContext entry stack"));
-        }
         if (sslRef != null) {
             try {
                 sslCfgExists = AccessController.doPrivileged(new PrivilegedExceptionAction<Boolean>() {
@@ -224,12 +139,6 @@ public class JaxRsSSLManager {
                 throw (SSLException) cause;
             }
 
-            if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-                Tr.debug(tc, "JaxRsSSLManager.getSSLContext explicit sslRef existence check"
-                             + ", inputSslRef=" + sslRef
-                             + ", sslCfgExists=" + sslCfgExists);
-            }
-
             if (!sslCfgExists.booleanValue())
                 return null;
         }
@@ -239,40 +148,10 @@ public class JaxRsSSLManager {
                 @Override
                 public SSLContext run() throws SSLConfigurationNotAvailableException, SSLException {
                     if (sslRef != null) {
-                        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-                            Tr.debug(tc, "JaxRsSSLManager.getSSLContext using explicit sslRef path"
-                                         + ", inputSslRef=" + sslRef
-                                         + ", connectionInfo=" + connectionInfo);
-                        }
-                        SSLContext sslContext = jsseHelper.getSSLContext(sslRef, connectionInfo, null, false);
-                        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-                            Tr.debug(tc, "JaxRsSSLManager.getSSLContext explicit sslRef path result"
-                                         + ", inputSslRef=" + sslRef
-                                         + ", sslContextIdentity=" + (sslContext == null ? "null" : Integer.toHexString(System.identityHashCode(sslContext)))
-                                         + ", sslContextClass=" + (sslContext == null ? "null" : sslContext.getClass().getName()));
-                        }
-                        return sslContext;
+                        return jsseHelper.getSSLContext(sslRef, connectionInfo, null, false);
                     } else {
                         // get the default ssl context with possible dynamic outbound mapping
-                        Properties resolvedProps = getSSLProperties(sslRef, connectionInfo);
-                        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-                            Tr.debug(tc, "JaxRsSSLManager.getSSLContext dynamic path resolved properties"
-                                         + ", inputSslRef=" + sslRef
-                                         + ", connectionInfo=" + connectionInfo
-                                         + ", resolvedAlias=" + (resolvedProps == null ? "null" : resolvedProps.getProperty(Constants.SSLPROP_ALIAS))
-                                         + ", resolvedTrustStore=" + (resolvedProps == null ? "null" : resolvedProps.getProperty(Constants.SSLPROP_TRUST_STORE))
-                                         + ", propertiesIdentity=" + (resolvedProps == null ? "null" : Integer.toHexString(System.identityHashCode(resolvedProps))));
-                        }
-                        SSLContext sslContext = jsseHelper.getSSLContext(connectionInfo, resolvedProps);
-                        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-                            Tr.debug(tc, "JaxRsSSLManager.getSSLContext dynamic path result"
-                                         + ", inputSslRef=" + sslRef
-                                         + ", connectionInfo=" + connectionInfo
-                                         + ", resolvedAlias=" + (resolvedProps == null ? "null" : resolvedProps.getProperty(Constants.SSLPROP_ALIAS))
-                                         + ", sslContextIdentity=" + (sslContext == null ? "null" : Integer.toHexString(System.identityHashCode(sslContext)))
-                                         + ", sslContextClass=" + (sslContext == null ? "null" : sslContext.getClass().getName()));
-                        }
-                        return sslContext;
+                        return jsseHelper.getSSLContext(connectionInfo, getSSLProperties(sslRef, connectionInfo));
                     }
                 }
             });


### PR DESCRIPTION
- [X] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [X] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [X] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
