### PR TITLE
Update TestServer waitForSSLRestart

### DIFF
--- a/dev/com.ibm.ws.security.fat.common/src/com/ibm/ws/security/fat/common/TestServer.java
+++ b/dev/com.ibm.ws.security.fat.common/src/com/ibm/ws/security/fat/common/TestServer.java
@@ -951,8 +951,9 @@ public class TestServer extends ExternalResource {
 
         // look for the "CWWKO0220I: TCP Channel defaultHttpEndpoint-ssl has stopped listening for requests on host " message
         // if we find it, then wait for "CWWKO0219I: TCP Channel defaultHttpEndpoint-ssl has been started and is now listening for requests on host"
-        String sslStopMsg = server.waitForStringInLogUsingMark("CWWKO0220I:.*defaultHttpEndpoint-ssl.*", 500);
-        if (sslStopMsg != null) {
+        // count instances instead of standard wait, as we then don't log a timed out message causing a test to bail if too many occur
+        int sslStopMsgs = server.waitForMultipleStringsInLogUsingMark(1, "CWWKO0220I:.*defaultHttpEndpoint-ssl.*", 500, server.getDefaultLogFile());
+        if (sslStopMsgs > 0) {
             String sslStartMsg = server.waitForDefaultHTTPEndpointSSLStart(true);
             if (sslStartMsg == null) {
                 Log.warning(thisClass, "SSL may not have started properly - future failures may be due to this");


### PR DESCRIPTION
Instead of a standard wait which prints out `Timed Out` in the logs, replace with a instance check which does not and use that as an initial indicator that we might be restarting SSL.

it should be noted that this does not fix the fact 10+ tests check for the restarting of SSL within a number of the security buckets

Fixes [#310797](https://wasrtc.hursley.ibm.com:9443/jazz/web/projects/WS-CD#action=com.ibm.team.workitem.viewWorkItem&id=310797)

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
