### PR TITLE
Convert jdbc_fat to H2

### DIFF
--- a/dev/com.ibm.ws.jdbc_fat/build.gradle
+++ b/dev/com.ibm.ws.jdbc_fat/build.gradle
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2025 IBM Corporation and others.
+ * Copyright (c) 2019, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.jdbc_fat/build.gradle
+++ b/dev/com.ibm.ws.jdbc_fat/build.gradle
@@ -35,6 +35,7 @@ task copyAnonymousDrivers(type: Copy) {
   rename 'ojdbc8.*.jar', 'driver3.jar'
   rename 'postgresql.*.jar', 'driver4.jar'
   rename 'mssql-jdbc.*.jar', 'driver5.jar'
+  rename 'h2-.*.jar', 'driver6.jar'
 }
 
 //Automatically discovered derby jar
@@ -55,6 +56,7 @@ task copyDB2(type: Copy) {
 
  addRequiredLibraries {
   //Database drivers
+  dependsOn addH2Java8
   dependsOn addDerby
   dependsOn copyAnonymousDrivers
   dependsOn copyAutomaticDerby

--- a/dev/com.ibm.ws.jdbc_fat/cognitiveMetadata.yml
+++ b/dev/com.ibm.ws.jdbc_fat/cognitiveMetadata.yml
@@ -4,3 +4,4 @@
 # description: Uncomment this field and add a description to give some notes about this bucket.
 # triageNotes: Uncomment this field if there are some short notes you would like Pipeline Monitors to see when triaging this bucket.
 functionalArea: Database (jdbc, oracle, db2, derby)
+description: Migrated from derby to h2

--- a/dev/com.ibm.ws.jdbc_fat/fat/src/com/ibm/ws/jdbc/fat/tests/ConfigTest.java
+++ b/dev/com.ibm.ws.jdbc_fat/fat/src/com/ibm/ws/jdbc/fat/tests/ConfigTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2025 IBM Corporation and others.
+ * Copyright (c) 2019, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -15,10 +15,14 @@ package com.ibm.ws.jdbc.fat.tests;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
 
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -56,11 +60,13 @@ import com.ibm.websphere.simplicity.config.dsprops.Properties_derby_client;
 import com.ibm.websphere.simplicity.config.dsprops.Properties_derby_embedded;
 import com.ibm.websphere.simplicity.log.Log;
 
+import componenttest.annotation.AllowedFFDC;
 import componenttest.annotation.ExpectedFFDC;
 import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.topology.database.H2Database;
 import componenttest.topology.database.container.DatabaseContainerFactory;
 import componenttest.topology.database.container.DatabaseContainerType;
 import componenttest.topology.database.container.DatabaseContainerUtil;
@@ -85,8 +91,12 @@ public class ConfigTest extends FATServletClient {
     public static LibertyServer server;
 
     //Test container
+    private static final H2Database h2Database = H2Database.create("dbuser1", "dbpwd1")
+                    .withUser("dbuser2", "dbpwd2")
+                    .withDatabaseName("jdbcfat");
+
     @ClassRule
-    public static final JdbcDatabaseContainer<?> testContainer = DatabaseContainerFactory.create();
+    public static final JdbcDatabaseContainer<?> testContainer = DatabaseContainerFactory.createH2(Optional.of(h2Database));
 
     //List of apps tested by this test suite
     private static final Set<String> appNames = new HashSet<String>(Arrays.asList(dsdfat, jdbcapp));
@@ -138,6 +148,9 @@ public class ConfigTest extends FATServletClient {
         server.addEnvVar("ANON_DRIVER", type.getAnonymousDriverName());
         server.addEnvVar("DB_USER", testContainer.getUsername());
         server.addEnvVar("DB_PASSWORD", testContainer.getPassword());
+        String h2DbDir = Paths.get("results", "h2").toAbsolutePath().toString();
+        server.addEnvVar("H2_DB_DIR", h2DbDir);
+        server.addBootstrapProperties(Collections.singletonMap("h2.db.dir", h2DbDir));
 
         //Setup server DataSource properties (use database specific properties in order to run testTrace() )
         DatabaseContainerUtil.setupDataSourceDatabaseProperties(server, testContainer);
@@ -1041,7 +1054,7 @@ public class ConfigTest extends FATServletClient {
      * Update data source configuration to add, modify and remove validationTimeout while the server is running.
      */
     @Test
-    @ExpectedFFDC({ "javax.resource.ResourceException" })
+    @AllowedFFDC({ "javax.resource.ResourceException", "java.sql.SQLNonTransientConnectionException" })
     public void testConfigChangeForValidationTimeout() throws Throwable {
         String method = "testConfigChangeForValidationTimeout";
         Log.info(c, method, "Executing " + method);
@@ -1408,6 +1421,7 @@ public class ConfigTest extends FATServletClient {
                 server.addEnvVar("ANON_DRIVER", "driver" + DatabaseContainerType.valueOf(testContainer).ordinal() + ".jar");
                 server.addEnvVar("DB_USER", testContainer.getUsername());
                 server.addEnvVar("DB_PASSWORD", testContainer.getPassword());
+                server.addEnvVar("DB_URL", testContainer.getJdbcUrl());
             } finally {
                 server.startServer();
             }
@@ -1570,6 +1584,7 @@ public class ConfigTest extends FATServletClient {
                     server.addEnvVar("ANON_DRIVER", "driver" + DatabaseContainerType.valueOf(testContainer).ordinal() + ".jar");
                     server.addEnvVar("DB_USER", testContainer.getUsername());
                     server.addEnvVar("DB_PASSWORD", testContainer.getPassword());
+                    server.addEnvVar("DB_URL", testContainer.getJdbcUrl());
                 } finally {
                     server.startServer();
                 }
@@ -1643,6 +1658,7 @@ public class ConfigTest extends FATServletClient {
                 server.addEnvVar("ANON_DRIVER", "driver" + DatabaseContainerType.valueOf(testContainer).ordinal() + ".jar");
                 server.addEnvVar("DB_USER", testContainer.getUsername());
                 server.addEnvVar("DB_PASSWORD", testContainer.getPassword());
+                server.addEnvVar("DB_URL", testContainer.getJdbcUrl());
             } finally {
                 server.startServer();
             }

--- a/dev/com.ibm.ws.jdbc_fat/fat/src/com/ibm/ws/jdbc/fat/tests/ConfigTest.java
+++ b/dev/com.ibm.ws.jdbc_fat/fat/src/com/ibm/ws/jdbc/fat/tests/ConfigTest.java
@@ -15,7 +15,6 @@ package com.ibm.ws.jdbc.fat.tests;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
 
-import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/dev/com.ibm.ws.jdbc_fat/fat/src/com/ibm/ws/jdbc/fat/tests/DataSourceJaasTest.java
+++ b/dev/com.ibm.ws.jdbc_fat/fat/src/com/ibm/ws/jdbc/fat/tests/DataSourceJaasTest.java
@@ -12,7 +12,6 @@
  *******************************************************************************/
 package com.ibm.ws.jdbc.fat.tests;
 
-import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.Optional;

--- a/dev/com.ibm.ws.jdbc_fat/fat/src/com/ibm/ws/jdbc/fat/tests/DataSourceJaasTest.java
+++ b/dev/com.ibm.ws.jdbc_fat/fat/src/com/ibm/ws/jdbc/fat/tests/DataSourceJaasTest.java
@@ -1,16 +1,21 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2020 IBM Corporation and others.
+ * Copyright (c) 2019, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package com.ibm.ws.jdbc.fat.tests;
+
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Collections;
+import java.util.Optional;
 
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
@@ -27,6 +32,7 @@ import com.ibm.websphere.simplicity.ShrinkHelper;
 
 import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
+import componenttest.topology.database.H2Database;
 import componenttest.topology.database.container.DatabaseContainerFactory;
 import componenttest.topology.database.container.DatabaseContainerType;
 import componenttest.topology.database.container.DatabaseContainerUtil;
@@ -41,8 +47,12 @@ public class DataSourceJaasTest extends FATServletClient {
     private static final String basicfat = "basicfat";
     private static final String dsdfat = "dsdfat";
 
+    private static final H2Database h2Database = H2Database.create("dbuser1", "dbpwd1")
+                    .withUser("dbuser2", "dbpwd2")
+                    .withDatabaseName("jdbcfat");
+
     @ClassRule
-    public static final JdbcDatabaseContainer<?> testContainer = DatabaseContainerFactory.create();
+    public static final JdbcDatabaseContainer<?> testContainer = DatabaseContainerFactory.createH2(Optional.of(h2Database));
 
     //Server used for DataSourceJaasTest.java
     @Server("com.ibm.ws.jdbc.jaas.fat")
@@ -62,6 +72,9 @@ public class DataSourceJaasTest extends FATServletClient {
         server.addEnvVar("ANON_DRIVER", type.getAnonymousDriverName());
         server.addEnvVar("DB_USER", testContainer.getUsername());
         server.addEnvVar("DB_PASSWORD", testContainer.getPassword());
+        String h2DbDir = Paths.get("results", "h2").toAbsolutePath().toString();
+        server.addEnvVar("H2_DB_DIR", h2DbDir);
+        server.addBootstrapProperties(Collections.singletonMap("h2.db.dir", h2DbDir));
 
         //Setup server DataSource properties
         DatabaseContainerUtil.setupDataSourceProperties(server, testContainer);

--- a/dev/com.ibm.ws.jdbc_fat/fat/src/com/ibm/ws/jdbc/fat/tests/DataSourceTest.java
+++ b/dev/com.ibm.ws.jdbc_fat/fat/src/com/ibm/ws/jdbc/fat/tests/DataSourceTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2025 IBM Corporation and others.
+ * Copyright (c) 2019, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -13,12 +13,17 @@
 package com.ibm.ws.jdbc.fat.tests;
 
 import static com.ibm.websphere.simplicity.config.DataSourceProperties.DERBY_EMBEDDED;
-import static componenttest.annotation.SkipIfSysProp.DB_Oracle;
+import static com.ibm.websphere.simplicity.config.DataSourceProperties.H2;
+import static componenttest.annotation.OnlyIfSysProp.DB_Not_Default;
 import static componenttest.annotation.SkipIfSysProp.DB_SQLServer;
 import static org.junit.Assert.fail;
 
 import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
@@ -39,9 +44,11 @@ import componenttest.annotation.AllowedFFDC;
 import componenttest.annotation.ExpectedFFDC;
 import componenttest.annotation.Server;
 import componenttest.annotation.SkipIfSysProp;
+import componenttest.annotation.OnlyIfSysProp;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.topology.database.H2Database;
 import componenttest.topology.database.container.DatabaseContainerFactory;
 import componenttest.topology.database.container.DatabaseContainerType;
 import componenttest.topology.database.container.DatabaseContainerUtil;
@@ -59,8 +66,12 @@ public class DataSourceTest extends FATServletClient {
     private static final String dsdfat_global_lib = "dsdfat_global_lib";
     private static final String dsdfat_override_lib = "dsdfat_override_lib";
 
+    private static final H2Database h2Database = H2Database.create("dbuser1", "dbpwd1")
+                    .withUser("dbuser2", "dbpwd2")
+                    .withDatabaseName("jdbcfat");
+
     @ClassRule
-    public static final JdbcDatabaseContainer<?> testContainer = DatabaseContainerFactory.create();
+    public static final JdbcDatabaseContainer<?> testContainer = DatabaseContainerFactory.createH2(Optional.of(h2Database));
 
     //Server used for ConfigTest.java and DataSourceTest.java
     @Server("com.ibm.ws.jdbc.fat")
@@ -81,6 +92,9 @@ public class DataSourceTest extends FATServletClient {
         server.addEnvVar("ANON_DRIVER", type.getAnonymousDriverName());
         server.addEnvVar("DB_USER", testContainer.getUsername());
         server.addEnvVar("DB_PASSWORD", testContainer.getPassword());
+        String h2DbDir = Paths.get("results", "h2").toAbsolutePath().toString();
+        server.addEnvVar("H2_DB_DIR", h2DbDir);
+        server.addBootstrapProperties(Collections.singletonMap("h2.db.dir", h2DbDir));
 
         //Setup server DataSource properties
         DatabaseContainerUtil.setupDataSourceProperties(server, testContainer);
@@ -230,7 +244,7 @@ public class DataSourceTest extends FATServletClient {
 
     @Test
     @Mode(TestMode.FULL)
-    @AllowedFFDC({ "javax.resource.ResourceException" })
+    @AllowedFFDC({ "javax.resource.ResourceException", "java.sql.SQLNonTransientConnectionException" })
     public void testMinPoolSize() throws Exception {
         runTest();
     }
@@ -338,7 +352,7 @@ public class DataSourceTest extends FATServletClient {
 
     @Test
     @AllowedFFDC({ "com.ibm.ws.rsadapter.exceptions.DataStoreAdapterException", "javax.transaction.xa.XAException" })
-    @SkipIfSysProp(DB_Oracle)
+    @OnlyIfSysProp(DB_Not_Default)
     public void testXARecovery() throws Exception {
         runTest();
     }
@@ -355,13 +369,13 @@ public class DataSourceTest extends FATServletClient {
     }
 
     @Test
-    @OnlyIfDataSourceProperties(DERBY_EMBEDDED)
+    @OnlyIfDataSourceProperties(H2)
     public void testDataSourceDefGlobalLib() throws Exception {
         runTest(server, dsdfat_global_lib, testName);
     }
 
     @Test
-    @OnlyIfDataSourceProperties(DERBY_EMBEDDED)
+    @OnlyIfDataSourceProperties(H2)
     public void testDataSourceDefOverrideLib() throws Exception {
         runTest(server, dsdfat_override_lib, testName);
     }

--- a/dev/com.ibm.ws.jdbc_fat/fat/src/com/ibm/ws/jdbc/fat/tests/DataSourceTest.java
+++ b/dev/com.ibm.ws.jdbc_fat/fat/src/com/ibm/ws/jdbc/fat/tests/DataSourceTest.java
@@ -352,6 +352,7 @@ public class DataSourceTest extends FATServletClient {
 
     @Test
     @AllowedFFDC({ "com.ibm.ws.rsadapter.exceptions.DataStoreAdapterException", "javax.transaction.xa.XAException" })
+    // TODO remove once H2 XAResource is fixed to behave correctly for two-phase commit
     @OnlyIfSysProp(DB_Not_Default)
     public void testXARecovery() throws Exception {
         runTest();

--- a/dev/com.ibm.ws.jdbc_fat/fat/src/com/ibm/ws/jdbc/fat/tests/DataSourceTest.java
+++ b/dev/com.ibm.ws.jdbc_fat/fat/src/com/ibm/ws/jdbc/fat/tests/DataSourceTest.java
@@ -19,7 +19,6 @@ import static componenttest.annotation.SkipIfSysProp.DB_SQLServer;
 import static org.junit.Assert.fail;
 
 import java.io.File;
-import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.List;

--- a/dev/com.ibm.ws.jdbc_fat/publish/servers/com.ibm.ws.jdbc.fat/bootstrap.properties
+++ b/dev/com.ibm.ws.jdbc_fat/publish/servers/com.ibm.ws.jdbc.fat/bootstrap.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2019, 2024 IBM Corporation and others.
+# Copyright (c) 2019, 2026 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.jdbc_fat/publish/servers/com.ibm.ws.jdbc.fat/bootstrap.properties
+++ b/dev/com.ibm.ws.jdbc_fat/publish/servers/com.ibm.ws.jdbc.fat/bootstrap.properties
@@ -10,11 +10,7 @@
 # Contributors:
 #     IBM Corporation - initial API and implementation
 ###############################################################################
-com.ibm.ws.logging.trace.specification=*=info=enabled:\
-com.ibm.ws.jdbc.*=all=enabled:\
-com.ibm.ejs.j2c.*=all=enabled:\
-com.ibm.ws.rsadapter.*=all=enabled:\
-com.ibm.ws.security.jca.*=all=enabled
+com.ibm.ws.logging.trace.specification=*=info=enabled:com.ibm.ws.jdbc.*=all=enabled:com.ibm.ejs.j2c.*=all=enabled:com.ibm.ws.rsadapter.*=all=enabled:com.ibm.ws.security.jca.*=all=enabled
 com.ibm.ws.logging.max.file.size=0
 osgi.console=5678
 ds.loglevel=debug

--- a/dev/com.ibm.ws.jdbc_fat/publish/servers/com.ibm.ws.jdbc.fat/server.xml
+++ b/dev/com.ibm.ws.jdbc_fat/publish/servers/com.ibm.ws.jdbc.fat/server.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2025 IBM Corporation and others.
+    Copyright (c) 2025, 2026 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.jdbc_fat/publish/servers/com.ibm.ws.jdbc.fat/server.xml
+++ b/dev/com.ibm.ws.jdbc_fat/publish/servers/com.ibm.ws.jdbc.fat/server.xml
@@ -31,7 +31,7 @@
 <!-- ### JDBC Drivers + library ### -->
 	<!-- Test: global library -->
 	<library id="global">
-      <fileset dir="${shared.resource.dir}/derby"/>
+      <fileset dir="${shared.resource.dir}/h2Java8"/>
     </library>
 
 	<!-- Test: library + nested fileset -->
@@ -46,11 +46,11 @@
       </library>
     </jdbcDriver>
     
-    <!-- Test: nested Library -> fileset --> 
+    <!-- Test: nested Library -> fileset -->
     <jdbcDriver id="FATJDBCDriver1">
       <library filesetRef="FATfileset1"/>
     </jdbcDriver>
-    <fileset id="FATfileset1" dir="${shared.resource.dir}/jdbc" includes="${env.DB_DRIVER}"/>    
+    <fileset id="FATfileset1" dir="${shared.resource.dir}/jdbc" includes="${env.DB_DRIVER}"/>
 
 	<!-- Test: nested Library + nested fileset -->
     <jdbcDriver id="FATJDBCDriver2" libraryRef="FATLib2"/>
@@ -90,26 +90,26 @@
     
 <!-- ### Datasources using different jdbcDriver configurations ### -->
     <dataSource id="dsfatboot" jndiName="jdbc/dsfatboot" fat.modify="true" jdbcDriverRef="FATJDBCDriver" type="javax.sql.ConnectionPoolDataSource" transactional="false">
-      <properties.derby.embedded databaseName="${shared.resource.dir}/data/jdbcfat" createDatabase="create" user="dbuser1" password="{xor}Oz0vKDtu"/>
+      <properties.h2 url="${env.DB_URL}" user="dbuser1" password="{xor}Oz0vKDtu"/>
     </dataSource>
 
     <dataSource id="dsfatboot1" jndiName="jdbc/dsfatboot1" fat.modify="true" jdbcDriverRef="FATJDBCDriver1" type="javax.sql.ConnectionPoolDataSource" transactional="false">
-      <properties.derby.embedded databaseName="${shared.resource.dir}/data/jdbcfat" createDatabase="create" user="dbuser1" password="{xor}Oz0vKDtu"/>
+      <properties.h2 url="${env.DB_URL}" user="dbuser1" password="{xor}Oz0vKDtu"/>
     </dataSource>
     
     <dataSource id="dsfatboot2" jndiName="jdbc/dsfatboot2" fat.modify="true" jdbcDriverRef="FATJDBCDriver2" type="javax.sql.ConnectionPoolDataSource" transactional="false">
-      <properties.derby.embedded databaseName="${shared.resource.dir}/data/jdbcfat" createDatabase="create" user="dbuser1" password="{xor}Oz0vKDtu"/>
+      <properties.h2 url="${env.DB_URL}" user="dbuser1" password="{xor}Oz0vKDtu"/>
     </dataSource>
 
     <dataSource id="dsfatboot3" jndiName="jdbc/dsfatboot3" fat.modify="true" jdbcDriverRef="FATJDBCDriver3" type="javax.sql.ConnectionPoolDataSource" transactional="false">
-      <properties.derby.embedded databaseName="${shared.resource.dir}/data/jdbcfat" createDatabase="create" user="dbuser1" password="{xor}Oz0vKDtu"/>
+      <properties.h2 url="${env.DB_URL}" user="dbuser1" password="{xor}Oz0vKDtu"/>
     </dataSource>
     
     <!-- Test: nested jdbcDriver -> library -> fileset -->
     <dataSource id="dsfatboot4" jndiName="jdbc/dsfatboot4" fat.modify="true" type="javax.sql.ConnectionPoolDataSource" transactional="false">
       <jdbcDriver libraryRef="FATLib4"/>
-      <properties.derby.embedded databaseName="${shared.resource.dir}/data/jdbcfat" createDatabase="create" user="dbuser1" password="{xor}Oz0vKDtu"/>
-    </dataSource>    
+      <properties.h2 url="${env.DB_URL}" user="dbuser1" password="{xor}Oz0vKDtu"/>
+    </dataSource>
     <library id="FATLib4" filesetRef="FATfileset4"/>
     <fileset id="FATfileset4" dir="${shared.resource.dir}/jdbc" includes="${env.DB_DRIVER}"/>
     
@@ -118,40 +118,40 @@
       <jdbcDriver id="FATJDBCDriver5">
         <library id="FATLib5" filesetRef="FATfileset5"/>
       </jdbcDriver>
-      <properties.derby.embedded databaseName="${shared.resource.dir}/data/jdbcfat" createDatabase="create" user="dbuser1" password="{xor}Oz0vKDtu"/>
-    </dataSource>        
-    <fileset id="FATfileset5" dir="${shared.resource.dir}/jdbc" includes="${env.DB_DRIVER}"/>    
+      <properties.h2 url="${env.DB_URL}" user="dbuser1" password="{xor}Oz0vKDtu"/>
+    </dataSource>
+    <fileset id="FATfileset5" dir="${shared.resource.dir}/jdbc" includes="${env.DB_DRIVER}"/>
 
 	<!-- Test: nested jdbcDriver + nested library + nested fileset -->
     <dataSource id="dsfatboot6" jndiName="jdbc/dsfatboot6" fat.modify="true" type="javax.sql.ConnectionPoolDataSource" transactional="false">
       <jdbcDriver id="FATJDBCDriver6">
         <library id="FATLib6">
-          <fileset id="FATfileset6" dir="${shared.resource.dir}/jdbc" includes="${env.DB_DRIVER}"/>    
+          <fileset id="FATfileset6" dir="${shared.resource.dir}/jdbc" includes="${env.DB_DRIVER}"/>
         </library>
       </jdbcDriver>
-      <properties.derby.embedded databaseName="${shared.resource.dir}/data/jdbcfat" createDatabase="create" user="dbuser1" password="{xor}Oz0vKDtu"/>
-    </dataSource>        
+      <properties.h2 url="${env.DB_URL}" user="dbuser1" password="{xor}Oz0vKDtu"/>
+    </dataSource>
     
 <!-- ### Datasources using different connection properties ###  -->
     <dataSource id="dsfat0" jndiName="jdbc/dsfat0" fat.modify="true" jdbcDriverRef="FATJDBCDriver" type="javax.sql.DataSource" connectionSharing="MatchOriginalRequest">
       <connectionManager/>
-      <properties.derby.embedded databaseName="${shared.resource.dir}/data/jdbcfat" createDatabase="create" user="dbuser1" password="{xor}Oz0vKDtu"/>
+      <properties.h2 url="${env.DB_URL}" user="dbuser1" password="{xor}Oz0vKDtu"/>
      </dataSource>
 
-    <dataSource id="dsfat1" jndiName="jdbc/dsfat1" fat.modify="true" jdbcDriverRef="FATJDBCDriver" connectionManagerRef="conMgr1" connectionSharing="MatchCurrentState" transactional="true">
-      <properties.derby.embedded databaseName="${shared.resource.dir}/data/jdbcfat" createDatabase="create" user="dbuser1" password="{xor}Oz0vKDtu"/>
+    <dataSource id="dsfat1" jndiName="jdbc/dsfat1" fat.modify="true" jdbcDriverRef="FATJDBCDriver" type="javax.sql.DataSource" connectionManagerRef="conMgr1" connectionSharing="MatchCurrentState" transactional="true">
+      <properties.h2 url="${env.DB_URL}" user="dbuser1" password="{xor}Oz0vKDtu"/>
     </dataSource>
 
     <dataSource id="dsfat2" jndiName="jdbc/dsfat2" fat.modify="true" jdbcDriverRef="FATJDBCDriver" connectionManagerRef="conMgr2" type="javax.sql.XADataSource" isolationLevel="TRANSACTION_READ_COMMITTED" recoveryAuthDataRef="recoveryAuth">
-      <properties.derby.embedded databaseName="${shared.resource.dir}/data/jdbcfat" createDatabase="create" user="dbuser1" password="{xor}Oz0vKDtu"/>
+      <properties.h2 url="${env.DB_URL}" user="dbuser1" password="{xor}Oz0vKDtu"/>
     </dataSource>
 
     <dataSource id="dsfat3" jndiName="jdbc/dsfat3" fat.modify="true" jdbcDriverRef="FATJDBCDriver" type="javax.sql.ConnectionPoolDataSource" transactional="false">
-      <properties.derby.embedded databaseName="${shared.resource.dir}/data/jdbcfat" createDatabase="create"/>
+      <properties.h2 url="${env.DB_URL}"/>
     </dataSource>
 
     <dataSource jndiName="jdbc/dsfat4" fat.modify="true" jdbcDriverRef="FATJDBCDriver" type="javax.sql.XADataSource" transactional="true" connectionSharing="MatchCurrentState" recoveryAuthDataRef="recoveryAuth">
-      <properties.derby.embedded databaseName="${shared.resource.dir}/data/jdbcfat" createDatabase="create" user="dbuser1" password="{xor}Oz0vKDtu"/>
+      <properties.h2 url="${env.DB_URL}" user="dbuser1" password="{xor}Oz0vKDtu"/>
     </dataSource>
     
     <!-- This is a Derby-only data source -->
@@ -199,22 +199,22 @@
 	</dataSource>
 	
     <dataSource id="dsfat20" fat.modify="true" jndiName="jdbc/dsfat20" jdbcDriverRef="FATJDBCDriver" connectionManagerRef="conMgr6" type="javax.sql.XADataSource" isolationLevel="TRANSACTION_READ_COMMITTED" recoveryAuthDataRef="recoveryAuth">
-      <properties.derby.embedded databaseName="${shared.resource.dir}/data/jdbcfat" createDatabase="create" user="dbuser1" password="{xor}Oz0vKDtu"/>
+      <properties.h2 url="${env.DB_URL}" user="dbuser1" password="{xor}Oz0vKDtu"/>
     </dataSource>
     
     <dataSource id="dsfat21" fat.modify="true" jndiName="jdbc/dsfat21" jdbcDriverRef="FATJDBCDriver" type="javax.sql.ConnectionPoolDataSource">
       <connectionManager reapTime="0"/>
-      <properties.derby.embedded databaseName="${shared.resource.dir}/data/jdbcfat" createDatabase="create" user="dbuser1" password="{xor}Oz0vKDtu"/>
+      <properties.h2 url="${env.DB_URL}" user="dbuser1" password="{xor}Oz0vKDtu"/>
     </dataSource>
     
     <dataSource id="dsfat22" fat.modify="true" jndiName="jdbc/dsfat22" jdbcDriverRef="FATJDBCDriver" type="javax.sql.ConnectionPoolDataSource">
       <connectionManager agedTimeout="0" connectionTimeout="-1" maxPoolSize="2"/>
-      <properties.derby.embedded databaseName="${shared.resource.dir}/data/jdbcfat" createDatabase="create" user="dbuser1" password="{xor}Oz0vKDtu"/>
+      <properties.h2 url="${env.DB_URL}" user="dbuser1" password="{xor}Oz0vKDtu"/>
     </dataSource>
     
     <dataSource id="dsfat23" fat.modify="true" jndiName="jdbc/dsfat23" jdbcDriverRef="FATJDBCDriver" type="javax.sql.ConnectionPoolDataSource">
       <connectionManager maxIdleTime="0"/>
-      <properties.derby.embedded databaseName="${shared.resource.dir}/data/jdbcfat" createDatabase="create" user="dbuser1" password="{xor}Oz0vKDtu"/>
+      <properties.h2 url="${env.DB_URL}" user="dbuser1" password="{xor}Oz0vKDtu"/>
     </dataSource>
 
     <dataSource id="dsfatmca" jndiName="jdbc/dsfatmca" jdbcDriverRef="Derby1" connectionManagerRef="conMgr5mca" jaasLoginContextEntryRef="myJAASLoginEntry" type="javax.sql.DataSource" connectionSharing="MatchOriginalRequest">
@@ -240,17 +240,22 @@
     </application>
     
     <application name="dsdfat_global_lib" location="dsdfat_global_lib.war">
-      <!-- 
-      This classloader element should be implied.  All applications should have 
+      <!--
+      This classloader element should be implied.  All applications should have
       access to the global shared lib, unless specified otherwise.
-      <classloader commonLibraryRef="global"/> 
+      <classloader commonLibraryRef="global"/>
       -->
     </application>
 
     <application type="war" id="dsdfat_override_lib" location="dsdfat_override_lib.war">
-      <classloader overrideLibraryRef="DerbyLib" privateLibraryRef="empty"/>
+      <classloader overrideLibraryRef="H2Lib" privateLibraryRef="empty"/>
     </application>
 	<library id="empty"/>
+
+    <!-- H2 library for applications using the rotated database -->
+    <library id="H2Lib">
+      <fileset dir="${shared.resource.dir}/h2Java8"/>
+    </library>
 <!-- ### Permissions ### -->
 	<!-- Note that until using a nested <file> works the following ACEs will be thrown: createClassLoader,
 	java.util.PropertyPermission, javax.management.MBeanPermission -->
@@ -260,13 +265,19 @@
 	<javaPermission className="java.lang.reflect.ReflectPermission" name="suppressAccessChecks"/>
 	
 	<!-- JDBC permissions -->
-    <javaPermission codebase="${shared.resource.dir}derby/derby.jar" className="java.security.AllPermission"/>
-    <javaPermission codebase="${shared.resource.dir}derby/derbyclient.jar" className="java.security.AllPermission"/>
-    <javaPermission codebase="${shared.resource.dir}jdbc/${env.DB_DRIVER}" className="java.security.AllPermission"/>
-    <javaPermission codebase="${shared.resource.dir}anonymous/${env.ANON_DRIVER}" className="java.security.AllPermission"/>
-    <javaPermission codebase="${shared.resource.dir}AutomaticDerbyLibrary/derby.jar" className="java.security.AllPermission"/>
+	   <javaPermission codebase="${shared.resource.dir}derby/derby.jar" className="java.security.AllPermission"/>
+	   <javaPermission codebase="${shared.resource.dir}derby/derbyclient.jar" className="java.security.AllPermission"/>
+	   <javaPermission codebase="${shared.resource.dir}jdbc/${env.DB_DRIVER}" className="java.security.AllPermission"/>
+	   <javaPermission codebase="${shared.resource.dir}anonymous/${env.ANON_DRIVER}" className="java.security.AllPermission"/>
+	   <javaPermission codebase="${shared.resource.dir}AutomaticDerbyLibrary/derby.jar" className="java.security.AllPermission"/>
 	<javaPermission codebase="${shared.resource.dir}db2/jcc.jar" className="java.security.AllPermission"/>
-	
+	<javaPermission codebase="${shared.resource.dir}h2Java8/h2.jar" className="java.security.AllPermission"/>
+
+	<!-- H2 in-file database directory: allow read/write of the directory itself and read/write/delete of files inside -->
+	<javaPermission className="java.io.FilePermission" name="${h2.db.dir}" actions="read,write"/>
+	<javaPermission className="java.io.FilePermission" name="${h2.db.dir}/*" actions="read,write,delete"/>
+	<javaPermission className="java.io.FilePermission" name="${h2.db.dir}/-" actions="read,write,delete"/>
+
 	<!-- Login module -->
 	<javaPermission codebase="${shared.resource.dir}/loginmodule/TestLoginModule.jar" className="java.security.AllPermission"/>
 

--- a/dev/com.ibm.ws.jdbc_fat/publish/servers/com.ibm.ws.jdbc.fat/server.xml
+++ b/dev/com.ibm.ws.jdbc_fat/publish/servers/com.ibm.ws.jdbc.fat/server.xml
@@ -265,11 +265,11 @@
 	<javaPermission className="java.lang.reflect.ReflectPermission" name="suppressAccessChecks"/>
 	
 	<!-- JDBC permissions -->
-	   <javaPermission codebase="${shared.resource.dir}derby/derby.jar" className="java.security.AllPermission"/>
-	   <javaPermission codebase="${shared.resource.dir}derby/derbyclient.jar" className="java.security.AllPermission"/>
-	   <javaPermission codebase="${shared.resource.dir}jdbc/${env.DB_DRIVER}" className="java.security.AllPermission"/>
-	   <javaPermission codebase="${shared.resource.dir}anonymous/${env.ANON_DRIVER}" className="java.security.AllPermission"/>
-	   <javaPermission codebase="${shared.resource.dir}AutomaticDerbyLibrary/derby.jar" className="java.security.AllPermission"/>
+    <javaPermission codebase="${shared.resource.dir}derby/derby.jar" className="java.security.AllPermission"/>
+    <javaPermission codebase="${shared.resource.dir}derby/derbyclient.jar" className="java.security.AllPermission"/>
+    <javaPermission codebase="${shared.resource.dir}jdbc/${env.DB_DRIVER}" className="java.security.AllPermission"/>
+    <javaPermission codebase="${shared.resource.dir}anonymous/${env.ANON_DRIVER}" className="java.security.AllPermission"/>
+    <javaPermission codebase="${shared.resource.dir}AutomaticDerbyLibrary/derby.jar" className="java.security.AllPermission"/>
 	<javaPermission codebase="${shared.resource.dir}db2/jcc.jar" className="java.security.AllPermission"/>
 	<javaPermission codebase="${shared.resource.dir}h2Java8/h2.jar" className="java.security.AllPermission"/>
 

--- a/dev/com.ibm.ws.jdbc_fat/publish/servers/com.ibm.ws.jdbc.jaas.fat/server.xml
+++ b/dev/com.ibm.ws.jdbc_fat/publish/servers/com.ibm.ws.jdbc.jaas.fat/server.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2019, 2020 IBM Corporation and others.
+    Copyright (c) 2019, 2026 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -48,18 +48,18 @@
     <jdbcDriver id="FATJDBCDriver1" fat.modify="true">
       <library filesetRef="FATfileset1"/>
     </jdbcDriver>
-    <fileset id="FATfileset1" dir="${shared.resource.dir}/derby" includes="${env.DB_DRIVER}"/>    
+    <fileset id="FATfileset1" dir="${shared.resource.dir}/h2Java8" includes="${env.DB_DRIVER}"/>
 
 	<!-- Test: nested Library + nested fileset -->
     <jdbcDriver id="FATJDBCDriver2" libraryRef="FATLib2" fat.modify="true"/>
     <library id="FATLib2">
-      <fileset dir="${shared.resource.dir}/derby" includes="${env.DB_DRIVER}"/>
+      <fileset dir="${shared.resource.dir}/h2Java8" includes="${env.DB_DRIVER}"/>
     </library>
 
 	<!-- Test: jdbcDriver -> library -> fileset -->
     <jdbcDriver id="FATJDBCDriver3" libraryRef="FATLib3" fat.modify="true"/>
     <library id="FATLib3" filesetRef="FATfileset3"/>
-    <fileset id="FATfileset3" dir="${shared.resource.dir}/derby" includes="${env.DB_DRIVER}"/>
+    <fileset id="FATfileset3" dir="${shared.resource.dir}/h2Java8" includes="${env.DB_DRIVER}"/>
     
     <!-- Derby-only JDBC driver -->
     <jdbcDriver id="Derby" libraryRef="DerbyLib"/>
@@ -85,68 +85,68 @@
 
 <!-- ### Datasources using different jdbcDriver configurations ### -->
     <dataSource id="dsfatboot" jndiName="jdbc/dsfatboot" fat.modify="true" jdbcDriverRef="FATJDBCDriver" type="javax.sql.ConnectionPoolDataSource" transactional="false">
-      <properties.derby.embedded databaseName="${shared.resource.dir}/data/jdbcfat" createDatabase="create" user="dbuser1" password="{xor}Oz0vKDtu"/>
+      <properties.h2 url="${env.DB_URL}" user="dbuser1" password="{xor}Oz0vKDtu"/>
     </dataSource>
 
     <dataSource id="dsfatboot1" jndiName="jdbc/dsfatboot1" fat.modify="true" jdbcDriverRef="FATJDBCDriver1" type="javax.sql.ConnectionPoolDataSource" transactional="false">
-      <properties.derby.embedded databaseName="${shared.resource.dir}/data/jdbcfat" createDatabase="create" user="dbuser1" password="{xor}Oz0vKDtu"/>
+      <properties.h2 url="${env.DB_URL}" user="dbuser1" password="{xor}Oz0vKDtu"/>
     </dataSource>
     
     <dataSource id="dsfatboot2" jndiName="jdbc/dsfatboot2" fat.modify="true" jdbcDriverRef="FATJDBCDriver2" type="javax.sql.ConnectionPoolDataSource" transactional="false">
-      <properties.derby.embedded databaseName="${shared.resource.dir}/data/jdbcfat" createDatabase="create" user="dbuser1" password="{xor}Oz0vKDtu"/>
+      <properties.h2 url="${env.DB_URL}" user="dbuser1" password="{xor}Oz0vKDtu"/>
     </dataSource>
 
     <dataSource id="dsfatboot3" jndiName="jdbc/dsfatboot3" fat.modify="true" jdbcDriverRef="FATJDBCDriver3" type="javax.sql.ConnectionPoolDataSource" transactional="false">
-      <properties.derby.embedded databaseName="${shared.resource.dir}/data/jdbcfat" createDatabase="create" user="dbuser1" password="{xor}Oz0vKDtu"/>
+      <properties.h2 url="${env.DB_URL}" user="dbuser1" password="{xor}Oz0vKDtu"/>
     </dataSource>
     
     <!-- Test: nested jdbcDriver -> library -> fileset -->
     <dataSource id="dsfatboot4" jndiName="jdbc/dsfatboot4" fat.modify="true" type="javax.sql.ConnectionPoolDataSource" transactional="false">
       <jdbcDriver libraryRef="FATLib4"/>
-      <properties.derby.embedded databaseName="${shared.resource.dir}/data/jdbcfat" createDatabase="create" user="dbuser1" password="{xor}Oz0vKDtu"/>
-    </dataSource>    
+      <properties.h2 url="${env.DB_URL}" user="dbuser1" password="{xor}Oz0vKDtu"/>
+    </dataSource>
     <library id="FATLib4" filesetRef="FATfileset4"/>
-    <fileset id="FATfileset4" dir="${shared.resource.dir}/derby" includes="${env.DB_DRIVER}"/>
+    <fileset id="FATfileset4" dir="${shared.resource.dir}/h2Java8" includes="${env.DB_DRIVER}"/>
     
     <!-- Test: nested jdbcDriver + nested library -->
     <dataSource id="dsfatboot5" jndiName="jdbc/dsfatboot5" fat.modify="true" type="javax.sql.ConnectionPoolDataSource" transactional="false">
       <jdbcDriver id="FATJDBCDriver5">
         <library id="FATLib5" filesetRef="FATfileset5"/>
       </jdbcDriver>
-      <properties.derby.embedded databaseName="${shared.resource.dir}/data/jdbcfat" createDatabase="create" user="dbuser1" password="{xor}Oz0vKDtu"/>
-    </dataSource>        
-    <fileset id="FATfileset5" dir="${shared.resource.dir}/derby" includes="${env.DB_DRIVER}"/>    
+      <properties.h2 url="${env.DB_URL}" user="dbuser1" password="{xor}Oz0vKDtu"/>
+    </dataSource>
+    <fileset id="FATfileset5" dir="${shared.resource.dir}/h2Java8" includes="${env.DB_DRIVER}"/>
 
 	<!-- Test: nested jdbcDriver + nested library + nested fileset -->
     <dataSource id="dsfatboot6" jndiName="jdbc/dsfatboot6" fat.modify="true" type="javax.sql.ConnectionPoolDataSource" transactional="false">
       <jdbcDriver id="FATJDBCDriver6">
         <library id="FATLib6">
-          <fileset id="FATfileset6" dir="${shared.resource.dir}/derby" includes="${env.DB_DRIVER}"/>    
+          <fileset id="FATfileset6" dir="${shared.resource.dir}/h2Java8" includes="${env.DB_DRIVER}"/>
         </library>
       </jdbcDriver>
-      <properties.derby.embedded databaseName="${shared.resource.dir}/data/jdbcfat" createDatabase="create" user="dbuser1" password="{xor}Oz0vKDtu"/>
-    </dataSource>        
+      <properties.h2 url="${env.DB_URL}" user="dbuser1" password="{xor}Oz0vKDtu"/>
+    </dataSource>
 
 <!-- ### Datasources using different connection properties ###  -->
     <dataSource id="dsfat0" jndiName="jdbc/dsfat0" fat.modify="true" jdbcDriverRef="FATJDBCDriver" type="javax.sql.DataSource" connectionSharing="MatchOriginalRequest">
       <connectionManager/>
-      <properties.derby.embedded databaseName="${shared.resource.dir}/data/jdbcfat" createDatabase="create" user="dbuser1" password="{xor}Oz0vKDtu"/>
+      <properties.h2 url="${env.DB_URL}" user="dbuser1" password="{xor}Oz0vKDtu"/>
      </dataSource>
 
     <dataSource id="dsfat1" jndiName="jdbc/dsfat1" fat.modify="true" jdbcDriverRef="FATJDBCDriver" connectionManagerRef="conMgr1" connectionSharing="MatchCurrentState" transactional="true">
-      <properties.derby.embedded databaseName="${shared.resource.dir}/data/jdbcfat" createDatabase="create" user="dbuser1" password="{xor}Oz0vKDtu"/>
+      <properties.h2 url="${env.DB_URL}" user="dbuser1" password="{xor}Oz0vKDtu"/>
     </dataSource>
 
     <dataSource id="dsfat2" jndiName="jdbc/dsfat2" fat.modify="true" jdbcDriverRef="FATJDBCDriver" connectionManagerRef="conMgr2" type="javax.sql.XADataSource" isolationLevel="TRANSACTION_READ_COMMITTED" recoveryAuthDataRef="recoveryAuth">
-      <properties.derby.embedded databaseName="${shared.resource.dir}/data/jdbcfat" createDatabase="create" user="dbuser1" password="{xor}Oz0vKDtu"/>
+      <properties.h2 url="${env.DB_URL}" user="dbuser1" password="{xor}Oz0vKDtu"/>
     </dataSource>
 
     <dataSource id="dsfat3" jndiName="jdbc/dsfat3" fat.modify="true" jdbcDriverRef="FATJDBCDriver" type="javax.sql.ConnectionPoolDataSource" transactional="false">
-      <properties.derby.embedded databaseName="${shared.resource.dir}/data/jdbcfat" createDatabase="create"/>
+      <properties.h2 url="${env.DB_URL}"/>
     </dataSource>
 
     <dataSource jndiName="jdbc/dsfat4" fat.modify="true" jdbcDriverRef="FATJDBCDriver" type="javax.sql.XADataSource" transactional="true" connectionSharing="MatchCurrentState" recoveryAuthDataRef="recoveryAuth">
-      <properties.derby.embedded databaseName="${shared.resource.dir}/data/jdbcfat" createDatabase="create" user="dbuser1" password="{xor}Oz0vKDtu"/>
+      <properties.h2 url="${env.DB_URL}" user="dbuser1" password="{xor}Oz0vKDtu"/>
     </dataSource>
     
     <!-- This is a Derby-only data source -->
@@ -169,22 +169,22 @@
     </dataSource>
 
     <dataSource id="dsfat20" fat.modify="true" jndiName="jdbc/dsfat20" jdbcDriverRef="FATJDBCDriver" connectionManagerRef="conMgr6" type="javax.sql.XADataSource" isolationLevel="TRANSACTION_READ_COMMITTED" recoveryAuthDataRef="recoveryAuth">
-      <properties.derby.embedded databaseName="${shared.resource.dir}/data/jdbcfat" createDatabase="create" user="dbuser1" password="{xor}Oz0vKDtu"/>
+      <properties.h2 url="${env.DB_URL}" user="dbuser1" password="{xor}Oz0vKDtu"/>
     </dataSource>
     
     <dataSource id="dsfat21" fat.modify="true" jndiName="jdbc/dsfat21" jdbcDriverRef="FATJDBCDriver" type="javax.sql.ConnectionPoolDataSource">
       <connectionManager reapTime="0"/>
-      <properties.derby.embedded databaseName="${shared.resource.dir}/data/jdbcfat" createDatabase="create" user="dbuser1" password="{xor}Oz0vKDtu"/>
+      <properties.h2 url="${env.DB_URL}" user="dbuser1" password="{xor}Oz0vKDtu"/>
     </dataSource>
     
     <dataSource id="dsfat22" fat.modify="true" jndiName="jdbc/dsfat22" jdbcDriverRef="FATJDBCDriver" type="javax.sql.ConnectionPoolDataSource">
       <connectionManager agedTimeout="0" connectionTimeout="-1" maxPoolSize="2"/>
-      <properties.derby.embedded databaseName="${shared.resource.dir}/data/jdbcfat" createDatabase="create" user="dbuser1" password="{xor}Oz0vKDtu"/>
+      <properties.h2 url="${env.DB_URL}" user="dbuser1" password="{xor}Oz0vKDtu"/>
     </dataSource>
    
     <dataSource id="dsfat23" fat.modify="true" jndiName="jdbc/dsfat23" jdbcDriverRef="FATJDBCDriver" type="javax.sql.ConnectionPoolDataSource">
       <connectionManager maxIdleTime="0"/>
-      <properties.derby.embedded databaseName="${shared.resource.dir}/data/jdbcfat" createDatabase="create" user="dbuser1" password="{xor}Oz0vKDtu"/>
+      <properties.h2 url="${env.DB_URL}" user="dbuser1" password="{xor}Oz0vKDtu"/>
     </dataSource>
 
     <dataSource id="dsfatmca" jndiName="jdbc/dsfatmca" jdbcDriverRef="Derby" connectionManagerRef="conMgr5mca" jaasLoginContextEntryRef="myJAASLoginEntry" type="javax.sql.DataSource" connectionSharing="MatchOriginalRequest">
@@ -226,18 +226,29 @@
       <classloader privateLibraryRef="DerbyLib"/>
     </application>
 
+    <!-- H2 library for applications using the rotated database -->
+    <library id="H2Lib">
+      <fileset dir="${shared.resource.dir}/h2Java8"/>
+    </library>
+
 <!-- ### Permissions ### -->
 	<!-- General permissions -->
 	<javaPermission className="javax.management.MBeanServerPermission" name="createMBeanServer"/>
 	
 	<!-- JDBC permissions -->
-    <javaPermission codebase="${shared.resource.dir}derby/derby.jar" className="java.security.AllPermission"/>
-    <javaPermission codebase="${shared.resource.dir}derby/derbyclient.jar" className="java.security.AllPermission"/>
-    <javaPermission codebase="${shared.resource.dir}jdbc/${env.DB_DRIVER}" className="java.security.AllPermission"/>
-    <javaPermission codebase="${shared.resource.dir}anonymous/${env.ANON_DRIVER}" className="java.security.AllPermission"/>
-    <javaPermission codebase="${shared.resource.dir}AutomaticDerbyLibrary/derby.jar" className="java.security.AllPermission"/>
-	<javaPermission codebase="${shared.resource.dir}db2/jcc.jar" className="java.security.AllPermission"/>
-	
+	<javaPermission codebase="${shared.resource.dir}derby/derby.jar" className="java.security.AllPermission"/>
+	<javaPermission codebase="${shared.resource.dir}derby/derbyclient.jar" className="java.security.AllPermission"/>
+	<javaPermission codebase="${shared.resource.dir}jdbc/${env.DB_DRIVER}" className="java.security.AllPermission"/>
+	<javaPermission codebase="${shared.resource.dir}anonymous/${env.ANON_DRIVER}" className="java.security.AllPermission"/>
+	<javaPermission codebase="${shared.resource.dir}AutomaticDerbyLibrary/derby.jar" className="java.security.AllPermission"/>
+<javaPermission codebase="${shared.resource.dir}db2/jcc.jar" className="java.security.AllPermission"/>
+<javaPermission codebase="${shared.resource.dir}h2Java8/h2.jar" className="java.security.AllPermission"/>
+
+	<!-- H2 in-file database directory: allow read/write of the directory itself and read/write/delete of files inside -->
+	<javaPermission className="java.io.FilePermission" name="${h2.db.dir}" actions="read,write"/>
+	<javaPermission className="java.io.FilePermission" name="${h2.db.dir}/*" actions="read,write,delete"/>
+	<javaPermission className="java.io.FilePermission" name="${h2.db.dir}/-" actions="read,write,delete"/>
+
 	<!-- Login module permission-->
     <javaPermission codebase="${shared.resource.dir}/loginmodule/TestLoginModule.jar" className="java.security.AllPermission"/>
     

--- a/dev/com.ibm.ws.jdbc_fat/publish/servers/com.ibm.ws.jdbc.jaas.fat/server.xml
+++ b/dev/com.ibm.ws.jdbc_fat/publish/servers/com.ibm.ws.jdbc.jaas.fat/server.xml
@@ -241,8 +241,8 @@
 	<javaPermission codebase="${shared.resource.dir}jdbc/${env.DB_DRIVER}" className="java.security.AllPermission"/>
 	<javaPermission codebase="${shared.resource.dir}anonymous/${env.ANON_DRIVER}" className="java.security.AllPermission"/>
 	<javaPermission codebase="${shared.resource.dir}AutomaticDerbyLibrary/derby.jar" className="java.security.AllPermission"/>
-<javaPermission codebase="${shared.resource.dir}db2/jcc.jar" className="java.security.AllPermission"/>
-<javaPermission codebase="${shared.resource.dir}h2Java8/h2.jar" className="java.security.AllPermission"/>
+    <javaPermission codebase="${shared.resource.dir}db2/jcc.jar" className="java.security.AllPermission"/>
+    <javaPermission codebase="${shared.resource.dir}h2Java8/h2.jar" className="java.security.AllPermission"/>
 
 	<!-- H2 in-file database directory: allow read/write of the directory itself and read/write/delete of files inside -->
 	<javaPermission className="java.io.FilePermission" name="${h2.db.dir}" actions="read,write"/>

--- a/dev/com.ibm.ws.jdbc_fat/test-applications/basicfat/resources/WEB-INF/ibm-web-ext.xml
+++ b/dev/com.ibm.ws.jdbc_fat/test-applications/basicfat/resources/WEB-INF/ibm-web-ext.xml
@@ -2,7 +2,8 @@
 <web-ext xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://websphere.ibm.com/xml/ns/javaee"
     xsi:schemaLocation="http://websphere.ibm.com/xml/ns/javaee http://websphere.ibm.com/xml/ns/javaee/ibm-web-ext_1_0.xsd" version="1.0">
 
-  <resource-ref name="jdbc/dsfat4ref2" commit-priority="2" isolation-level="TRANSACTION_READ_COMMITTED"/>
+  <!-- Branch coupling Loose prevents Oracle from using XA optimizations that prevent XA Recovery -->
+  <resource-ref name="jdbc/dsfat4ref2" branch-coupling="LOOSE" commit-priority="2" isolation-level="TRANSACTION_READ_COMMITTED"/>
 
   <resource-ref name="jdbc/dsfat4ref8" commit-priority="2" isolation-level="TRANSACTION_SERIALIZABLE"/>
 

--- a/dev/com.ibm.ws.jdbc_fat/test-applications/basicfat/src/basicfat/DataSourceTestServlet.java
+++ b/dev/com.ibm.ws.jdbc_fat/test-applications/basicfat/src/basicfat/DataSourceTestServlet.java
@@ -3207,58 +3207,65 @@ public class DataSourceTestServlet extends FATServlet {
         // At this point, the transaction is in-doubt.
         // We won't be able to access the data until the transaction manager recovers
         // the transaction and resolves it.
-        //
-        // A connection configured with TRANSACTION_SERIALIZABLE is necessary in
-        // order to allow the recovery to kick in before using the connection.
 
         System.out.println("attempting to access data (only possible after recovery)");
-        Connection con = ds4u_8.getConnection();
 
-        int isolation = con.getTransactionIsolation();
-        if (isolation != Connection.TRANSACTION_SERIALIZABLE)
-            throw new Exception("The isolation-level of the resource-ref is not honored, instead: " + isolation);
+        // Verify the isolation-level resource-ref attribute is honored by ds4u_8
+        Connection verifyIsolation = ds4u_8.getConnection();
         try {
-            ResultSet result;
-            PreparedStatement pstmt = con.prepareStatement("select name, population, county from cities where name = ?");
-
-            /*
-             * Poll for results once a second for up to 2 minutes.
-             * Most databases will have XA recovery done by this point
-             *
-             */
-            List<String> cities = new ArrayList<>();
-            for (int count = 0; cities.size() < numPrepares && count < 120; Thread.sleep(1000)) {
-                if (!cities.contains("Edina")) {
-                    pstmt.setString(1, "Edina");
-                    result = pstmt.executeQuery();
-                    if (result.next())
-                        cities.add(0, "Edina");
-                }
-
-                if (!cities.contains("St. Louis Park")) {
-                    pstmt.setString(1, "St. Louis Park");
-                    result = pstmt.executeQuery();
-                    if (result.next())
-                        cities.add(1, "St. Louis Park");
-                }
-
-                if (numPrepares == 3 && !cities.contains("Moorhead")) {
-                    pstmt.setString(1, "Moorhead");
-                    result = pstmt.executeQuery();
-                    if (result.next())
-                        cities.add(2, "Moorhead");
-                }
-                count++;
-                System.out.println("Attempt " + count + " to retrieve recovered XA data. Current status: " + cities);
-            }
-
-            if (cities.size() < numPrepares)
-                throw new Exception("Missing entry in database. Results: " + cities);
-            else
-                System.out.println("successfully accessed the data");
+            int isolation = verifyIsolation.getTransactionIsolation();
+            if (isolation != Connection.TRANSACTION_SERIALIZABLE)
+                throw new Exception("The isolation-level of the resource-ref is not honored, instead: " + isolation);
         } finally {
-            con.close();
+            verifyIsolation.close();
         }
+
+        /*
+         * Poll for results once a second for up to 2 minutes.
+         * A new READ_COMMITTED connection is obtained on each attempt so that Oracle's
+         * SERIALIZABLE snapshot issues (ORA-08177) do not prevent reading recovered data.
+         * READ_COMMITTED always sees committed data, which is what we need here.
+         */
+        List<String> cities = new ArrayList<>();
+        for (int count = 0; cities.size() < numPrepares && count < 120; Thread.sleep(1000)) {
+            Connection con = ds4u_2.getConnection();
+            try {
+                PreparedStatement pstmt = con.prepareStatement("select name, population, county from cities where name = ?");
+                try {
+                    if (!cities.contains("Edina")) {
+                        pstmt.setString(1, "Edina");
+                        ResultSet result = pstmt.executeQuery();
+                        if (result.next())
+                            cities.add(0, "Edina");
+                    }
+
+                    if (!cities.contains("St. Louis Park")) {
+                        pstmt.setString(1, "St. Louis Park");
+                        ResultSet result = pstmt.executeQuery();
+                        if (result.next())
+                            cities.add(1, "St. Louis Park");
+                    }
+
+                    if (numPrepares == 3 && !cities.contains("Moorhead")) {
+                        pstmt.setString(1, "Moorhead");
+                        ResultSet result = pstmt.executeQuery();
+                        if (result.next())
+                            cities.add(2, "Moorhead");
+                    }
+                } finally {
+                    pstmt.close();
+                }
+            } finally {
+                con.close();
+            }
+            count++;
+            System.out.println("Attempt " + count + " to retrieve recovered XA data. Current status: " + cities);
+        }
+
+        if (cities.size() < numPrepares)
+            throw new Exception("Missing entry in database. Results: " + cities);
+        else
+            System.out.println("successfully accessed the data");
     }
 
     /**

--- a/dev/com.ibm.ws.jdbc_fat/test-applications/basicfat/src/basicfat/DataSourceTestServlet.java
+++ b/dev/com.ibm.ws.jdbc_fat/test-applications/basicfat/src/basicfat/DataSourceTestServlet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2023 IBM Corporation and others.
+ * Copyright (c) 2019, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.jdbc_fat/test-applications/dsdfat_global_lib/resources/WEB-INF/web.xml
+++ b/dev/com.ibm.ws.jdbc_fat/test-applications/dsdfat_global_lib/resources/WEB-INF/web.xml
@@ -16,8 +16,7 @@
   
   <data-source>
     <name>java:app/jdbc/xmlDS</name>
-    <class-name>org.apache.derby.jdbc.EmbeddedXADataSource40</class-name>
-    <database-name>memory:dsdfat_global_lib</database-name>
-    <property><name>createDatabase</name><value>create</value></property>
+    <class-name>org.h2.jdbcx.JdbcDataSource</class-name>
+    <url>${env.DB_URL}</url>
   </data-source>
 </web-app>

--- a/dev/com.ibm.ws.jdbc_fat/test-applications/dsdfat_global_lib/src/dsdfat_global_lib/DSDGlobalLibTestServlet.java
+++ b/dev/com.ibm.ws.jdbc_fat/test-applications/dsdfat_global_lib/src/dsdfat_global_lib/DSDGlobalLibTestServlet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2025 IBM Corporation and others.
+ * Copyright (c) 2019, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -22,9 +22,8 @@ import componenttest.app.FATServlet;
 
 @SuppressWarnings("serial")
 @DataSourceDefinition(name = "java:comp/env/jdbc/annoDS",
-                      className = "org.apache.derby.jdbc.EmbeddedXADataSource40",
-                      databaseName = "memory:dsdfat_global_lib",
-                      properties = { "createDatabase=create" })
+                      className = "org.h2.jdbcx.JdbcDataSource",
+                      url = "${env.DB_URL}")
 public class DSDGlobalLibTestServlet extends FATServlet {
 
     @Resource(lookup = "java:comp/env/jdbc/annoDS")

--- a/dev/com.ibm.ws.jdbc_fat/test-applications/dsdfat_override_lib/resources/WEB-INF/web.xml
+++ b/dev/com.ibm.ws.jdbc_fat/test-applications/dsdfat_override_lib/resources/WEB-INF/web.xml
@@ -16,8 +16,7 @@
   
   <data-source>
     <name>java:app/jdbc/xmlDSOverride</name>
-    <class-name>org.apache.derby.jdbc.EmbeddedXADataSource40</class-name>
-    <database-name>memory:dsdfat_override_lib</database-name>
-    <property><name>createDatabase</name><value>create</value></property>
+    <class-name>org.h2.jdbcx.JdbcDataSource</class-name>
+    <url>${env.DB_URL}</url>
   </data-source>
 </web-app>

--- a/dev/com.ibm.ws.jdbc_fat/test-applications/dsdfat_override_lib/src/dsdfat_override_lib/DSDOverrideLibTestServlet.java
+++ b/dev/com.ibm.ws.jdbc_fat/test-applications/dsdfat_override_lib/src/dsdfat_override_lib/DSDOverrideLibTestServlet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2025 IBM Corporation and others.
+ * Copyright (c) 2025, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -22,9 +22,8 @@ import componenttest.app.FATServlet;
 
 @SuppressWarnings("serial")
 @DataSourceDefinition(name = "java:comp/env/jdbc/annoDSOverride",
-                      className = "org.apache.derby.jdbc.EmbeddedXADataSource40",
-                      databaseName = "memory:dsdfat_override_lib",
-                      properties = { "createDatabase=create" })
+                      className = "org.h2.jdbcx.JdbcDataSource",
+                      url = "${env.DB_URL}")
 public class DSDOverrideLibTestServlet extends FATServlet {
 
     @Resource(lookup = "java:comp/env/jdbc/annoDSOverride")

--- a/dev/fattest.simplicity/src/componenttest/annotation/SkipIfSysProp.java
+++ b/dev/fattest.simplicity/src/componenttest/annotation/SkipIfSysProp.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2025 IBM Corporation and others.
+ * Copyright (c) 2017, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/dev/fattest.simplicity/src/componenttest/annotation/SkipIfSysProp.java
+++ b/dev/fattest.simplicity/src/componenttest/annotation/SkipIfSysProp.java
@@ -72,6 +72,7 @@ public @interface SkipIfSysProp {
     public static final String DB_DB2 = "fat.bucket.db.type=DB2";
     public static final String DB_Derby = "fat.bucket.db.type=Derby";
     public static final String DB_DerbyClient = "fat.bucket.db.type=DerbyClient";
+    public static final String DB_H2 = "fat.bucket.db.type=H2";
     public static final String DB_Informix = "fat.bucket.db.type=Informix";
     public static final String DB_Oracle = "fat.bucket.db.type=Oracle";
     public static final String DB_Postgres = "fat.bucket.db.type=Postgres";


### PR DESCRIPTION
Converts most of the jdbc_fat test bucket from Derby to H2. There are a few tests left that use derby specific classes, which could be reviewed for potential migration to H2 specific classes in the future.

This also updates the XARecovery test to support Oracle.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".


