### PR TITLE
Add --enable-native-access flag for z/OS server create commands

### DIFF
--- a/dev/com.ibm.ws.kernel.boot.ws-server/publish/bin/server
+++ b/dev/com.ibm.ws.kernel.boot.ws-server/publish/bin/server
@@ -312,12 +312,36 @@ checkServer()
 }
 
 ##
+##
+## addZosNativeAccessFlag: Add --enable-native-access flag for z/OS Java 24+
+##
+addZosNativeAccessFlag()
+{
+  # Determine Java version and add z/OS native access flag for Java 24+ to avoid warnings
+  if [ "${uname}" = OS/390 ]; then
+    # Try to determine Java version if JAVA_HOME is set
+    if [ -n "${JAVA_HOME}" ] && [ -f "${JAVA_HOME}/release" ]; then
+      JAVA_VERSION_MAJOR=$(readNativeFile "${JAVA_HOME}/release" '[A-Za-z0-9]' | LC_ALL=C tr -d '\r' | grep ^JAVA_VERSION\s*= | tr -d '"' | awk -F= '{print $2}' | awk -F. '{if ($1 > 1) {print $1} else {print $2}}')
+      # Only add flag if version was successfully detected and is >= 24
+      if [ -n "${JAVA_VERSION_MAJOR}" ] && [ "${JAVA_VERSION_MAJOR}" -ge 24 ] 2>/dev/null; then
+        case "${JVM_OPTIONS_QUOTED}" in
+          *--enable-native-access=ALL-UNNAMED*) ;;
+          *)
+            JVM_OPTIONS_QUOTED="${JVM_OPTIONS_QUOTED} '--enable-native-access=ALL-UNNAMED'"
+            ;;
+        esac
+      fi
+    fi
+  fi
+}
+
 ## installEnv: Set variables for a non-server or nonexistent server command.
 installEnv()
 {
   readServerEnv "${WLP_INSTALL_DIR}/etc/server.env"
   installEnvDefaults
   serverEnvDefaults
+  addZosNativeAccessFlag
 }
 
 ##
@@ -493,23 +517,7 @@ serverEnv()
   readServerEnv "${WLP_USER_DIR}/shared/server.env"
   readServerEnv "${SERVER_CONFIG_DIR}/server.env"
   serverEnvDefaults
-  
-  # Determine Java version and add z/OS native access flag for Java 24+ to avoid warnings
-  if [ "${uname}" = OS/390 ]; then
-    # Try to determine Java version if JAVA_HOME is set
-    if [ -n "${JAVA_HOME}" ] && [ -f "${JAVA_HOME}/release" ]; then
-      JAVA_VERSION_MAJOR=$(readNativeFile "${JAVA_HOME}/release" '[A-Za-z0-9]' | LC_ALL=C tr -d '\r' | grep ^JAVA_VERSION\s*= | tr -d '"' | awk -F= '{print $2}' | awk -F. '{if ($1 > 1) {print $1} else {print $2}}')
-      # Only add flag if version was successfully detected and is >= 24
-      if [ -n "${JAVA_VERSION_MAJOR}" ] && [ "${JAVA_VERSION_MAJOR}" -ge 24 ] 2>/dev/null; then
-        case "${JVM_OPTIONS_QUOTED}" in
-          *--enable-native-access=ALL-UNNAMED*) ;;
-          *)
-            JVM_OPTIONS_QUOTED="${JVM_OPTIONS_QUOTED} '--enable-native-access=ALL-UNNAMED'"
-            ;;
-        esac
-      fi
-    fi
-  fi
+  addZosNativeAccessFlag
 }
 
 ## Initialize base JVM options that are always needed


### PR DESCRIPTION

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #35121" 
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

The server create command (and other commands using installEnv subroutine in the server script) were missing the --enable-native-access=ALL-UNNAMED flag needed for Java 24+ on z/OS to avoid restricted method warnings when calling System.loadLibrary.

This fix:
- Extracts the z/OS native access flag logic into a reusable addZosNativeAccessFlag() function
- Adds the function call to installEnv() to fix: create, list, help, help:usage commands
- Refactors serverEnv() to use the same function to eliminate code duplication

All server commands that start a JVM on z/OS with Java 24+ now properly add the --enable-native-access=ALL-UNNAMED flag to avoid warnings.