### PR TITLE
H2Client test bucket with initial tests

### DIFF
--- a/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
+++ b/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
@@ -192,6 +192,11 @@
       <version>3.2.0</version>
     </dependency>
     <dependency>
+      <groupId>com.h2database</groupId>
+      <artifactId>h2</artifactId>
+      <version>2.4.240</version>
+    </dependency>
+    <dependency>
       <groupId>com.hazelcast</groupId>
       <artifactId>hazelcast-client</artifactId>
       <version>3.12.12</version>

--- a/dev/cnf/oss_dependencies.maven
+++ b/dev/cnf/oss_dependencies.maven
@@ -34,6 +34,7 @@ com.google.protobuf:protobuf-java:3.25.5
 com.googlecode.json-simple:json-simple:1.1.1
 com.graphql-java:graphql-java:20.9
 com.graphql-java:java-dataloader:3.2.0
+com.h2database:h2:2.4.240
 com.hazelcast:hazelcast-client:3.12.12
 com.hazelcast:hazelcast:3.12.12
 com.hazelcast:hazelcast:5.1.3

--- a/dev/com.ibm.ws.jdbc_fat_h2client/.project
+++ b/dev/com.ibm.ws.jdbc_fat_h2client/.project
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>com.ibm.ws.jdbc_fat_h2client</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>bndtools.core.bndbuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>bndtools.core.bndnature</nature>
+	</natures>
+</projectDescription>

--- a/dev/com.ibm.ws.jdbc_fat_h2client/bnd.bnd
+++ b/dev/com.ibm.ws.jdbc_fat_h2client/bnd.bnd
@@ -1,0 +1,31 @@
+#*******************************************************************************
+# Copyright (c) 2026 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-2.0/
+# 
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+#*******************************************************************************
+-include= ~../cnf/resources/bnd/bundle.props
+bVersion=1.0
+
+src: \
+  fat/src,\
+  test-applications/H2ClientTestApp/src
+
+javac.source: 17
+javac.target: 17
+
+fat.minimum.java.level: 17
+fat.project: true
+
+-buildpath: \
+  com.h2database:h2;strategy=exact;version=2.4.240,\
+  com.ibm.ws.componenttest.2.0;version=latest,\
+  io.openliberty.jakarta.annotation.2.1,\
+  io.openliberty.jakarta.servlet.6.0;version=latest,\
+  io.openliberty.jakarta.transaction.2.0;version=latest

--- a/dev/com.ibm.ws.jdbc_fat_h2client/build.gradle
+++ b/dev/com.ibm.ws.jdbc_fat_h2client/build.gradle
@@ -1,0 +1,15 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+addRequiredLibraries.dependsOn addH2
+

--- a/dev/com.ibm.ws.jdbc_fat_h2client/cognitiveMetadata.yml
+++ b/dev/com.ibm.ws.jdbc_fat_h2client/cognitiveMetadata.yml
@@ -1,0 +1,6 @@
+---
+# YML metadata file made use of by the Cognitive Ecosystem.
+# Reference Cognitive Metadata is available at: https://github.com/OpenLiberty/open-liberty/tree/integration/dev/build.example_fat/cognitiveMetadata.yml
+# description: Uncomment this field and add a description to give some notes about this bucket.
+# triageNotes: Uncomment this field if there are some short notes you would like Pipeline Monitors to see when triaging this bucket.
+functionalArea: Database (jdbc, oracle, db2, derby)

--- a/dev/com.ibm.ws.jdbc_fat_h2client/fat/src/test/jdbc/h2/client/FATSuite.java
+++ b/dev/com.ibm.ws.jdbc_fat_h2client/fat/src/test/jdbc/h2/client/FATSuite.java
@@ -1,0 +1,28 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package test.jdbc.h2.client;
+
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+import org.junit.runners.Suite.SuiteClasses;
+
+import componenttest.custom.junit.runner.AlwaysPassesTest;
+import test.jdbc.h2.client.H2ClientTest;
+
+@RunWith(Suite.class)
+@SuiteClasses({
+                AlwaysPassesTest.class,
+                H2ClientTest.class
+})
+public class FATSuite {
+}

--- a/dev/com.ibm.ws.jdbc_fat_h2client/fat/src/test/jdbc/h2/client/H2ClientTest.java
+++ b/dev/com.ibm.ws.jdbc_fat_h2client/fat/src/test/jdbc/h2/client/H2ClientTest.java
@@ -1,0 +1,67 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package test.jdbc.h2.client;
+
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.runner.RunWith;
+
+import com.ibm.websphere.simplicity.ShrinkHelper;
+
+import componenttest.annotation.MinimumJavaLevel;
+import componenttest.annotation.Server;
+import componenttest.annotation.TestServlet;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.utils.FATServletClient;
+import test.jdbc.h2.client.web.H2ClientTestServlet;
+
+@RunWith(FATRunner.class)
+@MinimumJavaLevel(javaLevel = 17)
+public class H2ClientTest extends FATServletClient {
+
+    @Server("com.ibm.ws.jdbc.fat.h2client")
+    @TestServlet(servlet = H2ClientTestServlet.class, contextRoot = "H2ClientTestApp")
+    public static LibertyServer server;
+
+    private static org.h2.tools.Server h2TcpServer;
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        // -tcpPort 0: let the OS assign a free ephemeral port to avoid collisions
+        //             with other processes or parallel test runs; actual port is
+        //             retrieved via getPort() and passed to Liberty as h2TcpPort.
+        // -ifNotExists: allow the server to create the database on first connect
+        //               without requiring it to exist beforehand.
+        h2TcpServer = org.h2.tools.Server.createTcpServer("-tcpPort", "0", "-ifNotExists").start();
+
+        server.addEnvVar("h2TcpPort", String.valueOf(h2TcpServer.getPort()));
+
+        WebArchive war = ShrinkHelper.buildDefaultApp("H2ClientTestApp",
+                                                      "test.jdbc.h2.client.web");
+        ShrinkHelper.exportAppToServer(server, war);
+
+        server.startServer();
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        try {
+            server.stopServer();
+        } finally {
+            if (h2TcpServer != null)
+                h2TcpServer.stop();
+        }
+    }
+}

--- a/dev/com.ibm.ws.jdbc_fat_h2client/publish/servers/com.ibm.ws.jdbc.fat.h2client/bootstrap.properties
+++ b/dev/com.ibm.ws.jdbc_fat_h2client/publish/servers/com.ibm.ws.jdbc.fat.h2client/bootstrap.properties
@@ -11,4 +11,4 @@
 #     IBM Corporation - initial API and implementation
 ###############################################################################
 bootstrap.include=../testports.properties
-com.ibm.ws.logging.trace.specification=*=info:RRA=all
+com.ibm.ws.logging.trace.specification=*=info:RRA=all:com.ibm.ws.h2.logwriter=all

--- a/dev/com.ibm.ws.jdbc_fat_h2client/publish/servers/com.ibm.ws.jdbc.fat.h2client/bootstrap.properties
+++ b/dev/com.ibm.ws.jdbc_fat_h2client/publish/servers/com.ibm.ws.jdbc.fat.h2client/bootstrap.properties
@@ -1,0 +1,14 @@
+###############################################################################
+# Copyright (c) 2026 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-2.0/
+# 
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+###############################################################################
+bootstrap.include=../testports.properties
+com.ibm.ws.logging.trace.specification=*=info:RRA=all

--- a/dev/com.ibm.ws.jdbc_fat_h2client/publish/servers/com.ibm.ws.jdbc.fat.h2client/jvm.options
+++ b/dev/com.ibm.ws.jdbc_fat_h2client/publish/servers/com.ibm.ws.jdbc.fat.h2client/jvm.options
@@ -1,0 +1,1 @@
+-Dcom.ibm.ws.beta.edition=true

--- a/dev/com.ibm.ws.jdbc_fat_h2client/publish/servers/com.ibm.ws.jdbc.fat.h2client/server.xml
+++ b/dev/com.ibm.ws.jdbc_fat_h2client/publish/servers/com.ibm.ws.jdbc.fat.h2client/server.xml
@@ -53,8 +53,7 @@
     <properties url="jdbc:h2:tcp://localhost:${h2TcpPort}/./testdb" user="dbuser1" password="dbpwd1"/>
   </dataSource>
 
-  <dataSource jndiName="jdbc/H2XADataSource"
-              type="javax.sql.XADataSource">
+  <dataSource jndiName="jdbc/H2XADataSource">
     <jdbcDriver libraryRef="H2Lib"/>
     <properties url="jdbc:h2:tcp://localhost:${h2TcpPort}/./testdb" user="dbuser1" password="dbpwd1"/>
   </dataSource>

--- a/dev/com.ibm.ws.jdbc_fat_h2client/publish/servers/com.ibm.ws.jdbc.fat.h2client/server.xml
+++ b/dev/com.ibm.ws.jdbc_fat_h2client/publish/servers/com.ibm.ws.jdbc.fat.h2client/server.xml
@@ -38,24 +38,24 @@
   <dataSource jndiName="jdbc/H2ConnectionPoolDataSource"
               type="javax.sql.ConnectionPoolDataSource">
     <jdbcDriver libraryRef="H2Lib"/>
-    <properties url="jdbc:h2:tcp://localhost:${h2TcpPort}/./testdb" user="dbuser1" password="dbpwd1"/>
+    <properties.h2 url="jdbc:h2:tcp://localhost:${h2TcpPort}/mem:testdb"/>
   </dataSource>
 
   <dataSource jndiName="jdbc/H2DataSource"
               type="javax.sql.DataSource">
     <jdbcDriver libraryRef="H2Lib"/>
-    <properties url="jdbc:h2:tcp://localhost:${h2TcpPort}/./testdb" user="dbuser1" password="dbpwd1"/>
+    <properties.h2 url="jdbc:h2:tcp://localhost:${h2TcpPort}/mem:testdb"/>
   </dataSource>
 
   <dataSource jndiName="jdbc/H2Driver"
               type="java.sql.Driver">
     <jdbcDriver libraryRef="H2Lib"/>
-    <properties url="jdbc:h2:tcp://localhost:${h2TcpPort}/./testdb" user="dbuser1" password="dbpwd1"/>
+    <properties.h2 url="jdbc:h2:tcp://localhost:${h2TcpPort}/mem:testdb"/>
   </dataSource>
 
   <dataSource jndiName="jdbc/H2XADataSource">
     <jdbcDriver libraryRef="H2Lib"/>
-    <properties url="jdbc:h2:tcp://localhost:${h2TcpPort}/./testdb" user="dbuser1" password="dbpwd1"/>
+    <properties.h2 url="jdbc:h2:tcp://localhost:${h2TcpPort}/mem:testdb"/>
   </dataSource>
 
 </server>

--- a/dev/com.ibm.ws.jdbc_fat_h2client/publish/servers/com.ibm.ws.jdbc.fat.h2client/server.xml
+++ b/dev/com.ibm.ws.jdbc_fat_h2client/publish/servers/com.ibm.ws.jdbc.fat.h2client/server.xml
@@ -1,0 +1,62 @@
+<!--
+    Copyright (c) 2026 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License 2.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-2.0/
+    
+    SPDX-License-Identifier: EPL-2.0
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<server>
+
+  <featureManager>
+    <feature>componenttest-2.0</feature>
+    <feature>jdbc-4.3</feature>
+    <feature>jndi-1.0</feature>
+    <feature>servlet-6.1</feature>
+  </featureManager>
+
+  <include location="../fatTestPorts.xml"/>
+
+  <!-- h2TcpPort is overridden at runtime via server.addEnvVar() in H2ClientTest.setUp() -->
+  <variable name="h2TcpPort" defaultValue="9092"/>
+
+  <application location="H2ClientTestApp.war">
+    <classloader commonLibraryRef="H2Lib"/>
+  </application>
+
+  <library id="H2Lib">
+    <file name="${shared.resource.dir}/h2/h2.jar"/>
+  </library>
+
+  <javaPermission codeBase="${shared.resource.dir}/h2/h2.jar"
+                  className="java.security.AllPermission"/>
+
+  <dataSource jndiName="jdbc/H2ConnectionPoolDataSource"
+              type="javax.sql.ConnectionPoolDataSource">
+    <jdbcDriver libraryRef="H2Lib"/>
+    <properties url="jdbc:h2:tcp://localhost:${h2TcpPort}/./testdb" user="dbuser1" password="dbpwd1"/>
+  </dataSource>
+
+  <dataSource jndiName="jdbc/H2DataSource"
+              type="javax.sql.DataSource">
+    <jdbcDriver libraryRef="H2Lib"/>
+    <properties url="jdbc:h2:tcp://localhost:${h2TcpPort}/./testdb" user="dbuser1" password="dbpwd1"/>
+  </dataSource>
+
+  <dataSource jndiName="jdbc/H2Driver"
+              type="java.sql.Driver">
+    <jdbcDriver libraryRef="H2Lib"/>
+    <properties url="jdbc:h2:tcp://localhost:${h2TcpPort}/./testdb" user="dbuser1" password="dbpwd1"/>
+  </dataSource>
+
+  <dataSource jndiName="jdbc/H2XADataSource"
+              type="javax.sql.XADataSource">
+    <jdbcDriver libraryRef="H2Lib"/>
+    <properties url="jdbc:h2:tcp://localhost:${h2TcpPort}/./testdb" user="dbuser1" password="dbpwd1"/>
+  </dataSource>
+
+</server>

--- a/dev/com.ibm.ws.jdbc_fat_h2client/test-applications/H2ClientTestApp/src/test/jdbc/h2/client/web/H2ClientTestServlet.java
+++ b/dev/com.ibm.ws.jdbc_fat_h2client/test-applications/H2ClientTestApp/src/test/jdbc/h2/client/web/H2ClientTestServlet.java
@@ -149,44 +149,45 @@ public class H2ClientTestServlet extends FATServlet {
 
             con1.setAutoCommit(false);
 
-            // Insert a new planet in con1's uncommitted transaction
-            try (PreparedStatement ps = con1.prepareStatement(
-                         "INSERT INTO PLANETS VALUES (?, ?, ?)")) {
-                ps.setString(1, "Jupiter");
-                ps.setInt(2, 71492);
-                ps.setDouble(3, 4332.589);
-                ps.executeUpdate();
-            }
-
-            // con2 must not see con1's uncommitted row
-            try (PreparedStatement ps = con2.prepareStatement(
-                         "SELECT COUNT(*) FROM PLANETS WHERE NAME=?")) {
-                ps.setString(1, "Jupiter");
-                try (ResultSet rs = ps.executeQuery()) {
-                    rs.next();
-                    assertEquals("con2 must not see con1's uncommitted INSERT",
-                                 0, rs.getInt(1));
+            try {
+                // Insert a new planet in con1's uncommitted transaction
+                try (PreparedStatement ps = con1.prepareStatement(
+                             "INSERT INTO PLANETS VALUES (?, ?, ?)")) {
+                    ps.setString(1, "Jupiter");
+                    ps.setInt(2, 71492);
+                    ps.setDouble(3, 4332.589);
+                    ps.executeUpdate();
                 }
-            }
 
-            con1.commit();
-
-            // After commit, con2 must see the row
-            try (PreparedStatement ps = con2.prepareStatement(
-                         "SELECT COUNT(*) FROM PLANETS WHERE NAME=?")) {
-                ps.setString(1, "Jupiter");
-                try (ResultSet rs = ps.executeQuery()) {
-                    rs.next();
-                    assertEquals("con2 must see con1's committed INSERT",
-                                 1, rs.getInt(1));
+                // con2 must not see con1's uncommitted row
+                try (PreparedStatement ps = con2.prepareStatement(
+                             "SELECT COUNT(*) FROM PLANETS WHERE NAME=?")) {
+                    ps.setString(1, "Jupiter");
+                    try (ResultSet rs = ps.executeQuery()) {
+                        rs.next();
+                        assertEquals("con2 must not see con1's uncommitted INSERT",
+                                     0, rs.getInt(1));
+                    }
                 }
-            }
 
-            // Clean up
-            try (Statement stmt = con1.createStatement()) {
-                stmt.executeUpdate("DELETE FROM PLANETS WHERE NAME='Jupiter'");
+                con1.commit();
+
+                // After commit, con2 must see the row
+                try (PreparedStatement ps = con2.prepareStatement(
+                             "SELECT COUNT(*) FROM PLANETS WHERE NAME=?")) {
+                    ps.setString(1, "Jupiter");
+                    try (ResultSet rs = ps.executeQuery()) {
+                        rs.next();
+                        assertEquals("con2 must see con1's committed INSERT",
+                                     1, rs.getInt(1));
+                    }
+                }
+            } finally {
+                try (Statement stmt = con1.createStatement()) {
+                    stmt.executeUpdate("DELETE FROM PLANETS WHERE NAME='Jupiter'");
+                }
+                con1.commit();
             }
-            con1.commit();
         }
     }
 }

--- a/dev/com.ibm.ws.jdbc_fat_h2client/test-applications/H2ClientTestApp/src/test/jdbc/h2/client/web/H2ClientTestServlet.java
+++ b/dev/com.ibm.ws.jdbc_fat_h2client/test-applications/H2ClientTestApp/src/test/jdbc/h2/client/web/H2ClientTestServlet.java
@@ -54,13 +54,11 @@ public class H2ClientTestServlet extends FATServlet {
     DataSource h2driverDataSource;
 
     /** Backed by H2 XADataSource via TCP */
-    @Resource(lookup = "jdbc/H2XADataSource", shareable = false)
+    @Resource(lookup = "jdbc/H2XADataSource")
     DataSource h2xaDataSource;
 
     /**
      * Create the PLANETS table and populate initial rows.
-     * The table must not exist beforehand; an error here indicates a problem
-     * with server or test setup (stale state from a previous run, etc.).
      */
     @Override
     public void init(ServletConfig config) throws ServletException {
@@ -94,14 +92,6 @@ public class H2ClientTestServlet extends FATServlet {
         }
     }
 
-    // -------------------------------------------------------------------------
-    // Smoke tests — one assert each, one per JDBC interface type
-    // -------------------------------------------------------------------------
-
-    /**
-     * Smoke test: ConnectionPoolDataSource TCP path.
-     * Verifies a basic TCP connection can be established and the catalog is correct.
-     */
     @Test
     public void testConnectionPoolDataSource() throws Exception {
         try (Connection con = h2cpDataSource.getConnection()) {
@@ -109,10 +99,6 @@ public class H2ClientTestServlet extends FATServlet {
         }
     }
 
-    /**
-     * Smoke test: DataSource TCP path.
-     * Verifies a basic TCP connection can be established and the catalog is correct.
-     */
     @Test
     public void testDataSource() throws Exception {
         try (Connection con = h2DataSource.getConnection()) {
@@ -120,10 +106,6 @@ public class H2ClientTestServlet extends FATServlet {
         }
     }
 
-    /**
-     * Smoke test: Driver TCP path.
-     * Verifies a basic TCP connection can be established and the catalog is correct.
-     */
     @Test
     public void testDriver() throws Exception {
         try (Connection con = h2driverDataSource.getConnection()) {
@@ -131,20 +113,12 @@ public class H2ClientTestServlet extends FATServlet {
         }
     }
 
-    /**
-     * Smoke test: XADataSource TCP path.
-     * Verifies a basic TCP connection can be established and the catalog is correct.
-     */
     @Test
     public void testXADataSource() throws Exception {
         try (Connection con = h2xaDataSource.getConnection()) {
             assertEquals("TESTDB", con.getCatalog());
         }
     }
-
-    // -------------------------------------------------------------------------
-    // TCP-unique tests
-    // -------------------------------------------------------------------------
 
     /**
      * Verifies the DatabaseMetaRemote TCP path returns correct values for

--- a/dev/com.ibm.ws.jdbc_fat_h2client/test-applications/H2ClientTestApp/src/test/jdbc/h2/client/web/H2ClientTestServlet.java
+++ b/dev/com.ibm.ws.jdbc_fat_h2client/test-applications/H2ClientTestApp/src/test/jdbc/h2/client/web/H2ClientTestServlet.java
@@ -1,0 +1,214 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package test.jdbc.h2.client.web;
+
+import static org.junit.Assert.assertEquals;
+
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+import jakarta.annotation.Resource;
+import jakarta.servlet.ServletConfig;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+
+import javax.sql.DataSource;
+
+import org.junit.Test;
+
+import componenttest.app.FATServlet;
+
+/**
+ * Tests for H2 in TCP client/server mode. Exercises behaviors unique to
+ * TCP connectivity: remote metadata path and session isolation across
+ * independent TCP sessions.
+ */
+@SuppressWarnings("serial")
+@WebServlet("/*")
+public class H2ClientTestServlet extends FATServlet {
+
+    /** Backed by H2 ConnectionPoolDataSource via TCP */
+    @Resource(lookup = "jdbc/H2ConnectionPoolDataSource")
+    DataSource h2cpDataSource;
+
+    /** Backed by H2 DataSource via TCP */
+    @Resource(lookup = "jdbc/H2DataSource")
+    DataSource h2DataSource;
+
+    /** Backed by H2 Driver via TCP */
+    @Resource(lookup = "jdbc/H2Driver")
+    DataSource h2driverDataSource;
+
+    /** Backed by H2 XADataSource via TCP */
+    @Resource(lookup = "jdbc/H2XADataSource", shareable = false)
+    DataSource h2xaDataSource;
+
+    /**
+     * Create the PLANETS table and populate initial rows.
+     * The table must not exist beforehand; an error here indicates a problem
+     * with server or test setup (stale state from a previous run, etc.).
+     */
+    @Override
+    public void init(ServletConfig config) throws ServletException {
+        try (Connection con = h2cpDataSource.getConnection();
+             Statement stmt = con.createStatement()) {
+            stmt.execute("""
+                            CREATE TABLE PLANETS (
+                                NAME       VARCHAR(20)    NOT NULL PRIMARY KEY,
+                                RADIUS_KM  INT            NOT NULL,
+                                ORBIT_DAYS DECIMAL(10,3)  NOT NULL
+                            )
+                            """);
+            String insert = "INSERT INTO PLANETS VALUES (?, ?, ?)";
+            try (PreparedStatement ps = con.prepareStatement(insert)) {
+                Object[][] rows = {
+                    { "Mercury", 2440,  87.969  },
+                    { "Venus",   6052,  224.701 },
+                    { "Earth",   6371,  365.256 },
+                    { "Mars",    3390,  686.971 },
+                };
+                for (Object[] row : rows) {
+                    ps.setString(1, (String) row[0]);
+                    ps.setInt(2, (Integer) row[1]);
+                    ps.setDouble(3, (Double) row[2]);
+                    ps.addBatch();
+                }
+                ps.executeBatch();
+            }
+        } catch (SQLException x) {
+            throw new ServletException(x.getMessage(), x);
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Smoke tests — one assert each, one per JDBC interface type
+    // -------------------------------------------------------------------------
+
+    /**
+     * Smoke test: ConnectionPoolDataSource TCP path.
+     * Verifies a basic TCP connection can be established and the catalog is correct.
+     */
+    @Test
+    public void testConnectionPoolDataSource() throws Exception {
+        try (Connection con = h2cpDataSource.getConnection()) {
+            assertEquals("TESTDB", con.getCatalog());
+        }
+    }
+
+    /**
+     * Smoke test: DataSource TCP path.
+     * Verifies a basic TCP connection can be established and the catalog is correct.
+     */
+    @Test
+    public void testDataSource() throws Exception {
+        try (Connection con = h2DataSource.getConnection()) {
+            assertEquals("TESTDB", con.getCatalog());
+        }
+    }
+
+    /**
+     * Smoke test: Driver TCP path.
+     * Verifies a basic TCP connection can be established and the catalog is correct.
+     */
+    @Test
+    public void testDriver() throws Exception {
+        try (Connection con = h2driverDataSource.getConnection()) {
+            assertEquals("TESTDB", con.getCatalog());
+        }
+    }
+
+    /**
+     * Smoke test: XADataSource TCP path.
+     * Verifies a basic TCP connection can be established and the catalog is correct.
+     */
+    @Test
+    public void testXADataSource() throws Exception {
+        try (Connection con = h2xaDataSource.getConnection()) {
+            assertEquals("TESTDB", con.getCatalog());
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // TCP-unique tests
+    // -------------------------------------------------------------------------
+
+    /**
+     * Verifies the DatabaseMetaRemote TCP path returns correct values for
+     * getDatabaseProductName() and getDriverName(). These values are sent over
+     * the TCP wire in H2's remote protocol rather than returned from local state.
+     */
+    @Test
+    public void testRemoteMetadata() throws Exception {
+        try (Connection con = h2DataSource.getConnection()) {
+            DatabaseMetaData meta = con.getMetaData();
+            assertEquals("H2", meta.getDatabaseProductName());
+            assertEquals("H2 JDBC Driver", meta.getDriverName());
+        }
+    }
+
+    /**
+     * Verifies session isolation across two independent TCP sessions.
+     * Writes in one session (con1, autoCommit off) are not visible to a second
+     * session (con2) until con1 commits. This is meaningful only over TCP where
+     * each connection is an independent SessionRemote instance on the server.
+     */
+    @Test
+    public void testSessionIsolation() throws Exception {
+        try (Connection con1 = h2cpDataSource.getConnection();
+             Connection con2 = h2cpDataSource.getConnection()) {
+
+            con1.setAutoCommit(false);
+
+            // Insert a new planet in con1's uncommitted transaction
+            try (PreparedStatement ps = con1.prepareStatement(
+                         "INSERT INTO PLANETS VALUES (?, ?, ?)")) {
+                ps.setString(1, "Jupiter");
+                ps.setInt(2, 71492);
+                ps.setDouble(3, 4332.589);
+                ps.executeUpdate();
+            }
+
+            // con2 must not see con1's uncommitted row
+            try (PreparedStatement ps = con2.prepareStatement(
+                         "SELECT COUNT(*) FROM PLANETS WHERE NAME=?")) {
+                ps.setString(1, "Jupiter");
+                ResultSet rs = ps.executeQuery();
+                rs.next();
+                assertEquals("con2 must not see con1's uncommitted INSERT",
+                             0, rs.getInt(1));
+            }
+
+            con1.commit();
+
+            // After commit, con2 must see the row
+            try (PreparedStatement ps = con2.prepareStatement(
+                         "SELECT COUNT(*) FROM PLANETS WHERE NAME=?")) {
+                ps.setString(1, "Jupiter");
+                ResultSet rs = ps.executeQuery();
+                rs.next();
+                assertEquals("con2 must see con1's committed INSERT",
+                             1, rs.getInt(1));
+            }
+
+            // Clean up
+            try (Statement stmt = con1.createStatement()) {
+                stmt.executeUpdate("DELETE FROM PLANETS WHERE NAME='Jupiter'");
+            }
+            con1.commit();
+        }
+    }
+}

--- a/dev/com.ibm.ws.jdbc_fat_h2client/test-applications/H2ClientTestApp/src/test/jdbc/h2/client/web/H2ClientTestServlet.java
+++ b/dev/com.ibm.ws.jdbc_fat_h2client/test-applications/H2ClientTestApp/src/test/jdbc/h2/client/web/H2ClientTestServlet.java
@@ -57,6 +57,8 @@ public class H2ClientTestServlet extends FATServlet {
     @Resource(lookup = "jdbc/H2XADataSource")
     DataSource h2xaDataSource;
 
+    record Planet(String name, int radiusKm, double orbitDays) {}
+
     /**
      * Create the PLANETS table and populate initial rows.
      */
@@ -73,16 +75,16 @@ public class H2ClientTestServlet extends FATServlet {
                             """);
             String insert = "INSERT INTO PLANETS VALUES (?, ?, ?)";
             try (PreparedStatement ps = con.prepareStatement(insert)) {
-                Object[][] rows = {
-                    { "Mercury", 2440,  87.969  },
-                    { "Venus",   6052,  224.701 },
-                    { "Earth",   6371,  365.256 },
-                    { "Mars",    3390,  686.971 },
+                Planet[] planets = {
+                    new Planet("Mercury", 2440,  87.969),
+                    new Planet("Venus",   6052, 224.701),
+                    new Planet("Earth",   6371, 365.256),
+                    new Planet("Mars",    3390, 686.971),
                 };
-                for (Object[] row : rows) {
-                    ps.setString(1, (String) row[0]);
-                    ps.setInt(2, (Integer) row[1]);
-                    ps.setDouble(3, (Double) row[2]);
+                for (Planet p : planets) {
+                    ps.setString(1, p.name());
+                    ps.setInt(2, p.radiusKm());
+                    ps.setDouble(3, p.orbitDays());
                     ps.addBatch();
                 }
                 ps.executeBatch();
@@ -160,10 +162,11 @@ public class H2ClientTestServlet extends FATServlet {
             try (PreparedStatement ps = con2.prepareStatement(
                          "SELECT COUNT(*) FROM PLANETS WHERE NAME=?")) {
                 ps.setString(1, "Jupiter");
-                ResultSet rs = ps.executeQuery();
-                rs.next();
-                assertEquals("con2 must not see con1's uncommitted INSERT",
-                             0, rs.getInt(1));
+                try (ResultSet rs = ps.executeQuery()) {
+                    rs.next();
+                    assertEquals("con2 must not see con1's uncommitted INSERT",
+                                 0, rs.getInt(1));
+                }
             }
 
             con1.commit();
@@ -172,10 +175,11 @@ public class H2ClientTestServlet extends FATServlet {
             try (PreparedStatement ps = con2.prepareStatement(
                          "SELECT COUNT(*) FROM PLANETS WHERE NAME=?")) {
                 ps.setString(1, "Jupiter");
-                ResultSet rs = ps.executeQuery();
-                rs.next();
-                assertEquals("con2 must see con1's committed INSERT",
-                             1, rs.getInt(1));
+                try (ResultSet rs = ps.executeQuery()) {
+                    rs.next();
+                    assertEquals("con2 must see con1's committed INSERT",
+                                 1, rs.getInt(1));
+                }
             }
 
             // Clean up


### PR DESCRIPTION
Add the initial H2 client/server bucket and tests. Includes some basic tests of H2 code paths that are different in client/server vs embedded. Additional testing in this bucket should be covered under the Security and XA stories

fixes #34828

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".