### PR TITLE
H2 URL Password rejection

### DIFF
--- a/dev/com.ibm.ws.jdbc/resources/com/ibm/ws/rsadapter/resources/IBMDataStoreAdapterNLS.nlsprops
+++ b/dev/com.ibm.ws.jdbc/resources/com/ibm/ws/rsadapter/resources/IBMDataStoreAdapterNLS.nlsprops
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2001, 2023 IBM Corporation and others.
+# Copyright (c) 2001, 2026 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -366,6 +366,11 @@ PROP_SET_ERROR.useraction=Verify that the value that is specified is valid for t
 8069_HELPER_INIT_ERR=DSRA8069E: DataSource {0} is unable to initialize DataStoreHelper implementation {1} due to an error: {2}
 8069_HELPER_INIT_ERR.explanation=The configured DataStoreHelper class was either inaccessible, lacked a public constructor with a single java.util.Properties parameter, or raised an error when invoked.
 8069_HELPER_INIT_ERR.useraction=Inspect the chained exception to determine the cause.
+
+# {0}        The DataSource id
+8070_H2_URL_PASSWORD=DSRA8070E: The H2 database URL for DataSource {0} contains a PASSWORD parameter. For security, use the password attribute on the properties.h2 element or configure containerAuthData instead.
+8070_H2_URL_PASSWORD.explanation=Embedding passwords in database URLs is a security risk because the password may be exposed in logs, traces, or configuration dumps. The H2 database driver supports secure alternatives for password configuration.
+8070_H2_URL_PASSWORD.useraction=Remove the PASSWORD parameter from the URL and use one of the following secure alternatives: 1) Add a password attribute to the properties.h2 element, or 2) Configure containerAuthData with user and password.
 
 # {0}        Type of Connection: XAConnection or PooledConnection.
 JAVAX_CONN_ERR=DSRA8100E: Unable to get a {0} from the DataSource.

--- a/dev/com.ibm.ws.jdbc/resources/com/ibm/ws/rsadapter/resources/IBMDataStoreAdapterNLS.nlsprops
+++ b/dev/com.ibm.ws.jdbc/resources/com/ibm/ws/rsadapter/resources/IBMDataStoreAdapterNLS.nlsprops
@@ -370,7 +370,7 @@ PROP_SET_ERROR.useraction=Verify that the value that is specified is valid for t
 # {0}        The DataSource id
 8070_H2_URL_PASSWORD=DSRA8070E: The H2 database URL for DataSource {0} contains a PASSWORD parameter. For security, use the password attribute on the properties.h2 element or configure containerAuthData instead.
 8070_H2_URL_PASSWORD.explanation=Embedding passwords in database URLs is a security risk because the password may be exposed in logs, traces, or configuration dumps. The H2 database driver supports secure alternatives for password configuration.
-8070_H2_URL_PASSWORD.useraction=Remove the PASSWORD parameter from the URL and use one of the following secure alternatives: 1) Add a password attribute to the properties.h2 element, or 2) Configure containerAuthData with user and password.
+8070_H2_URL_PASSWORD.useraction=Remove the PASSWORD parameter from the H2 URL and instead specify the password using the password attribute on the properties.h2 element or the containerAuthData configuration.
 
 # {0}        Type of Connection: XAConnection or PooledConnection.
 JAVAX_CONN_ERR=DSRA8100E: Unable to get a {0} from the DataSource.

--- a/dev/com.ibm.ws.jdbc/resources/com/ibm/ws/rsadapter/resources/IBMDataStoreAdapterNLS.nlsprops
+++ b/dev/com.ibm.ws.jdbc/resources/com/ibm/ws/rsadapter/resources/IBMDataStoreAdapterNLS.nlsprops
@@ -369,7 +369,7 @@ PROP_SET_ERROR.useraction=Verify that the value that is specified is valid for t
 
 # {0}        The DataSource id
 8070_H2_URL_PASSWORD=DSRA8070E: The H2 database URL for DataSource {0} contains a PASSWORD parameter. For security, use the password attribute on the properties.h2 element or configure containerAuthData instead.
-8070_H2_URL_PASSWORD.explanation=Embedding passwords in database URLs is a security risk because the password may be exposed in logs, traces, or configuration dumps. The H2 database driver supports secure alternatives for password configuration.
+8070_H2_URL_PASSWORD.explanation=Embedding passwords in database URLs is a security risk because the password might be exposed in logs, traces, or configuration dumps. The H2 database driver supports secure alternatives for password configuration.
 8070_H2_URL_PASSWORD.useraction=Remove the PASSWORD parameter from the H2 URL and instead specify the password using the password attribute on the properties.h2 element or the containerAuthData configuration.
 
 # {0}        Type of Connection: XAConnection or PooledConnection.

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/jdbc/DataSourceService.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/jdbc/DataSourceService.java
@@ -862,6 +862,20 @@ public class DataSourceService extends AbstractConnectionFactoryService implemen
             }
         }
 
+        // Validate H2 URLs don't contain PASSWORD parameter
+        if (vPropsPID != null && vPropsPID.contains(".h2")) {
+            // Check if URL property exists and contains PASSWORD
+            for (String key : vProps.stringPropertyNames()) {
+                if ("url".equalsIgnoreCase(key)) {
+                    String url = vProps.getProperty(key);
+                    if (url != null && url.matches("(?i).*;\\bPASSWORD=.*")) { // Case-insensitive check for ;PASSWORD= with word boundary
+                        throw new IllegalArgumentException(AdapterUtil.getNLSMessage("8070_H2_URL_PASSWORD", id));
+                    }
+                    break;
+                }
+            }
+        }
+
         // identifyException, which is a group of
         // (identifyException.#.sqlState, identifyException.#.errorCode, identifyException.#.as)
         // is parsed separately to have a predictable order of precedence when collisions occur

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/jdbc/DataSourceService.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/jdbc/DataSourceService.java
@@ -863,7 +863,7 @@ public class DataSourceService extends AbstractConnectionFactoryService implemen
         }
 
         // Validate H2 URLs don't contain PASSWORD parameter
-        if (vPropsPID != null && vPropsPID.contains(".h2")) {
+        if (vPropsPID != null && vPropsPID.endsWith(".h2")) {
             String url = vProps.getProperty("URL", vProps.getProperty("url"));
             if (url != null && url.matches("(?i).*;\\bPASSWORD=.*")) {
                 throw new IllegalArgumentException(AdapterUtil.getNLSMessage("8070_H2_URL_PASSWORD", id));

--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/jdbc/DataSourceService.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/jdbc/DataSourceService.java
@@ -864,15 +864,9 @@ public class DataSourceService extends AbstractConnectionFactoryService implemen
 
         // Validate H2 URLs don't contain PASSWORD parameter
         if (vPropsPID != null && vPropsPID.contains(".h2")) {
-            // Check if URL property exists and contains PASSWORD
-            for (String key : vProps.stringPropertyNames()) {
-                if ("url".equalsIgnoreCase(key)) {
-                    String url = vProps.getProperty(key);
-                    if (url != null && url.matches("(?i).*;\\bPASSWORD=.*")) { // Case-insensitive check for ;PASSWORD= with word boundary
-                        throw new IllegalArgumentException(AdapterUtil.getNLSMessage("8070_H2_URL_PASSWORD", id));
-                    }
-                    break;
-                }
+            String url = vProps.getProperty("URL", vProps.getProperty("url"));
+            if (url != null && url.matches("(?i).*;\\bPASSWORD=.*")) {
+                throw new IllegalArgumentException(AdapterUtil.getNLSMessage("8070_H2_URL_PASSWORD", id));
             }
         }
 

--- a/dev/com.ibm.ws.jdbc_fat_h2/fat/src/test/jakarta/data/validation/H2Test.java
+++ b/dev/com.ibm.ws.jdbc_fat_h2/fat/src/test/jakarta/data/validation/H2Test.java
@@ -27,6 +27,7 @@ import org.junit.runner.RunWith;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
 
+import componenttest.annotation.AllowedFFDC;
 import componenttest.annotation.MinimumJavaLevel;
 import componenttest.annotation.Server;
 import componenttest.annotation.TestServlet;
@@ -37,6 +38,7 @@ import test.jdbc.h2.web.H2TestServlet;
 
 @RunWith(FATRunner.class)
 @MinimumJavaLevel(javaLevel = 17)
+@AllowedFFDC("java.lang.IllegalArgumentException")
 public class H2Test extends FATServletClient {
 
     @Server("com.ibm.ws.jdbc.fat.h2")
@@ -49,6 +51,51 @@ public class H2Test extends FATServletClient {
                                                       "test.jdbc.h2.web");
         ShrinkHelper.exportAppToServer(server, war);
         server.startServer();
+    }
+
+    /**
+     * Test that a datasource with password attribute (not in URL) works correctly.
+     */
+    @Test
+    public void testValidPasswordAttribute() throws Exception {
+        runTest(server, "H2TestApp/H2TestServlet", "testValidPasswordAttribute");
+    }
+
+    /**
+     * Test that a datasource with containerAuthData (not in URL) works correctly.
+     */
+    @Test
+    public void testValidContainerAuthData() throws Exception {
+        runTest(server, "H2TestApp/H2TestServlet", "testValidContainerAuthData");
+    }
+
+    /**
+     * Test that a datasource with PASSWORD in URL (uppercase) is rejected.
+     * Validates that DSRA8070E error message appears in the logs.
+     */
+    @Test
+    public void testPasswordinURL() throws Exception {
+        runTest(server, "H2TestApp/H2TestServlet", "testPasswordinURL");
+        
+        // Verify the expected error message appears in the logs
+        List<String> dsra8070e = server.findStringsInLogsAndTrace("DSRA8070E.*h2ds-invalid-password[^-].*PASSWORD");
+        assertTrue("Expected DSRA8070E error for PASSWORD in URL to appear in logs",
+                   !dsra8070e.isEmpty());
+    }
+
+    /**
+     * Test that a datasource with password in URL (any case) is rejected,
+     * even when mixed with other parameters.
+     * Validates that DSRA8070E error message appears in the logs.
+     */
+    @Test
+    public void testPasswordInURLMixedLowerCase() throws Exception {
+        runTest(server, "H2TestApp/H2TestServlet", "testPasswordInURLMixedLowerCase");
+        
+        // Verify the expected error message appears in the logs
+        List<String> dsra8070e = server.findStringsInLogsAndTrace("DSRA8070E.*h2ds-invalid-password-mixed.*PASSWORD");
+        assertTrue("Expected DSRA8070E error for password in URL to appear in logs",
+                   !dsra8070e.isEmpty());
     }
 
     @AfterClass
@@ -87,7 +134,8 @@ public class H2Test extends FATServletClient {
         assertEquals("All Content: lines should be filtered in trace.log",
                      0, unfilteredContent.size());
 
-        server.stopServer();
+        // Stop server and expect errors from URL validation tests
+        server.stopServer("DSRA8070E", "CWWKE0701E");
     }
 
 }

--- a/dev/com.ibm.ws.jdbc_fat_h2/fat/src/test/jakarta/data/validation/H2Test.java
+++ b/dev/com.ibm.ws.jdbc_fat_h2/fat/src/test/jakarta/data/validation/H2Test.java
@@ -38,7 +38,6 @@ import test.jdbc.h2.web.H2TestServlet;
 
 @RunWith(FATRunner.class)
 @MinimumJavaLevel(javaLevel = 17)
-@AllowedFFDC("java.lang.IllegalArgumentException")
 public class H2Test extends FATServletClient {
 
     @Server("com.ibm.ws.jdbc.fat.h2")
@@ -74,8 +73,9 @@ public class H2Test extends FATServletClient {
      * Validates that DSRA8070E error message appears in the logs.
      */
     @Test
-    public void testPasswordinURL() throws Exception {
-        runTest(server, "H2TestApp/H2TestServlet", "testPasswordinURL");
+    @AllowedFFDC("java.lang.IllegalArgumentException")
+    public void testPasswordInURL() throws Exception {
+        runTest(server, "H2TestApp/H2TestServlet", "testPasswordInURL");
         
         // Verify the expected error message appears in the logs
         List<String> dsra8070e = server.findStringsInLogsAndTrace("DSRA8070E.*h2ds-invalid-password[^-].*PASSWORD");
@@ -89,6 +89,7 @@ public class H2Test extends FATServletClient {
      * Validates that DSRA8070E error message appears in the logs.
      */
     @Test
+    @AllowedFFDC("java.lang.IllegalArgumentException")
     public void testPasswordInURLMixedLowerCase() throws Exception {
         runTest(server, "H2TestApp/H2TestServlet", "testPasswordInURLMixedLowerCase");
         
@@ -100,42 +101,43 @@ public class H2Test extends FATServletClient {
 
     @AfterClass
     public static void tearDown() throws Exception {
-        
-        /**
-         * Test that passwords are not leaked in H2 logwriter output.
-         * The H2 logwriter is enabled via bootstrap.properties with:
-         * com.ibm.ws.h2.logwriter=all
-         *
-         * This test verifies that the password "dbpwd1" used in the
-         * DataSourceDefinition is not leaked in the trace logs.
-         */
+        try {
+            /**
+             * Test that passwords are not leaked in H2 logwriter output.
+             * The H2 logwriter is enabled via bootstrap.properties with:
+             * com.ibm.ws.h2.logwriter=all
+             *
+             * This test verifies that the password "dbpwd1" used in the
+             * DataSourceDefinition is not leaked in the trace logs.
+             */
 
-        // Explicitly verify that the password "dbpwd1" is not in trace.log
-        List<String> passwordsInTrace = server.findStringsInLogsAndTrace("dbpwd1");
-        assertEquals("Password 'dbpwd1' should not appear in trace.log",
-                     0, passwordsInTrace.size());
+            // Explicitly verify that the password "dbpwd1" is not in trace.log
+            List<String> passwordsInTrace = server.findStringsInLogsAndTrace("dbpwd1");
+            assertEquals("Password 'dbpwd1' should not appear in trace.log",
+                         0, passwordsInTrace.size());
 
-        // Verify that H2 logwriter output exists (shows trace is enabled)
-        List<String> h2LogWriterOutput = server.findStringsInLogsAndTrace("com\\.ibm\\.ws\\.h2\\.logwriter");
-        assertTrue("H2 logwriter output should be present in trace.log",
-                   !h2LogWriterOutput.isEmpty());
+            // Verify that H2 logwriter output exists (shows trace is enabled)
+            List<String> h2LogWriterOutput = server.findStringsInLogsAndTrace("com\\.ibm\\.ws\\.h2\\.logwriter");
+            assertTrue("H2 logwriter output should be present in trace.log",
+                       !h2LogWriterOutput.isEmpty());
 
-        // Verify exact Type:/Content: password filtering behavior
-        List<String> passwordTypeLines = server.findStringsInLogsAndTrace("Type: password");
-        assertTrue("Type: password should be present in trace.log",
-                   !passwordTypeLines.isEmpty());
+            // Verify exact Type:/Content: password filtering behavior
+            List<String> passwordTypeLines = server.findStringsInLogsAndTrace("Type: password");
+            assertTrue("Type: password should be present in trace.log",
+                       !passwordTypeLines.isEmpty());
 
-        List<String> filteredContent = server.findStringsInLogsAndTrace("Content: \\*\\*\\*\\*\\*\\*");
-        assertTrue("Filtered content markers (Content: ******) should be present in trace.log",
-                   !filteredContent.isEmpty());
+            List<String> filteredContent = server.findStringsInLogsAndTrace("Content: \\*\\*\\*\\*\\*\\*");
+            assertTrue("Filtered content markers (Content: ******) should be present in trace.log",
+                       !filteredContent.isEmpty());
 
-        // Verify that all Content: lines are filtered (no unfiltered content should appear)
-        List<String> unfilteredContent = server.findStringsInLogsAndTrace("Content: (?!\\*\\*\\*\\*\\*\\*).*");
-        assertEquals("All Content: lines should be filtered in trace.log",
-                     0, unfilteredContent.size());
-
-        // Stop server and expect errors from URL validation tests
-        server.stopServer("DSRA8070E", "CWWKE0701E");
+            // Verify that all Content: lines are filtered (no unfiltered content should appear)
+            List<String> unfilteredContent = server.findStringsInLogsAndTrace("Content: (?!\\*\\*\\*\\*\\*\\*).*");
+            assertEquals("All Content: lines should be filtered in trace.log",
+                         0, unfilteredContent.size());
+        } finally {
+            // Stop server and expect errors from URL validation tests
+            server.stopServer("DSRA8070E", "CWWKE0701E");
+        }
     }
 
 }

--- a/dev/com.ibm.ws.jdbc_fat_h2/publish/servers/com.ibm.ws.jdbc.fat.h2/server.xml
+++ b/dev/com.ibm.ws.jdbc_fat_h2/publish/servers/com.ibm.ws.jdbc.fat.h2/server.xml
@@ -29,26 +29,26 @@
     <file name="${shared.resource.dir}/h2/h2.jar"/>
   </library>
 
-  <!-- Test Scenario 1: Valid - password attribute -->
+  <!-- Valid - password attribute -->
   <dataSource id="h2ds-valid-password" jndiName="jdbc/h2ds-valid-password">
     <jdbcDriver libraryRef="H2Lib"/>
     <properties.h2 URL="jdbc:h2:mem:testdb1" password="secret123"/>
   </dataSource>
 
-  <!-- Test Scenario 2: Valid - containerAuthData -->
+  <!-- Valid - containerAuthData -->
   <authData id="h2AuthData" user="dbuser" password="secret456"/>
   <dataSource id="h2ds-valid-authdata" jndiName="jdbc/h2ds-valid-authdata" containerAuthDataRef="h2AuthData">
     <jdbcDriver libraryRef="H2Lib"/>
     <properties.h2 URL="jdbc:h2:mem:testdb2"/>
   </dataSource>
 
-  <!-- Test Scenario 3: Invalid - PASSWORD in URL (uppercase) -->
+  <!-- Invalid - PASSWORD in URL (uppercase) -->
   <dataSource id="h2ds-invalid-password" jndiName="jdbc/h2ds-invalid-password">
     <jdbcDriver libraryRef="H2Lib"/>
     <properties.h2 URL="jdbc:h2:mem:testdb3;PASSWORD=secret789"/>
   </dataSource>
 
-  <!-- Test Scenario 4: Invalid - password in URL (any case, with or without other parameters) -->
+  <!-- Invalid - password in URL (any case, with or without other parameters) -->
   <dataSource id="h2ds-invalid-password-mixed" jndiName="jdbc/h2ds-invalid-password-mixed">
     <jdbcDriver libraryRef="H2Lib"/>
     <properties.h2 URL="jdbc:h2:mem:testdb4;DB_CLOSE_DELAY=-1;password=secret012;MODE=MySQL"/>

--- a/dev/com.ibm.ws.jdbc_fat_h2/publish/servers/com.ibm.ws.jdbc.fat.h2/server.xml
+++ b/dev/com.ibm.ws.jdbc_fat_h2/publish/servers/com.ibm.ws.jdbc.fat.h2/server.xml
@@ -16,6 +16,7 @@
     <feature>componenttest-2.0</feature>
     <feature>jdbc-4.3</feature>
     <feature>servlet-6.1</feature>
+    <feature>jndi-1.0</feature>
   </featureManager>
 
   <include location="../fatTestPorts.xml"/>
@@ -27,6 +28,31 @@
   <library id="H2Lib">
     <file name="${shared.resource.dir}/h2/h2.jar"/>
   </library>
+
+  <!-- Test Scenario 1: Valid - password attribute -->
+  <dataSource id="h2ds-valid-password" jndiName="jdbc/h2ds-valid-password">
+    <jdbcDriver libraryRef="H2Lib"/>
+    <properties.h2 URL="jdbc:h2:mem:testdb1" password="secret123"/>
+  </dataSource>
+
+  <!-- Test Scenario 2: Valid - containerAuthData -->
+  <authData id="h2AuthData" user="dbuser" password="secret456"/>
+  <dataSource id="h2ds-valid-authdata" jndiName="jdbc/h2ds-valid-authdata" containerAuthDataRef="h2AuthData">
+    <jdbcDriver libraryRef="H2Lib"/>
+    <properties.h2 URL="jdbc:h2:mem:testdb2"/>
+  </dataSource>
+
+  <!-- Test Scenario 3: Invalid - PASSWORD in URL (uppercase) -->
+  <dataSource id="h2ds-invalid-password" jndiName="jdbc/h2ds-invalid-password">
+    <jdbcDriver libraryRef="H2Lib"/>
+    <properties.h2 URL="jdbc:h2:mem:testdb3;PASSWORD=secret789"/>
+  </dataSource>
+
+  <!-- Test Scenario 4: Invalid - password in URL (any case, with or without other parameters) -->
+  <dataSource id="h2ds-invalid-password-mixed" jndiName="jdbc/h2ds-invalid-password-mixed">
+    <jdbcDriver libraryRef="H2Lib"/>
+    <properties.h2 URL="jdbc:h2:mem:testdb4;DB_CLOSE_DELAY=-1;password=secret012;MODE=MySQL"/>
+  </dataSource>
 
   <javaPermission codeBase="${shared.resource.dir}/h2/h2.jar"
                   className="java.security.AllPermission"/>

--- a/dev/com.ibm.ws.jdbc_fat_h2/test-applications/H2TestApp/src/test/jdbc/h2/web/H2TestServlet.java
+++ b/dev/com.ibm.ws.jdbc_fat_h2/test-applications/H2TestApp/src/test/jdbc/h2/web/H2TestServlet.java
@@ -39,6 +39,7 @@ import jakarta.servlet.annotation.WebServlet;
 import jakarta.transaction.UserTransaction;
 
 import javax.naming.InitialContext;
+import javax.naming.NamingException;
 import javax.naming.Referenceable;
 import javax.sql.ConnectionPoolDataSource;
 import javax.sql.DataSource;
@@ -481,8 +482,10 @@ public class H2TestServlet extends FATServlet {
         try {
             DataSource ds = (DataSource) new InitialContext().lookup("jdbc/h2ds-invalid-password");
             fail("Expected exception for PASSWORD in URL, but datasource was created: " + ds);
-        } catch (Exception e) {
-            // Pass. The DSRA8070E error message will be in the server logs (checked by FAT test)
+        } catch (NamingException e) {
+            String msg = e.getMessage();
+            assertTrue("Expected CWWKN0008E in exception message but got: " + msg, msg.contains("CWWKN0008E"));
+            assertTrue("Expected datasource name 'jdbc/h2ds-invalid-password' in exception message but got: " + msg, msg.contains("jdbc/h2ds-invalid-password"));
         }
     }
 
@@ -495,8 +498,10 @@ public class H2TestServlet extends FATServlet {
         try {
             DataSource ds = (DataSource) new InitialContext().lookup("jdbc/h2ds-invalid-password-mixed");
             fail("Expected exception for password in URL, but datasource was created: " + ds);
-        } catch (Exception e) {
-			//pass
+        } catch (NamingException e) {
+            String msg = e.getMessage();
+            assertTrue("Expected CWWKN0008E in exception message but got: " + msg, msg.contains("CWWKN0008E"));
+            assertTrue("Expected datasource name 'jdbc/h2ds-invalid-password-mixed' in exception message but got: " + msg, msg.contains("jdbc/h2ds-invalid-password-mixed"));
         }
     }
 }

--- a/dev/com.ibm.ws.jdbc_fat_h2/test-applications/H2TestApp/src/test/jdbc/h2/web/H2TestServlet.java
+++ b/dev/com.ibm.ws.jdbc_fat_h2/test-applications/H2TestApp/src/test/jdbc/h2/web/H2TestServlet.java
@@ -18,6 +18,8 @@ import static java.sql.Connection.TRANSACTION_READ_UNCOMMITTED;
 import static java.sql.Connection.TRANSACTION_REPEATABLE_READ;
 import static java.sql.Connection.TRANSACTION_SERIALIZABLE;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.sql.Connection;
@@ -36,6 +38,7 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.annotation.WebServlet;
 import jakarta.transaction.UserTransaction;
 
+import javax.naming.InitialContext;
 import javax.naming.Referenceable;
 import javax.sql.ConnectionPoolDataSource;
 import javax.sql.DataSource;
@@ -451,6 +454,49 @@ public class H2TestServlet extends FATServlet {
             pstmt.setString(1, "Sodium chloride");
             pstmt.setString(2, "Salt");
             assertEquals(1, pstmt.executeUpdate());
+        }
+    }
+
+    /**
+     * Test that a datasource with password attribute (not in URL) works correctly.
+     */
+    public void testValidPasswordAttribute() throws Exception {
+        DataSource ds = (DataSource) new InitialContext().lookup("jdbc/h2ds-valid-password");
+        assertNotNull("DataSource should be successfully created", ds);
+    }
+
+    /**
+     * Test that a datasource with containerAuthData (not in URL) works correctly.
+     */
+    public void testValidContainerAuthData() throws Exception {
+        DataSource ds = (DataSource) new InitialContext().lookup("jdbc/h2ds-valid-authdata");
+        assertNotNull("DataSource should be successfully created", ds);
+    }
+
+    /**
+     * Test that a datasource with PASSWORD in URL (uppercase) is rejected.
+     * The JNDI lookup should fail. The DSRA8070E error will be in the server logs.
+     */
+    public void testPasswordinURL() throws Exception {
+        try {
+            DataSource ds = (DataSource) new InitialContext().lookup("jdbc/h2ds-invalid-password");
+            fail("Expected exception for PASSWORD in URL, but datasource was created: " + ds);
+        } catch (Exception e) {
+            // Pass. The DSRA8070E error message will be in the server logs (checked by FAT test)
+        }
+    }
+
+    /**
+     * Test that a datasource with password in URL (any case) is rejected,
+     * even when mixed with other parameters.
+     * The JNDI lookup should fail. The DSRA8070E error will be in the server logs.
+     */
+    public void testPasswordInURLMixedLowerCase() throws Exception {
+        try {
+            DataSource ds = (DataSource) new InitialContext().lookup("jdbc/h2ds-invalid-password-mixed");
+            fail("Expected exception for password in URL, but datasource was created: " + ds);
+        } catch (Exception e) {
+			//pass
         }
     }
 }

--- a/dev/com.ibm.ws.jdbc_fat_h2/test-applications/H2TestApp/src/test/jdbc/h2/web/H2TestServlet.java
+++ b/dev/com.ibm.ws.jdbc_fat_h2/test-applications/H2TestApp/src/test/jdbc/h2/web/H2TestServlet.java
@@ -478,7 +478,7 @@ public class H2TestServlet extends FATServlet {
      * Test that a datasource with PASSWORD in URL (uppercase) is rejected.
      * The JNDI lookup should fail. The DSRA8070E error will be in the server logs.
      */
-    public void testPasswordinURL() throws Exception {
+    public void testPasswordInURL() throws Exception {
         try {
             DataSource ds = (DataSource) new InitialContext().lookup("jdbc/h2ds-invalid-password");
             fail("Expected exception for PASSWORD in URL, but datasource was created: " + ds);


### PR DESCRIPTION
Rejects URLs in the properties.h2 element which contain a password. H2 logging logs the URL in quite a few places making it difficult to hide in all locations, so this will prevent users from using a password on the URL and direct them to using the password property or conatinerAuthData.

fixes #34827


- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
