### PR TITLE
Fixes for TestContainers

### DIFF
--- a/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/conformance/tests/ConformanceTests.java
+++ b/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/conformance/tests/ConformanceTests.java
@@ -85,9 +85,11 @@ public class ConformanceTests extends FATServletClient {
     public McpClient client = new McpClient(server, "/conformanceTests");
     private final static Logger logger = Logger.getLogger(ConformanceTests.class.getName());
 
+    @SuppressWarnings("resource")
     @ClassRule
     public static GenericContainer<?> container = new GenericContainer<>(DOCKER_REGISTRY).withCommand("tail", "-f", "/dev/null")
                                                                                          .withAccessToHost(true)
+                                                                                         .withStartupAttempts(3)
                                                                                          .withWorkingDirectory(CONTAINER_WORKING_DIR)
                                                                                          .withCopyFileToContainer(SRC_PACKAGE_JSON, CONTAINER_PACKAGE_JSON)
                                                                                          .withCopyFileToContainer(SRC_PACKAGE_LOCK_JSON, CONTAINER_PACKAGE_LOCK_JSON)
@@ -98,6 +100,8 @@ public class ConformanceTests extends FATServletClient {
         WebArchive war = ShrinkWrap.create(WebArchive.class, "conformanceTests.war").addPackage(ConformanceTools.class.getPackage());
         ShrinkHelper.exportDropinAppToServer(server, war, SERVER_ONLY);
         server.startServer();
+        Testcontainers.exposeHostPorts(server.getHttpDefaultPort());
+
         assertNotNull(server.waitForStringInLog("MCP server endpoint: .*/mcp$")); // regex matches string that ends with /mcp e.g. "MCP server endpoint: http://macbookpro.home:8010/toolTest/mcp"
         setupContainer();
     }
@@ -105,7 +109,6 @@ public class ConformanceTests extends FATServletClient {
     private static void setupContainer() throws IOException, InterruptedException {
         final int localServerPort = server.getHttpDefaultPort();
         MCP_SERVER_URL_FROM_CONTAINER = "http://host.testcontainers.internal:" + localServerPort + "/conformanceTests/mcp";
-        Testcontainers.exposeHostPorts(localServerPort);
 
         if (artifactoryConfigIsPresent()) {
             String credentials = artUser + ":" + artToken;

--- a/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/oidc/tests/OidcTests.java
+++ b/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/oidc/tests/OidcTests.java
@@ -36,7 +36,6 @@ import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.skyscreamer.jsonassert.JSONAssert;
-import org.testcontainers.Testcontainers;
 import org.testcontainers.containers.Container;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
@@ -81,11 +80,13 @@ public class OidcTests extends FATServletClient {
 
     @SuppressWarnings("resource")
     @ClassRule
+
     public static GenericContainer<?> keycloakContainer = new GenericContainer<>(KEYCLOAK_REGISTRY).withExposedPorts(8080)
+                                                                                                   .withStartupAttempts(3)
                                                                                                    .withEnv("KEYCLOAK_ADMIN", "admin")
                                                                                                    .withEnv("KEYCLOAK_ADMIN_PASSWORD", "admin")
                                                                                                    .withCommand("start-dev")
-                                                                                                   .withLogConsumer(new SimpleLogConsumer(OidcTests.class, "keycloak-containe"))
+                                                                                                   .withLogConsumer(new SimpleLogConsumer(OidcTests.class, "keycloak-container"))
                                                                                                    .waitingFor(Wait.forLogMessage(".*Listening on:.*", 1)
                                                                                                                    .withStartupTimeout(Duration.ofMinutes(2)));
 
@@ -95,7 +96,6 @@ public class OidcTests extends FATServletClient {
                                    .addPackage(RolesAllowedTools.class.getPackage())
                                    .addAsWebInfResource(new File("publish/servers/mcp-server-oidc/resources/WEB-INF/web.xml"), "web.xml");
         ShrinkHelper.exportAppToServer(server, war, SERVER_ONLY);
-
         setupKeycloak();
         updateOidcConfigAttributes();
         server.startServer();
@@ -289,10 +289,6 @@ public class OidcTests extends FATServletClient {
     }
 
     private static void setupKeycloak() throws CloneNotSupportedException, Exception {
-        // Expose Liberty server port to container
-        final int localServerPort = server.getHttpDefaultPort();
-        Testcontainers.exposeHostPorts(localServerPort);
-
         // Create realm
         runCommandInContainer("/opt/keycloak/bin/kcadm.sh config credentials --server http://localhost:8080 " +
                               "--realm master --user admin --password admin");


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).

Part of #34726 (problem with podman socket timing out every 5s when the container timeout is 3 min, this created the problem with tests failing as the podman socket was unavailable)
Fixed by using   .withStartupAttempts(3) on the containers so that they would retry to start the container until the podman socket was available. 3 retries was the minimum that worked.
