### PR TITLE
Sortable expressions from Data 1400

### DIFF
--- a/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/QueryInfo.java
+++ b/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/QueryInfo.java
@@ -268,7 +268,7 @@ public abstract class QueryInfo {
      * Be careful when using this count. It changes as parameters are
      * found and/or generated.
      */
-    int qlParamCount;
+    protected int qlParamCount;
 
     /**
      * Names of named parameters in query language, ordered according to the
@@ -283,7 +283,7 @@ public abstract class QueryInfo {
      * rather than named parameters. The constant UNKNOWN represents the former
      * and the constant NO_NAMED_PARAMS represents the latter two cases.
      */
-    volatile Set<String> qlParamNames = Collections.emptySet();
+    protected volatile Set<String> qlParamNames = Collections.emptySet();
 
     /**
      * The interface that is annotated with @Repository.
@@ -501,6 +501,25 @@ public abstract class QueryInfo {
                                                       int prevNumJPQLParams,
                                                       boolean isCollection,
                                                       Annotation[] annos);
+
+    /**
+     * Appends the expression to the given partially built query.
+     *
+     * @param sort       sort criterion that has an expression
+     * @param q          string builder to which to append
+     * @param jpqlParams Map to be populated with JPQL parameter name/value for
+     *                       Constraints, Restrictions, and Sorts. Keys are the
+     *                       named parameter name or positional parameter index.
+     *                       Map values are obtained from the Constraint,
+     *                       Restriction, or Sort. The first positional parameter
+     *                       index starts at qlParamCount, which is updated by
+     *                       this method when JPQL parameters for repository
+     *                       method special parameters are added. The map is null
+     *                       when only the OrderBy annotation or keyword is used
+     */
+    protected abstract void appendExpression(Sort<?> sort,
+                                             StringBuilder q,
+                                             Map<Object, Object> jpqlParams);
 
     /**
      * Asks the Jakarta Persistence provider whether the given query uses named
@@ -993,7 +1012,7 @@ public abstract class QueryInfo {
                 order = order == null //
                                 ? new StringBuilder(100).append(" ORDER BY ") //
                                 : order.append(", ");
-                info.generateSort(order, sort, forward);
+                info.generateSort(order, sort, forward, jpqlParams);
             }
 
         if (pageReq == null ||
@@ -2452,11 +2471,11 @@ public abstract class QueryInfo {
         for (Sort<?> sort : sorts) {
             validateSort(sort);
             fwd.append(first ? " ORDER BY " : ", ");
-            generateSort(fwd, sort, true);
+            generateSort(fwd, sort, true, null);
 
             if (needsCursorQueries) {
                 prev.append(first ? " ORDER BY " : ", ");
-                generateSort(prev, sort, false);
+                generateSort(prev, sort, false, null);
             }
             first = false;
         }
@@ -2902,7 +2921,11 @@ public abstract class QueryInfo {
 
     /**
      * Generates and appends JPQL to sort based on the specified entity attribute.
-     * For most attributes, this will be of a form such as o.name or LOWER(o.name) DESC or ...
+     * For most attributes, this will be of a form such as:
+     * o.name
+     * LOWER(o.name) DESC NULLS LAST
+     * o.length * o.width * o.height
+     * ...
      *
      * @param q             builder for the JPQL query.
      * @param sort          sort criteria for a single attribute (name must already
@@ -2910,14 +2933,29 @@ public abstract class QueryInfo {
      * @param sameDirection indicate to append the Sort in the normal direction.
      *                          Otherwise reverses it (for cursor pagination in the
      *                          previous page direction).
+     * @param jpqlParams    Map to be populated with JPQL parameter name/value for
+     *                          Constraints, Restrictions, and Sorts. Keys are the
+     *                          named parameter name or positional parameter index.
+     *                          Map values are obtained from the Constraint,
+     *                          Restriction, or Sort. The first positional parameter
+     *                          index starts at qlParamCount, which is updated by
+     *                          this method when JPQL parameters for repository
+     *                          method special parameters are added. The map is null
+     *                          when only the OrderBy annotation or keyword is used.
      */
     @Trivial
-    private void generateSort(StringBuilder q, Sort<?> sort, boolean sameDirection) {
-        String propName = sort.property();
+    private void generateSort(StringBuilder q,
+                              Sort<?> sort,
+                              boolean sameDirection,
+                              Map<Object, Object> jpqlParams) {
         if (sort.ignoreCase())
             q.append("LOWER(");
 
-        appendAttributeName(propName, q);
+        String attributeName = sort.property();
+        if (attributeName == null)
+            appendExpression(sort, q, jpqlParams);
+        else
+            appendAttributeName(attributeName, q);
 
         if (sort.ignoreCase())
             q.append(")");
@@ -5918,19 +5956,21 @@ public abstract class QueryInfo {
             combined = sorts == null ? new ArrayList<>() : new ArrayList<>(sorts);
         while (addIt.hasNext()) {
             Sort<Object> sort = addIt.next();
-            if (sort == null) {
+            if (sort == null)
                 throw new IllegalArgumentException("Sort: null");
-            } else if (hasIdClass && ID.equalsIgnoreCase(sort.property())) {
+            String attributeName = sort.property();
+            if (attributeName == null) {
+                combined.add(sort); // sort on expression instead of attribute
+            } else if (hasIdClass && ID.equalsIgnoreCase(attributeName)) {
                 // IdClass is split up so that it can be possible to create a cursor
                 // that corresponds to sort criteria
                 for (String name : entityInfo.idClassAttributeAccessors.keySet()) {
                     name = getAttributeName(name, true);
-                    sort = name == sort.property() ? sort : createSort(name, sort);
-                    combined.add(sort);
+                    combined.add(createSort(name, sort));
                 }
             } else {
-                String name = getAttributeName(sort.property(), true);
-                sort = name == sort.property() ? sort : createSort(name, sort);
+                String name = getAttributeName(attributeName, true);
+                sort = name == attributeName ? sort : createSort(name, sort);
                 combined.add(sort);
             }
         }
@@ -5948,24 +5988,27 @@ public abstract class QueryInfo {
      */
     @Trivial
     List<Sort<Object>> supplySorts(List<Sort<Object>> combined,
-                                   @SuppressWarnings("unchecked") Sort<Object>... additional) {
+                                   @SuppressWarnings("unchecked") //
+                                   Sort<Object>... additional) {
         boolean hasIdClass = entityInfo.idClassAttributeAccessors != null;
         if (combined == null && additional.length > 0)
             combined = sorts == null ? new ArrayList<>() : new ArrayList<>(sorts);
         for (Sort<Object> sort : additional) {
-            if (sort == null) {
+            if (sort == null)
                 throw new IllegalArgumentException("Sort: null");
-            } else if (hasIdClass && ID.equalsIgnoreCase(sort.property())) {
+            String attributeName = sort.property();
+            if (attributeName == null) {
+                combined.add(sort); // sort on expression instead of attribute
+            } else if (hasIdClass && ID.equalsIgnoreCase(attributeName)) {
                 // IdClass is split up so that it can be possible to create a cursor
                 // that corresponds to sort criteria
                 for (String name : entityInfo.idClassAttributeAccessors.keySet()) {
                     name = getAttributeName(name, true);
-                    sort = name == sort.property() ? sort : createSort(name, sort);
-                    combined.add(sort);
+                    combined.add(createSort(name, sort));
                 }
             } else {
-                String name = getAttributeName(sort.property(), true);
-                sort = name == sort.property() ? sort : createSort(name, sort);
+                String name = getAttributeName(attributeName, true);
+                sort = name == attributeName ? sort : createSort(name, sort);
                 combined.add(sort);
             }
         }
@@ -6336,22 +6379,24 @@ public abstract class QueryInfo {
      */
     @Trivial
     private void validateSort(Sort<?> sort) {
-        String propName = sort.property();
-        if (propName.charAt(propName.length() - 1) == ')') {
-            // skip for version(o) and id(o), the latter of which which could be a composite value
+        String attrName = sort.property();
+        if (attrName == null ||
+            attrName.charAt(attrName.length() - 1) == ')') {
+            // skip for expressions, "version(o)", and "id(o)", the latter of which
+            // could be a composite value
         } else {
-            Class<?> propertyClass = entityInfo.attributeTypes.get(propName);
+            Class<?> attributeType = entityInfo.attributeTypes.get(attrName);
 
             if (sort.ignoreCase() //
-                && !CharSequence.class.isAssignableFrom(propertyClass)
-                && !char.class.equals(propertyClass)
-                && !Character.class.equals(propertyClass))
+                && !CharSequence.class.isAssignableFrom(attributeType)
+                && !char.class.equals(attributeType)
+                && !Character.class.equals(attributeType))
                 throw exc(UnsupportedOperationException.class,
                           "CWWKD1026.ignore.case.not.text",
-                          propName,
+                          attrName,
                           entityInfo.getType().getName(),
                           sort,
-                          propertyClass.getName(),
+                          attributeType.getName(),
                           method.getName(),
                           repositoryInterface.getName());
         }

--- a/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/v1_0/QueryInfo_1_0.java
+++ b/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/v1_0/QueryInfo_1_0.java
@@ -112,6 +112,14 @@ public class QueryInfo_1_0 extends QueryInfo {
 
     @Override
     @Trivial
+    protected void appendExpression(Sort<?> sort,
+                                    StringBuilder q,
+                                    Map<Object, Object> jpqlParams) {
+        throw new IllegalArgumentException(sort.toString());
+    }
+
+    @Override
+    @Trivial
     protected <T> Sort<T> createSort(String expression, OrderBy orderBy) {
         return new Sort<T>( //
                         expression, //

--- a/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/v1_1/QueryInfo_1_1.java
+++ b/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/v1_1/QueryInfo_1_1.java
@@ -338,6 +338,19 @@ public class QueryInfo_1_1 extends QueryInfo {
         return q;
     }
 
+    @Override
+    @Trivial
+    protected void appendExpression(Sort<?> sort,
+                                    StringBuilder q,
+                                    Map<Object, Object> jpqlParams) {
+        qlParamCount = generateExpression(q,
+                                          entityVar_,
+                                          sort.expression(),
+                                          qlParamCount,
+                                          qlParamNames,
+                                          jpqlParams);
+    }
+
     /**
      * Appends JQPL for a repository method parameter. Either of the form ?1 or LOWER(?1)
      *
@@ -356,6 +369,7 @@ public class QueryInfo_1_1 extends QueryInfo {
     @Trivial
     protected <T> Sort<T> createSort(String expression, OrderBy orderBy) {
         return new Sort<T>( //
+                        null, //
                         expression, //
                         !orderBy.descending(), //
                         orderBy.ignoreCase(), //
@@ -366,6 +380,7 @@ public class QueryInfo_1_1 extends QueryInfo {
     @Trivial
     protected <T> Sort<T> createSort(String expression, Sort<T> sort) {
         return new Sort<T>( //
+                        null, //
                         expression, //
                         sort.isAscending(), //
                         sort.ignoreCase(), //
@@ -768,7 +783,7 @@ public class QueryInfo_1_1 extends QueryInfo {
      * @param expression     the Expression for which to generate JPQL.
      * @param jpqlParamCount number of named or positional parameters in the
      *                           partially built query.
-     * @param jpqlParamNames names of named parameters in the partially bulit
+     * @param jpqlParamNames names of named parameters in the partially built
      *                           query. Empty if the query uses positional
      *                           parameeters or has none. If using named parameters,
      *                           this method should add any that are generated.

--- a/dev/io.openliberty.data.internal_fat_1_1/test-applications/Data_1_1_App/src/test/jakarta/data/v1_1/web/Data_1_1_Servlet.java
+++ b/dev/io.openliberty.data.internal_fat_1_1/test-applications/Data_1_1_App/src/test/jakarta/data/v1_1/web/Data_1_1_Servlet.java
@@ -45,6 +45,7 @@ import jakarta.data.constraint.Like;
 import jakarta.data.constraint.NotBetween;
 import jakarta.data.constraint.NotNull;
 import jakarta.data.exceptions.DataException;
+import jakarta.data.expression.NumericExpression;
 import jakarta.data.expression.TextExpression;
 import jakarta.data.page.CursoredPage;
 import jakarta.data.page.Page;
@@ -2321,6 +2322,43 @@ public class Data_1_1_Servlet extends FATServlet {
     }
 
     /**
+     * Use a repository method that includes a Restriction and also has
+     * sorting by expressions.
+     */
+    @Test
+    public void testRestrictionsAndSortByExpressions() {
+
+        Restriction<Fraction> denominator8or9 = //
+                        Restrict.any(_Fraction.denominator.equalTo(8),
+                                     _Fraction.denominator.equalTo(9));
+
+        Sort<Fraction> chars8thThrough3rdFromRightAsc = //
+                        _Fraction.name.right(8).left(6).asc();
+
+        NumericExpression<Fraction, Integer> fifteenTimesInverse = //
+                        _Fraction.denominator.times(15)
+                                        .dividedBy(_Fraction.numerator);
+
+        Sort<Fraction> fifteenTimesInverseDesc = isHibernatePersistence() //
+                        ? fifteenTimesInverse.desc() //
+                        // works around EclipseLink parsing bug:
+                        : fifteenTimesInverse.abs().desc();
+
+        assertEquals(List.of("Three Eighths",
+                             "Five Eighths",
+                             "One Eighth",
+                             "Three Ninths",
+                             "Five Ninths",
+                             "One Ninth"),
+                     fractions.withNameLike("%e %",
+                                            denominator8or9,
+                                            Order.by(chars8thThrough3rdFromRightAsc,
+                                                     fifteenTimesInverseDesc))
+                                     .map(f -> f.name)
+                                     .toList());
+    }
+
+    /**
      * Use a repository method that performs a Query consisting of a SELECT
      * clause that uses the NEW keyword to specify the constructor for a
      * Java record.
@@ -2403,6 +2441,89 @@ public class Data_1_1_Servlet extends FATServlet {
                                      .sorted()
                                      .limit(15)
                                      .collect(Collectors.toList()));
+    }
+
+    /**
+     * Request sorting of results according to a mixture of
+     * two sort expressions and one entity attribute.
+     */
+    @Test
+    public void testSortByMixtureOfExpressionsAndAttributes() {
+
+        //                                      sort1 sort2 sort3 sort4
+        assertEquals(List.of("Two Sixteenths", //   7     F Two
+                             "Two Fifteenths", //   7     T Two   3
+                             "Ten Seventeenths", // 7     T Ten   588..
+                             "Two Eighteenths", //  8     F Two   1
+                             "Two Fourteenths", //  8     F Two   142..
+                             "Ten Eighteenths", //  8     F Ten   5
+                             "Ten Fourteenths", //  8     F Ten   714..
+                             "Two Nineteenths", //  8     T Two   105..
+                             "Two Thirteenths", //  8     T Two   153..
+                             "Ten Nineteenths", //  8     T Ten   526..
+                             "Ten Thirteenths", //  8     T Ten   769..
+                             "Ten Sixteenths"), //  9     F Ten
+                     fractions.named(Like.pattern("T?? #teenths", '?', '#', '!'),
+                                     Order.by(_Fraction.numerator.times(2)
+                                                     .minus(_Fraction.name.length())
+                                                     .plus(3)
+                                                     .abs()
+                                                     .asc(),
+                                              _Fraction.reduced.asc(),
+                                              _Fraction.name.left(4).desc(),
+                                              _Fraction.decimal.navigate(_Decimal.digits)
+                                                              .navigate(_Digits.repeating)
+                                                              .asc()),
+                                     Limit.of(12)));
+    }
+
+    /**
+     * Request sorting of results according to a single sort expression.
+     */
+    @Test
+    public void testSortBySingleExpression() {
+        In<Integer> numeratorExpressions = //
+                        In.expressions(_Fraction.denominator.minus(3),
+                                       NumericLiteral.of(1),
+                                       _Fraction.name.length().dividedBy(2));
+
+        Sort<Fraction> nameLengthDesc = _Fraction.name.length().desc();
+
+        assertEquals(List.of("Seven Twelfths", // length / 2 = 7
+                             "Nine Twelfths", // 12 - 3 = 9
+                             "Six Twelfths", // length / 2 = 6
+                             "One Twelfth"), // literal of 1
+                     fractions.withNumeratorsAndDenominator(numeratorExpressions,
+                                                            12,
+                                                            nameLengthDesc));
+    }
+
+    /**
+     * Request sorting of results according to two sort expressions.
+     */
+    @Test
+    public void testSortByTwoExpressions() {
+
+        Sort<Fraction> numDenomDifferenceAsc = //
+                        _Fraction.denominator.minus(_Fraction.numerator).asc();
+        Sort<Fraction> right4Desc = _Fraction.name.upper().right(4).desc();
+
+        assertEquals(List.of("Three Fourths",
+                             "Two Thirds",
+                             "One Half",
+                             "Four Fifths",
+                             "Two Fourths",
+                             "One Third",
+                             "Three Fifths",
+                             "One Fourth",
+                             "Two Fifths",
+                             "One Fifth"),
+                     fractions.denominatoredUpTo(NotNull.instance(),
+                                                 AtMost.max(5),
+                                                 numDenomDifferenceAsc,
+                                                 right4Desc)
+                                     .map(f -> f.name)
+                                     .toList());
     }
 
     /**

--- a/dev/io.openliberty.jakarta.data.1.1/src/jakarta/data/Sort.java
+++ b/dev/io.openliberty.jakarta.data.1.1/src/jakarta/data/Sort.java
@@ -12,12 +12,17 @@
  *******************************************************************************/
 package jakarta.data;
 
+import jakarta.data.expression.ComparableExpression;
+import jakarta.data.expression.TextExpression;
 import jakarta.data.messages.Messages;
+import jakarta.data.metamodel.Attribute;
 
 /**
  * Method signatures copied from jakarta.data.Sort from the Jakarta Data repo.
  */
-public record Sort<T>(String property,
+public record Sort<T>(
+                ComparableExpression<T, ? extends Comparable<?>> expression,
+                String property,
                 boolean isAscending,
                 boolean ignoreCase,
                 Nulls nullOrdering) {
@@ -29,43 +34,82 @@ public record Sort<T>(String property,
     }
 
     public Sort {
-        Messages.requireNonNull(property, "property");
+        if (expression == null && property == null)
+            throw new NullPointerException(Messages.get("001.arg.required",
+                                                        "expression"));
+
         Messages.requireNonNull(nullOrdering, "nullOrdering");
+
+        if (expression != null) {
+            if (property != null)
+                throw new IllegalArgumentException("property: " + property +
+                                                   ", expression: " + expression);
+
+            if (expression instanceof Attribute<?> attribute)
+                property = attribute.name();
+        }
     }
 
     public Sort(String property, boolean isAscending, boolean ignoreCase) {
-        this(property, //
+        this(null, //
+             property, //
              isAscending, //
              ignoreCase, //
              Nulls.UNSPECIFIED);
     }
 
+    public static <T, V extends Comparable<?>> Sort<T> //
+                    asc(ComparableExpression<T, V> expression) {
+        return new Sort<>(expression, null, true, false, Nulls.UNSPECIFIED);
+    }
+
     public static <T> Sort<T> asc(String attribute) {
-        return new Sort<>(attribute, //
+        return new Sort<>( //
+                        null, //
+                        attribute, //
                         true, //
                         false, //
                         Nulls.UNSPECIFIED);
     }
 
     public static <T> Sort<T> ascIgnoreCase(String attribute) {
-        return new Sort<>(attribute, //
+        return new Sort<>( //
+                        null, //
+                        attribute, //
                         true, //
                         true, //
                         Nulls.UNSPECIFIED);
     }
 
+    public static <T> Sort<T> ascIgnoreCase(TextExpression<T> expression) {
+        return new Sort<>(expression, null, true, true, Nulls.UNSPECIFIED);
+    }
+
+    public static <T, V extends Comparable<?>> Sort<T> //
+                    desc(ComparableExpression<T, V> expression) {
+        return new Sort<>(expression, null, false, false, Nulls.UNSPECIFIED);
+    }
+
     public static <T> Sort<T> desc(String attribute) {
-        return new Sort<>(attribute, //
+        return new Sort<>( //
+                        null, //
+                        attribute, //
                         false, //
                         false, //
                         Nulls.UNSPECIFIED);
     }
 
     public static <T> Sort<T> descIgnoreCase(String attribute) {
-        return new Sort<>(attribute, //
+        return new Sort<>( //
+                        null, //
+                        attribute, //
                         false, //
                         true, //
                         Nulls.UNSPECIFIED);
+    }
+
+    public static <T> Sort<T> descIgnoreCase(TextExpression<T> expression) {
+        return new Sort<>(expression, null, false, true, Nulls.UNSPECIFIED);
     }
 
     public boolean isDescending() {
@@ -73,14 +117,18 @@ public record Sort<T>(String property,
     }
 
     public Sort<T> nullsFirst() {
-        return new Sort<>(property, //
+        return new Sort<>( //
+                        expression, //
+                        expression == null ? property : null, //
                         isAscending, //
                         ignoreCase, //
                         Nulls.FIRST);
     }
 
     public Sort<T> nullsLast() {
-        return new Sort<>(property, //
+        return new Sort<>( //
+                        expression, //
+                        expression == null ? property : null, //
                         isAscending, //
                         ignoreCase, //
                         Nulls.LAST);
@@ -91,7 +139,9 @@ public record Sort<T>(String property,
                                  boolean ignoreCase) {
         Messages.requireNonNull(direction, "direction");
 
-        return new Sort<>(attribute, //
+        return new Sort<>( //
+                        null, //
+                        attribute, //
                         Direction.ASC.equals(direction), //
                         ignoreCase, //
                         Nulls.UNSPECIFIED);
@@ -103,7 +153,9 @@ public record Sort<T>(String property,
                                  Nulls nullOrdering) {
         Messages.requireNonNull(direction, "direction");
 
-        return new Sort<>(attribute, //
+        return new Sort<>( //
+                        null, //
+                        attribute, //
                         Direction.ASC.equals(direction), //
                         ignoreCase, //
                         nullOrdering);

--- a/dev/io.openliberty.jakarta.data.1.1/src/jakarta/data/expression/ComparableExpression.java
+++ b/dev/io.openliberty.jakarta.data.1.1/src/jakarta/data/expression/ComparableExpression.java
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package jakarta.data.expression;
 
+import jakarta.data.Sort;
 import jakarta.data.constraint.AtLeast;
 import jakarta.data.constraint.AtMost;
 import jakarta.data.constraint.Between;
@@ -27,6 +28,9 @@ import jakarta.data.restrict.Restriction;
  */
 public interface ComparableExpression<T, V extends Comparable<?>> //
                 extends Expression<T, V> {
+    default Sort<T> asc() {
+        return Sort.asc(this);
+    }
 
     default <U extends ComparableExpression<? super T, V>> Restriction<T> //
                     between(U minExpression,
@@ -39,6 +43,10 @@ public interface ComparableExpression<T, V extends Comparable<?>> //
     default Restriction<T> between(V min, V max) {
         Constraint<V> constraint = Between.bounds(min, max);
         return BasicRestriction.of(this, constraint);
+    }
+
+    default Sort<T> desc() {
+        return Sort.desc(this);
     }
 
     default Restriction<T> greaterThan//

--- a/dev/io.openliberty.jakarta.data.1.1/src/jakarta/data/expression/TextExpression.java
+++ b/dev/io.openliberty.jakarta.data.1.1/src/jakarta/data/expression/TextExpression.java
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package jakarta.data.expression;
 
+import jakarta.data.Sort;
 import jakarta.data.constraint.Like;
 import jakarta.data.constraint.NotLike;
 import jakarta.data.messages.Messages;
@@ -39,9 +40,17 @@ public interface TextExpression<T> extends ComparableExpression<T, String> {
                                          this);
     }
 
+    default Sort<T> ascIgnoreCase() {
+        return Sort.ascIgnoreCase(this);
+    }
+
     default Restriction<T> contains(String substring) {
         Like constraint = Like.substring(substring);
         return BasicRestriction.of(this, constraint);
+    }
+
+    default Sort<T> descIgnoreCase() {
+        return Sort.descIgnoreCase(this);
     }
 
     default Restriction<T> endsWith(String suffix) {

--- a/dev/io.openliberty.jakarta.data.1.1/src/jakarta/data/metamodel/ComparableAttribute.java
+++ b/dev/io.openliberty.jakarta.data.1.1/src/jakarta/data/metamodel/ComparableAttribute.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2025 IBM Corporation and others.
+ * Copyright (c) 2025,2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package jakarta.data.metamodel;
 
+import jakarta.data.Sort;
 import jakarta.data.expression.ComparableExpression;
 import jakarta.data.messages.Messages;
 
@@ -34,5 +35,15 @@ public interface ComparableAttribute<T, V extends Comparable<?>> //
         Messages.requireNonNull(attributeType, "attributeType");
 
         return new ComparableAttributeRecord<>(entityClass, name, attributeType);
+    }
+
+    @Override
+    default Sort<T> asc() {
+        return Sort.asc(this);
+    }
+
+    @Override
+    default Sort<T> desc() {
+        return Sort.desc(this);
     }
 }

--- a/dev/io.openliberty.jakarta.data.1.1/src/jakarta/data/metamodel/TextAttribute.java
+++ b/dev/io.openliberty.jakarta.data.1.1/src/jakarta/data/metamodel/TextAttribute.java
@@ -12,7 +12,6 @@
  *******************************************************************************/
 package jakarta.data.metamodel;
 
-import jakarta.data.Sort;
 import jakarta.data.expression.TextExpression;
 import jakarta.data.messages.Messages;
 
@@ -20,14 +19,6 @@ import jakarta.data.messages.Messages;
  * Method signatures are copied from Jakarta Data.
  */
 public interface TextAttribute<T> extends ComparableAttribute<T, String>, TextExpression<T> {
-
-    default Sort<T> ascIgnoreCase() {
-        return Sort.ascIgnoreCase(name());
-    }
-
-    default Sort<T> descIgnoreCase() {
-        return Sort.descIgnoreCase(name());
-    }
 
     static <T> TextAttribute<T> of(Class<T> entityClass,
                                    String name) {

--- a/dev/io.openliberty.jakarta.data.1.1/src/jakarta/data/metamodel/impl/TextAttributeRecord.java
+++ b/dev/io.openliberty.jakarta.data.1.1/src/jakarta/data/metamodel/impl/TextAttributeRecord.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024,2025 IBM Corporation and others.
+ * Copyright (c) 2024,2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package jakarta.data.metamodel.impl;
 
+import jakarta.data.Sort;
 import jakarta.data.metamodel.TextAttribute;
 
 /**
@@ -20,4 +21,23 @@ import jakarta.data.metamodel.TextAttribute;
 @Deprecated(since = "1.1")
 public record TextAttributeRecord<T>(String name) implements TextAttribute<T> {
 
+    @Override
+    public Sort<T> asc() {
+        return Sort.asc(name);
+    }
+
+    @Override
+    public Sort<T> ascIgnoreCase() {
+        return Sort.ascIgnoreCase(name);
+    }
+
+    @Override
+    public Sort<T> desc() {
+        return Sort.desc(name);
+    }
+
+    @Override
+    public Sort<T> descIgnoreCase() {
+        return Sort.descIgnoreCase(name);
+    }
 }


### PR DESCRIPTION
Brings in the Data API updates for sortable expressions,
adds implementation,
and tests scenarios where there is
- a single sortable expression
- multiple sortable expressions
- sortable expressions intermixed with a normal sort
- restrictions on a repository method to which sortable expressions are supplied


- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
