### PR TITLE
NativeQuery methods that perform SQL INSERT, UPDATE, and DELETE

### DIFF
--- a/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/QueryInfo.java
+++ b/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/QueryInfo.java
@@ -4547,7 +4547,8 @@ public abstract class QueryInfo {
 
                 setParameters(query, args, Collections.emptyMap(), null);
 
-                returnValue = query.executeUpdate();
+                returnValue = toReturnValue(query.executeUpdate(),
+                                            singleType);
             } else {
                 query = ehCreateNativeQuery(entityHandler);
 

--- a/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/v1_1/QueryInfo_1_1.java
+++ b/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/v1_1/QueryInfo_1_1.java
@@ -436,13 +436,14 @@ public class QueryInfo_1_1 extends QueryInfo {
 
         // TODO Persistence 4.0 API
         //if (entityHandler instanceof EntityHandler handler) ...
+        //    handler.createNativeStatement(ql)
 
         if (entityHandler instanceof EntityManager em) {
             query = em.createNativeQuery(ql);
         } else {
             try {
                 query = (jakarta.persistence.Query) entityHandler.getClass() //
-                                .getMethod("createNativeStatement", String.class) //
+                                .getMethod("createNativeMutationQuery", String.class) //
                                 .invoke(entityHandler, ql);
             } catch (IllegalAccessException | NoSuchMethodException x) {
                 throw new RuntimeException(x); // should be impossible

--- a/dev/io.openliberty.data.internal_fat_1_1/test-applications/Data_1_1_App/src/test/jakarta/data/v1_1/web/Data_1_1_Servlet.java
+++ b/dev/io.openliberty.data.internal_fat_1_1/test-applications/Data_1_1_App/src/test/jakarta/data/v1_1/web/Data_1_1_Servlet.java
@@ -65,6 +65,7 @@ import org.junit.Test;
 import componenttest.annotation.AllowedFFDC;
 import componenttest.app.FATServlet;
 import test.jakarta.data.v1_1.web.Fraction.Decimal;
+import test.jakarta.data.v1_1.web.Fraction.Decimal.Type;
 
 @SuppressWarnings("serial")
 @WebServlet("/*")
@@ -1508,6 +1509,47 @@ public class Data_1_1_Servlet extends FATServlet {
                                             Order.by(_Fraction.numerator.desc())) //
                                      .map(f -> f.name)
                                      .collect(Collectors.toList()));
+    }
+
+    /**
+     * Use a NativeQuery method that performs SQL INSERT, UPDATE, and DELETE
+     * statements.
+     */
+    @Test
+    public void testNativeQueryExecutesStatements() {
+        // Populate with 14/23.
+        // Ensure deletion in the finally block.
+        fractions.create(14,
+                         23,
+                         "Fourteen Twenty-Thirds",
+                         true,
+                         14.0 / 23.0,
+                         23.0 / 14.0,
+                         BigDecimal.valueOf(6090L, 4),
+                         BigDecimal.valueOf(6080L, 4),
+                         Type.REPEATING.ordinal(),
+                         "",
+                         "60869565");
+        try {
+            assertEquals(BigDecimal.valueOf(6090L, 4),
+                         fractions.roundedUp(14, 23)
+                                         .orElseThrow());
+
+            System.out.println("Update 14/23");
+
+            assertEquals(true, fractions.change(BigDecimal.valueOf(6087L, 4),
+                                                BigDecimal.valueOf(6086L, 4),
+                                                14,
+                                                23));
+
+            assertEquals(BigDecimal.valueOf(6087L, 4),
+                         fractions.roundedUp(14, 23)
+                                         .orElseThrow());
+        } finally {
+            // Ensure no fractions with denominator of 23 or more are left around
+            assertEquals(1L,
+                         fractions.destroy(14, "Twenty-Thirds"));
+        }
     }
 
     /**

--- a/dev/io.openliberty.data.internal_fat_1_1/test-applications/Data_1_1_App/src/test/jakarta/data/v1_1/web/Data_1_1_Servlet.java
+++ b/dev/io.openliberty.data.internal_fat_1_1/test-applications/Data_1_1_App/src/test/jakarta/data/v1_1/web/Data_1_1_Servlet.java
@@ -1117,6 +1117,9 @@ public class Data_1_1_Servlet extends FATServlet {
                          f18_23.decimal.value(),
                          0.0001);
             tx.commit();
+
+            // allow error to be raised if any
+            lockDB.get(TIMEOUT_S, TimeUnit.SECONDS);
         } finally {
             locked.countDown();
             blocked.countDown();
@@ -1841,6 +1844,72 @@ public class Data_1_1_Servlet extends FATServlet {
 
         assertEquals(false,
                      fractions.greatestLessThan1(0).isPresent());
+    }
+
+    /**
+     * Use the QueryOptions annotation to establish a query timeout on a
+     * repository method annotated NativeQuery.
+     */
+    @AllowedFFDC("javax.transaction.xa.XAException") // due to query timeout
+    @Test
+    public void testQueryTimeoutAsQueryOptionOnNativeQuery() throws Exception {
+        // Derby ignores query timeout and the lock timeout ends up applying instead
+        if (isDerby())
+            return;
+
+        CountDownLatch locked = new CountDownLatch(1);
+        CountDownLatch blocked = new CountDownLatch(1);
+
+        CompletableFuture<Boolean> lockDB = CompletableFuture.supplyAsync(() -> {
+            try {
+                tx.setTransactionTimeout((int) TIMEOUT_S * 3);
+                tx.begin();
+                boolean found = fractions.change(BigDecimal.valueOf(1880, 4),
+                                 BigDecimal.valueOf(1870, 4),
+                                 3,
+                                 16);
+                System.out.println("Obtained lock on 3/16");
+                locked.countDown();
+                blocked.await(TIMEOUT_S * 2, TimeUnit.SECONDS);
+                System.out.println("Release lock on 3/16");
+                tx.rollback();
+                return found;
+            } catch (RuntimeException x) {
+                throw x;
+            } catch (Exception x) {
+                throw new CompletionException(x);
+            }
+        });
+
+        try {
+            assertEquals(true, locked.await(TIMEOUT_S, TimeUnit.SECONDS));
+            try {
+                boolean found = fractions.change(BigDecimal.valueOf(1900, 4),
+                                                 BigDecimal.valueOf(1800, 4),
+                                                 3,
+                                                 16);
+                fail("Query timeout on QueryOptions should have caused the" +
+                     " query to time out. Instead found entity? " + found);
+            } catch (DataException x) {
+                // expected for query timeout
+            }
+
+            blocked.countDown();
+
+            // changes must be rolled back and the lock released
+            Fraction f3_16 = fractions.of(3, 16)
+                            .orElseThrow();
+            assertEquals(BigDecimal.valueOf(1875, 4),
+                         f3_16.decimal.ceiling());
+            assertEquals(BigDecimal.valueOf(1875, 4),
+                         f3_16.decimal.truncated());
+
+            // allow error to be raised if any
+            lockDB.get(TIMEOUT_S, TimeUnit.SECONDS);
+        } finally {
+            locked.countDown();
+            blocked.countDown();
+        }
     }
 
     /**

--- a/dev/io.openliberty.data.internal_fat_1_1/test-applications/Data_1_1_App/src/test/jakarta/data/v1_1/web/Fractions.java
+++ b/dev/io.openliberty.data.internal_fat_1_1/test-applications/Data_1_1_App/src/test/jakarta/data/v1_1/web/Fractions.java
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package test.jakarta.data.v1_1.web;
 
+import java.math.BigDecimal;
 import java.sql.CallableStatement;
 import java.sql.Connection;
 import java.sql.SQLException;
@@ -65,6 +66,18 @@ public interface Fractions {
                                      Restriction<Fraction> filter,
                                      Order<Fraction> sortBy);
 
+    @NativeQuery("""
+                    UPDATE Fraction
+                       SET ceiling = ?,
+                           truncated = ?
+                     WHERE numerator = ?
+                       AND denominator = ?
+                    """)
+    boolean change(BigDecimal ceiling,
+                   BigDecimal truncated,
+                   int numerator,
+                   int denominator);
+
     Connection connect();
 
     Long count(Restriction<Fraction> filter);
@@ -72,6 +85,24 @@ public interface Fractions {
     long countByDenominatorBetween(int min,
                                    int max,
                                    Restriction<Fraction> filter);
+
+    @NativeQuery("""
+                    INSERT INTO Fraction
+                         (numerator, denominator, name, reduced, VAL, inverse,
+                          ceiling, truncated, type, nonrepeating, repeating )
+                         values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    """)
+    void create(int numerator,
+                int denominator,
+                String name,
+                boolean reduced,
+                double value,
+                double inverse,
+                BigDecimal ceiling,
+                BigDecimal truncated,
+                int decimalType, // ordinal value of Fraction.Decimal.Type enum
+                String nonrepeating,
+                String repeating);
 
     int deleteByNameStartsWith(String prefix,
                                Restriction<Fraction> filter);
@@ -81,6 +112,14 @@ public interface Fractions {
     (@By(_Fraction.DENOMINATOR) NotNull<Integer> notNull,
      @By(_Fraction.DENOMINATOR) AtMost<Integer> max,
      Sort<?>... sorts);
+
+    @NativeQuery("""
+                    DELETE FROM Fraction
+                     WHERE numerator = ?
+                       AND name LIKE CONCAT('% ', ?)
+                    """)
+    long destroy(int numerator,
+                 String denominatorName);
 
     @Delete
     long discard(@By("denominator") AtLeast<Integer> minDenominator,
@@ -188,6 +227,11 @@ public interface Fractions {
     @Delete
     List<Fraction> remove(Like name,
                           Restriction<Fraction> filter);
+
+    @Find
+    @Select(_Fraction.DECIMAL_CEILING)
+    Optional<BigDecimal> roundedUp(@By(_Fraction.NUMERATOR) int numerator,
+                                   @By(_Fraction.DENOMINATOR) int denominator);
 
     /**
      * This is a workaround for Derby, which ignores query timeout

--- a/dev/io.openliberty.data.internal_fat_1_1/test-applications/Data_1_1_App/src/test/jakarta/data/v1_1/web/Fractions.java
+++ b/dev/io.openliberty.data.internal_fat_1_1/test-applications/Data_1_1_App/src/test/jakarta/data/v1_1/web/Fractions.java
@@ -73,6 +73,7 @@ public interface Fractions {
                      WHERE numerator = ?
                        AND denominator = ?
                     """)
+    @QueryOptions(timeout = 12000) // query timeout = 12 seconds
     boolean change(BigDecimal ceiling,
                    BigDecimal truncated,
                    int numerator,


### PR DESCRIPTION
A repository method that is annotated `@NativeQuery` can perform INSERT, UPDATE, and DELETE statements with the latter two returning an update count.  Additionally, `@QueryOptions` can be included to apply additional customization to the query, such as setting a timeout

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
