### PR TITLE
Support version matching in feature provision capability filters

### DIFF
--- a/dev/com.ibm.ws.kernel.feature.core/src/com/ibm/ws/kernel/feature/internal/subsystem/FeatureDefinitionUtils.java
+++ b/dev/com.ibm.ws.kernel.feature.core/src/com/ibm/ws/kernel/feature/internal/subsystem/FeatureDefinitionUtils.java
@@ -80,6 +80,7 @@ public class FeatureDefinitionUtils {
     static final String FILTER_ATTR_NAME = "filter";
     static final String FILTER_FEATURE_KEY = "osgi.identity";
     static final String FILTER_TYPE_KEY = "type";
+    static final String FILTER_VERSION_KEY = "version";
 
     static final List<String> LOCALIZABLE_HEADERS = Collections.unmodifiableList(Arrays.asList(new String[] { "Subsystem-Name", "Subsystem-Description" }));
 

--- a/dev/com.ibm.ws.kernel.feature.core/src/com/ibm/ws/kernel/feature/internal/subsystem/SubsystemFeatureDefinitionImpl.java
+++ b/dev/com.ibm.ws.kernel.feature.core/src/com/ibm/ws/kernel/feature/internal/subsystem/SubsystemFeatureDefinitionImpl.java
@@ -433,9 +433,11 @@ public class SubsystemFeatureDefinitionImpl implements ProvisioningFeatureDefini
                     // headers. So we need to add a new property for osgi.identity (filter key) that contains the value of the
                     // Subsystem-SymbolicName (manifest header).
                     // We also have to do this for the Subsystem-Type(manifest header) and the type (filter key).
-                    Map<String, String> filterProps = new HashMap<String, String>();
+                    // The Subsystem-Version header is mapped to version so OSGi filter version comparisons work.
+                    Map<String, Object> filterProps = new HashMap<String, Object>();
 
                     filterProps.put(FeatureDefinitionUtils.FILTER_FEATURE_KEY, featureDef.getSymbolicName());
+                    filterProps.put(FeatureDefinitionUtils.FILTER_VERSION_KEY, featureDef.getVersion());
                     try {
                         filterProps.put(FeatureDefinitionUtils.FILTER_TYPE_KEY,
                                         mfDetails.getMainAttributeValue(FeatureDefinitionUtils.TYPE));

--- a/dev/com.ibm.ws.kernel.feature/test/com/ibm/ws/kernel/feature/internal/subsystem/FeatureDefinitionUtilsTest.java
+++ b/dev/com.ibm.ws.kernel.feature/test/com/ibm/ws/kernel/feature/internal/subsystem/FeatureDefinitionUtilsTest.java
@@ -399,6 +399,19 @@ public class FeatureDefinitionUtilsTest {
     }
 
     @Test
+    public void testCapabilityFilterMatchesFeatureVersion() throws Exception {
+        String provisionCapability = "IBM-Provision-Capability: osgi.identity; filter:=\"(&(type=osgi.subsystem.feature)(osgi.identity=com.ibm.websphere.versioned)(version>=2.0.0))\" \n";
+        SubsystemFeatureDefinitionImpl autoFeature = createSubsystemFeatureDefinition("com.ibm.websphere.auto.version", "1.0.0", provisionCapability);
+        SubsystemFeatureDefinitionImpl lowerVersionFeature = createSubsystemFeatureDefinition("com.ibm.websphere.versioned", "1.9.0");
+        SubsystemFeatureDefinitionImpl matchingVersionFeature = createSubsystemFeatureDefinition("com.ibm.websphere.versioned", "2.0.0");
+
+        Assert.assertFalse("Capability should not be satisfied by a lower feature version",
+                           autoFeature.isCapabilitySatisfied(Arrays.asList(lowerVersionFeature)));
+        Assert.assertTrue("Capability should be satisfied by a matching feature version",
+                          autoFeature.isCapabilitySatisfied(Arrays.asList(matchingVersionFeature)));
+    }
+
+    @Test
     public void testInstallIsValidVisibilityDirective() throws IOException {
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         PrintWriter writer = new PrintWriter(out, true);
@@ -415,6 +428,24 @@ public class FeatureDefinitionUtilsTest {
 
         Assert.assertEquals("symbolicName should return com.ibm.websphere.install-1.0", "com.ibm.websphere.install-1.0", iAttr.symbolicName);
         Assert.assertEquals("Visibility should return INSTALL", Visibility.INSTALL, iAttr.visibility);
+    }
+
+    private SubsystemFeatureDefinitionImpl createSubsystemFeatureDefinition(String symbolicName,
+                                                                           String subsystemVersion,
+                                                                           String... extraHeaders) throws IOException {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        PrintWriter writer = new PrintWriter(out, true);
+        writer.write("Manifest-Version: 1.0 \n");
+        writer.write("Subsystem-SymbolicName: " + symbolicName + " \n");
+        writer.write("Subsystem-Type: osgi.subsystem.feature \n");
+        writer.write("Subsystem-Version: " + subsystemVersion + " \n");
+        writer.write("IBM-Feature-Version: 2 \n");
+        for (String extraHeader : extraHeaders) {
+            writer.write(extraHeader);
+        }
+        writer.flush();
+
+        return new SubsystemFeatureDefinitionImpl("", new ByteArrayInputStream(out.toByteArray()));
     }
 
     void assertAttributesEqual(Class<?> c, Object o1, Object o2, String... fieldNames) throws Exception {


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [ ] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

## What

This PR adds the feature `version` property when evaluating `IBM-Provision-Capability` filters in `SubsystemFeatureDefinitionImpl#isCapabilitySatisfied`.

The filter properties now include the candidate feature's `Subsystem-Version` as an `org.osgi.framework.Version`, using the OSGi identity capability filter key:

```text
version
```

This allows manifest filters such as:

```text
(version>=2.0.0)
```

to use OSGi version comparison semantics.

## Why

Previously, auto-feature capability filters could match candidate features by `osgi.identity` and `type`, but version predicates could not be evaluated because no `version` property was supplied to the filter.

## Behavior Change / Migration Impact

Existing filters that match only `osgi.identity` and `type` are unchanged.

The only behavior change is that filters containing a `version` predicate can now match as intended. This should have no migration impact for existing feature manifests that do not use version predicates.

## Testing

Ran:

```powershell
.\gradlew.bat cnf:initialize
.\gradlew.bat :com.ibm.ws.kernel.feature:test --tests com.ibm.ws.kernel.feature.internal.subsystem.FeatureDefinitionUtilsTest
```

Result:

```text
BUILD SUCCESSFUL
15 total tests
15 total passing
0 total failing
0 total skipped
```