### PR TITLE
fix(typo): SHA512(should be SHA-512) is not a valid MessageDigest for some jdk

### DIFF
--- a/dev/com.ibm.ws.webcontainer.security/src/com/ibm/ws/webcontainer/security/LoggedOutCookieCacheHelper.java
+++ b/dev/com.ibm.ws.webcontainer.security/src/com/ibm/ws/webcontainer/security/LoggedOutCookieCacheHelper.java
@@ -36,7 +36,7 @@ public class LoggedOutCookieCacheHelper {
     private static LoggedOutCookieCache cookieCacheService = null;
     
     public static final String LOGOUT_KEY_PREFIX = "LOGOUT:";
-    private static final String SHA_512 = CryptoUtils.MESSAGE_DIGEST_ALGORITHM_SHA512;
+    private static final String SHA_512 = CryptoUtils.MESSAGE_DIGEST_ALGORITHM_SHA_512;
     private static final Object SYNC_OBJECT = new Object();
     private static MessageDigest CLONEABLE_MESSAGE_DIGEST = null;
 


### PR DESCRIPTION
Fixes https://github.com/OpenLiberty/open-liberty/issues/35108
fixes rtc defect 310316


- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [ ] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

