### PR TITLE
NativeQuery repository methods that return entities

### DIFF
--- a/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/EntityInfo.java
+++ b/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/EntityInfo.java
@@ -70,7 +70,7 @@ public class EntityInfo {
     // properly cased/qualified JPQL attribute name --> type of collection
     final Map<String, Class<?>> collectionElementTypes;
 
-    final Class<?> entityClass; // will be a generated class for entity records
+    public final Class<?> entityClass; // will be a generated class for entity records
     final EntityHandlerFactory factory;
     final Class<?> idType; // type of the id, which could be a JPA IdClass for composite ids
     final SortedMap<String, Member> idClassAttributeAccessors; // null if no IdClass

--- a/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/Fail.java
+++ b/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/Fail.java
@@ -746,6 +746,9 @@ public class Fail {
     static UnsupportedOperationException orderByAnnoIncompat(QueryInfo info) {
         // disallow on incompatible operations
         if (info.type != FIND && info.type != FIND_AND_DELETE)
+            // TODO need appropriate error for (type == NATIVE) where the
+            // @OrderBy is not allowed on a NativeQuery even if it is a
+            // find operation
             throw exc(UnsupportedOperationException.class,
                       "CWWKD1096.orderby.incompat",
                       info.method.getName(),

--- a/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/QueryInfo.java
+++ b/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/QueryInfo.java
@@ -3630,12 +3630,13 @@ public abstract class QueryInfo {
                 if (i < specialParamsStartAt)
                     specialParamsStartAt = i;
                 // Reject all special parameters on native queries until we
-                // determine which, if any, can be supported
-                throw new UnsupportedOperationException //
-                ("The " + method.getName() + " method of the " +
-                 repositoryInterface.getName() + " repository cannot have a " +
-                 paramType.getSimpleName() + " parameter because the method is " +
-                 "annotated " + "@NativeQuery" + "."); // TODO NLS
+                // TODO determine which, if any, can be supported
+                if (!Limit.class.equals(paramType))
+                    throw new UnsupportedOperationException //
+                    ("The " + method.getName() + " method of the " +
+                     repositoryInterface.getName() + " repository cannot have a " +
+                     paramType.getSimpleName() + " parameter because the method is " +
+                     "annotated " + "@NativeQuery" + "."); // TODO NLS
             } else if (i > specialParamsStartAt) {
                 throw exc(UnsupportedOperationException.class,
                           "CWWKD1098.spec.param.position.err",

--- a/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/v1_1/QueryInfo_1_1.java
+++ b/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/v1_1/QueryInfo_1_1.java
@@ -375,12 +375,25 @@ public class QueryInfo_1_1 extends QueryInfo {
     @Override
     protected jakarta.persistence.Query //
                     ehCreateNativeQuery(AutoCloseable entityHandler) {
+        // If the repository method return type is the entity class or multiple
+        // entities, consider the entity class to be the result type. Otherwise
+        // the result could be a count or single entity attribute.
+        Class<?> resultClass = singleType != null &&
+                               entityInfo.entityClass.isAssignableFrom(singleType) //
+                                               ? entityInfo.entityClass //
+                                               : entityInfo.isHibernate //
+                                                               ? Object.class //
+                                                               : null;
+
         // TODO Persistence 4.0 API
         //if (entityHandler instanceof EntityHandler handler) ...
 
         jakarta.persistence.Query query;
         if (entityHandler instanceof EntityManager em) {
-            query = em.createNativeQuery(ql);
+            if (resultClass == null)
+                query = em.createNativeQuery(ql);
+            else
+                query = em.createNativeQuery(ql, resultClass);
         } else {
             try {
                 query = (jakarta.persistence.Query) entityHandler.getClass() //
@@ -389,7 +402,7 @@ public class QueryInfo_1_1 extends QueryInfo {
                                            Class.class) //
                                 .invoke(entityHandler,
                                         ql,
-                                        Object.class);
+                                        resultClass);
             } catch (IllegalAccessException | NoSuchMethodException x) {
                 throw new RuntimeException(x); // should be impossible
             } catch (InvocationTargetException x) {

--- a/dev/io.openliberty.data.internal_fat_1_1/test-applications/Data_1_1_App/src/test/jakarta/data/v1_1/web/Data_1_1_Servlet.java
+++ b/dev/io.openliberty.data.internal_fat_1_1/test-applications/Data_1_1_App/src/test/jakarta/data/v1_1/web/Data_1_1_Servlet.java
@@ -31,6 +31,7 @@ import java.util.concurrent.CompletionException;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import jakarta.annotation.Resource;
 import jakarta.data.Limit;
@@ -1510,11 +1511,98 @@ public class Data_1_1_Servlet extends FATServlet {
     }
 
     /**
+     * Use a NativeQuery method that returns subsets of entity attributes
+     * as an array of Java records
+     */
+    // @Test // TODO Java record results?
+    public void testNativeQueryReturnsArrayOfRecord() {
+        assertEquals(List.of("1:8",
+                             "2:7",
+                             "3:6",
+                             "4:5",
+                             "5:4",
+                             "6:3",
+                             "7:2",
+                             "8:1"),
+                     Stream.of(fractions.ratioArrayWithDenominator(9))
+                                     .map(Ratio::toString)
+                                     .toList());
+    }
+
+    /**
+     * Use a NativeQuery method that selects the first matching entity.
+     */
+    @Test
+    public void testNativeQueryReturnsFirstEntity() {
+        assertEquals("Seven Twentieths",
+                     fractions.firstValueWithin(0.334, 0.4)
+                                     .orElseThrow().name);
+    }
+
+    /**
+     * Use a NativeQuery method that selects multiple entities as a list.
+     */
+    @Test
+    public void testNativeQueryReturnsListOfEntities() {
+        assertEquals(List.of("1/2",
+                             "1/3",
+                             "1/4", "2/4",
+                             "1/5", "2/5",
+                             "1/6", "2/6",
+                             "1/7", "2/7",
+                             "1/8", "2/8",
+                             "1/9", "2/9", "3/9"),
+                     fractions.numeratorLTESquareRootOfDenominator(Limit.of(15))
+                                     .stream()
+                                     .map(f -> f.numerator + "/" + f.denominator)
+                                     .toList());
+    }
+
+    /**
+     * Use a NativeQuery method that returns subsets of entity attributes
+     * as a List of Java records
+     */
+    // @Test // TODO Java record results?
+    public void testNativeQueryReturnsListOfRecord() {
+        assertEquals(List.of("1:11",
+                             "2:12",
+                             "3:13",
+                             "4:14",
+                             "5:15",
+                             "6:16",
+                             "7:17",
+                             "8:18",
+                             "9:19"),
+                     fractions.ratioListWithDifferenceOfTerms(10)
+                                     .stream()
+                                     .map(Ratio::toString)
+                                     .toList());
+    }
+
+    /**
+     * Use a NativeQuery method that returns subsets of entity attributes
+     * as a Stream of Java records
+     */
+    // @Test // TODO Java record results?
+    public void testNativeQueryReturnsStreamOfRecord() {
+        assertEquals(List.of("1:7",
+                             "2:6",
+                             "3:5",
+                             "4:4",
+                             "5:3",
+                             "6:2",
+                             "7:1"),
+                     fractions.ratioStreamWithSumOfTerms(8)
+                                     .map(Ratio::toString)
+                                     .toList());
+    }
+
+    /**
      * Use a NativeQuery method that selects the result of a count operation
      * as a single value.
      */
     @Test
-    public void testNativeSelectCount() {
+    public void testNativeQuerySelectsCount() {
         assertEquals(6L, // 1/18, 5/18, 7/18, 11/18, 13/18, 17/18
                      fractions.numReducedWithDenominatorOf(18, true));
     }

--- a/dev/io.openliberty.data.internal_fat_1_1/test-applications/Data_1_1_App/src/test/jakarta/data/v1_1/web/Fractions.java
+++ b/dev/io.openliberty.data.internal_fat_1_1/test-applications/Data_1_1_App/src/test/jakarta/data/v1_1/web/Fractions.java
@@ -94,6 +94,15 @@ public interface Fractions {
      int exclusiveMax,
      Restriction<Fraction> filter);
 
+    @First
+    @NativeQuery("""
+                    SELECT *
+                      FROM Fraction
+                     WHERE val >= ? AND val <= ?
+                     ORDER BY val
+                    """)
+    Optional<Fraction> firstValueWithin(double minValue, double maxValue);
+
     @Query("WHERE denominator = ?1 AND numerator < denominator")
     @First
     @OrderBy(value = _Fraction.NUMERATOR, descending = true)
@@ -120,6 +129,14 @@ public interface Fractions {
      PageRequest pageReq);
 
     @NativeQuery("""
+                    SELECT *
+                      FROM Fraction
+                     WHERE numerator <= CAST(FLOOR(SQRT(denominator)) AS INT)
+                     ORDER BY denominator, numerator
+                    """)
+    List<Fraction> numeratorLTESquareRootOfDenominator(Limit limit);
+
+    @NativeQuery("""
                     SELECT COUNT(*)
                       FROM Fraction
                      WHERE denominator = ? AND reduced = ?
@@ -134,6 +151,39 @@ public interface Fractions {
     @Query("SELECT numerator, denominator - numerator" +
            " ORDER BY denominator - numerator DESC, numerator ASC")
     Page<Ratio> pageOfRatios(PageRequest pageReq);
+
+    @NativeQuery("""
+                    SELECT numerator, denominator - numerator
+                      FROM Fraction
+                     WHERE denominator = ?
+                     ORDER BY numerator
+                    """)
+    // TODO Java record results?
+    default Ratio[] ratioArrayWithDenominator(int sum) {
+        return new Ratio[0];
+    }
+
+    @NativeQuery("""
+                    SELECT numerator, denominator
+                      FROM Fraction
+                     WHERE ABS(numerator - denominator) = ?
+                     ORDER BY numerator
+                    """)
+    // TODO Java record results?
+    default List<Ratio> ratioListWithDifferenceOfTerms(int difference) {
+        return List.of();
+    }
+
+    @NativeQuery("""
+                    SELECT numerator, denominator
+                      FROM Fraction
+                     WHERE numerator + denominator = ?
+                     ORDER BY numerator
+                    """)
+    // TODO Java record results?
+    default Stream<Ratio> ratioStreamWithSumOfTerms(int sum) {
+        return Stream.of();
+    }
 
     @Delete
     List<Fraction> remove(Like name,


### PR DESCRIPTION
Enable NativeQuery repository methods to return Java entities.
Enable the First annotation and Limit special parameter to be used with NativeQuery.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
