### PR TITLE
Disable MCP OIDC test

### DIFF
--- a/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/FATSuite.java
+++ b/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/FATSuite.java
@@ -27,7 +27,6 @@ import io.openliberty.mcp.internal.fat.lifecycle.tests.AsyncToolLifecycleTest;
 import io.openliberty.mcp.internal.fat.lifecycle.tests.BeanLifecycleTest;
 import io.openliberty.mcp.internal.fat.lifecycle.tests.LifecycleTest;
 import io.openliberty.mcp.internal.fat.monitor.McpMonitorTest;
-import io.openliberty.mcp.internal.fat.oidc.tests.OidcTests;
 import io.openliberty.mcp.internal.fat.protocol.HttpTest;
 import io.openliberty.mcp.internal.fat.protocol.ProtocolVersionSchemaTest;
 import io.openliberty.mcp.internal.fat.protocol.ProtocolVersionTest;
@@ -115,7 +114,6 @@ import io.openliberty.mcp.internal.fat.tool.ToolTest;
                 NonRequiredArgsToolsTest.class,
                 NoParamNameTest.class,
                 // TestContainer Tests
-                OidcTests.class,
                 ConformanceTests.class,
 
                 CustomServerInfoTest.class,


### PR DESCRIPTION
There are some bugs in the test that prevent it running in the build. Disabling it first so it doesn't break things before fixing it.

Build break seen in the PB for #35117

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
