### PR TITLE
OIDC FAT tests for restricted tools

### DIFF
--- a/dev/io.openliberty.mcp.internal_fat/bnd.bnd
+++ b/dev/io.openliberty.mcp.internal_fat/bnd.bnd
@@ -26,7 +26,8 @@ tested.features: \
     cdi-4.1,\
     concurrent-3.1,\
     restfulws-4.0,\
-    servlet-6.1
+    servlet-6.1,\
+    pages-3.1
 
 -buildpath: \
 	com.ibm.ws.componenttest.2.0;version=latest,\
@@ -48,7 +49,7 @@ tested.features: \
 	io.openliberty.io.opentelemetry.2.1;version=latest,\
 	io.openliberty.mpTelemetry.2.0.thirdparty,\
 	com.ibm.websphere.javaee.servlet.3.1;version=latest,\
-	io.openliberty.io.opentelemetry.internal.2.1;version=latest
+	io.openliberty.io.opentelemetry.internal.2.1;version=latest,\
+	io.openliberty.org.testcontainers;version=latest
 	
-	
-fat.test.container.images=public.ecr.aws/docker/library/node:20-alpine
+fat.test.container.images=public.ecr.aws/docker/library/node:20-alpine,quay.io/keycloak/keycloak:26.6.2

--- a/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/FATSuite.java
+++ b/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/FATSuite.java
@@ -26,8 +26,8 @@ import io.openliberty.mcp.internal.fat.isolation.MultiAppIsolationTest;
 import io.openliberty.mcp.internal.fat.lifecycle.tests.AsyncToolLifecycleTest;
 import io.openliberty.mcp.internal.fat.lifecycle.tests.BeanLifecycleTest;
 import io.openliberty.mcp.internal.fat.lifecycle.tests.LifecycleTest;
-import io.openliberty.mcp.internal.fat.oidc.tests.OidcTests;
 import io.openliberty.mcp.internal.fat.monitor.McpMonitorTest;
+import io.openliberty.mcp.internal.fat.oidc.tests.OidcTests;
 import io.openliberty.mcp.internal.fat.protocol.HttpTest;
 import io.openliberty.mcp.internal.fat.protocol.ProtocolVersionSchemaTest;
 import io.openliberty.mcp.internal.fat.protocol.ProtocolVersionTest;
@@ -114,7 +114,10 @@ import io.openliberty.mcp.internal.fat.tool.ToolTest;
                 MultiModuleToolTestToolManager.class,
                 NonRequiredArgsToolsTest.class,
                 NoParamNameTest.class,
+                // TestContainer Tests
                 OidcTests.class,
+                ConformanceTests.class,
+
                 CustomServerInfoTest.class,
                 ProtocolVersionTest.class,
                 ProtocolVersionSchemaTest.class,
@@ -140,9 +143,7 @@ import io.openliberty.mcp.internal.fat.tool.ToolTest;
                 PermitAllTestsStateless.class,
                 DenyAllTestsStateless.class,
                 NoClassAnnotationTestsStateless.class,
-                AdminsRoleAllowedTestsStateless.class,
-                // Conformance Tests
-                ConformanceTests.class
+                AdminsRoleAllowedTestsStateless.class
 
 })
 

--- a/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/FATSuite.java
+++ b/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/FATSuite.java
@@ -26,6 +26,7 @@ import io.openliberty.mcp.internal.fat.isolation.MultiAppIsolationTest;
 import io.openliberty.mcp.internal.fat.lifecycle.tests.AsyncToolLifecycleTest;
 import io.openliberty.mcp.internal.fat.lifecycle.tests.BeanLifecycleTest;
 import io.openliberty.mcp.internal.fat.lifecycle.tests.LifecycleTest;
+import io.openliberty.mcp.internal.fat.oidc.tests.OidcTests;
 import io.openliberty.mcp.internal.fat.monitor.McpMonitorTest;
 import io.openliberty.mcp.internal.fat.protocol.HttpTest;
 import io.openliberty.mcp.internal.fat.protocol.ProtocolVersionSchemaTest;
@@ -113,6 +114,7 @@ import io.openliberty.mcp.internal.fat.tool.ToolTest;
                 MultiModuleToolTestToolManager.class,
                 NonRequiredArgsToolsTest.class,
                 NoParamNameTest.class,
+                OidcTests.class,
                 CustomServerInfoTest.class,
                 ProtocolVersionTest.class,
                 ProtocolVersionSchemaTest.class,

--- a/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/oidc/tests/OidcTests.java
+++ b/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/oidc/tests/OidcTests.java
@@ -1,0 +1,491 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.mcp.internal.fat.oidc.tests;
+
+import static com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions.SERVER_ONLY;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpRequest.Builder;
+import java.net.http.HttpResponse;
+import java.net.http.HttpResponse.BodyHandlers;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.skyscreamer.jsonassert.JSONAssert;
+import org.testcontainers.Testcontainers;
+import org.testcontainers.containers.Container;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+
+import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.websphere.simplicity.config.OpenidConnectClient;
+import com.ibm.websphere.simplicity.config.ServerConfiguration;
+
+import componenttest.annotation.Server;
+import componenttest.containers.SimpleLogConsumer;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.utils.FATServletClient;
+import io.openliberty.mcp.internal.fat.oidc.tools.RolesAllowedTools;
+import io.openliberty.mcp.internal.fat.utils.McpClient;
+import io.openliberty.mcp.internal.fat.utils.McpClient.McpDetailedAuthResponse;
+import io.openliberty.mcp.internal.fat.utils.McpClient.StateMode;
+
+@RunWith(FATRunner.class)
+public class OidcTests extends FATServletClient {
+
+    // Keycloak
+    private static final String KEYCLOAK_REALM = "mcp-realm";
+    private static final String TEST_ADMIN_USERNAME = "admin@example.com";
+    private static final String TEST_USER_USERNAME = "user@example.com";
+    private static final String TEST_PASSWORD = "123";
+    private static final String LIBERTY_MCP_SERVER_CLIENT_ID = "liberty-mcp-server-conf-client";
+    private static final String TEST_PUBLIC_CLIENT_ID = "mcp-public-client";
+
+    private static String keycloakConfidentialClientUUID = null;
+    private static String keycloakConfidentialClientSecret = null;
+    private static String keycloakPublicClientUUID = null;
+
+    // Container config
+    private static final String KEYCLOAK_TAG = "26.6.2";
+    private static final String KEYCLOAK_REGISTRY = "quay.io/keycloak/keycloak:" + KEYCLOAK_TAG;
+
+    // Note: We don't use @Rule for McpClient because it runs McpClient.before() which sends the MCP initialize request without an authorization header.
+    // This would cause a 401 as the sever in this test use OIDC which requires a token each request
+    @Server("mcp-server-oidc")
+    public static LibertyServer server;
+
+    @SuppressWarnings("resource")
+    @ClassRule
+    public static GenericContainer<?> keycloakContainer = new GenericContainer<>(KEYCLOAK_REGISTRY).withExposedPorts(8080)
+                                                                                                   .withEnv("KEYCLOAK_ADMIN", "admin")
+                                                                                                   .withEnv("KEYCLOAK_ADMIN_PASSWORD", "admin")
+                                                                                                   .withCommand("start-dev")
+                                                                                                   .withLogConsumer(new SimpleLogConsumer(OidcTests.class, "keycloak-containe"))
+                                                                                                   .waitingFor(Wait.forLogMessage(".*Listening on:.*", 1)
+                                                                                                                   .withStartupTimeout(Duration.ofMinutes(2)));
+
+    @BeforeClass
+    public static void setup() throws Exception {
+        WebArchive war = ShrinkWrap.create(WebArchive.class, "oidcTests.war")
+                                   .addPackage(RolesAllowedTools.class.getPackage())
+                                   .addAsWebInfResource(new File("publish/servers/mcp-server-oidc/resources/WEB-INF/web.xml"), "web.xml");
+        ShrinkHelper.exportAppToServer(server, war, SERVER_ONLY);
+
+        setupKeycloak();
+        updateOidcConfigAttributes();
+        server.startServer();
+        assertNotNull(server.waitForStringInLog("MCP server endpoint: .*/mcp$")); // regex matches string that ends with /mcp e.g. "MCP server endpoint: http://macbookpro.home:8010/toolTest/mcp"
+    }
+
+    @AfterClass
+    public static void teardown() throws Exception {
+        server.stopServer();
+    }
+
+    @Test
+    public void testProctectedToolCallWithoutAccessTokenFailsWith401Unauthorized() throws Exception {
+        testUnauthroizedToolCallAssertion("adminTool");
+        testUnauthroizedToolCallAssertion("userTool");
+
+    }
+
+    private void testUnauthroizedToolCallAssertion(String toolName) throws Exception {
+        McpClient client = new McpClient(server, "/oidcTests", StateMode.STATELESS);
+        String request = String.format("""
+                          {
+                          "jsonrpc": "2.0",
+                          "id": 1,
+                          "method": "tools/call",
+                          "params": {
+                            "name": "%s",
+                            "arguments": {}
+                          }
+                        }
+                        """, toolName);
+
+        McpDetailedAuthResponse mcpResponse = client.callMCP401AuthErrorExpected(request);
+        assertEquals(401, mcpResponse.statusCode());
+
+        String wwwAuthenticate = mcpResponse.wwwAuthenticate();
+        assertNotNull(wwwAuthenticate);
+        assertTrue(wwwAuthenticate.contains("Bearer realm=\"oauth\""));
+        assertTrue(wwwAuthenticate.contains("error=\"invalid_token\""));
+    }
+
+    @Test
+    public void testUserRestrictedToolCallWithUserAccessTokenSucceeds() throws Exception {
+        String accessToken = getAccessToken(TEST_USER_USERNAME, TEST_PASSWORD);
+        assertNotNull("Access token should not be null", accessToken);
+
+        McpClient client = new McpClient(server, "/oidcTests", StateMode.STATELESS, accessToken);
+
+        String request = """
+                        {
+                          "jsonrpc": "2.0",
+                          "id": 1,
+                          "method": "tools/call",
+                          "params": {
+                            "name": "userTool",
+                            "arguments": {}
+                          }
+                        }
+                        """;
+
+        String response = client.callMCPWithBearerToken(request);
+        String expectedResponseString = """
+                        {"id":1,"jsonrpc":"2.0","result":{"content":[{"type":"text","text":"Hello you basic user"}], "isError": false}}
+                        """;
+
+        JSONAssert.assertEquals(expectedResponseString, response, true);
+    }
+
+    @Test
+    public void testUserRestrictedToolCallWithAdminAccessTokenSucceeds() throws Exception {
+        String accessToken = getAccessToken(TEST_ADMIN_USERNAME, TEST_PASSWORD);
+        assertNotNull("Access token should not be null", accessToken);
+
+        McpClient client = new McpClient(server, "/oidcTests", StateMode.STATELESS, accessToken);
+
+        String request = """
+                        {
+                          "jsonrpc": "2.0",
+                          "id": 1,
+                          "method": "tools/call",
+                          "params": {
+                            "name": "userTool",
+                            "arguments": {}
+                          }
+                        }
+                        """;
+
+        String response = client.callMCPWithBearerToken(request);
+        String expectedResponseString = """
+                        {"id":1,"jsonrpc":"2.0","result":{"content":[{"type":"text","text":"Hello you basic user"}], "isError": false}}
+                        """;
+
+        JSONAssert.assertEquals(expectedResponseString, response, true);
+    }
+
+    @Test
+    public void testToolCallWithAdminAccessTokenSucceeds() throws Exception {
+        String accessToken = getAccessToken(TEST_ADMIN_USERNAME, TEST_PASSWORD);
+        assertNotNull("Access token should not be null", accessToken);
+
+        McpClient client = new McpClient(server, "/oidcTests", StateMode.STATELESS, accessToken);
+
+        String request = """
+                        {
+                          "jsonrpc": "2.0",
+                          "id": 1,
+                          "method": "tools/call",
+                          "params": {
+                            "name": "adminTool",
+                            "arguments": {}
+                          }
+                        }
+                        """;
+
+        String response = client.callMCPWithBearerToken(request);
+        String expectedResponseString = """
+                        {"id":1,"jsonrpc":"2.0","result":{"content":[{"type":"text","text":"Hello you handsome admin!"}], "isError": false}}
+                        """;
+
+        JSONAssert.assertEquals(expectedResponseString, response, true);
+    }
+
+    @Test
+    public void testAdminRestrictedToolCallWithBasicUserTokenFails() throws Exception {
+        String accessToken = getAccessToken(TEST_USER_USERNAME, TEST_PASSWORD);
+        assertNotNull("Access token should not be null", accessToken);
+
+        McpClient client = new McpClient(server, "/oidcTests", StateMode.STATELESS, accessToken);
+
+        String request = """
+                        {
+                          "jsonrpc": "2.0",
+                          "id": 1,
+                          "method": "tools/call",
+                          "params": {
+                            "name": "adminTool",
+                            "arguments": {}
+                          }
+                        }
+                        """;
+
+        client.callMCPWithBearerTokenAuthorisationErrorExpected(request);
+    }
+
+    private String getAccessToken(String username, String password) throws Exception {
+        Pattern accessTokenPattern = Pattern.compile("\"access_token\"\\s*:\\s*\"([^\"]+)\"");
+
+        String tokenEndpoint = "http://localhost:" + keycloakContainer.getMappedPort(8080)
+                               + "/realms/" + KEYCLOAK_REALM + "/protocol/openid-connect/token";
+
+        String formData = String.join("&",
+                                      "client_id=" + encode(TEST_PUBLIC_CLIENT_ID),
+                                      "username=" + encode(username),
+                                      "password=" + encode(password),
+                                      "grant_type=password");
+
+        Builder requestBuilder = HttpRequest.newBuilder()
+                                            .uri(URI.create(tokenEndpoint))
+                                            .header("Content-Type", "application/x-www-form-urlencoded")
+                                            .POST(HttpRequest.BodyPublishers.ofString(formData));
+
+        HttpResponse<String> response = HttpClient.newHttpClient()
+                                                  .send(requestBuilder.build(), BodyHandlers.ofString());
+
+        if (response.statusCode() != 200) {
+            throw new RuntimeException("Failed to get access token. Status: " + response.statusCode()
+                                       + "\nBody: " + response.body());
+        }
+
+        Matcher matcher = accessTokenPattern.matcher(response.body());
+        if (!matcher.find()) {
+            throw new RuntimeException("No access_token found in Keycloak response: " + response.body());
+        }
+
+        String accessToken = matcher.group(1);
+        return accessToken;
+    }
+
+    /**
+     * URL encodes a string value using UTF-8 encoding.
+     *
+     * This makes values safe to put inside that form body. Without encoding, special characters could break the request.
+     *
+     * For example, encode("user@example.com") becomes user%40example.com.
+     *
+     * @param value the string to be URL encoded
+     * @return the URL encoded string
+     */
+    private static String encode(String value) {
+        return URLEncoder.encode(value, StandardCharsets.UTF_8);
+    }
+
+    private static void setupKeycloak() throws CloneNotSupportedException, Exception {
+        // Expose Liberty server port to container
+        final int localServerPort = server.getHttpDefaultPort();
+        Testcontainers.exposeHostPorts(localServerPort);
+
+        // Create realm
+        runCommandInContainer("/opt/keycloak/bin/kcadm.sh config credentials --server http://localhost:8080 " +
+                              "--realm master --user admin --password admin");
+
+        runCommandInContainer("/opt/keycloak/bin/kcadm.sh create realms -s realm=" + KEYCLOAK_REALM + " -s enabled=true");
+
+        // Create confidential client
+        keycloakConfidentialClientUUID = runCommandInContainer(
+                                                               "/opt/keycloak/bin/kcadm.sh create clients -r " + KEYCLOAK_REALM + " " +
+                                                               "-s clientId=" + LIBERTY_MCP_SERVER_CLIENT_ID + " " +
+                                                               "-s name=" + LIBERTY_MCP_SERVER_CLIENT_ID + " " +
+                                                               "-s enabled=true " +
+                                                               "-s publicClient=false " +
+                                                               "-s clientAuthenticatorType=client-secret " +
+                                                               "-s standardFlowEnabled=true " +
+                                                               "-s directAccessGrantsEnabled=true " +
+                                                               "-s serviceAccountsEnabled=true " +
+                                                               "-s 'redirectUris=[\"*\"]' " +
+                                                               "-s 'webOrigins=[\"*\"]' " +
+                                                               "-i").trim();
+
+        // Get confidential client secret
+        String secretResponse = runCommandInContainer(
+                                                      "/opt/keycloak/bin/kcadm.sh get clients/" + keycloakConfidentialClientUUID + "/client-secret -r " + KEYCLOAK_REALM)
+                                                                                                                                                                         .trim();
+        keycloakConfidentialClientSecret = extractClientSecret(secretResponse);
+
+        // Create public client
+        keycloakPublicClientUUID = runCommandInContainer(
+                                                         "/opt/keycloak/bin/kcadm.sh create clients -r " + KEYCLOAK_REALM + " " +
+                                                         "-s clientId=" + TEST_PUBLIC_CLIENT_ID + " " +
+                                                         "-s name=" + TEST_PUBLIC_CLIENT_ID + " " +
+                                                         "-s enabled=true " +
+                                                         "-s publicClient=true " +
+                                                         "-s standardFlowEnabled=true " +
+                                                         "-s directAccessGrantsEnabled=true " +
+                                                         "-s authorizationServicesEnabled=false " +
+                                                         "-s 'redirectUris=[\"*\"]' " +
+                                                         "-s 'webOrigins=[\"*\"]' " +
+                                                         "-i").trim();
+
+        // Create normal user
+        String regularUserId = runCommandInContainer(
+                                                     "/opt/keycloak/bin/kcadm.sh create users -r " + KEYCLOAK_REALM + " " +
+                                                     "-s username=" + TEST_USER_USERNAME + " " +
+                                                     "-s email=" + TEST_USER_USERNAME + " " +
+                                                     "-s firstName=Test " +
+                                                     "-s lastName=Admin " +
+                                                     "-s enabled=true " +
+                                                     "-s emailVerified=true " +
+                                                     "-s 'requiredActions=[]' " +
+                                                     "-i").trim();
+
+        setNonTemporaryPassword(regularUserId);
+
+        // Create admin user
+        String adminUserId = runCommandInContainer(
+                                                   "/opt/keycloak/bin/kcadm.sh create users -r " + KEYCLOAK_REALM + " " +
+                                                   "-s username=" + TEST_ADMIN_USERNAME + " " +
+                                                   "-s email=" + TEST_ADMIN_USERNAME + " " +
+                                                   "-s firstName=Test " +
+                                                   "-s lastName=User " +
+                                                   "-s enabled=true " +
+                                                   "-s emailVerified=true " +
+                                                   "-s 'requiredActions=[]' " +
+                                                   "-i").trim();
+
+        setNonTemporaryPassword(adminUserId);
+
+        // Create groups
+        String userGroupId = runCommandInContainer(
+                                                   "/opt/keycloak/bin/kcadm.sh create groups -r " + KEYCLOAK_REALM + " " +
+                                                   "-s name=mcp-user " +
+                                                   "-i").trim();
+
+        String adminGroupId = runCommandInContainer(
+                                                    "/opt/keycloak/bin/kcadm.sh create groups -r " + KEYCLOAK_REALM + " " +
+                                                    "-s name=mcp-admin " +
+                                                    "-i").trim();
+
+        // Add regular user to mcp-user group
+        runCommandInContainer(
+                              "/opt/keycloak/bin/kcadm.sh update users/" + regularUserId + "/groups/" + userGroupId + " " +
+                              "-r " + KEYCLOAK_REALM + " " +
+                              "-s realm=" + KEYCLOAK_REALM + " " +
+                              "-s userId=" + regularUserId + " " +
+                              "-s groupId=" + userGroupId + " " +
+                              "-n");
+
+        // Add admin user to mcp-user group
+        runCommandInContainer(
+                              "/opt/keycloak/bin/kcadm.sh update users/" + adminUserId + "/groups/" + userGroupId + " " +
+                              "-r " + KEYCLOAK_REALM + " " +
+                              "-s realm=" + KEYCLOAK_REALM + " " +
+                              "-s userId=" + adminUserId + " " +
+                              "-s groupId=" + userGroupId + " " +
+                              "-n");
+
+        // Add admin user to mcp-admin group
+        runCommandInContainer(
+                              "/opt/keycloak/bin/kcadm.sh update users/" + adminUserId + "/groups/" + adminGroupId + " " +
+                              "-r " + KEYCLOAK_REALM + " " +
+                              "-s realm=" + KEYCLOAK_REALM + " " +
+                              "-s userId=" + adminUserId + " " +
+                              "-s groupId=" + adminGroupId + " " +
+                              "-n");
+
+        // Add group mapper to public client
+        runCommandInContainer(
+                              "/opt/keycloak/bin/kcadm.sh create clients/" + keycloakPublicClientUUID + "/protocol-mappers/models " +
+                              "-r " + KEYCLOAK_REALM + " " +
+                              "-s name=groups " +
+                              "-s protocol=openid-connect " +
+                              "-s protocolMapper=oidc-group-membership-mapper " +
+                              "-s 'config.\"claim.name\"=groups' " +
+                              "-s 'config.\"full.path\"=false' " +
+                              "-s 'config.\"id.token.claim\"=true' " +
+                              "-s 'config.\"access.token.claim\"=true' " +
+                              "-s 'config.\"userinfo.token.claim\"=true' " +
+                              "-s 'config.\"introspection.token.claim\"=true'");
+
+        // Add audience mapper to public client
+        runCommandInContainer(
+                              "/opt/keycloak/bin/kcadm.sh create clients/" + keycloakPublicClientUUID + "/protocol-mappers/models " +
+                              "-r " + KEYCLOAK_REALM + " " +
+                              "-s name=liberty-mcp-server-audience " +
+                              "-s protocol=openid-connect " +
+                              "-s protocolMapper=oidc-audience-mapper " +
+                              "-s 'config.\"included.client.audience\"=" + LIBERTY_MCP_SERVER_CLIENT_ID + "' " +
+                              "-s 'config.\"id.token.claim\"=false' " +
+                              "-s 'config.\"access.token.claim\"=true' " +
+                              "-s 'config.\"introspection.token.claim\"=true'");
+
+    }
+
+    private static void updateOidcConfigAttributes() throws CloneNotSupportedException, Exception {
+        // Update the Liberty server configuration with dynamic Keycloak values
+        String keycloakBaseUrl = "http://localhost:" + keycloakContainer.getMappedPort(8080);
+        ServerConfiguration config = server.getServerConfiguration().clone();
+        OpenidConnectClient openidConnectClient = config.getOpenidConnectClients().get(0);
+
+        // Update with dynamically created Keycloak client credentials
+        openidConnectClient.setClientId(LIBERTY_MCP_SERVER_CLIENT_ID);
+        openidConnectClient.setClientSecret(keycloakConfidentialClientSecret);
+        openidConnectClient.setJwkEndpointUrl(keycloakBaseUrl + "/realms/" + KEYCLOAK_REALM + "/protocol/openid-connect/certs");
+        openidConnectClient.setIssuerIdentifier(keycloakBaseUrl + "/realms/" + KEYCLOAK_REALM);
+        openidConnectClient.setAudiences(LIBERTY_MCP_SERVER_CLIENT_ID);
+
+        updateConfigDynamically(server, config);
+    }
+
+    protected static void updateConfigDynamically(LibertyServer server, ServerConfiguration config) throws Exception {
+        server.updateServerConfiguration(config);
+        // Wait for server config update to complete before continuing
+        server.waitForStringInLogUsingMark("CWWKG001[7-8]I");
+    }
+
+    private static void setNonTemporaryPassword(String userId) throws Exception {
+        // Set the user's non temporary password
+        runCommandInContainer(
+                              "/opt/keycloak/bin/kcadm.sh update users/" + userId + "/reset-password " +
+                              "-r " + KEYCLOAK_REALM + " " +
+                              "-s type=password " +
+                              "-s value=" + TEST_PASSWORD + " " +
+                              "-s temporary=false " +
+                              "-n");
+
+        // Marks the user’s email as verified and clears any required actions on the account, avoid "Account is not fully set up" errors.
+        runCommandInContainer(
+                              "/opt/keycloak/bin/kcadm.sh update users/" + userId + " " +
+                              "-r " + KEYCLOAK_REALM + " " +
+                              "-s enabled=true " +
+                              "-s emailVerified=true " +
+                              "-s 'requiredActions=[]'");
+    }
+
+    private static String extractClientSecret(String response) {
+        Pattern clientSecretPattern = Pattern.compile("\"value\"\\s*:\\s*\"([^\"]+)\"");
+        Matcher matcher = clientSecretPattern.matcher(response);
+        if (!matcher.find()) {
+            throw new RuntimeException("Could not extract Keycloak client secret from: " + response);
+        }
+        return matcher.group(1);
+    }
+
+    private static String runCommandInContainer(String command) throws IOException, InterruptedException {
+        Container.ExecResult result = keycloakContainer.execInContainer("sh", "-c", command);
+        if (result.getExitCode() != 0) {
+            throw new RuntimeException("Command failed: " + command +
+                                       "\nStdout: " + result.getStdout() +
+                                       "\nStderr: " + result.getStderr());
+        }
+        return result.getStdout();
+    }
+
+}

--- a/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/oidc/tools/RolesAllowedTools.java
+++ b/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/oidc/tools/RolesAllowedTools.java
@@ -1,0 +1,31 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.mcp.internal.fat.oidc.tools;
+
+import io.openliberty.mcp.annotations.Tool;
+import jakarta.annotation.security.RolesAllowed;
+import jakarta.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class RolesAllowedTools {
+
+    @RolesAllowed("mcp-admin")
+    @Tool(name = "adminTool", title = "Admin Tool", description = "A tool that can only be used by admins")
+    public String adminTool() {
+        return "Hello you handsome admin!";
+    }
+
+    @RolesAllowed("mcp-user")
+    @Tool(name = "userTool", title = "User Tool", description = "A tool that can only be used by mcp users and admins")
+    public String userTool() {
+        return "Hello you basic user";
+    }
+
+}

--- a/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/utils/McpClient.java
+++ b/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/utils/McpClient.java
@@ -57,6 +57,7 @@ public class McpClient extends ExternalResource {
     private final StateMode mode;
     private final String username;
     private final String password;
+    private final String bearerToken;
 
     private static final String DEFAULT_MCP_PATH = "/mcp";
     private final String path;
@@ -71,7 +72,7 @@ public class McpClient extends ExternalResource {
     }
 
     public McpClient(LibertyServer server, String contextRoot) {
-        this(server, contextRoot, DEFAULT_MCP_PATH, StateMode.STATEFUL, null, null);
+        this(server, contextRoot, DEFAULT_MCP_PATH, StateMode.STATEFUL, null, null, null);
     }
 
     /**
@@ -80,11 +81,11 @@ public class McpClient extends ExternalResource {
      * @param mode whether to expect the server to be in stateful or stateless mode
      */
     public McpClient(LibertyServer server, String contextRoot, StateMode mode) {
-        this(server, contextRoot, DEFAULT_MCP_PATH, mode, null, null);
+        this(server, contextRoot, DEFAULT_MCP_PATH, mode, null, null, null);
     }
 
     public McpClient(LibertyServer server, String contextRoot, String path) {
-        this(server, contextRoot, path, StateMode.STATEFUL, null, null);
+        this(server, contextRoot, path, StateMode.STATEFUL, null, null, null);
     }
 
     /**
@@ -93,14 +94,21 @@ public class McpClient extends ExternalResource {
      * @param path The full request endpoint path e.g {@code path + "/mcp"}.
      */
     public McpClient(LibertyServer server, String contextRoot, String path, StateMode mode) {
-        this(server, contextRoot, path, mode, null, null);
+        this(server, contextRoot, path, mode, null, null, null);
+    }
+
+    /**
+     * Use this constructor if you have the StateMode and bearerToken
+     */
+    public McpClient(LibertyServer server, String contextRoot, StateMode mode, String bearerToken) {
+        this(server, contextRoot, DEFAULT_MCP_PATH, mode, bearerToken, null, null);
     }
 
     /**
      * Use this constructor if you have the StateMode, username and password
      */
     public McpClient(LibertyServer server, String contextRoot, StateMode mode, String username, String password) {
-        this(server, contextRoot, DEFAULT_MCP_PATH, mode, username, password);
+        this(server, contextRoot, DEFAULT_MCP_PATH, mode, null, username, password);
     }
 
     /**
@@ -110,12 +118,13 @@ public class McpClient extends ExternalResource {
      * @param username for basic auth
      * @param password for basic auth
      */
-    public McpClient(LibertyServer server, String contextRoot, String path, StateMode mode, String username, String password) {
+    public McpClient(LibertyServer server, String contextRoot, String path, StateMode mode, String bearerToken, String username, String password) {
         super();
         this.server = server;
         this.contextRoot = contextRoot.startsWith("/") ? contextRoot : "/" + contextRoot;
         this.path = path.startsWith("/") ? path : "/" + path;
         this.mode = mode;
+        this.bearerToken = bearerToken;
         this.username = username;
         this.password = password;
     }
@@ -356,6 +365,34 @@ public class McpClient extends ExternalResource {
         return setupAndRunRequest(request, jsonRequestBody);
     }
 
+    public String callMCPWithBearerToken(String jsonRequestBody) throws Exception {
+        final HttpRequest request = new HttpRequest(server, getMcpPath())
+                                                                         .requestProp("Authorization", "Bearer " + bearerToken);
+        return setupAndRunRequest(request, jsonRequestBody);
+    }
+
+    /**
+     * Calls MCP without an access token, where authentication is expected.
+     *
+     * Expected response when OIDC bearer authentication is active:
+     * statusCode=401
+     * WWW-Authenticate=Bearer realm="oauth", error="invalid_token", error_description="Check access token"
+     *
+     * @param jsonRequestBody JSON-RPC request body
+     * @return detailed authentication error response including status, headers and body
+     * @throws Exception if the request fails unexpectedly
+     */
+    public McpDetailedAuthResponse callMCP401AuthErrorExpected(String jsonRequestBody) throws Exception {
+        final HttpRequest request = new HttpRequest(server, getMcpPath()).expectCode(401);
+        String responseBody = setupAndRunRequest(request, jsonRequestBody);
+
+        return new McpDetailedAuthResponse(
+                                           request.getResponseCode(),
+                                           request.getResponseHeader("WWW-Authenticate"),
+                                           request.getResponseHeader("Content-Type"),
+                                           responseBody);
+    }
+
     public String callMCPAuthorisationErrorExpected(String jsonRequestBody) throws Exception {
         final HttpRequest request = new HttpRequest(server, getMcpPath()).expectCode(403);
         return setupAndRunRequest(request, jsonRequestBody);
@@ -364,6 +401,11 @@ public class McpClient extends ExternalResource {
     public String callMCPwithBasicAuth_AuthorisationErrorExpected(String jsonRequestBody, String user, String password) throws Exception {
         final HttpRequest request = new HttpRequest(server, getMcpPath()).expectCode(403)
                                                                          .basicAuth(user, password);
+        return setupAndRunRequest(request, jsonRequestBody);
+    }
+
+    public String callMCPWithBearerTokenAuthorisationErrorExpected(String jsonRequestBody) throws Exception {
+        final HttpRequest request = new HttpRequest(server, getMcpPath()).requestProp("Authorization", "Bearer " + bearerToken).expectCode(403);
         return setupAndRunRequest(request, jsonRequestBody);
     }
 
@@ -494,6 +536,8 @@ public class McpClient extends ExternalResource {
 
         return combinedResponse.toString();
     }
+
+    public record McpDetailedAuthResponse(int statusCode, String wwwAuthenticate, String contentType, String body) {}
 
     public void setSessionDeleted(boolean deleted) {
         this.sessionDeleted = deleted;

--- a/dev/io.openliberty.mcp.internal_fat/publish/servers/mcp-server-oidc/bootstrap.properties
+++ b/dev/io.openliberty.mcp.internal_fat/publish/servers/mcp-server-oidc/bootstrap.properties
@@ -1,0 +1,2 @@
+bootstrap.include=../testports.properties
+com.ibm.ws.logging.trace.specification=*=info=:MCP=all

--- a/dev/io.openliberty.mcp.internal_fat/publish/servers/mcp-server-oidc/resources/WEB-INF/web.xml
+++ b/dev/io.openliberty.mcp.internal_fat/publish/servers/mcp-server-oidc/resources/WEB-INF/web.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2026 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License 2.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-2.0/
+    
+    SPDX-License-Identifier: EPL-2.0
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<web-app xmlns="https://jakarta.ee/xml/ns/jakartaee"
+         version="6.0">
+
+    <security-role>
+        <role-name>mcp-user</role-name>
+    </security-role>
+
+    <security-role>
+        <role-name>mcp-admin</role-name>
+    </security-role>
+
+    <security-constraint>
+        <web-resource-collection>
+            <web-resource-name>MCP endpoint</web-resource-name>
+            <url-pattern>/mcp</url-pattern>
+            <url-pattern>/mcp/*</url-pattern>
+        </web-resource-collection>
+
+        <auth-constraint>
+            <role-name>mcp-user</role-name>
+            <role-name>mcp-admin</role-name>
+        </auth-constraint>
+    </security-constraint>
+    
+</web-app>

--- a/dev/io.openliberty.mcp.internal_fat/publish/servers/mcp-server-oidc/server.xml
+++ b/dev/io.openliberty.mcp.internal_fat/publish/servers/mcp-server-oidc/server.xml
@@ -1,0 +1,37 @@
+<server description="Sample Liberty server">
+
+  <featureManager>
+    <feature>servlet-6.0</feature>
+    <feature>cdi-4.0</feature>
+    <feature>mcpServer-1.0</feature>
+    <feature>openidConnectClient-1.0</feature>
+    <feature>appSecurity-5.0</feature>
+  </featureManager>
+
+  <application location="oidcTests.war">
+  	<mcpServer stateless="true"/>
+  </application>
+  
+  <include location="../fatTestPorts.xml" />
+  
+   <openidConnectClient
+        id="liberty-mcp-server-conf-client"
+        clientId="${oidc.clientId}"
+        clientSecret="${oidc.clientSecret}"
+        jwkEndpointUrl="${oidc.jwkEndpointUrl}"
+        issuerIdentifier="${oidc.issuerIdentifier}"
+        audiences="${oidc.audiences}"
+        signatureAlgorithm="RS256"
+        inboundPropagation="required"
+        groupIdentifier="groups"
+        authnSessionDisabled="true"
+        httpsRequired="false"
+        disableLtpaCookie="true"
+        tokenReuse="true">
+   </openidConnectClient>
+
+ <ssl id="defaultSSLConfig" trustDefaultCerts="true" />
+ 
+ <keyStore password="keypass" />
+  
+</server>

--- a/dev/io.openliberty.org.testcontainers/cache/externals
+++ b/dev/io.openliberty.org.testcontainers/cache/externals
@@ -50,6 +50,7 @@ public.ecr.aws/docker/library/postgres:17-alpine
 public.ecr.aws/docker/library/python:3.11.6
 public.ecr.aws/elastic/logstash:9.3.3
 quay.io/jaegertracing/all-in-one:1.76.0
+quay.io/keycloak/keycloak:26.6.2
 ryanesch/acme-boulder:1.2
 seleniarm/standalone-chromium:4.8.3
 selenium/standalone-chrome:4.8.3

--- a/dev/io.openliberty.org.testcontainers/cache/images
+++ b/dev/io.openliberty.org.testcontainers/cache/images
@@ -53,3 +53,4 @@ wasliberty-internal-docker-local/openliberty/testcontainers/spnego-kdc-server:1.
 wasliberty-internal-docker-local/openliberty/testcontainers/sqlserver-ssl:2022.0.0.1-latest
 wasliberty-mcr-docker-remote/mssql/server:2022-latest
 wasliberty-quay-docker-remote/jaegertracing/all-in-one:1.76.0
+wasliberty-quay-docker-remote/keycloak/keycloak:26.6.2


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #34726".

The issue can't be fully complete because we can't fully test the [MCP authorization flow](https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization) until we implement protected resource metadata. So for this issue I focused on

- Setting up Keycloak as an authorisation server using TestContainers
- Setting up the Liberty server used in the tests to use `oidcConnectClient` with Keycloak to authenticate users
- Used the access token retrieved from keycloak to test authorization of tools with different roles

In the FAT tests, I mainly mimicked the setup documented [here](https://ibm.box.com/s/vkdppnqml6c2p18ktyr8tgjd4rgiwgh0) for doing it manually.

**Note:** For the FAT test to work with Keycloak in test containers, you must do the following:
- Ensure you have Podman downloaded (steps to download it are in this wiki in case you don’t have it already https://github.ibm.com/websphere/WS-CD-Open/wiki/Automated-Tests#using-artifactory-or-internal-registries)
- Follow the steps from https://github.ibm.com/websphere/WS-CD-Open/wiki/Automated-Tests#using-artifactory-or-internal-registries up to and including the part with the command below:
```
$ echo '[your-w3-password]' | \
    podman login --authfile=$HOME/.docker/config.json --cert-dir=$HOME/.docker/certs.d/ -u=[your-w3-email] \
      --password-stdin [libr|libs|libh]-[proxy1.fyre.ibm.com:5002](http://proxy1.fyre.ibm.com:5002/)
```

