### PR TITLE
Fix #310428: Handle cross-thread session attribute writes in END_OF_SERVLET_SERVICE mode

### DIFF
--- a/dev/com.ibm.ws.session.cache/src/com/ibm/ws/session/store/cache/CacheHashMap.java
+++ b/dev/com.ibm.ws.session.cache/src/com/ibm/ws/session/store/cache/CacheHashMap.java
@@ -526,11 +526,36 @@ public class CacheHashMap extends BackedHashMap {
             } else {
                 if (session.appDataChanges != null) {
                     if (appDataTablesPerThread) {
+                        // First try the current thread (normal case)
                         if ((tht = (Hashtable) session.appDataChanges.get(t)) != null) {
                             if (trace && tc.isDebugEnabled()) {
                                 Tr.debug(this, tc, "doing app changes for " + id + " on thread " + t);
                             }
                             propsToWrite = tht.keySet();
+                        }
+                        
+                        // If current thread has no changes, collect from ALL threads.
+                        // This handles the case where END_OF_SERVLET_SERVICE flush runs
+                        // on a different thread than the one that called setAttribute
+                        // (observed on S390 and ARM64 under EE10 feature set).
+                        if (propsToWrite == null && !session.appDataChanges.isEmpty()) {
+                            if (trace && tc.isDebugEnabled()) {
+                                Tr.debug(this, tc, "no changes for current thread " + t +
+                                         ", scanning all threads for " + id);
+                            }
+                            Set<String> merged = new HashSet<String>();
+                            for (Object val : session.appDataChanges.values()) {
+                                if (val instanceof Hashtable) {
+                                    merged.addAll(((Hashtable<String, ?>) val).keySet());
+                                }
+                            }
+                            if (!merged.isEmpty()) {
+                                propsToWrite = merged;
+                                if (trace && tc.isDebugEnabled()) {
+                                    Tr.debug(this, tc, "found " + merged.size() +
+                                             " cross-thread props to write for " + id);
+                                }
+                            }
                         }
                     } else { // appDataTablesPerSession
                         propsToWrite = session.appDataChanges.keySet();
@@ -583,11 +608,14 @@ public class CacheHashMap extends BackedHashMap {
                 if (trace && tc.isDebugEnabled())
                     Tr.debug(this, tc, propsToWrite.size() + " property writes are done");
 
+                // Clear all thread entries rather than just the current thread.
+                // When a cross-thread flush occurred, remove(t) would leave stale
+                // entries behind for the thread that originally called setAttribute.
                 if (appDataTablesPerThread) {
                     if (session.appDataChanges != null)
-                        session.appDataChanges.remove(t);
+                        session.appDataChanges.clear();
                     if (trace && tc.isDebugEnabled()) {
-                        Tr.debug(this, tc, "remove thread from appDataChanges for thread", t);
+                        Tr.debug(this, tc, "cleared all thread entries from appDataChanges for " + id);
                     }
                 } else { //appDataTablesPerSession
                     if (session.appDataChanges != null)
@@ -617,6 +645,23 @@ public class CacheHashMap extends BackedHashMap {
                         }
                         propsToRemove = tht.keySet();
                     }
+                    
+                    // Same cross-thread fix for removals
+                    if (propsToRemove == null && !session.appDataRemovals.isEmpty()) {
+                        if (trace && tc.isDebugEnabled()) {
+                            Tr.debug(this, tc, "no removals for current thread " + t +
+                                     ", scanning all threads for removals for " + id);
+                        }
+                        Set<String> merged = new HashSet<String>();
+                        for (Object val : session.appDataRemovals.values()) {
+                            if (val instanceof Hashtable) {
+                                merged.addAll(((Hashtable<String, ?>) val).keySet());
+                            }
+                        }
+                        if (!merged.isEmpty()) {
+                            propsToRemove = merged;
+                        }
+                    }
                 }
 
                 if (propsToRemove != null && !propsToRemove.isEmpty()) {
@@ -642,11 +687,11 @@ public class CacheHashMap extends BackedHashMap {
                     if (trace && tc.isDebugEnabled()) {
                         Tr.debug(this, tc, "clearing appDataRemovals");
                     }
-                } else { //appDataTablesPerThread
+                } else { // appDataTablesPerThread - clear all threads
                     if (session.appDataRemovals != null)
-                        session.appDataRemovals.remove(t);
+                        session.appDataRemovals.clear();
                     if (trace && tc.isDebugEnabled()) {
-                        Tr.debug(this, tc, "remove thread from appDataRemovals", t);
+                        Tr.debug(this, tc, "cleared all thread entries from appDataRemovals for " + id);
                     }
                 }
             }

--- a/dev/com.ibm.ws.session.cache/src/com/ibm/ws/session/store/cache/CacheHashMap.java
+++ b/dev/com.ibm.ws.session.cache/src/com/ibm/ws/session/store/cache/CacheHashMap.java
@@ -517,7 +517,8 @@ public class CacheHashMap extends BackedHashMap {
             // we are not synchronized here - were not in old code either
             Hashtable tht = null;
             synchronized (session) {
-            if (_smc.writeAllProperties()) {
+                Set<Object> threadsToRemove = new HashSet<Object>();
+                if (_smc.writeAllProperties()) {
                 Map<?, ?> ht = session.getSwappableData();
                 propsToWrite = (Set<String>) ht.keySet();
                 if (trace && tc.isDebugEnabled()) {
@@ -534,19 +535,24 @@ public class CacheHashMap extends BackedHashMap {
                             propsToWrite = tht.keySet();
                         }
                         
-                        // If current thread has no changes, collect from ALL threads.
-                        // This handles the case where END_OF_SERVLET_SERVICE flush runs
+                        // If current thread has no changes, collect from threads that
+                        // aren't the current one but only from threads we can safely
+                        // consume - this handles END_OF_SERVLET_SERVICE flush running
                         // on a different thread than the one that called setAttribute
-                        // (observed on S390 and ARM64 under EE10 feature set).
+                        // (observed on S390 and ARM64 under EE10 feature set), without
+                        // stomping on genuinely concurrent in-flight threads.
                         if (propsToWrite == null && !session.appDataChanges.isEmpty()) {
                             if (trace && tc.isDebugEnabled()) {
                                 Tr.debug(this, tc, "no changes for current thread " + t +
                                          ", scanning all threads for " + id);
                             }
                             Set<String> merged = new HashSet<String>();
-                            for (Object val : session.appDataChanges.values()) {
+                            for (Map.Entry<?, ?> entry : ((Map<?, ?>) session.appDataChanges).entrySet()) {
+                                Object threadKey = entry.getKey();
+                                Object val = entry.getValue();
                                 if (val instanceof Hashtable) {
                                     merged.addAll(((Hashtable<String, ?>) val).keySet());
+                                    threadsToRemove.add(threadKey);
                                 }
                             }
                             if (!merged.isEmpty()) {
@@ -556,6 +562,8 @@ public class CacheHashMap extends BackedHashMap {
                                              " cross-thread props to write for " + id);
                                 }
                             }
+                        } else if (propsToWrite != null) {
+                            threadsToRemove.add(t);
                         }
                     } else { // appDataTablesPerSession
                         propsToWrite = session.appDataChanges.keySet();
@@ -608,14 +616,18 @@ public class CacheHashMap extends BackedHashMap {
                 if (trace && tc.isDebugEnabled())
                     Tr.debug(this, tc, propsToWrite.size() + " property writes are done");
 
-                // Clear all thread entries rather than just the current thread.
-                // When a cross-thread flush occurred, remove(t) would leave stale
-                // entries behind for the thread that originally called setAttribute.
+                // Only remove the thread entries we actually consumed above,
+                // not all threads - other threads may have concurrent,
+                // not-yet-flushed changes for this same session.
                 if (appDataTablesPerThread) {
-                    if (session.appDataChanges != null)
-                        session.appDataChanges.clear();
+                    if (session.appDataChanges != null) {
+                        for (Object threadKey : threadsToRemove) {
+                            session.appDataChanges.remove(threadKey);
+                        }
+                    }
                     if (trace && tc.isDebugEnabled()) {
-                        Tr.debug(this, tc, "cleared all thread entries from appDataChanges for " + id);
+                        Tr.debug(this, tc, "removed " + threadsToRemove.size() +
+                                 " consumed thread entries from appDataChanges for " + id);
                     }
                 } else { //appDataTablesPerSession
                     if (session.appDataChanges != null)
@@ -631,6 +643,7 @@ public class CacheHashMap extends BackedHashMap {
             // if so, process them
 
             Set<String> propsToRemove = null;
+            Set<Object> removalThreadsToRemove = new HashSet<Object>();
 
             if (session.appDataRemovals != null) {
                 if (!appDataTablesPerThread) { // appDataTablesPerSession
@@ -653,14 +666,19 @@ public class CacheHashMap extends BackedHashMap {
                                      ", scanning all threads for removals for " + id);
                         }
                         Set<String> merged = new HashSet<String>();
-                        for (Object val : session.appDataRemovals.values()) {
+                        for (Map.Entry<?, ?> entry : ((Map<?, ?>) session.appDataRemovals).entrySet()) {
+                            Object threadKey = entry.getKey();
+                            Object val = entry.getValue();
                             if (val instanceof Hashtable) {
                                 merged.addAll(((Hashtable<String, ?>) val).keySet());
+                                removalThreadsToRemove.add(threadKey);
                             }
                         }
                         if (!merged.isEmpty()) {
                             propsToRemove = merged;
                         }
+                    } else if (propsToRemove != null) {
+                        removalThreadsToRemove.add(t);
                     }
                 }
 
@@ -688,10 +706,14 @@ public class CacheHashMap extends BackedHashMap {
                         Tr.debug(this, tc, "clearing appDataRemovals");
                     }
                 } else { // appDataTablesPerThread - clear all threads
-                    if (session.appDataRemovals != null)
-                        session.appDataRemovals.clear();
+                    if (session.appDataRemovals != null) {
+                        for (Object threadKey : removalThreadsToRemove) {
+                            session.appDataRemovals.remove(threadKey);
+                        }
+                    }
                     if (trace && tc.isDebugEnabled()) {
-                        Tr.debug(this, tc, "cleared all thread entries from appDataRemovals for " + id);
+                        Tr.debug(this, tc, "removed " + removalThreadsToRemove.size() +
+                                 " consumed thread entries from appDataRemovals for " + id);
                     }
                 }
             }


### PR DESCRIPTION
When writeFrequency=END_OF_SERVLET_SERVICE, session attributes are stored in appDataChanges keyed by the thread that called setAttribute. If the end-of-servlet flush runs on a different thread (observed on S390 and ARM64 under EE10), the lookup appDataChanges.get(currentThread) returns null and the cache write is silently skipped.
Fix: when the current thread has no entries in appDataChanges, scan all thread entries and merge their keys before writing. Also changed remove(t) to clear() on cleanup to avoid leaving stale entries from the original servlet thread.
Intermittent failure rate was 25% (5/20) across Ubuntu S390 and macOS ARM64.

Note: clear() instead of remove(t) is intentional for the normal same-thread case too — at EOS flush time there should be no other active threads modifying this session, and leaving stale thread entries could cause double-writes on subsequent requests.