### PR TITLE
Add LTPA waits for Jakarta Sec 4.0 tests that attempt logins

### DIFF
--- a/dev/io.openliberty.security.jakartasec.4.0.internal_fat/fat/src/io/openliberty/security/jakartasec/fat/tests/InMemoryIdStoreAesEncodedPwdTests.java
+++ b/dev/io.openliberty.security.jakartasec.4.0.internal_fat/fat/src/io/openliberty/security/jakartasec/fat/tests/InMemoryIdStoreAesEncodedPwdTests.java
@@ -83,6 +83,8 @@ public class InMemoryIdStoreAesEncodedPwdTests extends BaseJakartaSecurity40Test
         ShrinkHelper.exportDropinAppToServer(server, app, DeployOptions.SERVER_ONLY);
 
         instance.startServer();
+
+        server.waitForLTPAConfigReady();
     }
 
     /**

--- a/dev/io.openliberty.security.jakartasec.4.0.internal_fat/fat/src/io/openliberty/security/jakartasec/fat/tests/InMemoryIdStoreBadlyEncodedPwdTests.java
+++ b/dev/io.openliberty.security.jakartasec.4.0.internal_fat/fat/src/io/openliberty/security/jakartasec/fat/tests/InMemoryIdStoreBadlyEncodedPwdTests.java
@@ -81,6 +81,8 @@ public class InMemoryIdStoreBadlyEncodedPwdTests extends BaseJakartaSecurity40Te
         ShrinkHelper.exportDropinAppToServer(server, app, DeployOptions.SERVER_ONLY);
 
         instance.startServer();
+
+        server.waitForLTPAConfigReady();
     }
 
     /**

--- a/dev/io.openliberty.security.jakartasec.4.0.internal_fat/fat/src/io/openliberty/security/jakartasec/fat/tests/InMemoryIdentityStorePropertyNotFoundTest.java
+++ b/dev/io.openliberty.security.jakartasec.4.0.internal_fat/fat/src/io/openliberty/security/jakartasec/fat/tests/InMemoryIdentityStorePropertyNotFoundTest.java
@@ -82,6 +82,8 @@ public class InMemoryIdentityStorePropertyNotFoundTest extends BaseJakartaSecuri
         ShrinkHelper.exportDropinAppToServer(server, app, DeployOptions.SERVER_ONLY);
 
         instance.startServer();
+
+        server.waitForLTPAConfigReady();
     }
 
     /**

--- a/dev/io.openliberty.security.jakartasec.4.0.internal_fat/fat/src/io/openliberty/security/jakartasec/fat/tests/MultipleAppsInMemoryIdStoresTests.java
+++ b/dev/io.openliberty.security.jakartasec.4.0.internal_fat/fat/src/io/openliberty/security/jakartasec/fat/tests/MultipleAppsInMemoryIdStoresTests.java
@@ -92,6 +92,8 @@ public class MultipleAppsInMemoryIdStoresTests extends BaseJakartaSecurity40Test
         ShrinkHelper.exportDropinAppToServer(server, multiapp2, DeployOptions.SERVER_ONLY);
 
         instance.startServer();
+
+        server.waitForLTPAConfigReady();
     }
 
     /**

--- a/dev/io.openliberty.security.jakartasec.4.0.internal_fat/fat/src/io/openliberty/security/jakartasec/fat/tests/MultipleHAMCustomTests.java
+++ b/dev/io.openliberty.security.jakartasec.4.0.internal_fat/fat/src/io/openliberty/security/jakartasec/fat/tests/MultipleHAMCustomTests.java
@@ -72,6 +72,8 @@ public class MultipleHAMCustomTests extends BaseJakartaSecurity40Test {
         ShrinkHelper.exportDropinAppToServer(server, multipleHamApp, DeployOptions.SERVER_ONLY);
 
         server.startServer();
+
+        server.waitForLTPAConfigReady();
     }
 
     /*

--- a/dev/io.openliberty.security.jakartasec.4.0.internal_fat/fat/src/io/openliberty/security/jakartasec/fat/tests/MultipleHAMDuplicateTests.java
+++ b/dev/io.openliberty.security.jakartasec.4.0.internal_fat/fat/src/io/openliberty/security/jakartasec/fat/tests/MultipleHAMDuplicateTests.java
@@ -72,6 +72,8 @@ public class MultipleHAMDuplicateTests extends BaseJakartaSecurity40Test {
         ShrinkHelper.exportDropinAppToServer(server, multipleHamApp, DeployOptions.SERVER_ONLY);
 
         instance.startServer();
+
+        server.waitForLTPAConfigReady();
     }
 
     /*

--- a/dev/io.openliberty.security.jakartasec.4.0.internal_fat/fat/src/io/openliberty/security/jakartasec/fat/tests/MultipleHAMInbuiltQualifiersTests.java
+++ b/dev/io.openliberty.security.jakartasec.4.0.internal_fat/fat/src/io/openliberty/security/jakartasec/fat/tests/MultipleHAMInbuiltQualifiersTests.java
@@ -73,6 +73,8 @@ public class MultipleHAMInbuiltQualifiersTests extends BaseJakartaSecurity40Test
         ShrinkHelper.exportDropinAppToServer(server, multipleHamApp, DeployOptions.SERVER_ONLY);
 
         instance.startServer();
+
+        server.waitForLTPAConfigReady();
     }
 
     /*

--- a/dev/io.openliberty.security.jakartasec.4.0.internal_fat/fat/src/io/openliberty/security/jakartasec/fat/tests/MultipleHAMInbuiltTests.java
+++ b/dev/io.openliberty.security.jakartasec.4.0.internal_fat/fat/src/io/openliberty/security/jakartasec/fat/tests/MultipleHAMInbuiltTests.java
@@ -69,6 +69,8 @@ public class MultipleHAMInbuiltTests extends BaseJakartaSecurity40Test {
         ShrinkHelper.exportDropinAppToServer(server, multipleHamApp, DeployOptions.SERVER_ONLY);
 
         instance.startServer();
+
+        server.waitForLTPAConfigReady();
     }
 
     /*

--- a/dev/io.openliberty.security.jakartasec.4.0.internal_fat/fat/src/io/openliberty/security/jakartasec/fat/tests/MultipleIdentityStoreTypesTests.java
+++ b/dev/io.openliberty.security.jakartasec.4.0.internal_fat/fat/src/io/openliberty/security/jakartasec/fat/tests/MultipleIdentityStoreTypesTests.java
@@ -105,6 +105,8 @@ public class MultipleIdentityStoreTypesTests extends BaseJakartaSecurity40Test {
         ShrinkHelper.exportDropinAppToServer(server, app, DeployOptions.SERVER_ONLY);
 
         instance.startServer();
+
+        server.waitForLTPAConfigReady();
     }
 
     /**

--- a/dev/io.openliberty.security.jakartasec.4.0.internal_fat/fat/src/io/openliberty/security/jakartasec/fat/tests/MultipleIdentityStoresPriorityTests.java
+++ b/dev/io.openliberty.security.jakartasec.4.0.internal_fat/fat/src/io/openliberty/security/jakartasec/fat/tests/MultipleIdentityStoresPriorityTests.java
@@ -85,6 +85,8 @@ public class MultipleIdentityStoresPriorityTests extends BaseJakartaSecurity40Te
         ShrinkHelper.exportDropinAppToServer(server, app, DeployOptions.SERVER_ONLY);
 
         instance.startServer();
+
+        server.waitForLTPAConfigReady();
     }
 
     /**

--- a/dev/io.openliberty.security.jakartasec.4.0.internal_fat/fat/src/io/openliberty/security/jakartasec/fat/tests/MultipleInMemoryIdentityStoresTests.java
+++ b/dev/io.openliberty.security.jakartasec.4.0.internal_fat/fat/src/io/openliberty/security/jakartasec/fat/tests/MultipleInMemoryIdentityStoresTests.java
@@ -83,6 +83,8 @@ public class MultipleInMemoryIdentityStoresTests extends BaseJakartaSecurity40Te
         ShrinkHelper.exportDropinAppToServer(server, app, DeployOptions.SERVER_ONLY);
 
         instance.startServer();
+
+        server.waitForLTPAConfigReady();
     }
 
     /**

--- a/dev/io.openliberty.security.jakartasec.4.0.internal_fat/fat/src/io/openliberty/security/jakartasec/fat/tests/SingleHAMInbuiltCustomQualifierTests.java
+++ b/dev/io.openliberty.security.jakartasec.4.0.internal_fat/fat/src/io/openliberty/security/jakartasec/fat/tests/SingleHAMInbuiltCustomQualifierTests.java
@@ -75,6 +75,8 @@ public class SingleHAMInbuiltCustomQualifierTests extends BaseJakartaSecurity40T
         ShrinkHelper.exportDropinAppToServer(server, multipleHamApp, DeployOptions.SERVER_ONLY);
 
         instance.startServer();
+
+        server.waitForLTPAConfigReady();
     }
 
     /*


### PR DESCRIPTION
A number of more recent tests missed by the mega LTPA update are failing due to LTPA not being ready on windows or other platforms.

Fixes [#310810](https://wasrtc.hursley.ibm.com:9443/jazz/web/projects/WS-CD#action=com.ibm.team.workitem.viewWorkItem&id=310810)

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".