### PR TITLE
Print unencrypted password warning without verbose mode

### DIFF
--- a/dev/com.ibm.ws.install/src/com/ibm/ws/install/internal/ArtifactDownloaderUtils.java
+++ b/dev/com.ibm.ws.install/src/com/ibm/ws/install/internal/ArtifactDownloaderUtils.java
@@ -348,7 +348,7 @@ public class ArtifactDownloaderUtils {
             return;
         }
         if (!PasswordUtil.isEncrypted(pwd)) {
-            logger.log(Level.FINE, Messages.INSTALL_KERNEL_MESSAGES.getLogMessage("ERROR_TOOL_PWD_NOT_ENCRYPTED")
+            logger.log(Level.WARNING, Messages.INSTALL_KERNEL_MESSAGES.getLogMessage("ERROR_TOOL_PWD_NOT_ENCRYPTED")
                                    + InstallUtils.NEWLINE);
         }
         String crypto_algorithm = PasswordUtil.getCryptoAlgorithm(pwd);


### PR DESCRIPTION
## Summary
Fixes https://github.ibm.com/was-install-l3/work-items/issues/105

Currently, featureUtility only prints the CWWKF1374E warning about unencrypted passwords when verbose mode is enabled. This change makes the warning always print, regardless of verbose mode, to improve security awareness.

## Changes
- Changed log level from `Level.FINE` to `Level.WARNING` in `ArtifactDownloaderUtils.java` line 351
- The warning message CWWKF1374E now always prints when a password is not encrypted

## Testing
**Before (with verbose mode only):**
- Warning only appeared when running featureUtility with `--verbose` flag
- Users with unencrypted passwords in `featureUtility.properties` would not see the warning in normal mode

**After (always prints):**
- Warning now appears whenever an unencrypted password is detected
- Users are always informed to encrypt passwords using: `securityUtility encode --encoding=aes <password>`

## Related Issues
- Related to #28101 (previous fix for authentication warnings)
- Addresses security best practice of always warning about unencrypted credentials

## Reviewer Notes
This is a simple one-line change that improves security by ensuring users are always warned about unencrypted passwords, not just in verbose mode.
