### PR TITLE
34465: Add new WebServer Plug-in configuration option ServerIOTimeoutMarksDown

### DIFF
--- a/dev/com.ibm.ws.webcontainer/resources/OSGI-INF/l10n/metatype-mbeans.properties
+++ b/dev/com.ibm.ws.webcontainer/resources/OSGI-INF/l10n/metatype-mbeans.properties
@@ -51,7 +51,10 @@ plugin.persistTimeoutReduction.name=Reduce persistTimeout for ConnectionTTL
 plugin.persistTimeoutReduction.desc=Specifies the amount of time to subtract from the value of the persistTimeout parameter to calculate the value of ConnectionTTL.
 
 plugin.serverIOTimeout.name=Use read/write timeout
-plugin.serverIOTimeout.desc=Identifies the maximum amount of time that the web server plugin waits to send a request or receive a response from the application server.  
+plugin.serverIOTimeout.desc=Identifies the maximum amount of time that the web server plugin waits to send a request or receive a response from the application server.
+
+plugin.serverIOTimeoutMarksDown.name=ServerIOTimeout marks server down
+plugin.serverIOTimeoutMarksDown.desc=When set to true, the application server is marked as down immediately after the ServerIOTimeout is exceeded. The default value is false.
 
 plugin.wsServerIOTimeout.name=Use read/write timeout for websockets
 plugin.wsServerIOTimeout.desc=Identifies the maximum amount of time that the web server plugin waits to send a request or receive a websocket response from the application server.

--- a/dev/com.ibm.ws.webcontainer/resources/OSGI-INF/metatype/metatype-mbeans.xml
+++ b/dev/com.ibm.ws.webcontainer/resources/OSGI-INF/metatype/metatype-mbeans.xml
@@ -36,9 +36,11 @@
             id="httpEndpointRef" required="false" type="String" default="defaultHttpEndpoint" />
         <AD name="%plugin.connectTimeout.name" description="%plugin.connectTimeout.desc"
             id="connectTimeout" required="false" type="String" ibm:type="duration(s)" default="5s" />
-        <AD name="%plugin.serverIOTimeout.name" description="%plugin.serverIOTimeout.desc" 
+        <AD name="%plugin.serverIOTimeout.name" description="%plugin.serverIOTimeout.desc"
             id="serverIOTimeout" required="false" type="String" ibm:type="duration(s)" default="900s" />
-        <AD name="%plugin.wsServerIOTimeout.name" description="%plugin.wsServerIOTimeout.desc" 
+        <AD name="%plugin.serverIOTimeoutMarksDown.name" description="%plugin.serverIOTimeoutMarksDown.desc"
+            id="serverIOTimeoutMarksDown" required="false" type="Boolean" default="false" />
+        <AD name="%plugin.wsServerIOTimeout.name" description="%plugin.wsServerIOTimeout.desc"
             id="wsServerIOTimeout" required="false" type="String" ibm:type="duration(s)" />
         <AD name="%plugin.wsServerIdleTimeout.name" description="%plugin.wsServerIdleTimeout.desc" 
             id="wsServerIdleTimeout" required="false" type="String" ibm:type="duration(s)" />

--- a/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/osgi/mbeans/PluginGenerator.java
+++ b/dev/com.ibm.ws.webcontainer/src/com/ibm/ws/webcontainer/osgi/mbeans/PluginGenerator.java
@@ -511,7 +511,9 @@ public class PluginGenerator {
                     // Set server attributes
                     // Could not find the best match values in liberty now, so just use the default value of metatype
                     serverElem.setAttribute("ConnectTimeout", sd.connectTimeout.toString());
-                    serverElem.setAttribute("ServerIOTimeout", sd.serverIOTimeout.toString());
+                    // A negative ServerIOTimeout allows plugin to mark the server down after timeout
+                    long serverIOTimeoutValue = sd.serverIOTimeoutMarksDown ? -sd.serverIOTimeout : sd.serverIOTimeout;
+                    serverElem.setAttribute("ServerIOTimeout", Long.toString(serverIOTimeoutValue));
                     if (sd.wsServerIOTimeout != null)
                         serverElem.setAttribute("wsServerIOTimeout", sd.wsServerIOTimeout.toString());
                     if (sd.wsServerIdleTimeout != null)
@@ -1768,6 +1770,7 @@ protected class XMLRootHandler extends DefaultHandler implements LexicalHandler 
         protected Boolean IPv6Preferred = null;
         protected String httpEndpointPid = null;
         protected Long serverIOTimeout = null;
+        protected Boolean serverIOTimeoutMarksDown = null;
         protected Long wsServerIOTimeout = null; //optional
         protected Long wsServerIdleTimeout = null; //optional
         public Long connectTimeout = null;
@@ -1803,6 +1806,7 @@ protected class XMLRootHandler extends DefaultHandler implements LexicalHandler 
             ignoreAffinityRequests = (Boolean) config.get("ignoreAffinityRequests");
             httpEndpointPid = (String) config.get("httpEndpointRef");
             serverIOTimeout = (Long) config.get("serverIOTimeout");
+            serverIOTimeoutMarksDown = (Boolean) config.get("serverIOTimeoutMarksDown");
             wsServerIOTimeout = (Long) config.get("wsServerIOTimeout");
             wsServerIdleTimeout = (Long) config.get("wsServerIdleTimeout");
             connectTimeout = (Long) config.get("connectTimeout");
@@ -1912,6 +1916,7 @@ protected class XMLRootHandler extends DefaultHandler implements LexicalHandler 
                 Tr.debug(trace, "   postSizeLimit           : " + postSizeLimit);
                 Tr.debug(trace, "   postBufferSize          : " + postBufferSize);
                 Tr.debug(trace, "   serverIOTimeout         : " + serverIOTimeout);
+                Tr.debug(trace, "   serverIOTimeoutMarksDown: " + serverIOTimeoutMarksDown);
                 Tr.debug(trace, "   wsServerIOTimeout       : " + wsServerIOTimeout);
                 Tr.debug(trace, "   wsServerIdleTimeout     : " + wsServerIdleTimeout);
                 Tr.debug(trace, "   GetDWLMTable            : " + GetDWLMTable);
@@ -2032,6 +2037,7 @@ protected class XMLRootHandler extends DefaultHandler implements LexicalHandler 
         protected List<TransportData> transports = new LinkedList<TransportData>();
         protected Long connectTimeout = Long.valueOf(5);
         protected Long serverIOTimeout = Long.valueOf(0);
+        protected Boolean serverIOTimeoutMarksDown = Boolean.FALSE;
         protected Long wsServerIOTimeout = null;//optional
         protected Long wsServerIdleTimeout = null;//optional
         protected Boolean waitForContinue = Boolean.FALSE;
@@ -2056,6 +2062,7 @@ protected class XMLRootHandler extends DefaultHandler implements LexicalHandler 
             }
             this.nodeName = null;
             this.serverIOTimeout = pcd.serverIOTimeout;
+            this.serverIOTimeoutMarksDown = pcd.serverIOTimeoutMarksDown;
             this.wsServerIOTimeout = pcd.wsServerIOTimeout;
             this.wsServerIdleTimeout = pcd.wsServerIdleTimeout;
             this.connectTimeout = pcd.connectTimeout;

--- a/dev/com.ibm.ws.webcontainer/test/com/ibm/ws/webcontainer/osgi/mbeans/PluginGeneratorTest.java
+++ b/dev/com.ibm.ws.webcontainer/test/com/ibm/ws/webcontainer/osgi/mbeans/PluginGeneratorTest.java
@@ -1316,4 +1316,207 @@ public class PluginGeneratorTest {
         /* rename generated file to leave a clean space for the next test, but keep the file for debug */
         testfile.renameTo(new File(testClassesDir + "/outboundinterface-bind-only-plugin-cfg.xml"));
     }
+
+    /*
+     * Test generation of XML file with serverIOTimeoutMarksDown set to true
+     * Verifies that ServerIOTimeout attribute is negative when the flag is enabled
+     */
+    @Test
+    public void testServerIOTimeoutMarksDownTrue() throws Exception {
+        setCommonVHostExpectations();
+        setXMLGenerateExpectations();
+        setCommonExpectations();
+
+        /* set expectations specific for this test */
+        context.checking(new Expectations() {
+            {
+                allowing(mockLocationAdmin).getServerOutputResource("plugin-cfg.xml");
+                will(returnValue(mockWsResource));
+                allowing(mockWsResource).putStream();
+                will(returnValue(new FileOutputStream(new File(testClassesDir + "/plugin-cfg.xml"))));
+                allowing(mockWsResource).asFile();
+                will(returnValue((new File(testClassesDir + "/plugin-cfg.xml"))));
+            }
+        });
+
+        Map<String, Object> config = new HashMap<String, Object>();
+        setDefaultConfig(config);
+        /* set config values for this test */
+        config.put("serverIOTimeout", new Long(900));
+        config.put("serverIOTimeoutMarksDown", new Boolean(true));
+
+        PluginGenerator pluginGen = new PluginGenerator(config, mockLocationAdmin, mockBundleContext);
+        pluginGen.generateXML("userSpecifiedWebserverLocation", "userSpecifiedServerName", mockWebContainer, mockSessionManager, mockVhostMgr, mockLocationAdmin, false, null);
+
+        /* check that the config file was created */
+        File testfile = new File(testClassesDir + "/plugin-cfg.xml");
+        assertTrue(testfile.exists());
+        /* and that it contains the negative ServerIOTimeout value */
+        DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+        Document dom = null;
+        try {
+            /* Using factory get an instance of document builder */
+            DocumentBuilder db = dbf.newDocumentBuilder();
+            /* parse using builder to get DOM representation of the XML file */
+            dom = db.parse(testfile);
+            Element docEle = dom.getDocumentElement();
+            /* get a nodelist of ServerCluster elements */
+            NodeList nl = docEle.getElementsByTagName("ServerCluster");
+            /* we're only expecting one ServerCluster */
+            assertEquals(1, nl.getLength());
+            Node clusterNode = nl.item(0);
+            Element clusterElement = (Element) clusterNode;
+            /* get Server elements within the ServerCluster */
+            NodeList serverList = clusterElement.getElementsByTagName("Server");
+            assertTrue("Expected at least one Server element", serverList.getLength() > 0);
+            Node serverNode = serverList.item(0);
+            Element serverElement = (Element) serverNode;
+            String value = serverElement.getAttribute("ServerIOTimeout");
+            /* When serverIOTimeoutMarksDown is true, the value should be negative */
+            assertEquals("-900", value);
+        } catch (ParserConfigurationException pce) {
+            pce.printStackTrace();
+        } catch (SAXException se) {
+            se.printStackTrace();
+        } catch (IOException ioe) {
+            ioe.printStackTrace();
+        }
+        /* rename generated file to leave a clean space for the next test, but keep the file for debug */
+        testfile.renameTo(new File(testClassesDir + "/serverIOTimeoutMarksDown-true-plugin-cfg.xml"));
+    }
+
+    /*
+     * Test generation of XML file with serverIOTimeoutMarksDown set to false
+     * Verifies that ServerIOTimeout attribute is positive when the flag is disabled
+     */
+    @Test
+    public void testServerIOTimeoutMarksDownFalse() throws Exception {
+        setCommonVHostExpectations();
+        setXMLGenerateExpectations();
+        setCommonExpectations();
+
+        /* set expectations specific for this test */
+        context.checking(new Expectations() {
+            {
+                allowing(mockLocationAdmin).getServerOutputResource("plugin-cfg.xml");
+                will(returnValue(mockWsResource));
+                allowing(mockWsResource).putStream();
+                will(returnValue(new FileOutputStream(new File(testClassesDir + "/plugin-cfg.xml"))));
+                allowing(mockWsResource).asFile();
+                will(returnValue((new File(testClassesDir + "/plugin-cfg.xml"))));
+            }
+        });
+
+        Map<String, Object> config = new HashMap<String, Object>();
+        setDefaultConfig(config);
+        /* set config values for this test */
+        config.put("serverIOTimeout", new Long(900));
+        config.put("serverIOTimeoutMarksDown", new Boolean(false));
+
+        PluginGenerator pluginGen = new PluginGenerator(config, mockLocationAdmin, mockBundleContext);
+        pluginGen.generateXML("userSpecifiedWebserverLocation", "userSpecifiedServerName", mockWebContainer, mockSessionManager, mockVhostMgr, mockLocationAdmin, false, null);
+
+        /* check that the config file was created */
+        File testfile = new File(testClassesDir + "/plugin-cfg.xml");
+        assertTrue(testfile.exists());
+        /* and that it contains the positive ServerIOTimeout value */
+        DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+        Document dom = null;
+        try {
+            /* Using factory get an instance of document builder */
+            DocumentBuilder db = dbf.newDocumentBuilder();
+            /* parse using builder to get DOM representation of the XML file */
+            dom = db.parse(testfile);
+            Element docEle = dom.getDocumentElement();
+            /* get a nodelist of ServerCluster elements */
+            NodeList nl = docEle.getElementsByTagName("ServerCluster");
+            /* we're only expecting one ServerCluster */
+            assertEquals(1, nl.getLength());
+            Node clusterNode = nl.item(0);
+            Element clusterElement = (Element) clusterNode;
+            /* get Server elements within the ServerCluster */
+            NodeList serverList = clusterElement.getElementsByTagName("Server");
+            assertTrue("Expected at least one Server element", serverList.getLength() > 0);
+            Node serverNode = serverList.item(0);
+            Element serverElement = (Element) serverNode;
+            String value = serverElement.getAttribute("ServerIOTimeout");
+            /* When serverIOTimeoutMarksDown is false, the value should be positive */
+            assertEquals("900", value);
+        } catch (ParserConfigurationException pce) {
+            pce.printStackTrace();
+        } catch (SAXException se) {
+            se.printStackTrace();
+        } catch (IOException ioe) {
+            ioe.printStackTrace();
+        }
+        /* rename generated file to leave a clean space for the next test, but keep the file for debug */
+        testfile.renameTo(new File(testClassesDir + "/serverIOTimeoutMarksDown-false-plugin-cfg.xml"));
+    }
+
+    /*
+     * Test generation of XML file with serverIOTimeoutMarksDown not set (default behavior)
+     * Verifies that ServerIOTimeout attribute is positive by default
+     */
+    @Test
+    public void testServerIOTimeoutMarksDownDefault() throws Exception {
+        setCommonVHostExpectations();
+        setXMLGenerateExpectations();
+        setCommonExpectations();
+
+        /* set expectations specific for this test */
+        context.checking(new Expectations() {
+            {
+                allowing(mockLocationAdmin).getServerOutputResource("plugin-cfg.xml");
+                will(returnValue(mockWsResource));
+                allowing(mockWsResource).putStream();
+                will(returnValue(new FileOutputStream(new File(testClassesDir + "/plugin-cfg.xml"))));
+                allowing(mockWsResource).asFile();
+                will(returnValue((new File(testClassesDir + "/plugin-cfg.xml"))));
+            }
+        });
+
+        Map<String, Object> config = new HashMap<String, Object>();
+        setDefaultConfig(config);
+        /* set config values for this test - do NOT set serverIOTimeoutMarksDown to test default */
+        config.put("serverIOTimeout", new Long(900));
+
+        PluginGenerator pluginGen = new PluginGenerator(config, mockLocationAdmin, mockBundleContext);
+        pluginGen.generateXML("userSpecifiedWebserverLocation", "userSpecifiedServerName", mockWebContainer, mockSessionManager, mockVhostMgr, mockLocationAdmin, false, null);
+
+        /* check that the config file was created */
+        File testfile = new File(testClassesDir + "/plugin-cfg.xml");
+        assertTrue(testfile.exists());
+        /* and that it contains the positive ServerIOTimeout value (default behavior) */
+        DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+        Document dom = null;
+        try {
+            /* Using factory get an instance of document builder */
+            DocumentBuilder db = dbf.newDocumentBuilder();
+            /* parse using builder to get DOM representation of the XML file */
+            dom = db.parse(testfile);
+            Element docEle = dom.getDocumentElement();
+            /* get a nodelist of ServerCluster elements */
+            NodeList nl = docEle.getElementsByTagName("ServerCluster");
+            /* we're only expecting one ServerCluster */
+            assertEquals(1, nl.getLength());
+            Node clusterNode = nl.item(0);
+            Element clusterElement = (Element) clusterNode;
+            /* get Server elements within the ServerCluster */
+            NodeList serverList = clusterElement.getElementsByTagName("Server");
+            assertTrue("Expected at least one Server element", serverList.getLength() > 0);
+            Node serverNode = serverList.item(0);
+            Element serverElement = (Element) serverNode;
+            String value = serverElement.getAttribute("ServerIOTimeout");
+            /* Default behavior should be positive value */
+            assertEquals("900", value);
+        } catch (ParserConfigurationException pce) {
+            pce.printStackTrace();
+        } catch (SAXException se) {
+            se.printStackTrace();
+        } catch (IOException ioe) {
+            ioe.printStackTrace();
+        }
+        /* rename generated file to leave a clean space for the next test, but keep the file for debug */
+        testfile.renameTo(new File(testClassesDir + "/serverIOTimeoutMarksDown-default-plugin-cfg.xml"));
+    }
 }


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

--- 

**Describe the bug**  
- In WebSphere 9.0.5.x and 8.5.5.x., negative `ServerIOTimeout` values are possible and allow Plug-in to mark servers down immediately after the `ServerIOTimeout`. 
- Liberty's metatype for `ServerIOTimeout` does not allow users to use negative values. 
- The proposed solution creates a new boolean property `ServerIOTimeoutMarksDown` to allow negative `ServerIOTimeout` values in Liberty's `plugin-cfg.xml` generation, porting over functionality available in WebSphere 9.0.5.x and 8.5.5.x into Liberty.

**Steps to Reproduce**  
- Configure a negative value for `ServerIOTimeout`. 
- The generated `plugin-cfg.xml` will have a positive `ServerIOTimeout` value instead.

**Expected behavior**  
- When a user sets `ServerIOTimeoutMarksDown=true`, the `ServerIOTimeout` in the `plugin-cfg.xml` is negative.

**Diagnostic information:**  
 - OpenLiberty Version: All
 - Affected feature(s): Plug-ins for WebServers

**Additional context**  
- The new changes only convert to `ServerIOTimeout` to a negative value for the `plugin-cfg.xml` generation. The `ServerIOTimeout` metatype remains unchanged.
- The new `ServerIOTimeoutMarksDown` property is opt-out by default.

---

Fixes #34465 
Fixes #PH70651