### PR TITLE
Repository in different module than persistence unit

### DIFF
--- a/dev/io.openliberty.data.internal_fat_datastore/fat/src/test/jakarta/data/datastore/DataStoreTest.java
+++ b/dev/io.openliberty.data.internal_fat_datastore/fat/src/test/jakarta/data/datastore/DataStoreTest.java
@@ -82,7 +82,9 @@ public class DataStoreTest extends FATServletClient {
 
         JavaArchive DataStoreTestAppLib = ShrinkWrap.create(JavaArchive.class,
                                                             "DataStoreTestAppLib.jar")
-                        .addPackage("test.jakarta.data.datastore.lib");
+                        .addPackage("test.jakarta.data.datastore.lib")
+                        .addAsResource(new File("test-applications/DataStoreTestApp/resources/META-INF/persistence.xml"),
+                                       "META-INF/persistence.xml");
 
         JavaArchive DataStoreTestAppWebLib = ShrinkWrap.create(JavaArchive.class,
                                                                "DataStoreTestAppWebLib.jar")

--- a/dev/io.openliberty.data.internal_fat_datastore/test-applications/DataStoreTestApp/resources/META-INF/persistence.xml
+++ b/dev/io.openliberty.data.internal_fat_datastore/test-applications/DataStoreTestApp/resources/META-INF/persistence.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- 
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+-->
+<persistence 
+    xmlns="http://java.sun.com/xml/ns/persistence"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://java.sun.com/xml/ns/persistence http://java.sun.com/xml/ns/persistence/persistence_1_0.xsd"
+    version="1.0">
+
+    <persistence-unit name="AppPersistenceUnit">
+        <jta-data-source>jdbc/ServerDataSource</jta-data-source>
+        <class>test.jakarta.data.datastore.lib.ServerDSEntity</class>
+        <properties>
+            <property name="eclipselink.logging.parameters"
+                      value="true"/>
+            <property name="jakarta.persistence.schema-generation.database.action"
+                      value="create"/>
+        </properties>
+    </persistence-unit>
+
+</persistence>

--- a/dev/io.openliberty.data.internal_fat_datastore/test-applications/DataStoreTestApp/src/test/jakarta/data/datastore/web/AppJarPersistenceUnitRepo.java
+++ b/dev/io.openliberty.data.internal_fat_datastore/test-applications/DataStoreTestApp/src/test/jakarta/data/datastore/web/AppJarPersistenceUnitRepo.java
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package test.jakarta.data.datastore.web;
+
+import jakarta.data.repository.DataRepository;
+import jakarta.data.repository.Query;
+import jakarta.data.repository.Repository;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceUnit;
+
+import test.jakarta.data.datastore.lib.ServerDSEntity;
+
+/**
+ * This repository has its dataStore reference a persistence unit that is defined
+ * in a JAR of the application. The persistence-unit is defined in
+ * META-INF/persistence.xml of lib/DataStoreTestAppLib.jar.
+ */
+@PersistenceUnit(name = "java:app/env/persistence/AppPersistenceUnitRef",
+                 unitName = "AppPersistenceUnit")
+@Repository(dataStore = "java:app/env/persistence/AppPersistenceUnitRef")
+public interface AppJarPersistenceUnitRepo extends DataRepository<ServerDSEntity, String> {
+
+    EntityManager entityMgr();
+
+    @Query("UPDATE ServerDSEntity SET value = value * 4 WHERE id = ?1")
+    boolean quadruple(String id);
+
+}

--- a/dev/io.openliberty.data.internal_fat_datastore/test-applications/DataStoreTestApp/src/test/jakarta/data/datastore/web/DataStoreTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat_datastore/test-applications/DataStoreTestApp/src/test/jakarta/data/datastore/web/DataStoreTestServlet.java
@@ -58,6 +58,9 @@ import test.jakarta.data.datastore.web.lib.WebLibRepo;
 public class DataStoreTestServlet extends FATServlet {
 
     @Inject
+    AppJarPersistenceUnitRepo appJarPersistenceUnitRepo;
+
+    @Inject
     DefaultDSRepo defaultDSRepo;
 
     @Inject
@@ -292,6 +295,44 @@ public class DataStoreTestServlet extends FATServlet {
             else
                 tx.rollback();
         }
+    }
+
+    /**
+     * Use a repository defined in the web module, but which requires a
+     * persistence unit that is defined in a JAR file of the enterprise
+     * application.
+     */
+    @Test
+    public void testPersistenceUnitInAppJarUsedByWebModule() {
+        // insert data using a different repository
+        ServerDSEntity forty_eight = ServerDSEntity.of("forty-eight", 12);
+        serverDSJNDIRepo.insert(forty_eight);
+
+        assertEquals(true,
+                     appJarPersistenceUnitRepo.quadruple("forty-eight"));
+
+        try (EntityManager em = appJarPersistenceUnitRepo.entityMgr()) {
+
+            String jpql = "FROM ServerDSEntity WHERE id = 'forty-eight'";
+            ServerDSEntity entity = em
+                            .createQuery(jpql, ServerDSEntity.class)
+                            .getSingleResult();
+            assertEquals("forty-eight", entity.id);
+            assertEquals(48, entity.value);
+
+            try {
+                Class<?> c = entity.getClass()
+                                .getClassLoader()
+                                .loadClass(AppJarPersistenceUnitRepo.class.getName());
+                fail("Loaded web module class from the class loader of a" +
+                     " persistence unit for an entity class defined in a" +
+                     " JAR of the application. Loaded: " + c);
+            } catch (ClassNotFoundException x) {
+                // expected
+            }
+        }
+
+        serverDSIdRepo.remove(ServerDSEntity.of("forty-eight", 48));
     }
 
     /**


### PR DESCRIPTION
Scenario where a persistence unit and entities are defined in an application JAR, which is used by a Jakarta Data repository in a web module.  The Jakarta Data repository has access to the persistence unit and entity classes, even though the persistence unit's class loader cannot load the Jakarta Data repository.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
