### PR TITLE
Fix RTC 310442: Allow intermittent cache init errors in testAddFeature

### DIFF
--- a/dev/com.ibm.ws.session.cache_fat_config/fat/src/com/ibm/ws/session/cache/config/fat/SessionCacheErrorPathsTest.java
+++ b/dev/com.ibm.ws.session.cache_fat_config/fat/src/com/ibm/ws/session/cache/config/fat/SessionCacheErrorPathsTest.java
@@ -71,7 +71,7 @@ public class SessionCacheErrorPathsTest extends FATServletClient {
     public void cleanUpPerTest() throws Exception {
         try {
             if (server.isStarted()) {
-                server.stopServer("CWWKG0033W");
+                server.stopServer("CWWKG0033W", "SESN0307E", "SRVE8059E");
             }
         } finally {
             server.updateServerConfiguration(savedConfig);
@@ -150,6 +150,7 @@ public class SessionCacheErrorPathsTest extends FATServletClient {
      * verifying that a session attribute added afterward is persisted, whereas a session attribute added before
      * (in absence of sessionCache-1.0 feature) is not.
      */
+    @AllowedFFDC(value = { "java.lang.IllegalStateException" })
     @Test
     public void testAddFeature() throws Exception {
         // Start the server with sessionCache-1.0 enabled


### PR DESCRIPTION
testAddFeature was intermittently failing (5%, 1/19 runs) on EE11 during server stop in cleanUpPerTest. The errors SESN0307E and SRVE8059E can occur when the JCache cache manager is in a transitional state during dynamic feature addition — the same race condition already acknowledged and allowed in testInvalidURI, testLibraryWithoutJCacheProvider, and testModifyFileset.
This is a test-side fix only. No product code changes.

Changes:

- Allow SESN0307E and SRVE8059E in cleanUpPerTest stopServer call
- Add @AllowedFFDC(IllegalStateException) to testAddFeature