### PR TITLE
Add allowed ffdc to testTagFileFromJarWithLoadTagFilesFromJarsDisabled

### DIFF
--- a/dev/com.ibm.ws.jsp.2.3_fat/fat/src/com/ibm/ws/jsp23/fat/tests/JSPTagFilesInJarTest.java
+++ b/dev/com.ibm.ws.jsp.2.3_fat/fat/src/com/ibm/ws/jsp23/fat/tests/JSPTagFilesInJarTest.java
@@ -31,6 +31,7 @@ import com.meterware.httpunit.WebConversation;
 import com.meterware.httpunit.WebRequest;
 import com.meterware.httpunit.WebResponse;
 
+import componenttest.annotation.AllowedFFDC;
 import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
@@ -176,6 +177,7 @@ public class JSPTagFilesInJarTest {
      * @throws Exception if the test fails
      */
     @Test
+    @AllowedFFDC("java.security.PrivilegedActionException")
     public void testTagFileFromJarWithLoadTagFilesFromJarsDisabled() throws Exception {
         // Disable loadTagFilesFromJars in server configuration
         ServerConfiguration configuration = server.getServerConfiguration();


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

For defect 310767


This behavior is expected. When Java 2 security is enabled and a tag file cannot be found, a PrivilegedActionException is thrown. This has been the established behavior in the codebase.

Reference: [AbstractJSPExtensionProcessor.java](https://github.com/OpenLiberty/open-liberty/blob/a6f18af4ba115008ea1e7489656342d93%5B%E2%80%A6%5Dm/ibm/ws/jsp/webcontainerext/AbstractJSPExtensionProcessor.java)

Root Cause:
The underlying issue originates from:

Caused by: com.ibm.ws.jsp.translator.JspTranslationException: /tag-test.jsp(20,9) --> JSPG0046E: Unable to locate tagfile for tag myTag

Note: JspTranslationException extends JspCoreException

This exception is subsequently wrapped by the PrivilegedActionException when Java 2 security is active.

While the code could be modified, this exception handling pattern has been in place historically and represents the expected behavior for this scenario.