### PR TITLE
Fix running FIPS140-3 Fat on IBM Java 8

### DIFF
--- a/dev/io.openliberty.security.fips.internal_fat/fat/src/io/openliberty/security/fips/fat/FIPSTestUtils.java
+++ b/dev/io.openliberty.security.fips.internal_fat/fat/src/io/openliberty/security/fips/fat/FIPSTestUtils.java
@@ -45,65 +45,60 @@ public class FIPSTestUtils {
     /**
      * IBM SDK 8 and Semeru Runtimes >=11 support FIPS, Any other Vendor and Version combination is not supported
      * So check the java information of the server to determine whether to run the actual tests
-     *
+     * <p>
      * If JAVA_HOME for a server is updated via setting JAVA_HOME in a .env file, then the systems JAVA_HOME is what will be picked up
-     *
-     *
+     * <p>
+     * <p>
      * There is a Semeru JDK 8 that does not support fips, so ensure that if running is skipped
      *
      * @param javaInfo
      * @return
      */
-    public static boolean validFIPS140_3Environment(JavaInfo javaInfo){
+    public static boolean validFIPS140_3Environment(JavaInfo javaInfo) {
         boolean validEnv = true;
-        // s390 for Linux is not supported with FIPS mode, so until it is, we should skip the platform, once Java FIPS support is available for s390x we can remove this check
-        if (System.getProperty("os.arch").contains("s390")){
-           validEnv = false;
-           Log.warning(FIPSTestUtils.class, "s390 architecture is not currently supported for either z/OS or Linux");
-        } else {
-            if (javaInfo.majorVersion() == 8) {
-                String dir = javaInfo.javaHome();
-                if (!dir.endsWith("jre")) {
-                    dir = dir + "/jre";
-                }
-                Set<String> dirs = Stream.of(new File(dir))
-                        .filter(file -> !file.isDirectory())
-                        .map(File::getName)
-                        .collect(Collectors.toSet());
-                if (!dirs.contains("fips140-3")) {
-                    validEnv = false;
-                    Log.warning(FIPSTestUtils.class, "Java 8 install does not support FIPS140-3");
-                }
-            } else {
-                String javaSecurityPath = javaInfo.javaHome() + "/conf/security/java.security";
-                Path path = Paths.get(javaSecurityPath);
 
-                try (BufferedReader reader = Files.newBufferedReader(path)) {
-                    String line;
-                    boolean fipsCompatible = false;
-                    while ((line = reader.readLine()) != null) {
-                        if (line.contains("OpenJCEPlusFIPS.FIPS140-3-Strongly-Enforced")) {
-                            fipsCompatible = true;
-                        }
+        if (javaInfo.majorVersion() == 8) {
+            String dir = javaInfo.javaHome();
+            if (!dir.endsWith("jre")) {
+                dir = dir + "/jre";
+            }
+            Set<String> dirs = Stream.of(new File(dir))
+                    .filter(file -> !file.isDirectory())
+                    .map(File::getName)
+                    .collect(Collectors.toSet());
+            if (!dirs.contains("fips140-3")) {
+                validEnv = false;
+                Log.warning(FIPSTestUtils.class, "Java 8 install does not support FIPS140-3");
+            }
+        } else {
+            String javaSecurityPath = javaInfo.javaHome() + "/conf/security/java.security";
+            Path path = Paths.get(javaSecurityPath);
+
+            try (BufferedReader reader = Files.newBufferedReader(path)) {
+                String line;
+                boolean fipsCompatible = false;
+                while ((line = reader.readLine()) != null) {
+                    if (line.contains("OpenJCEPlusFIPS.FIPS140-3-Strongly-Enforced")) {
+                        fipsCompatible = true;
                     }
-                    if (!fipsCompatible) {
-                        validEnv = fipsCompatible;
-                        Log.warning(FIPSTestUtils.class, "Java install is not FIPS compatible");
-                    }
-                } catch (IOException e) {
-                    validEnv = false;
-                    Log.warning(FIPSTestUtils.class, "unable to read java.security file, skipping the tests");
                 }
+                if (!fipsCompatible) {
+                    validEnv = fipsCompatible;
+                    Log.warning(FIPSTestUtils.class, "Java install is not FIPS compatible");
+                }
+            } catch (IOException e) {
+                validEnv = false;
+                Log.warning(FIPSTestUtils.class, "unable to read java.security file, skipping the tests");
             }
         }
         return validEnv;
     }
 
-    public static void checkServerLogForFipsEnablementMessage(LibertyServer server, String expectedProvider){
+    public static void checkServerLogForFipsEnablementMessage(LibertyServer server, String expectedProvider) {
         assertNotNull("Expected FIPS 140-3 enabled message to be found in Server logs, but was not found.", server.waitForStringInLog("CWWKS5903I:.*" + expectedProvider));
     }
 
-    public static void checkClientLogForFipsEnablementMessage(LibertyClient client, String expectedProvider){
+    public static void checkClientLogForFipsEnablementMessage(LibertyClient client, String expectedProvider) {
         // Check the copied logs as they are reliable
         assertNotNull("Expected FIPS 140-3 enabled message to be found in Client logs, but was not found.", client.waitForStringInCopiedLog("CWWKS5903I:.*" + expectedProvider));
     }

--- a/dev/io.openliberty.security.fips.internal_fat/fat/src/io/openliberty/security/fips/fat/FIPSTestUtils.java
+++ b/dev/io.openliberty.security.fips.internal_fat/fat/src/io/openliberty/security/fips/fat/FIPSTestUtils.java
@@ -63,7 +63,7 @@ public class FIPSTestUtils {
                 dir = dir + "/jre";
             }
             Set<String> dirs = Stream.of(new File(dir))
-                    .filter(file -> !file.isDirectory())
+                    .filter(File::isDirectory)
                     .map(File::getName)
                     .collect(Collectors.toSet());
             if (!dirs.contains("fips140-3")) {

--- a/dev/io.openliberty.security.fips.internal_fat/fat/src/io/openliberty/security/fips/fat/tests/fips1403/client/FIPS1403ClientTest.java
+++ b/dev/io.openliberty.security.fips.internal_fat/fat/src/io/openliberty/security/fips/fat/tests/fips1403/client/FIPS1403ClientTest.java
@@ -37,7 +37,7 @@ import static org.junit.Assume.assumeThat;
 
 @RunWith(FATRunner.class)
 @Mode(Mode.TestMode.LITE)
-@SkipIfSysProp({SkipIfSysProp.OS_ZOS, SkipIfSysProp.OS_IBMI, SkipIfSysProp.OS_ISERIES})
+@SkipIfSysProp({SkipIfSysProp.OS_IBMI, SkipIfSysProp.OS_ISERIES})
 public class FIPS1403ClientTest {
 
     public static final String CLIENT_NAME = "FIPSClient";

--- a/dev/io.openliberty.security.fips.internal_fat/fat/src/io/openliberty/security/fips/fat/tests/fips1403/security/utility/FIPS1403SecurityUtilityTests.java
+++ b/dev/io.openliberty.security.fips.internal_fat/fat/src/io/openliberty/security/fips/fat/tests/fips1403/security/utility/FIPS1403SecurityUtilityTests.java
@@ -53,7 +53,7 @@ import static org.junit.Assume.assumeThat;
 
 @RunWith(FATRunner.class)
 @Mode(Mode.TestMode.LITE)
-@SkipIfSysProp({SkipIfSysProp.OS_ZOS, SkipIfSysProp.OS_IBMI, SkipIfSysProp.OS_ISERIES})
+@SkipIfSysProp({SkipIfSysProp.OS_IBMI, SkipIfSysProp.OS_ISERIES})
 public class FIPS1403SecurityUtilityTests {
 
     private static final Class<?> thisClass = FIPS1403SecurityUtilityTests.class;

--- a/dev/io.openliberty.security.fips.internal_fat/fat/src/io/openliberty/security/fips/fat/tests/fips1403/server/FIPS1403ServerTest.java
+++ b/dev/io.openliberty.security.fips.internal_fat/fat/src/io/openliberty/security/fips/fat/tests/fips1403/server/FIPS1403ServerTest.java
@@ -45,7 +45,7 @@ import static org.junit.Assume.assumeThat;
 
 @RunWith(FATRunner.class)
 @Mode(Mode.TestMode.LITE)
-@SkipIfSysProp({SkipIfSysProp.OS_ZOS, SkipIfSysProp.OS_IBMI, SkipIfSysProp.OS_ISERIES})
+@SkipIfSysProp({SkipIfSysProp.OS_IBMI, SkipIfSysProp.OS_ISERIES})
 public class FIPS1403ServerTest {
 
     public static final String SERVER_NAME = "FIPSServer";


### PR DESCRIPTION
Turns out we weren't running any of the actual tests on IBM Java 8 platforms.

- [ ] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [ ] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".