### PR TITLE
Enable FIPS Fat for S390 platforms

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "package-lock.json|.*\\/OSGI-INF\\/.*\\.properties$|.+\\.(nlsprops)$|^dev\\/(.*(_test|_fat)).*\\/ltpa.keys$|^dev\\/com.ibm.ws.openapi.ui\\/swagger-ui\\/dist\\/liberty-swagger-ui-bundle-.*\\.js$|^.secrets.baseline.*|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-06-12T19:51:57Z",
+  "generated_at": "2026-07-30T09:28:47Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"

--- a/dev/com.ibm.ws.security.utility/src/com/ibm/ws/security/utility/tasks/ConfigureFIPSTask.java
+++ b/dev/com.ibm.ws.security.utility/src/com/ibm/ws/security/utility/tasks/ConfigureFIPSTask.java
@@ -20,10 +20,9 @@ import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.StringJoiner;
+import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.apache.commons.io.FilenameUtils;
 
@@ -121,19 +120,10 @@ public class ConfigureFIPSTask extends BaseCommandTask {
         this.stdout = stdout;
         this.stderr = stderr;
 
-        if (ProductInfo.getBetaEdition()) {
-            stdout.println("BETA: The SecurityUtility configureFIPS task is only available in beta." + NL);
-        }
-
         String serverName = getArgumentValue(ARG_SERVER, args, null);
         String clientName = getArgumentValue(ARG_CLIENT, args, null);
         String customProfileFile = getArgumentValue(ARG_CUSTOMPROFILE_FILE, args, null);
         boolean disable = Arrays.asList(args).contains(ARG_DISABLE);
-
-        if (isZOS) {
-            stdout.println(getMessage("configureFIPS.zosNotAvailable"));
-            return SecurityUtilityReturnCodes.ERR_GENERIC;
-        }
 
         try {
             if (!disable && (!isIbmSdk() && !isSemeru())) {
@@ -265,7 +255,7 @@ public class ConfigureFIPSTask extends BaseCommandTask {
         String javaHome = getJavaHome();
         String javaSecurity = javaHome + (javaHome.endsWith(SLASH) ? "" : SLASH) + "conf" + SLASH + "security" + SLASH + "java.security";
         if (fileUtility.exists(javaSecurity)) {
-            try (BufferedReader reader = new BufferedReader(new InputStreamReader(new FileInputStream(javaSecurity), CHARSET))) {
+            try (BufferedReader reader = new BufferedReader(new InputStreamReader(new FileInputStream(javaSecurity)))) {
                 String line = "";
                 while ((line = reader.readLine()) != null) {
                     if (line.startsWith("RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3-Strongly-Enforced.")) {
@@ -288,14 +278,21 @@ public class ConfigureFIPSTask extends BaseCommandTask {
         isIbmSdk = false;
 
         String javaHome = getJavaHome();
-        if (javaHome.endsWith("jre" + SLASH)) {
-            isIbmSdk = fileUtility.exists(javaHome + "fips140-3" + SLASH);
-        } else if (javaHome.endsWith("jre")) {
-            isIbmSdk = fileUtility.exists(javaHome + SLASH + "fips140-3" + SLASH);
-        } else if (javaHome.endsWith(SLASH)) {
-            isIbmSdk = fileUtility.exists(javaHome + "jre" + SLASH + "fips140-3" + SLASH);
-        } else {
-            isIbmSdk = fileUtility.exists(javaHome + SLASH + "jre" + SLASH + "fips140-3" + SLASH);
+
+        Set<String> dirs = Stream.of(new File(javaHome).listFiles())
+                .filter(File::isDirectory)
+                .map(File::getName)
+                .collect(Collectors.toSet());
+        // if dirs contains JRE, we need the contents of the jre directory
+        if(dirs.contains("jre")){
+            dirs = Stream.of(new File(javaHome + SLASH + "jre").listFiles())
+                    .filter(File::isDirectory)
+                    .map(File::getName)
+                    .collect(Collectors.toSet());
+        }
+
+        if(dirs.contains("fips140-3")){
+            isIbmSdk = true;
         }
 
         isIbmSdkChecked = true;
@@ -397,7 +394,7 @@ public class ConfigureFIPSTask extends BaseCommandTask {
         boolean fileEndsWithNewLineChar = false;
         boolean variableExpansionEnabled = false;
 
-        try (BufferedReader reader = new BufferedReader(new InputStreamReader(new FileInputStream(fileUtility.resolvePath(file)), CHARSET))) {
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(new FileInputStream(fileUtility.resolvePath(file))))) {
             String line = "";
             while ((line = reader.readLine()) != null) {
                 if (line.replaceAll("\\s", "").equalsIgnoreCase("#enable_variable_expansion")) {
@@ -447,7 +444,7 @@ public class ConfigureFIPSTask extends BaseCommandTask {
 
         try {
             backupFile(file);
-            fileUtility.writeToFile(stderr, joiner.toString() + (fileEndsWithNewLineChar ? NL : ""), file, CHARSET);
+            fileUtility.writeToFile(stderr, joiner.toString() + (fileEndsWithNewLineChar ? NL : ""), file);
             stdout.println(getMessage("configureFIPS.updatedEnvFileToEnableFips", fileUtility.resolvePath(file)));
             printRestartServerMessage(serverName, clientName);
             return SecurityUtilityReturnCodes.OK;
@@ -473,7 +470,7 @@ public class ConfigureFIPSTask extends BaseCommandTask {
         boolean disabled = false;
         StringJoiner joiner = new StringJoiner(NL);
         boolean fileEndsWithNewLineChar = false;
-        try (BufferedReader reader = new BufferedReader(new InputStreamReader(new FileInputStream(fileUtility.resolvePath(file)), CHARSET))) {
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(new FileInputStream(fileUtility.resolvePath(file))))) {
             String line = "";
             while ((line = reader.readLine()) != null) {
                 if (line.startsWith(ENABLE_FIPS140_3_ENV_VAR + "=") && !line.equals(ENABLE_FIPS140_3_ENV_VAR + "=false")) {
@@ -499,7 +496,7 @@ public class ConfigureFIPSTask extends BaseCommandTask {
 
         try {
             backupFile(file);
-            fileUtility.writeToFile(stderr, joiner.toString() + (fileEndsWithNewLineChar ? NL : ""), file, CHARSET);
+            fileUtility.writeToFile(stderr, joiner.toString() + (fileEndsWithNewLineChar ? NL : ""), file);
             stdout.println(getMessage("configureFIPS.updatedEnvFileToDisableFips", fileUtility.resolvePath(file)));
             printRestartServerMessage(serverName, clientName);
             return SecurityUtilityReturnCodes.OK;

--- a/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyClient.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyClient.java
@@ -689,7 +689,7 @@ public class LibertyClient {
                 Properties clientEnv = getClientEnv();
                 Properties defaultEnv = getDefaultEnv();
                 Map<String, String> opts = getJvmOptionsAsMap();
-                if (clientEnv.containsKey("ENABLE_FIPS140_3") || defaultEnv.containsKey("ENABLE_FIPS140_3") || opts.containsKey("-Xenablefips140-3")
+                if (clientEnv.containsKey("ENABLE_FIPS140_3") || defaultEnv.containsKey("ENABLE_FIPS140_3") || useEnvVars.containsKey("ENABLE_FIPS140_3") || opts.containsKey("-Xenablefips140-3")
                     || opts.containsKey("-Dsemeru.fips")) {
                     Log.info(c, method, "Test has defined its own settings for FIPS140-3");
                 } else {

--- a/dev/io.openliberty.security.fips.internal_fat/fat/src/io/openliberty/security/fips/fat/FATSuite.java
+++ b/dev/io.openliberty.security.fips.internal_fat/fat/src/io/openliberty/security/fips/fat/FATSuite.java
@@ -11,6 +11,7 @@
 package io.openliberty.security.fips.fat;
 
 import io.openliberty.security.fips.fat.tests.fips1403.client.FIPS1403ClientTest;
+import io.openliberty.security.fips.fat.tests.fips1403.security.utility.FIPS1403SecurityUtilityInvalidEnvTets;
 import io.openliberty.security.fips.fat.tests.fips1403.security.utility.FIPS1403SecurityUtilityTests;
 import io.openliberty.security.fips.fat.tests.fips1403.server.FIPS1403ServerTest;
 import org.junit.runner.RunWith;
@@ -24,7 +25,8 @@ import componenttest.custom.junit.runner.AlwaysPassesTest;
         AlwaysPassesTest.class,
         FIPS1403ServerTest.class,
         FIPS1403ClientTest.class,
-        FIPS1403SecurityUtilityTests.class
+        FIPS1403SecurityUtilityTests.class,
+        FIPS1403SecurityUtilityInvalidEnvTets.class
 })
 public class FATSuite {
 }

--- a/dev/io.openliberty.security.fips.internal_fat/fat/src/io/openliberty/security/fips/fat/FIPSTestUtils.java
+++ b/dev/io.openliberty.security.fips.internal_fat/fat/src/io/openliberty/security/fips/fat/FIPSTestUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2025 IBM Corporation and others.
+ * Copyright (c) 2025, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -18,6 +18,8 @@ import componenttest.topology.impl.LibertyServer;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -41,69 +43,77 @@ public class FIPSTestUtils {
     public static final String LIBERTY_BASE_FIPS_PROFILE_FILENAME = "FIPS140-3-Liberty.properties";
     public static final String LIBERTY_APPLICATION_FIPS_PROFILE_FILENAME = "FIPS140-3-Liberty-Application.properties";
     public static final String STANDALONE_FIPS_PROFILE_FILENAME = "semeruFips140_3CustomProfile.properties";
+    public static final Charset CHARSET = !System.getProperty("os.name").equalsIgnoreCase("z/OS")? StandardCharsets.UTF_8 : Charset.forName("IBM-1047");
 
     /**
      * IBM SDK 8 and Semeru Runtimes >=11 support FIPS, Any other Vendor and Version combination is not supported
      * So check the java information of the server to determine whether to run the actual tests
-     *
+     * <p>
      * If JAVA_HOME for a server is updated via setting JAVA_HOME in a .env file, then the systems JAVA_HOME is what will be picked up
-     *
-     *
+     * <p>
+     * <p>
      * There is a Semeru JDK 8 that does not support fips, so ensure that if running is skipped
      *
      * @param javaInfo
      * @return
      */
-    public static boolean validFIPS140_3Environment(JavaInfo javaInfo){
+    public static boolean validFIPS140_3Environment(JavaInfo javaInfo) {
         boolean validEnv = true;
-        // s390 for Linux is not supported with FIPS mode, so until it is, we should skip the platform, once Java FIPS support is available for s390x we can remove this check
-        if (System.getProperty("os.arch").contains("s390")){
-           validEnv = false;
-           Log.warning(FIPSTestUtils.class, "s390 architecture is not currently supported for either z/OS or Linux");
+        final String method_name = "validFIPS140_3Environment";
+
+        if (javaInfo.majorVersion() == 8) {
+            String dir = javaInfo.javaHome();
+            // z/OS Java 8 path does not include JRE
+            if (!System.getProperty("os.name").equalsIgnoreCase("z/OS") && !dir.endsWith("jre")) {
+                dir = dir + "/jre";
+            }
+            Log.info(FIPSTestUtils.class, method_name, "Checking Directory "+ dir + "for FIPS directory");
+            Set<String> dirs = Stream.of(new File(dir).listFiles())
+                    .filter(File::isDirectory)
+                    .map(File::getName)
+                    .collect(Collectors.toSet());
+            if (!dirs.contains("fips140-3")) {
+                validEnv = false;
+                Log.warning(FIPSTestUtils.class, "Java 8 install does not support FIPS140-3");
+            }
         } else {
-            if (javaInfo.majorVersion() == 8) {
-                String dir = javaInfo.javaHome();
-                if (!dir.endsWith("jre")) {
-                    dir = dir + "/jre";
-                }
-                Set<String> dirs = Stream.of(new File(dir))
-                        .filter(file -> !file.isDirectory())
-                        .map(File::getName)
-                        .collect(Collectors.toSet());
-                if (!dirs.contains("fips140-3")) {
-                    validEnv = false;
-                    Log.warning(FIPSTestUtils.class, "Java 8 install does not support FIPS140-3");
-                }
+            // Skip running tests on z/OS if the version is between Java 8 and 17
+            if(System.getProperty("os.name").equalsIgnoreCase("z/OS") && javaInfo.majorVersion() < 17){
+                validEnv = false;
+                Log.warning(FIPSTestUtils.class, "Java versions more then 8 and less then 17 do not support FIPS140-3 on z/OS");
             } else {
                 String javaSecurityPath = javaInfo.javaHome() + "/conf/security/java.security";
                 Path path = Paths.get(javaSecurityPath);
 
-                try (BufferedReader reader = Files.newBufferedReader(path)) {
-                    String line;
-                    boolean fipsCompatible = false;
-                    while ((line = reader.readLine()) != null) {
-                        if (line.contains("OpenJCEPlusFIPS.FIPS140-3-Strongly-Enforced")) {
-                            fipsCompatible = true;
+                Log.info(FIPSTestUtils.class, method_name, "Checking " + path.toAbsolutePath() + "for FIPS security");
+                if (path.toFile().exists()) {
+                    try (BufferedReader reader = Files.newBufferedReader(path, CHARSET)) {
+                        String line;
+                        boolean fipsCompatible = false;
+                        while ((line = reader.readLine()) != null) {
+                            if (line.contains("OpenJCEPlusFIPS.FIPS140-3-Strongly-Enforced")) {
+                                fipsCompatible = true;
+                            }
                         }
+                        if (!fipsCompatible) {
+                            validEnv = fipsCompatible;
+                            Log.warning(FIPSTestUtils.class, "Java install is not FIPS compatible");
+                        }
+                    } catch (IOException e) {
+                        validEnv = false;
+                        Log.error(FIPSTestUtils.class, method_name, e, "unable to read java.security file, skipping the tests");
                     }
-                    if (!fipsCompatible) {
-                        validEnv = fipsCompatible;
-                        Log.warning(FIPSTestUtils.class, "Java install is not FIPS compatible");
-                    }
-                } catch (IOException e) {
-                    validEnv = false;
-                    Log.warning(FIPSTestUtils.class, "unable to read java.security file, skipping the tests");
                 }
             }
         }
         return validEnv;
     }
 
-    public static void checkServerLogForFipsEnablementMessage(LibertyServer server, String expectedProvider){
+    public static void checkServerLogForFipsEnablementMessage(LibertyServer server, String expectedProvider) {
         assertNotNull("Expected FIPS 140-3 enabled message to be found in Server logs, but was not found.", server.waitForStringInLog("CWWKS5903I:.*" + expectedProvider));
     }
 
-    public static void checkClientLogForFipsEnablementMessage(LibertyClient client, String expectedProvider){
+    public static void checkClientLogForFipsEnablementMessage(LibertyClient client, String expectedProvider) {
         // Check the copied logs as they are reliable
         assertNotNull("Expected FIPS 140-3 enabled message to be found in Client logs, but was not found.", client.waitForStringInCopiedLog("CWWKS5903I:.*" + expectedProvider));
     }

--- a/dev/io.openliberty.security.fips.internal_fat/fat/src/io/openliberty/security/fips/fat/tests/fips1403/client/FIPS1403ClientTest.java
+++ b/dev/io.openliberty.security.fips.internal_fat/fat/src/io/openliberty/security/fips/fat/tests/fips1403/client/FIPS1403ClientTest.java
@@ -37,7 +37,7 @@ import static org.junit.Assume.assumeThat;
 
 @RunWith(FATRunner.class)
 @Mode(Mode.TestMode.LITE)
-@SkipIfSysProp({SkipIfSysProp.OS_ZOS, SkipIfSysProp.OS_IBMI, SkipIfSysProp.OS_ISERIES})
+@SkipIfSysProp({SkipIfSysProp.OS_IBMI, SkipIfSysProp.OS_ISERIES})
 public class FIPS1403ClientTest {
 
     public static final String CLIENT_NAME = "FIPSClient";
@@ -75,6 +75,7 @@ public class FIPS1403ClientTest {
 
     @Test
     public void clientJFIPS140_3JVMArgsTest() throws Exception {
+        // if FIPS140-3 is defined at a global level, the LibertyClient class will apply the settings for us
         if (!GLOBAL_CLIENT_FIPS) {
             Log.info(FIPS1403ClientTest.class,"setup","Setting FIPS140-3 JVM Options");
             HashMap<String, String> opts = new HashMap<>();
@@ -101,11 +102,9 @@ public class FIPS1403ClientTest {
     
     @Test
     public void clientFIPS140_3EnvTest() throws Exception {
-        assumeThat(GLOBAL_CLIENT_FIPS, is(false));
-        if(!GLOBAL_CLIENT_FIPS) {
-            client.copyFileToLibertyClientRoot("publish/resources", "resources" , STANDALONE_FIPS_PROFILE_FILENAME);
-            client.addEnvVar(ENABLE_FIPS140_3_ENV_VAR, client.getClientRoot()+"/resources/" + STANDALONE_FIPS_PROFILE_FILENAME);
-        }
+        client.copyFileToLibertyClientRoot("publish/resources", "resources" , STANDALONE_FIPS_PROFILE_FILENAME);
+        client.addEnvVar(ENABLE_FIPS140_3_ENV_VAR, client.getClientRoot()+"/resources/" + STANDALONE_FIPS_PROFILE_FILENAME);
+        // if global.client.fips_140-3=true is specified, the client will still use the envVar setting instead of applying the default args
         client.startClient();
         checkClientLogForFipsEnablementMessage(client, expectedProvider);
     }

--- a/dev/io.openliberty.security.fips.internal_fat/fat/src/io/openliberty/security/fips/fat/tests/fips1403/security/utility/FIPS1403SecurityUtilityInvalidEnvTets.java
+++ b/dev/io.openliberty.security.fips.internal_fat/fat/src/io/openliberty/security/fips/fat/tests/fips1403/security/utility/FIPS1403SecurityUtilityInvalidEnvTets.java
@@ -1,0 +1,52 @@
+package io.openliberty.security.fips.fat.tests.fips1403.security.utility;
+
+import com.ibm.websphere.simplicity.ProgramOutput;
+import componenttest.annotation.Server;
+import componenttest.annotation.SkipIfSysProp;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.custom.junit.runner.Mode;
+import componenttest.topology.impl.JavaInfo;
+import componenttest.topology.impl.LibertyServer;
+import io.openliberty.security.fips.fat.FIPSTestUtils;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.io.IOException;
+
+import static io.openliberty.security.fips.fat.tests.fips1403.security.utility.FIPS1403SecurityUtilityTests.SEC_CONF_FIPS_COMMAND;
+import static io.openliberty.security.fips.fat.tests.fips1403.security.utility.FIPS1403SecurityUtilityTests.runSecurityUtilityCommand;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeThat;
+
+@RunWith(FATRunner.class)
+@Mode(Mode.TestMode.LITE)
+@SkipIfSysProp({SkipIfSysProp.OS_IBMI, SkipIfSysProp.OS_ISERIES})
+public class FIPS1403SecurityUtilityInvalidEnvTets {
+
+    private static final String SERVER_NAME = "FIPSServer";
+
+    @Server(SERVER_NAME)
+    public static LibertyServer server;
+
+    @BeforeClass
+    public static void setup() throws IOException {
+        JavaInfo ji = JavaInfo.forServer(server);
+        assumeThat(FIPSTestUtils.validFIPS140_3Environment(ji), is(false));
+    }
+
+    @Test
+    public void invalidFIPSEnvironmentCheck() throws Exception {
+        ProgramOutput po = runSecurityUtilityCommand( new String[] {SEC_CONF_FIPS_COMMAND});
+        // cxommand should fail for non-FIPS envs
+        assertEquals("securityUtility configureFIPS did not result in expected return code.",1, po.getReturnCode());
+        // the error test comes out on Stdout, not stderr
+        String result = po.getStdout();
+        assertTrue(!result.isEmpty());
+        // Semeru version strings are most language agnostic part of the invalid env check
+        assertTrue(result.contains("11.0.29.0, 17.0.17.0, 21.0.9.0, 25.0.1.0"));
+
+    }
+}

--- a/dev/io.openliberty.security.fips.internal_fat/fat/src/io/openliberty/security/fips/fat/tests/fips1403/security/utility/FIPS1403SecurityUtilityTests.java
+++ b/dev/io.openliberty.security.fips.internal_fat/fat/src/io/openliberty/security/fips/fat/tests/fips1403/security/utility/FIPS1403SecurityUtilityTests.java
@@ -26,7 +26,6 @@ import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.HttpUtils;
 import componenttest.topology.utils.PrivHelper;
 import io.openliberty.security.fips.fat.FIPSTestUtils;
-import io.openliberty.security.fips.fat.tests.fips1403.server.FIPS1403ServerTest;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -38,6 +37,8 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
 import java.util.Properties;
@@ -47,13 +48,12 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assume.assumeThat;
 
 
 @RunWith(FATRunner.class)
 @Mode(Mode.TestMode.LITE)
-@SkipIfSysProp({SkipIfSysProp.OS_ZOS, SkipIfSysProp.OS_IBMI, SkipIfSysProp.OS_ISERIES})
+@SkipIfSysProp({SkipIfSysProp.OS_IBMI, SkipIfSysProp.OS_ISERIES})
 public class FIPS1403SecurityUtilityTests {
 
     private static final Class<?> thisClass = FIPS1403SecurityUtilityTests.class;
@@ -67,9 +67,9 @@ public class FIPS1403SecurityUtilityTests {
     private static Machine machine;
     private static Properties env;
     private static String installRoot;
-    private static final String SEC_UTILITY_COMMAND = "/bin/securityUtility";
-    private static final String SEC_CONF_FIPS_COMMAND = "configureFIPS";
-    private static final String DEFAULT_ENV_BACKUP_FILE = "default.env.bkp";
+    public static final String SEC_UTILITY_COMMAND = "/bin/securityUtility";
+    public static final String SEC_CONF_FIPS_COMMAND = "configureFIPS";
+    public static final String DEFAULT_ENV_BACKUP_FILE = "default.env.bkp";
 
     // Command Options
     private static final String OPT_DISABLE = "--disable";
@@ -140,9 +140,9 @@ public class FIPS1403SecurityUtilityTests {
         if(SEMERU_FIPS_PROVIDER.equals(expectedProvider)) {
             File fipsProfileFile = new File(installRoot + "/etc/" + FIPS_PROFILE_FILE_NAME);
             assertTrue(fipsProfileFile.exists());
-            checkFileExpectedValue(defaultEnv, ENABLE_FIPS140_3_ENV_VAR + "=" + fipsProfileFile.getPath());
+            checkFileExpectedValue(defaultEnv, ENABLE_FIPS140_3_ENV_VAR + "=" + fipsProfileFile.getPath(), StandardCharsets.UTF_8);
         } else {
-            checkFileExpectedValue(defaultEnv, ENABLE_FIPS140_3_ENV_VAR + "=true");
+            checkFileExpectedValue(defaultEnv, ENABLE_FIPS140_3_ENV_VAR + "=true", StandardCharsets.UTF_8);
         }
         server.startServer();
         checkServerLogForFipsEnablementMessage(server, expectedProvider);
@@ -185,9 +185,9 @@ public class FIPS1403SecurityUtilityTests {
         if(SEMERU_FIPS_PROVIDER.equals(expectedProvider)) {
             File fipsProfileFile = new File(server.getServerRoot() + "/resources/security/" + FIPS_PROFILE_FILE_NAME);
             assertTrue("FIPS Profile file does not exist", fipsProfileFile.exists());
-            checkFileExpectedValue(serverEnv, ENABLE_FIPS140_3_ENV_VAR + "=" + fipsProfileFile.getPath());
+            checkFileExpectedValue(serverEnv, ENABLE_FIPS140_3_ENV_VAR + "=" + fipsProfileFile.getPath(), StandardCharsets.UTF_8);
         } else {
-            checkFileExpectedValue(serverEnv, ENABLE_FIPS140_3_ENV_VAR + "=true");
+            checkFileExpectedValue(serverEnv, ENABLE_FIPS140_3_ENV_VAR + "=true", StandardCharsets.UTF_8);
         }
         server.startServer();
         checkServerLogForFipsEnablementMessage(server, expectedProvider);
@@ -203,9 +203,9 @@ public class FIPS1403SecurityUtilityTests {
         if(SEMERU_FIPS_PROVIDER.equals(expectedProvider)) {
             File fipsProfileFile = new File(client.getClientRoot() + "/resources/security/" + FIPS_PROFILE_FILE_NAME);
             assertTrue("FIPS Profile file does not exist", fipsProfileFile.exists());
-            checkFileExpectedValue(clientEnv, ENABLE_FIPS140_3_ENV_VAR + "=" + fipsProfileFile.getPath());
+            checkFileExpectedValue(clientEnv, ENABLE_FIPS140_3_ENV_VAR + "=" + fipsProfileFile.getPath(), StandardCharsets.UTF_8);
         } else {
-            checkFileExpectedValue(clientEnv, ENABLE_FIPS140_3_ENV_VAR + "=true");
+            checkFileExpectedValue(clientEnv, ENABLE_FIPS140_3_ENV_VAR + "=true", StandardCharsets.UTF_8);
         }
         client.startClient();
         checkClientLogForFipsEnablementMessage(client, expectedProvider);
@@ -226,7 +226,7 @@ public class FIPS1403SecurityUtilityTests {
         if(SEMERU_FIPS_PROVIDER.equals(expectedProvider)) {
             File fipsProfileFile = new File(installRoot + "/" + customProfileName + PROPS_FILE_EXTENSION);
             assertTrue(fipsProfileFile.exists());
-            checkFileExpectedValue(defaultEnv, ENABLE_FIPS140_3_ENV_VAR + "=" + fipsProfileFile.getPath());
+            checkFileExpectedValue(defaultEnv, ENABLE_FIPS140_3_ENV_VAR + "=" + fipsProfileFile.getPath(), StandardCharsets.UTF_8);
         }
         server.startServer();
         checkServerLogForFipsEnablementMessage(server, expectedProvider);
@@ -252,15 +252,15 @@ public class FIPS1403SecurityUtilityTests {
         assertTrue(serverEnv.exists());
         File fipsProfileFile1 = new File(server.getServerRoot() + "/resources/security/" + customProfile1 + PROPS_FILE_EXTENSION);
         assertTrue(fipsProfileFile1.exists());
-        checkFileExpectedValue(fipsProfileFile1, customProfile1);
+        checkFileExpectedValue(fipsProfileFile1, customProfile1, StandardCharsets.UTF_8);
         File fipsProfileFile2 = new File(server.getServerRoot() + "/resources/security/" + customProfile2 + PROPS_FILE_EXTENSION);
         assertTrue(fipsProfileFile2.exists());
-        checkFileExpectedValue(fipsProfileFile2, customProfile2);
+        checkFileExpectedValue(fipsProfileFile2, customProfile2, StandardCharsets.UTF_8);
         File fipsProfileFile3 = new File(server.getServerRoot() + "/resources/security/" + customProfile3 + PROPS_FILE_EXTENSION);
         assertTrue(fipsProfileFile3.exists());
-        checkFileExpectedValue(fipsProfileFile3, customProfile3);
+        checkFileExpectedValue(fipsProfileFile3, customProfile3, StandardCharsets.UTF_8);
         String expectedValue = fipsProfileFile1.getPath() + File.pathSeparator + fipsProfileFile2.getPath() + File.pathSeparator + fipsProfileFile3.getPath();
-        checkFileExpectedValue(serverEnv, ENABLE_FIPS140_3_ENV_VAR + "=" +expectedValue);
+        checkFileExpectedValue(serverEnv, ENABLE_FIPS140_3_ENV_VAR + "=" +expectedValue, StandardCharsets.UTF_8);
 
         server.startServer();
         checkServerLogForFipsEnablementMessage(server, expectedProvider);
@@ -283,7 +283,7 @@ public class FIPS1403SecurityUtilityTests {
         assertEquals("securityUtility configureFIPS did not result in expected return code.",0, ltpaPO.getReturnCode());
         File ltpaKeysFile = new File(server.getServerRoot() + "/resources/security/ltpa.keys");
         assertTrue("LTPA.keys file should exist", ltpaKeysFile.exists());
-        checkFileExpectedValue(ltpaKeysFile, "com.ibm.websphere.ltpa.version=2.0");
+        checkFileExpectedValue(ltpaKeysFile, "com.ibm.websphere.ltpa.version=2.0", StandardCharsets.UTF_8);
 
     }
 
@@ -405,12 +405,12 @@ public class FIPS1403SecurityUtilityTests {
         }
         assertEquals(0, po.getReturnCode());
         assertTrue(po.getStdout().contains(envFile.getPath()+ " file to disable FIPS 140-3."));
-        checkFileExpectedValue(envFile, ENABLE_FIPS140_3_ENV_VAR + "=false");
+        checkFileExpectedValue(envFile, ENABLE_FIPS140_3_ENV_VAR + "=false", StandardCharsets.UTF_8);
     }
 
-    public void checkFileExpectedValue(File file, String expectedValue) throws IOException {
+    public void checkFileExpectedValue(File file, String expectedValue, Charset charset) throws IOException {
         byte[] contentsB = Files.readAllBytes(file.toPath());
-        String contentsS = new String(contentsB);
+        String contentsS = new String(contentsB, charset);
         assertTrue("Contents "+ contentsS +" did not contain expected string: " + expectedValue, contentsS.contains(expectedValue));
     }
 
@@ -423,7 +423,7 @@ public class FIPS1403SecurityUtilityTests {
      * @return
      * @throws Exception
      */
-    public ProgramOutput runSecurityUtilityCommand(String[] parameters) throws Exception {
+    public static ProgramOutput runSecurityUtilityCommand(String[] parameters) throws Exception {
         ProgramOutput po = machine.execute(installRoot + SEC_UTILITY_COMMAND, parameters, env);
         Log.info(thisClass, "serverEnvFipsTest", "Executed securityUtility configureFIPS command: "+ po.getCommand());
         Log.info(thisClass, "serverEnvFipsTest", "Result: "+ po.getStdout());

--- a/dev/io.openliberty.security.fips.internal_fat/fat/src/io/openliberty/security/fips/fat/tests/fips1403/server/FIPS1403ServerTest.java
+++ b/dev/io.openliberty.security.fips.internal_fat/fat/src/io/openliberty/security/fips/fat/tests/fips1403/server/FIPS1403ServerTest.java
@@ -14,6 +14,7 @@ import com.ibm.websphere.simplicity.Machine;
 import com.ibm.websphere.simplicity.OperatingSystem;
 import com.ibm.websphere.simplicity.ProgramOutput;
 import com.ibm.websphere.simplicity.log.Log;
+import componenttest.annotation.MinimumJavaLevel;
 import componenttest.annotation.Server;
 import componenttest.annotation.SkipIfSysProp;
 import componenttest.custom.junit.runner.FATRunner;
@@ -37,22 +38,26 @@ import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 
 import static io.openliberty.security.fips.fat.FIPSTestUtils.*;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeThat;
 
 @RunWith(FATRunner.class)
 @Mode(Mode.TestMode.LITE)
-@SkipIfSysProp({SkipIfSysProp.OS_ZOS, SkipIfSysProp.OS_IBMI, SkipIfSysProp.OS_ISERIES})
+@SkipIfSysProp({SkipIfSysProp.OS_IBMI, SkipIfSysProp.OS_ISERIES})
 public class FIPS1403ServerTest {
+
+    private static final Class<?> c = FIPS1403ServerTest.class;
 
     public static final String SERVER_NAME = "FIPSServer";
     public static String expectedProvider="InvalidProvider";
     public static boolean isIBMJava8 = false;
     public static JavaInfo ji;
     public static boolean GLOBAL_FIPS=false;
+    public static final String OPEN_JCE_PLUS_FIPS_PROVIDER = "OpenJCEPlusFIPS";
+    public static final String IBM_JCE_PLUS_FIPS_PROVIDER = "IBMJCEPlusFIPS";
+    private static Path serverEnVPath = null;
 
     @Server(SERVER_NAME)
     public static LibertyServer server;
@@ -66,12 +71,13 @@ public class FIPS1403ServerTest {
             GLOBAL_FIPS=true;
         }
         if (ji.majorVersion() > 8) {
-            expectedProvider = "OpenJCEPlusFIPS";
+            expectedProvider = OPEN_JCE_PLUS_FIPS_PROVIDER;
         } else {
-            expectedProvider = "IBMJCEPlusFIPS";
+            expectedProvider = IBM_JCE_PLUS_FIPS_PROVIDER;
         }
         // Save configuration at this point, so each test can restore to this point so that we don't pollute each test
         server.saveServerConfiguration();
+        serverEnVPath = Paths.get(server.getServerRoot() + "/"+ SERVER_ENV_FILE);
     }
 
     @Test
@@ -79,14 +85,13 @@ public class FIPS1403ServerTest {
         Log.info(FIPS1403ServerTest.class,"setup","Setting FIPS140-3 JVM Options");
         HashMap<String, String> opts = new HashMap<>();
         //Semeru >=11
-        if (ji.majorVersion() > 8) {
+        if (expectedProvider.equals(OPEN_JCE_PLUS_FIPS_PROVIDER)) {
             server.copyFileToLibertyServerRoot("publish/resources", "resources", STANDALONE_FIPS_PROFILE_FILENAME);
             opts.put("-Dsemeru.fips", "true");
             opts.put("-Dsemeru.customprofile", "OpenJCEPlusFIPS.FIPS140-3-Custom");
             opts.put("-Djava.security.properties", server.getServerRoot() + "/resources/" + STANDALONE_FIPS_PROFILE_FILENAME);
         // IBM SDK 8
         } else {
-            isIBMJava8 = true;
             opts.put("-Xenablefips140-3", null);
             opts.put("-Dcom.ibm.jsse2.usefipsprovider", "true");
             opts.put("-Dcom.ibm.jsse2.usefipsProviderName", "IBMJCEPlusFIPS");
@@ -98,11 +103,11 @@ public class FIPS1403ServerTest {
 
     @Test
     public void serverFIPS140_3EnvVarTest() throws Exception {
-        if(isIBMJava8) {
-            server.addEnvVar(ENABLE_FIPS140_3_ENV_VAR, "true");
-        }else {
+        if (expectedProvider.equals(OPEN_JCE_PLUS_FIPS_PROVIDER)) {
             server.copyFileToLibertyServerRoot("publish/resources", "resources", LIBERTY_APPLICATION_FIPS_PROFILE_FILENAME);
             server.addEnvVar(ENABLE_FIPS140_3_ENV_VAR, server.getServerRoot() + "/resources/" + LIBERTY_APPLICATION_FIPS_PROFILE_FILENAME);
+        }else {
+            server.addEnvVar(ENABLE_FIPS140_3_ENV_VAR, "true");
         }
         server.startServer();
         checkServerLogForFipsEnablementMessage(server, expectedProvider);
@@ -114,19 +119,20 @@ public class FIPS1403ServerTest {
      */
     @Test
     public void serverFIPS140_3EmptyEnvVarTest() throws Exception {
-        Path path = Paths.get(server.getServerRoot() + "/"+ SERVER_ENV_FILE);
+        assumeThat(server.getMachine().getOperatingSystem(), not(OperatingSystem.ZOS));
         String serverEnv = VAR_EXPANSION_ENV + System.lineSeparator() + ENABLE_FIPS140_3_ENV_VAR + "=\"\"";
-        Files.write(path, serverEnv.getBytes(StandardCharsets.UTF_8));
+        Files.write(serverEnVPath, serverEnv.getBytes());
         server.startServer();
         checkServerLogForFipsEnablementMessage(server, expectedProvider);
     }
 
     @Test
+    @MinimumJavaLevel(javaLevel=11)
     public void serverFIPS140_3DirectoryQuotedTest() throws Exception {
+        assumeThat(server.getMachine().getOperatingSystem(), not(OperatingSystem.ZOS));
         server.copyFileToLibertyServerRoot("publish/resources", "resources" , LIBERTY_APPLICATION_FIPS_PROFILE_FILENAME);
-        Path path = Paths.get(server.getServerRoot() + "/"+ SERVER_ENV_FILE);
         String serverEnv = VAR_EXPANSION_ENV + System.lineSeparator() + ENABLE_FIPS140_3_ENV_VAR + "=\"" + server.getServerRoot() + "/resources/" + LIBERTY_APPLICATION_FIPS_PROFILE_FILENAME + "\"";
-        Files.write(path, serverEnv.getBytes(StandardCharsets.UTF_8));
+        Files.write(serverEnVPath, serverEnv.getBytes());
         server.startServer();
         checkServerLogForFipsEnablementMessage(server, expectedProvider);
     }
@@ -137,8 +143,9 @@ public class FIPS1403ServerTest {
      * @throws Exception
      */
     @Test
+    @MinimumJavaLevel(javaLevel=11)
     public void serverFIPS140_3DirectorySpaceNoQuotesTest() throws Exception {
-        assumeThat(server.getMachine().getOperatingSystem(), is(OperatingSystem.WINDOWS));
+        assumeThat(server.getMachine().getOperatingSystem(), not(anyOf(is(OperatingSystem.WINDOWS), is(OperatingSystem.ZOS))));
         String testDir = "resources/test dir";
         server.copyFileToLibertyServerRoot("publish/resources", testDir , LIBERTY_APPLICATION_FIPS_PROFILE_FILENAME);
         server.addEnvVar(ENABLE_FIPS140_3_ENV_VAR, server.getServerRoot()+"/" + testDir + "/" + LIBERTY_APPLICATION_FIPS_PROFILE_FILENAME);
@@ -148,25 +155,25 @@ public class FIPS1403ServerTest {
     }
 
     @Test
+    @MinimumJavaLevel(javaLevel=11)
     public void serverFIPS140_3DirectorySpaceQuotesTest() throws Exception {
-        assumeThat(server.getMachine().getOperatingSystem(), not(OperatingSystem.WINDOWS));
+        assumeThat(server.getMachine().getOperatingSystem(), not(anyOf(is(OperatingSystem.WINDOWS), is(OperatingSystem.ZOS))));
         String testDir = "resources/test dir";
         server.copyFileToLibertyServerRoot("publish/resources", testDir , LIBERTY_APPLICATION_FIPS_PROFILE_FILENAME);
-        Path path = Paths.get(server.getServerRoot() + "/"+ SERVER_ENV_FILE);
         String serverEnv = VAR_EXPANSION_ENV + System.lineSeparator() + ENABLE_FIPS140_3_ENV_VAR + "=\"" + server.getServerRoot() + "/" + testDir + "/" + LIBERTY_APPLICATION_FIPS_PROFILE_FILENAME + "\"";
-        Files.write(path, serverEnv.getBytes(StandardCharsets.UTF_8));
+        Files.write(serverEnVPath, serverEnv.getBytes(StandardCharsets.UTF_8));
         server.startServer();
         checkServerLogForFipsEnablementMessage(server, expectedProvider);
     }
 
     @Test
+    @MinimumJavaLevel(javaLevel=11)
     public void serverFIPS140_3DirectorySpaceSlashTest() throws Exception {
-        assumeThat(server.getMachine().getOperatingSystem(), not(OperatingSystem.WINDOWS));
+        assumeThat(server.getMachine().getOperatingSystem(), not(anyOf(is(OperatingSystem.WINDOWS), is(OperatingSystem.ZOS))));
         String testDir = "resources/test\\ dir";
         server.copyFileToLibertyServerRoot("publish/resources", testDir , LIBERTY_APPLICATION_FIPS_PROFILE_FILENAME);
-        Path path = Paths.get(server.getServerRoot() + "/"+ SERVER_ENV_FILE);
         String serverEnv = VAR_EXPANSION_ENV + System.lineSeparator() + ENABLE_FIPS140_3_ENV_VAR + "=" + server.getServerRoot() + "/" + testDir + "/" + LIBERTY_APPLICATION_FIPS_PROFILE_FILENAME + "";
-        Files.write(path, serverEnv.getBytes(StandardCharsets.UTF_8));
+        Files.write(serverEnVPath, serverEnv.getBytes(StandardCharsets.UTF_8));
         server.startServer();
         checkServerLogForFipsEnablementMessage(server, expectedProvider);
     }
@@ -180,16 +187,33 @@ public class FIPS1403ServerTest {
         Log.info(FIPS1403ServerTest.class, "fips140_3PacakageTest", "Result: "+ po.getStdout());
         Log.info(FIPS1403ServerTest.class, "fips140_3PacakageTest", "Error: "+ po.getStderr());
         assertEquals("Package command failed with a non-zero return code", 0, po.getReturnCode());
-        String zipName = server.getServerName()+".zip";
-        Path zipPath = Paths.get(server.getServerRoot()+"/"+zipName);
+
         boolean foundFipsSecurityFile = false;
-        try (ZipFile zipFile = new ZipFile(zipPath.toFile())) {
-            Enumeration<? extends ZipEntry> entries = zipFile.entries();
-            while (entries.hasMoreElements() && !foundFipsSecurityFile) {
-                ZipEntry entry = entries.nextElement();
-                String name = entry.getName();
-                if(name.endsWith(LIBERTY_BASE_FIPS_PROFILE_FILENAME)){
+        if(!server.getMachine().getOperatingSystem().equals(OperatingSystem.ZOS)) {
+            Path zipPath = Paths.get(server.getServerRoot() + "/" + server.getServerName() + ".zip");
+            try (ZipFile zipFile = new ZipFile(zipPath.toFile())) {
+                Enumeration<? extends ZipEntry> entries = zipFile.entries();
+                while (entries.hasMoreElements() && !foundFipsSecurityFile) {
+                    ZipEntry entry = entries.nextElement();
+                    String name = entry.getName();
+                    if (name.endsWith(LIBERTY_BASE_FIPS_PROFILE_FILENAME)) {
+                        foundFipsSecurityFile = true;
+                    }
+                }
+            }
+        // ZOS packaging produces `.pax` files instead of `.zip`
+        } else {
+            Path paxPath =  Paths.get(server.getServerRoot() + "/" + server.getServerName() + ".pax");
+            // run pax command without `r` or `w` to get a list of the contents
+            ProgramOutput paxcmd = server.getMachine().execute("pax -ppx -f " + paxPath);
+            Log.info(c, "unpax server package", " command:" + paxcmd.getCommand());
+            Log.info(c, "unpax server package", " command exit code: " + paxcmd.getReturnCode());
+            String[] contents = paxcmd.getStdout().split(System.lineSeparator());
+            Log.info(c, "pax list package contents" , "size: " + contents.length);
+            for(String line : contents) {
+                if (line.endsWith(LIBERTY_BASE_FIPS_PROFILE_FILENAME)) {
                     foundFipsSecurityFile = true;
+                    break;
                 }
             }
         }
@@ -202,20 +226,37 @@ public class FIPS1403ServerTest {
         Machine machine = server.getMachine();
         String[] parameters = new String[]{"package", server.getServerName(), "--include=minify"};
         ProgramOutput po = machine.execute(server.getInstallRoot()+"/bin/server", parameters);
-        Log.info(FIPS1403ServerTest.class, "serverEnvFipsTest", "Executed securityUtility configureFIPS command: "+ po.getCommand());
-        Log.info(FIPS1403ServerTest.class, "serverEnvFipsTest", "Result: "+ po.getStdout());
+        Log.info(FIPS1403ServerTest.class, "fips140_3MinifiedPackageTest", "Executed server package command: "+ po.getCommand());
+        Log.info(FIPS1403ServerTest.class, "fips140_3MinifiedPackageTest", "Result: "+ po.getStdout());
         Log.info(FIPS1403ServerTest.class, "serverEnvFipsTest", "Error: "+ po.getStderr());
         assertEquals("Package command failed with a non-zero return code", 0, po.getReturnCode());
-        String zipName = server.getServerName()+".zip";
-        Path zipPath = Paths.get(server.getServerRoot()+"/"+zipName);
+
         boolean foundFipsSecurityFile = false;
-        try (ZipFile zipFile = new ZipFile(zipPath.toFile())) {
-            Enumeration<? extends ZipEntry> entries = zipFile.entries();
-            while (entries.hasMoreElements() && !foundFipsSecurityFile) {
-                ZipEntry entry = entries.nextElement();
-                String name = entry.getName();
-                if(name.endsWith(LIBERTY_BASE_FIPS_PROFILE_FILENAME)){
+        if(!server.getMachine().getOperatingSystem().equals(OperatingSystem.ZOS)) {
+            Path zipPath = Paths.get(server.getServerRoot() + "/" + server.getServerName() + ".zip");
+            try (ZipFile zipFile = new ZipFile(zipPath.toFile())) {
+                Enumeration<? extends ZipEntry> entries = zipFile.entries();
+                while (entries.hasMoreElements() && !foundFipsSecurityFile) {
+                    ZipEntry entry = entries.nextElement();
+                    String name = entry.getName();
+                    if (name.endsWith(LIBERTY_BASE_FIPS_PROFILE_FILENAME)) {
+                        foundFipsSecurityFile = true;
+                    }
+                }
+            }
+            // ZOS packaging produces `.pax` files instead of `.zip`
+        } else {
+            Path paxPath =  Paths.get(server.getServerRoot() + "/" + server.getServerName() + ".pax");
+            // run pax command without `r` or `w` to get a list of the contents
+            ProgramOutput paxcmd = server.getMachine().execute("pax -ppx -f " + paxPath);
+            Log.info(c, "pax list package contents", " command:" + paxcmd.getCommand());
+            Log.info(c, "pax list package contents", " command exit code: " + paxcmd.getReturnCode());
+            String[] contents = paxcmd.getStdout().split(System.lineSeparator());
+            Log.info(c, "pax list package contents" , "size: " + contents.length);
+            for(String line : contents) {
+                if (line.endsWith(LIBERTY_BASE_FIPS_PROFILE_FILENAME)) {
                     foundFipsSecurityFile = true;
+                    break;
                 }
             }
         }
@@ -227,6 +268,10 @@ public class FIPS1403ServerTest {
     public void teardown() throws Exception {
         server.stopServer();
         server.restoreServerConfiguration();
+        // delete the server.env file to remove any potential conflicts in
+        if(Files.exists(serverEnVPath)) {
+            Files.delete(serverEnVPath);
+        }
         // restore Server does not change the JVM options
         HashMap<String, String> opts = new HashMap<>();
         server.setJvmOptions(opts);


### PR DESCRIPTION
The dedicated FIPS140-3 bucket currently skips all but the AlwaysPassesTest for z/OS and Linux s390. Remove these blocks

Fix the Java 8 directory check logic to actually look at the directories within the specified dir directory as opposed to just the directory itself and to actually store directories instead of files within the direcotry

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
