### PR TITLE
Fix build break where the server can use a different port

### DIFF
--- a/dev/com.ibm.ws.messaging.security_fat/publish/servers/cdi12MessageRoleOrderingServer/server.xml
+++ b/dev/com.ibm.ws.messaging.security_fat/publish/servers/cdi12MessageRoleOrderingServer/server.xml
@@ -55,7 +55,7 @@
   </messagingEngine>
   
   <jmsConnectionFactory id="TestConnectionFactory" jndiName="jms/TestConnectionFactory">
-    <properties.wasJms clientID="TestClientID" remoteServerAddress="localhost:7276:BootstrapBasicMessaging"/>
+    <properties.wasJms clientID="TestClientID" remoteServerAddress="localhost:${bvt.prop.jms.0}:BootstrapBasicMessaging"/>
   </jmsConnectionFactory>
   
   <jmsQueue id="TestQueue" jndiName="jms/TestQueue">


### PR DESCRIPTION
- When running on Mac, the jms port may not be 7276, so use the variable instead of the hardcoded value for the port

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [ ] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
