### PR TITLE
NativeQuery methods with named parameters

### DIFF
--- a/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/CursoredPageImpl.java
+++ b/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/CursoredPageImpl.java
@@ -176,9 +176,9 @@ public class CursoredPageImpl<T> extends PageImpl<T> implements CursoredPage<T> 
         if (queryInfo.sorts.size() != cursorSize)
             cursorSizeMismatchError(cursor);
 
-        Object[] paramNames = queryInfo.jpqlParamNames.isEmpty() //
+        Object[] paramNames = queryInfo.qlParamNames.isEmpty() //
                         ? null //
-                        : queryInfo.jpqlParamNames.toArray();
+                        : queryInfo.qlParamNames.toArray();
 
         int paramNum = queryInfo.qlParamCount + 1;
         for (int c = 0; c < cursorSize; c++, paramNum++) {

--- a/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/Fail.java
+++ b/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/Fail.java
@@ -601,7 +601,7 @@ public class Fail {
                                                            int methodNPCount) {
         String firstNamedParam = null;
         StringBuilder allNamedParams = new StringBuilder().append('(');
-        for (String name : info.jpqlParamNames) {
+        for (String name : info.qlParamNames) {
             if (firstNamedParam == null)
                 firstNamedParam = name;
             else

--- a/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/QueryInfo.java
+++ b/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/QueryInfo.java
@@ -47,6 +47,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -115,6 +116,13 @@ public abstract class QueryInfo {
                     Collections.emptyMap();
 
     /**
+     * Constant for qlParamNames that indicates we have determined that the
+     * a native query has no named parameters.
+     */
+    private static final Set<String> NO_NAMED_PARAMS = //
+                    Collections.unmodifiableSet(new HashSet<>(0));
+
+    /**
      * Indicates the repository method has no Sort, Sort[], or Order parameters
      * for dynamic sort criteria and also does not define any static sort criteria.
      */
@@ -151,6 +159,12 @@ public abstract class QueryInfo {
      * The implicit entity identifier variable defined by Jakarta Persistence.
      */
     private static final String THIS = "this";
+
+    /**
+     * Constant for qlParamNames that indicates it has not yet been determined
+     * whether a query has named parameters.
+     */
+    private static final Set<String> UNKNOWN = Collections.emptySet();
 
     /**
      * Information about the type of entity to which the query pertains.
@@ -221,9 +235,10 @@ public abstract class QueryInfo {
      * generated restrictions, such as those added for cursor pagination.
      * The empty set value is used when the field has not been initialized yet
      * or the query has no parameters or has positional parameters (?1, ?2, ...)
-     * rather than named parameters.
+     * rather than named parameters. The constant UNKNOWN represents the former
+     * and NO_NAMED_PARAMS represents the latter two cases.
      */
-    Set<String> jpqlParamNames = Collections.emptySet();
+    volatile Set<String> jpqlParamNames = Collections.emptySet();
 
     /**
      * Value from the First annotation, or findFirst#By, or 1 for findFirstBy,
@@ -486,6 +501,37 @@ public abstract class QueryInfo {
                                                       int prevNumJPQLParams,
                                                       boolean isCollection,
                                                       Annotation[] annos);
+
+    /**
+     * Asks the Jakarta Persistence provider whether the given query uses named
+     * parameters. The API for this is optional, but supported by Hibernate.
+     * If the API is not supported, assume named parameters are not permitted.
+     *
+     * @param query the query
+     * @return named parameter names if any; otherwise null
+     */
+    @FFDCIgnore(IllegalStateException.class) // not supported by provider
+    private Set<String> checkForNamedParameters(jakarta.persistence.Query query) {
+        Set<String> paramNames = null;
+        try {
+            Set<jakarta.persistence.Parameter<?>> p = query.getParameters();
+            if (!p.isEmpty() && p.iterator().next().getPosition() == null) {
+                Parameter[] params = method.getParameters();
+                if (params[0].isNamePresent()) {
+                    paramNames = new LinkedHashSet<>();
+                    for (int i = 0; i < specialParamsStartAt; i++)
+                        paramNames.add(params[i].getName());
+                }
+            }
+        } catch (IllegalStateException x) {
+            // not supported by Persistence provider for native queries
+            if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
+                Tr.debug(this, tc, "not supported by provider", x.getMessage());
+        }
+
+        jpqlParamNames = paramNames == null ? NO_NAMED_PARAMS : paramNames;
+        return paramNames;
+    }
 
     /**
      * Compute the zero-based offset to use as a starting point for a Limit range.
@@ -3644,8 +3690,29 @@ public abstract class QueryInfo {
                           repositoryInterface.getName(),
                           params[specialParamsStartAt].getName(),
                           Util.names(specialParamTypes));
+            } else { // positional or named parameter
+                Param param = params[i].getAnnotation(Param.class);
+                String paramName = null;
+                if (param == null) {
+                    if (!jpqlParamNames.isEmpty() && params[i].isNamePresent())
+                        // name of parameter (if using -parameters)
+                        paramName = params[i].getName();
+                    // else positional parameter
+                } else {
+                    // @Param annotation
+                    paramName = param.value();
+                }
+                if (paramName != null) {
+                    if (jpqlParamNames.isEmpty())
+                        jpqlParamNames = new LinkedHashSet<>();
+                    if (!jpqlParamNames.add(paramName))
+                        Fail.namedParamConflict(this, paramName, params[i]);
+                }
             }
         }
+        int namedParamCount = jpqlParamNames.size();
+        if (namedParamCount > 0 && namedParamCount < specialParamsStartAt)
+            throw Fail.mixedQLParamTypes(this, namedParamCount);
 
         qlParamCount = specialParamsStartAt;
 
@@ -5705,6 +5772,10 @@ public abstract class QueryInfo {
                        Map<Object, Object> addedJPQLParams) {
         final boolean trace = TraceComponent.isAnyTracingEnabled();
         final int numArgs = args == null ? 0 : args.length;
+
+        // delayed discovery of named parameters for native query
+        if (type == NATIVE && specialParamsStartAt > 0 && jpqlParamNames == UNKNOWN)
+            checkForNamedParameters(query);
 
         if (trace && tc.isDebugEnabled()) {
             Object addedLoggable = loggable(addedJPQLParams);

--- a/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/QueryInfo.java
+++ b/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/QueryInfo.java
@@ -226,21 +226,6 @@ public abstract class QueryInfo {
     String jpqlDelete;
 
     /**
-     * Names of named parameters in query language, ordered according to the
-     * position in which each appears as a repository method parameter.
-     * Repository method parameters identify the name with the
-     * <code>Param</code> annotation if present, or otherwise by the
-     * name of the parameter (if the -parameters compiler option is enabled).
-     * This set also includes names of named parameters that are used in
-     * generated restrictions, such as those added for cursor pagination.
-     * The empty set value is used when the field has not been initialized yet
-     * or the query has no parameters or has positional parameters (?1, ?2, ...)
-     * rather than named parameters. The constant UNKNOWN represents the former
-     * and NO_NAMED_PARAMS represents the latter two cases.
-     */
-    volatile Set<String> jpqlParamNames = Collections.emptySet();
-
-    /**
      * Value from the First annotation, or findFirst#By, or 1 for findFirstBy,
      * otherwise 0.
      */
@@ -284,6 +269,21 @@ public abstract class QueryInfo {
      * found and/or generated.
      */
     int qlParamCount;
+
+    /**
+     * Names of named parameters in query language, ordered according to the
+     * position in which each appears as a repository method parameter.
+     * Repository method parameters indicate a named parameter name with the
+     * <code>Param</code> annotation if present, or otherwise by the name of
+     * the method parameter (if the -parameters compiler option is enabled).
+     * This set also includes names of named parameters that are used in
+     * generated restrictions, such as those added for cursor pagination.
+     * The empty set value is used when the field has not been initialized yet
+     * or the query has no parameters or has positional parameters (?1, ?2, ...)
+     * rather than named parameters. The constant UNKNOWN represents the former
+     * and the constant NO_NAMED_PARAMS represents the latter two cases.
+     */
+    volatile Set<String> qlParamNames = Collections.emptySet();
 
     /**
      * The interface that is annotated with @Repository.
@@ -529,7 +529,7 @@ public abstract class QueryInfo {
                 Tr.debug(this, tc, "not supported by provider", x.getMessage());
         }
 
-        jpqlParamNames = paramNames == null ? NO_NAMED_PARAMS : paramNames;
+        qlParamNames = paramNames == null ? NO_NAMED_PARAMS : paramNames;
         return paramNames;
     }
 
@@ -926,9 +926,9 @@ public abstract class QueryInfo {
             info.jpqlCount = jpqlCount;
             info.jpqlDelete = jpqlDelete;
             info.qlParamCount = qlParamCount;
-            info.jpqlParamNames = jpqlParamNames.isEmpty() //
-                            ? jpqlParamNames //
-                            : new LinkedHashSet<>(jpqlParamNames);
+            info.qlParamNames = qlParamNames.isEmpty() //
+                            ? qlParamNames //
+                            : new LinkedHashSet<>(qlParamNames);
             info.restrictAt = restrictAt;
             info.specialParamsStartAt = specialParamsStartAt;
 
@@ -950,7 +950,7 @@ public abstract class QueryInfo {
                 info.qlParamCount = generateRestrictions(q,
                                                          restriction,
                                                          info.qlParamCount,
-                                                         info.jpqlParamNames,
+                                                         info.qlParamNames,
                                                          jpqlParams);
 
                 if (info.restrictAt >= 0 && info.restrictAt < len) {
@@ -974,7 +974,7 @@ public abstract class QueryInfo {
                 info.qlParamCount = generateRestrictions(q,
                                                          restriction,
                                                          info.qlParamCount,
-                                                         info.jpqlParamNames,
+                                                         info.qlParamNames,
                                                          jpqlParams);
             }
 
@@ -2258,7 +2258,7 @@ public abstract class QueryInfo {
                                        StringBuilder fwd,
                                        StringBuilder prev) {
         int numSorts = sorts.size();
-        boolean positionalParams = jpqlParamNames.isEmpty();
+        boolean positionalParams = qlParamNames.isEmpty();
         String[] paramNames = positionalParams ? null : new String[numSorts];
         StringBuilder a = fwd == null //
                         ? null //
@@ -2413,13 +2413,13 @@ public abstract class QueryInfo {
 
     /**
      * Generates the name of a named parameter with the given prefix and number
-     * which is not already in use (as represented by jpqlParamNames). This method
+     * which is not already in use (as represented by qlParamNames). This method
      * ensures a unique name by appending the _ character after the number until
      * the name is found to be unique. For example, a prefix of {@code cursor}
      * and number of {@code 2} might result in generated parameter name
      * {@code :cursor2} or {@code :cursor2_} or {@code :cursor2__} or so forth
      * depending on whether the prior names are already used in the query.
-     * This method updates the jpqlParamNames field to include the generated name,
+     * This method updates the qlParamNames field to include the generated name,
      * but does not add to the qlParamCount.
      *
      * @param prefix text to include at the beginning of the generated name.
@@ -2429,7 +2429,7 @@ public abstract class QueryInfo {
     @Trivial
     private String generateNamedParameterName(String prefix, int num) {
         String paramName = prefix + num;
-        while (!jpqlParamNames.add(paramName))
+        while (!qlParamNames.add(paramName))
             paramName += '_';
         return paramName;
     }
@@ -2571,7 +2571,7 @@ public abstract class QueryInfo {
                 numJPQLParams = generateConstraint(constraintJPQL[p],
                                                    constraint,
                                                    numJPQLParams,
-                                                   jpqlParamNames,
+                                                   qlParamNames,
                                                    jpqlParams);
             }
 
@@ -3694,7 +3694,7 @@ public abstract class QueryInfo {
                 Param param = params[i].getAnnotation(Param.class);
                 String paramName = null;
                 if (param == null) {
-                    if (!jpqlParamNames.isEmpty() && params[i].isNamePresent())
+                    if (!qlParamNames.isEmpty() && params[i].isNamePresent())
                         // name of parameter (if using -parameters)
                         paramName = params[i].getName();
                     // else positional parameter
@@ -3703,14 +3703,14 @@ public abstract class QueryInfo {
                     paramName = param.value();
                 }
                 if (paramName != null) {
-                    if (jpqlParamNames.isEmpty())
-                        jpqlParamNames = new LinkedHashSet<>();
-                    if (!jpqlParamNames.add(paramName))
+                    if (qlParamNames.isEmpty())
+                        qlParamNames = new LinkedHashSet<>();
+                    if (!qlParamNames.add(paramName))
                         Fail.namedParamConflict(this, paramName, params[i]);
                 }
             }
         }
-        int namedParamCount = jpqlParamNames.size();
+        int namedParamCount = qlParamNames.size();
         if (namedParamCount > 0 && namedParamCount < specialParamsStartAt)
             throw Fail.mixedQLParamTypes(this, namedParamCount);
 
@@ -3760,7 +3760,7 @@ public abstract class QueryInfo {
         qlParamCount = specialParamsStartAt;
 
         // for collecting names of named parameters:
-        LinkedHashSet<String> qlParamNames = new LinkedHashSet<>();
+        LinkedHashSet<String> jpqlParamNames = new LinkedHashSet<>();
 
         // indices at which the query needs to be modified, along with the
         // type of modification needed
@@ -3787,7 +3787,7 @@ public abstract class QueryInfo {
                                   false,
                                   addsToWHERE,
                                   entityInfos,
-                                  qlParamNames);
+                                  jpqlParamNames);
         } else if ((firstChar == 'U' || firstChar == 'u') &&
                    startAt + 13 < length &&
                    jpql.regionMatches(true, startAt + 1, "PDATE", 0, 5) &&
@@ -3815,7 +3815,7 @@ public abstract class QueryInfo {
                                   false,
                                   addsToWHERE,
                                   entityInfos,
-                                  qlParamNames);
+                                  jpqlParamNames);
 
             if (entityInfo == null || entityInfo.recordClass != null)
                 modifyAt.put(entityNameStartAt, QueryEdit.REPLACE_RECORD_ENTITY);
@@ -3839,7 +3839,7 @@ public abstract class QueryInfo {
                                   select0 >= 0,
                                   addsToWHERE,
                                   entityInfos,
-                                  qlParamNames);
+                                  jpqlParamNames);
         }
 
         if (entityInfo == null)
@@ -3851,7 +3851,7 @@ public abstract class QueryInfo {
             ql = replaceQuery(jpql, modifyAt);
 
         // Validation of method parameters vs parameters in the query
-        int qlParamNameCount = qlParamNames.size();
+        int qlParamNameCount = jpqlParamNames.size();
         boolean hasExtraParam = false;
         for (int i = 0; i < specialParamsStartAt; i++) {
             Param param = params[i].getAnnotation(Param.class);
@@ -3864,10 +3864,10 @@ public abstract class QueryInfo {
                 paramName = params[i].getName();
             }
             if (paramName != null) {
-                if (jpqlParamNames.isEmpty())
-                    jpqlParamNames = new LinkedHashSet<>();
-                boolean isDuplicate = !jpqlParamNames.add(paramName);
-                if (qlParamNames.contains(paramName)) {
+                if (qlParamNames.isEmpty())
+                    qlParamNames = new LinkedHashSet<>();
+                boolean isDuplicate = !qlParamNames.add(paramName);
+                if (jpqlParamNames.contains(paramName)) {
                     if (isDuplicate) // duplicate of a valid name
                         throw Fail.namedParamConflict(this, paramName, params[i]);
                 } else {
@@ -3881,19 +3881,19 @@ public abstract class QueryInfo {
             if (SORT_PARAM_TYPES.contains(params[i].getType()))
                 initDynamicSortPosition(i);
 
-        int paramNamesCount = jpqlParamNames.size();
+        int paramNamesCount = qlParamNames.size();
         if (hasExtraParam || qlParamNameCount != paramNamesCount) {
             // Does the method supply all named parameters that the query needs?
-            LinkedHashSet<String> lacking = new LinkedHashSet<>(qlParamNames);
-            lacking.removeAll(jpqlParamNames);
+            LinkedHashSet<String> lacking = new LinkedHashSet<>(jpqlParamNames);
+            lacking.removeAll(qlParamNames);
             if (!lacking.isEmpty())
                 throw Fail.methodLacksNamedParams(this, lacking);
 
             // Does the method supply any named parameters not needed by the query?
-            Set<String> extras = new LinkedHashSet<>(jpqlParamNames);
-            extras.removeAll(qlParamNames);
+            Set<String> extras = new LinkedHashSet<>(qlParamNames);
+            extras.removeAll(jpqlParamNames);
             if (!extras.isEmpty())
-                throw Fail.unusedNamedParamsOnMethod(this, extras, qlParamNames);
+                throw Fail.unusedNamedParamsOnMethod(this, extras, jpqlParamNames);
         }
 
         // Does the method supply a mixture of named and positional parameters?
@@ -4315,7 +4315,7 @@ public abstract class QueryInfo {
         Util.printlnIndented(jpqlDelete, writer, qlIndent);
 
         writer.println(indent + QL + " parameter count: " + qlParamCount);
-        writer.println(indent + "JPQL parameter names: " + jpqlParamNames);
+        writer.println(indent + QL + " parameter names: " + qlParamNames);
 
         writer.println(indent + "maximum results: " + maxResults);
         writer.println(indent + "restrictions can be added at: " + restrictAt);
@@ -4883,7 +4883,7 @@ public abstract class QueryInfo {
      *                               parentheses so that conditions can be added
      *                               to it (for cursor pagination or Restriction).
      * @param entityInfos        map of entity name to entity information.
-     * @param qlParamNames       list to populate with the names of named parameters.
+     * @param jpqlParamNames     list to populate with the names of named parameters.
      * @return indices at which the query needs to be modified, along with the type
      *         of modification needed
      */
@@ -4893,7 +4893,7 @@ public abstract class QueryInfo {
                                boolean startsWithSelect,
                                boolean encloseWhereClause,
                                Map<String, CompletableFuture<EntityInfo>> entityInfos,
-                               LinkedHashSet<String> qlParamNames) {
+                               LinkedHashSet<String> jpqlParamNames) {
         TreeMap<Integer, QueryEdit> modifyAt = new TreeMap<>();
 
         int length = ql.length();
@@ -4946,7 +4946,7 @@ public abstract class QueryInfo {
                 } else {
                     isLiteral = true;
                     if (paramName != null) {
-                        qlParamNames.add(paramName.toString());
+                        jpqlParamNames.add(paramName.toString());
                         paramName = null;
                     }
                 }
@@ -5103,7 +5103,7 @@ public abstract class QueryInfo {
                 if (depth == 0 && !isLiteral && ch == ',' && numPossibleConstructorArgs > 0)
                     numPossibleConstructorArgs++;
                 if (paramName != null) {
-                    qlParamNames.add(paramName.toString());
+                    jpqlParamNames.add(paramName.toString());
                     paramName = null;
                 }
             }
@@ -5115,7 +5115,7 @@ public abstract class QueryInfo {
         }
 
         if (paramName != null)
-            qlParamNames.add(paramName.toString());
+            jpqlParamNames.add(paramName.toString());
 
         if (countPages && countReplacesFirstSelectAt >= 0) {
             modifyAt.put(countReplacesFirstSelectAt,
@@ -5774,7 +5774,7 @@ public abstract class QueryInfo {
         final int numArgs = args == null ? 0 : args.length;
 
         // delayed discovery of named parameters for native query
-        if (type == NATIVE && specialParamsStartAt > 0 && jpqlParamNames == UNKNOWN)
+        if (type == NATIVE && specialParamsStartAt > 0 && qlParamNames == UNKNOWN)
             checkForNamedParameters(query);
 
         if (trace && tc.isDebugEnabled()) {
@@ -5782,13 +5782,13 @@ public abstract class QueryInfo {
             Tr.debug(this, tc, "setParameters",
                      numArgs + " method args",
                      "first special param at 0-based index " + specialParamsStartAt,
-                     jpqlParamNames,
+                     qlParamNames,
                      addedLoggable == addedJPQLParams //
                                      ? addedLoggable //
                                      : addedJPQLParams.keySet());
         }
 
-        if (jpqlParamNames.isEmpty()) { // positional parameters
+        if (qlParamNames.isEmpty()) { // positional parameters
             int paramNum = 1;
             for (int a = 0; a < specialParamsStartAt; a++) {
                 Object value;
@@ -5829,7 +5829,7 @@ public abstract class QueryInfo {
             // Named parameters are only available when the repository uses a
             // query annotation to supply the query directly in query language.
             // In this case, Constraint typed parameters will not be allowed.
-            Iterator<String> paramNames = jpqlParamNames.iterator();
+            Iterator<String> paramNames = qlParamNames.iterator();
             for (int a = 0; a < specialParamsStartAt; a++) {
                 if (!paramNames.hasNext())
                     throw Fail.extraMethodParams(this, a + 1, specialParamsStartAt + 1);
@@ -6134,7 +6134,7 @@ public abstract class QueryInfo {
         if (ql != null)
             b.append(ql);
         if (qlParamCount > 0)
-            b.append(" [").append(qlParamCount).append(jpqlParamNames.isEmpty() ? //
+            b.append(" [").append(qlParamCount).append(qlParamNames.isEmpty() ? //
                             " positional params]" : //
                             " named params]");
         return b.toString();

--- a/dev/io.openliberty.data.internal_fat_1_1/test-applications/Data_1_1_App/src/test/jakarta/data/v1_1/web/Data_1_1_Servlet.java
+++ b/dev/io.openliberty.data.internal_fat_1_1/test-applications/Data_1_1_App/src/test/jakarta/data/v1_1/web/Data_1_1_Servlet.java
@@ -1586,6 +1586,7 @@ public class Data_1_1_Servlet extends FATServlet {
 
     /**
      * Use a NativeQuery method that selects multiple entities as a list.
+     * Also covers a NativeQuery that has no parameters.
      */
     @Test
     public void testNativeQueryReturnsListOfEntities() {
@@ -1650,6 +1651,94 @@ public class Data_1_1_Servlet extends FATServlet {
     public void testNativeQuerySelectsCount() {
         assertEquals(6L, // 1/18, 5/18, 7/18, 11/18, 13/18, 17/18
                      fractions.numReducedWithDenominatorOf(18, true));
+    }
+
+    /**
+     * Use a NativeQuery method that executes a SQL query with named parameters,
+     * where the named parameter names are implied from the method parameter names.
+     */
+    @Test
+    public void testNativeQueryWithImplicitNamedParameters() {
+        // Relies on optional capability where Hibernate provides named parameters
+        // for SQL queries
+        if (isHibernatePersistence()) {
+            Fraction fiveTwelfths = fractions.ifReduced(true, 5, 12)
+                            .orElseThrow();
+            assertEquals(5,
+                         fiveTwelfths.numerator);
+            assertEquals(12,
+                         fiveTwelfths.denominator);
+            assertEquals("Five Twelfths",
+                         fiveTwelfths.name);
+            assertEquals(true,
+                         fiveTwelfths.reduced);
+            // TODO would require Hibernate support for
+            // @QueryOptions(entityGraph = "EagerlyLoadRoundedValues")
+            // on native queries
+            //assertEquals(List.of(BigDecimal.valueOf(400, 3),
+            //                     BigDecimal.valueOf(420, 3),
+            //                     BigDecimal.valueOf(417, 3)),
+            //             fiveTwelfths.rounded);
+            assertEquals(BigDecimal.valueOf(4167, 4),
+                         fiveTwelfths.decimal.ceiling());
+            assertEquals(BigDecimal.valueOf(4166, 4),
+                         fiveTwelfths.decimal.truncated());
+            assertEquals(5.0 / 12.0,
+                         fiveTwelfths.decimal.value(),
+                         0.0001);
+            assertEquals(2.4,
+                         fiveTwelfths.decimal.inverse(),
+                         0.0001);
+            assertEquals("41",
+                         fiveTwelfths.decimal.digits().nonrepeating());
+            assertEquals("6",
+                         fiveTwelfths.decimal.digits().repeating());
+        }
+    }
+
+    /**
+     * Use a NativeQuery method that executes a SQL query with some method
+     * parameters correponding to named parameters and another being a special
+     * parameter of type Limit.
+     */
+    @Test
+    public void testNativeQueryWithNamedAndSpecialParameters() {
+        // Relies on optional capability where Hibernate provides named parameters
+        // for SQL queries
+        if (isHibernatePersistence())
+            assertEquals(List.of("Eight Elevenths",
+                                 "Eight Fifteenths",
+                                 "Eight Nineteenths",
+                                 "Eight Ninths",
+                                 "Eight Seventeenths",
+                                 "Eight Thirteenths",
+                                 "Eighteen Nineteenths",
+                                 "Eleven Eighteenths",
+                                 "Eleven Fifteenths"),
+                         fractions.alphabetized(true, Limit.of(9)));
+    }
+
+    /**
+     * Use a NativeQuery method that executes a SQL query with named parameters,
+     * where the named parameter names are indicted by the Param annotation of each
+     * method parameter.
+     */
+    @Test
+    public void testNativeQueryWithNamedParameters() {
+        // Relies on optional capability where Hibernate provides named parameters
+        // for SQL queries
+        if (isHibernatePersistence())
+            assertEquals(List.of("Nine Eighteenths",
+                                 "Nine Fifteenths",
+                                 "Nine Fourteenths",
+                                 "Nine Nineteenths",
+                                 "Nine Seventeenths",
+                                 "Nine Sixteenths",
+                                 "Nine Thirteenths"),
+                         Stream.of(fractions.withNamePattern("Nine ",
+                                                             "teenths"))
+                                         .map(f -> f.name)
+                                         .toList());
     }
 
     /**
@@ -1865,9 +1954,9 @@ public class Data_1_1_Servlet extends FATServlet {
                 tx.setTransactionTimeout((int) TIMEOUT_S * 3);
                 tx.begin();
                 boolean found = fractions.change(BigDecimal.valueOf(1880, 4),
-                                 BigDecimal.valueOf(1870, 4),
-                                 3,
-                                 16);
+                                                 BigDecimal.valueOf(1870, 4),
+                                                 3,
+                                                 16);
                 System.out.println("Obtained lock on 3/16");
                 locked.countDown();
                 blocked.await(TIMEOUT_S * 2, TimeUnit.SECONDS);

--- a/dev/io.openliberty.data.internal_fat_1_1/test-applications/Data_1_1_App/src/test/jakarta/data/v1_1/web/Fractions.java
+++ b/dev/io.openliberty.data.internal_fat_1_1/test-applications/Data_1_1_App/src/test/jakarta/data/v1_1/web/Fractions.java
@@ -46,6 +46,7 @@ import jakarta.data.repository.Is;
 import jakarta.data.repository.JakartaQuery; // TODO replace with Persistence 4.0 anno once available
 import jakarta.data.repository.NativeQuery; // TODO replace with Persistence 4.0 anno once available
 import jakarta.data.repository.OrderBy;
+import jakarta.data.repository.Param;
 import jakarta.data.repository.Query;
 import jakarta.data.repository.QueryOptions; // TODO replace with Persistence 4.0 anno once available
 import jakarta.data.repository.Repository;
@@ -58,6 +59,15 @@ import jakarta.persistence.LockModeType;
  */
 @Repository(dataStore = "MyDataStore")
 public interface Fractions {
+
+    @NativeQuery("""
+                    SELECT name
+                      FROM Fraction
+                     WHERE reduced = :isReduced
+                     ORDER BY name ASC
+                    """)
+    List<String> alphabetized(@Param("isReduced") boolean reduced,
+                              Limit limit);
 
     @Find
     @First(10)
@@ -154,6 +164,17 @@ public interface Fractions {
     Stream<Fraction> havingDenominatorWithin//
     (@By(_Fraction.DENOMINATOR) @Is(AtLeast.class) long min,
      @By(_Fraction.DENOMINATOR) @Is(AtMost.class) long max);
+
+    @NativeQuery("""
+                    SELECT *
+                      FROM Fraction
+                     WHERE reduced = :reduced
+                       AND numerator = :numerator
+                       AND denominator = :denominator
+                    """)
+    Optional<Fraction> ifReduced(boolean reduced,
+                                 int numerator,
+                                 int denominator);
 
     @Find
     @Select(_Fraction.NAME)
@@ -296,6 +317,16 @@ public interface Fractions {
     (@By(_Fraction.NAME) @Is(Like.class) String pattern,
      Restriction<Fraction> filter,
      Order<Fraction> order);
+
+    @NativeQuery("""
+                    SELECT *
+                      FROM Fraction
+                     WHERE name LIKE CONCAT('%', :nameSuffix)
+                       AND name LIKE CONCAT(:namePrefix, '%')
+                     ORDER BY name
+                    """)
+    Fraction[] withNamePattern(@Param("namePrefix") String prefix,
+                               @Param("nameSuffix") String suffix);
 
     @Find
     @Select(_Fraction.NAME)


### PR DESCRIPTION
NativeQuery repository methods can have named parameters if the query language allows for it or the Persistence provider does so on its behalf, which is the case for Hibernate. Also include tests for various scenarios.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
