### PR TITLE
Cursor pagination with Sort expressions

### DIFF
--- a/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/CursoredPageImpl.java
+++ b/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/CursoredPageImpl.java
@@ -34,7 +34,6 @@ import com.ibm.websphere.ras.annotation.Trivial;
 
 import jakarta.data.Sort;
 import jakarta.data.exceptions.DataException;
-import jakarta.data.exceptions.MappingException;
 import jakarta.data.page.CursoredPage;
 import jakarta.data.page.PageRequest;
 import jakarta.data.page.PageRequest.Cursor;
@@ -50,15 +49,16 @@ public class CursoredPageImpl<T> extends PageImpl<T> implements CursoredPage<T> 
     /**
      * Construct a new CursoredPage.
      *
-     * @param queryInfo            query information.
-     * @param entityHandler        EntityAgent or EntityManager
-     * @param pageRequest          the request for this page.
-     * @param args                 values that are supplied to the repository method.
-     * @param deferredConstraints  map of method parameter index to non-Literal
-     *                                 Constraints that are supplied at execution time.
-     * @param constraintJPQLParams map of JPQL parameter names/indices and values that are
-     *                                 added due to Constraints and Restrictions.
-     *                                 Null indicates none are added.
+     * @param queryInfo           query information.
+     * @param entityHandler       EntityAgent or EntityManager
+     * @param pageRequest         the request for this page.
+     * @param args                values that are supplied to the repository method.
+     * @param deferredConstraints map of method parameter index to non-Literal
+     *                                Constraints that are supplied at execution time.
+     * @param requiredJPQLParams  map of JPQL parameter name/index to value for
+     *                                Constraints/Restrictions. Null indicates none
+     * @param orderJPQLParams     map of JPQL parameter name/index to value for
+     *                                expressions in Order/Sort. Null indicates none
      * @throws Exception if an error occurs.
      */
     @Trivial // avoid tracing customer data
@@ -67,8 +67,9 @@ public class CursoredPageImpl<T> extends PageImpl<T> implements CursoredPage<T> 
                      PageRequest pageRequest,
                      Object[] args,
                      Map<Integer, Object> deferredConstraints,
-                     Map<Object, Object> constraintJPQLParams) throws Exception {
-        super(queryInfo, pageRequest, args, deferredConstraints, constraintJPQLParams);
+                     Map<Object, Object> requiredJPQLParams,
+                     Map<Object, Object> orderJPQLParams) throws Exception {
+        super(queryInfo, pageRequest, args, deferredConstraints, requiredJPQLParams);
 
         final boolean trace = TraceComponent.isAnyTracingEnabled();
         if (trace && tc.isEntryEnabled())
@@ -77,7 +78,8 @@ public class CursoredPageImpl<T> extends PageImpl<T> implements CursoredPage<T> 
                      pageRequest,
                      queryInfo.loggable(args),
                      deferredConstraints.keySet(),
-                     constraintJPQLParams == null ? null : constraintJPQLParams.keySet());
+                     requiredJPQLParams == null ? null : requiredJPQLParams.keySet(),
+                     orderJPQLParams == null ? null : orderJPQLParams.keySet());
 
         int maxPageSize = this.pageRequest.size();
         int firstResult = this.pageRequest.mode() == PageRequest.Mode.OFFSET //
@@ -86,26 +88,30 @@ public class CursoredPageImpl<T> extends PageImpl<T> implements CursoredPage<T> 
 
         String jpql;
         Optional<PageRequest.Cursor> cursor = this.pageRequest.cursor();
-        Map<Object, Object> addedJPQLParams;
+        Map<Object, Object> cursorAndOrderJPQLParams;
 
         if (cursor.isPresent()) {
             jpql = isForward ? queryInfo.jpqlAfterCursor : queryInfo.jpqlBeforeCursor;
 
-            addedJPQLParams = constraintJPQLParams == null //
+            cursorAndOrderJPQLParams = orderJPQLParams == null //
                             ? new LinkedHashMap<>() //
-                            : new LinkedHashMap<>(constraintJPQLParams);
+                            : new LinkedHashMap<>(orderJPQLParams);
 
-            addParametersForCursor(cursor.get(), addedJPQLParams);
+            addParametersForCursor(cursor.get(), cursorAndOrderJPQLParams);
         } else { // no Cursor in PageRequest
             jpql = queryInfo.ql;
 
-            addedJPQLParams = constraintJPQLParams;
+            cursorAndOrderJPQLParams = orderJPQLParams;
         }
 
         TypedQuery<T> query = queryInfo.ehCreateTypedQuery(entityHandler,
                                                            jpql,
                                                            Object.class);
-        queryInfo.setParameters(query, args, deferredConstraints, addedJPQLParams);
+        queryInfo.setParameters(query,
+                                args,
+                                deferredConstraints,
+                                requiredJPQLParams,
+                                cursorAndOrderJPQLParams);
 
         query.setFirstResult(firstResult);
         query.setMaxResults(maxPageSize == Integer.MAX_VALUE //
@@ -209,19 +215,16 @@ public class CursoredPageImpl<T> extends PageImpl<T> implements CursoredPage<T> 
         for (int c = 0; c < cursorElements.length; c++)
             try {
                 Sort<?> sort = queryInfo.sorts.get(c);
-                List<Member> accessors = //
-                                entityInfo.attributeAccessors.get(sort.property());
+                String attr = sort.property();
+                List<Member> accessors = attr == null //
+                                ? null //
+                                : entityInfo.attributeAccessors.get(attr);
+                if (accessors == null)
+                    throw Fail.incompatibleSort(queryInfo, sort);
+
                 if (trace && tc.isDebugEnabled())
                     Tr.debug(this, tc, "get cursor element " + accessors);
-                if (accessors == null)
-                    throw exc(MappingException.class,
-                              "CWWKD1123.sort.incompat.with.cursor",
-                              queryInfo.method.getName(),
-                              queryInfo.repositoryInterface.getName(),
-                              sort.property(),
-                              "Cursor.forKey",
-                              entityInfo.getType().getName(),
-                              entityInfo.attributeTypes.keySet());
+
                 Object value = entity;
                 for (Member accessor : accessors)
                     if (accessor instanceof Method)
@@ -250,21 +253,27 @@ public class CursoredPageImpl<T> extends PageImpl<T> implements CursoredPage<T> 
 
         T entity = results.get(index);
 
-        final Object[] keyElements = new Object[queryInfo.sorts.size()];
+        final Object[] cursorElements = new Object[queryInfo.sorts.size()];
         int k = 0;
-        for (Sort<?> keyInfo : queryInfo.sorts)
+        for (Sort<?> cursorElement : queryInfo.sorts)
             try {
-                List<Member> accessors = queryInfo.entityInfo.attributeAccessors.get(keyInfo.property());
+                String attr = cursorElement.property();
+                List<Member> accessors = attr == null //
+                                ? null //
+                                : queryInfo.entityInfo.attributeAccessors.get(attr);
+                if (accessors == null)
+                    throw Fail.incompatibleSort(queryInfo, cursorElement);
+
                 Object value = entity;
                 for (Member accessor : accessors)
                     if (accessor instanceof Method)
                         value = ((Method) accessor).invoke(value);
                     else
                         value = ((Field) accessor).get(value);
-                keyElements[k++] = value;
+                cursorElements[k++] = value;
 
                 if (trace && tc.isDebugEnabled())
-                    Tr.debug(this, tc, "key element " + k + ": " +
+                    Tr.debug(this, tc, "cursor element " + k + ": " +
                                        queryInfo.loggable(value));
             } catch (IllegalAccessException | IllegalArgumentException x) {
                 throw new DataException(x);
@@ -272,7 +281,7 @@ public class CursoredPageImpl<T> extends PageImpl<T> implements CursoredPage<T> 
                 throw new DataException(x.getCause());
             }
 
-        return Cursor.forKey(keyElements);
+        return Cursor.forKey(cursorElements);
     }
 
     /**
@@ -387,7 +396,10 @@ public class CursoredPageImpl<T> extends PageImpl<T> implements CursoredPage<T> 
                     firstSort = false;
                 else
                     s.append(", ");
-                s.append(sort.property()); //
+                String expression = sort.property();
+                if (expression == null)
+                    expression = queryInfo.getExpression(sort).toString();
+                s.append(expression);
                 s.append(sort.isAscending() //
                                 ? sort.ignoreCase() ? " ASC IgnoreCase" : " ASC" //
                                 : sort.ignoreCase() ? " DESC IgnoreCase" : " DESC");

--- a/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/Fail.java
+++ b/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/Fail.java
@@ -26,6 +26,7 @@ import java.util.stream.Stream;
 import com.ibm.websphere.ras.annotation.Sensitive;
 
 import jakarta.data.Limit;
+import jakarta.data.Sort;
 import jakarta.data.exceptions.EmptyResultException;
 import jakarta.data.exceptions.MappingException;
 import jakarta.data.exceptions.NonUniqueResultException;
@@ -355,6 +356,26 @@ public class Fail {
     }
 
     /**
+     * Raise a new MappingException for the error where some operations are not
+     * available because a Sort expression was used to request a cursored page.
+     *
+     * @param info query information for the repository method
+     * @param sort the sort criterion
+     * @throws the MappingException
+     */
+    static MappingException incompatibleSort(QueryInfo info, Sort<?> sort) {
+        String attrName = sort.property();
+        throw exc(MappingException.class,
+                  "CWWKD1123.sort.incompat.with.cursor",
+                  info.method.getName(),
+                  info.repositoryInterface.getName(),
+                  attrName == null ? info.getExpression(sort) : attrName,
+                  "Cursor.forKey",
+                  info.entityInfo.getType().getName(),
+                  info.entityInfo.attributeTypes.keySet());
+    }
+
+    /**
      * Raises UnsupportedOperationException for a repository method that is not
      * valid as a life cycle method because it has no method parameters or more
      * than 1 method parameter.
@@ -419,20 +440,21 @@ public class Fail {
      * annotations that conflict with each other or with the type of the repository
      * method parameter.
      *
-     * @param info       query information for the repository method.
-     * @param errorCode  constant from DataVersionCompatibility that classifies
-     *                       the error.
-     * @param paramIndex index (0-based) of repository method parameter.
-     * @param paramType  Java class of the repository method parameter.
-     * @param paramAnnos annotations on the repository method parameter.
+     * @param info                    query information for the repository method
+     * @param conflictsWithConstraint indicates if he parameter annotation conflicts
+     *                                    with the type of Constraint
+     * @param paramIndex              index (0-based) of repository method parameter
+     * @param paramType               Java class of the repository method parameter
+     * @param paramAnnos              annotations on the repository method parameter
      * @throws the UnsupportedOperationException
      */
-    static UnsupportedOperationException methodParamAnnoConflict(QueryInfo info,
-                                                                 int errorCode,
-                                                                 int paramIndex,
-                                                                 Class<?> paramType,
-                                                                 Annotation[] paramAnnos) {
-        if (errorCode == QueryInfo.PARAM_ANNO_CONFLICTS_WITH_CONSTRAINT)
+    public static UnsupportedOperationException //
+                    methodParamAnnoConflict(QueryInfo info,
+                                            boolean conflictsWithConstraint,
+                                            int paramIndex,
+                                            Class<?> paramType,
+                                            Annotation[] paramAnnos) {
+        if (conflictsWithConstraint)
             throw exc(UnsupportedOperationException.class,
                       "CWWKD1117.anno.constraint.conflict",
                       paramIndex + 1, // switch to 1-based
@@ -440,15 +462,13 @@ public class Fail {
                       info.repositoryInterface.getName(),
                       Arrays.toString(paramAnnos),
                       paramType.getClass().getName());
-        else if (errorCode == QueryInfo.PARAM_ANNOS_CONFLICT)
+        else
             throw exc(UnsupportedOperationException.class,
                       "CWWKD1118.param.anno.conflict",
                       paramIndex + 1, // switch to 1-based
                       info.method.getName(),
                       info.repositoryInterface.getName(),
                       Arrays.toString(paramAnnos));
-        else // internal error
-            throw new IllegalArgumentException("errorCode: " + errorCode);
     }
 
     /**

--- a/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/PageImpl.java
+++ b/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/PageImpl.java
@@ -43,7 +43,7 @@ public class PageImpl<T> implements Page<T> {
      * Map of JPQL parameter names/indices and values that are added due to
      * repository special parameters. Null indicates none are added.
      */
-    final Map<Object, Object> addedJPQLParams;
+    final Map<Object, Object> requiredJPQLParams;
 
     /**
      * Values that are supplied when invoking the repository method that
@@ -94,8 +94,11 @@ public class PageImpl<T> implements Page<T> {
      * @param args                values that are supplied to the repository method.
      * @param deferredConstraints map of method parameter index to non-Literal
      *                                Constraints that are supplied at execution time.
-     * @param addedJPQLParams     map of JPQL parameter names/indices and values that are
-     *                                added due to repository special parameters.
+     * @param addedJPQLParams     map of JPQL parameter names/indices and values
+     *                                added due to repository special parameters other.
+     *                                than Sort/Order. Null indicates none are added.
+     * @param orderJPQLParams     map of JPQL parameter names/indices and values
+     *                                added for expressions in Sort/Order.
      *                                Null indicates none are added.
      * @throws Exception if an error occurs.
      */
@@ -105,7 +108,8 @@ public class PageImpl<T> implements Page<T> {
              PageRequest pageRequest,
              Object[] args,
              Map<Integer, Object> deferredConstraints,
-             Map<Object, Object> addedJPQLParams) {
+             Map<Object, Object> addedJPQLParams,
+             Map<Object, Object> orderJPQLParams) {
         this(queryInfo, pageRequest, args, deferredConstraints, addedJPQLParams);
 
         final boolean trace = TraceComponent.isAnyTracingEnabled();
@@ -124,7 +128,11 @@ public class PageImpl<T> implements Page<T> {
         TypedQuery<T> query = queryInfo.ehCreateTypedQuery(entityHandler,
                                                            queryInfo.ql,
                                                            Object.class);
-        queryInfo.setParameters(query, args, deferredConstraints, addedJPQLParams);
+        queryInfo.setParameters(query,
+                                args,
+                                deferredConstraints,
+                                addedJPQLParams,
+                                orderJPQLParams);
 
         int maxPageSize = pageRequest.size();
         query.setFirstResult(queryInfo.computeOffset(pageRequest));
@@ -146,9 +154,8 @@ public class PageImpl<T> implements Page<T> {
      * @param args                values that are supplied to the repository method.
      * @param deferredConstraints map of method parameter index to non-Literal
      *                                Constraints that are supplied at execution time.
-     * @param addedJPQLParams     map of JPQL parameter names/indices and values that are
-     *                                added due to repository special parameters.
-     *                                Null indicates none are added.
+     * @param requiredJPQLParams  map of JPQL parameter name/index to value for
+     *                                Constraints/Restrictions. Null indicates none
      * @throws Exception if an error occurs.
      */
     @Trivial
@@ -156,8 +163,8 @@ public class PageImpl<T> implements Page<T> {
              PageRequest pageRequest,
              Object[] args,
              Map<Integer, Object> deferredConstraints,
-             Map<Object, Object> addedJPQLParams) {
-        this.addedJPQLParams = addedJPQLParams;
+             Map<Object, Object> requiredJPQLParams) {
+        this.requiredJPQLParams = requiredJPQLParams;
         this.args = args;
         this.deferredConstraints = deferredConstraints;
         this.queryInfo = queryInfo;
@@ -225,7 +232,11 @@ public class PageImpl<T> implements Page<T> {
                             .ehCreateTypedQuery(entityHandlerSync.entityHandler(),
                                                 queryInfo.jpqlCount,
                                                 Long.class);
-            queryInfo.setParameters(query, args, deferredConstraints, addedJPQLParams);
+            queryInfo.setParameters(query,
+                                    args,
+                                    deferredConstraints,
+                                    requiredJPQLParams,
+                                    null); // count query does not use Sort/Order
 
             return query.getSingleResult();
         } catch (Exception x) {

--- a/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/QueryInfo.java
+++ b/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/QueryInfo.java
@@ -143,19 +143,6 @@ public abstract class QueryInfo {
     private static final int[] NONE_STATIC_SORT_ONLY = new int[0];
 
     /**
-     * Error condition returned by inspectMethodParam indicating that an annotation
-     * of the method parameter conflicts with the constraint type of the method
-     * parameter.
-     */
-    protected static final int PARAM_ANNO_CONFLICTS_WITH_CONSTRAINT = -1;
-
-    /**
-     * Error condition returned by inspectMethodParam indicating that two or more
-     * annotations on the method parameter conflict with each other.
-     */
-    protected static final int PARAM_ANNOS_CONFLICT = -2;
-
-    /**
      * The implicit entity identifier variable defined by Jakarta Persistence.
      */
     private static final String THIS = "this";
@@ -501,25 +488,6 @@ public abstract class QueryInfo {
                                                       int prevNumJPQLParams,
                                                       boolean isCollection,
                                                       Annotation[] annos);
-
-    /**
-     * Appends the expression to the given partially built query.
-     *
-     * @param sort       sort criterion that has an expression
-     * @param q          string builder to which to append
-     * @param jpqlParams Map to be populated with JPQL parameter name/value for
-     *                       Constraints, Restrictions, and Sorts. Keys are the
-     *                       named parameter name or positional parameter index.
-     *                       Map values are obtained from the Constraint,
-     *                       Restriction, or Sort. The first positional parameter
-     *                       index starts at qlParamCount, which is updated by
-     *                       this method when JPQL parameters for repository
-     *                       method special parameters are added. The map is null
-     *                       when only the OrderBy annotation or keyword is used
-     */
-    protected abstract void appendExpression(Sort<?> sort,
-                                             StringBuilder q,
-                                             Map<Object, Object> jpqlParams);
 
     /**
      * Asks the Jakarta Persistence provider whether the given query uses named
@@ -892,28 +860,33 @@ public abstract class QueryInfo {
      * Construct a copy of this QueryInfo, but with different JPQL and
      * possibly different sorts.
      *
-     * @param source        QueryInfo from which to copy.
-     * @param constraints   map of method parameter index (0-based) to deferred
-     *                          Constraint at the position. Empty if none.
-     * @param restriction   Restriction value that was supplied to the repository method.
-     *                          Otherwise null.
-     * @param jpqlParams    Map to be populated with JPQL parameter names and values
-     *                          for Constraints and Restrictions. Map keys are the
-     *                          named parameter name or positional parameter index.
-     *                          Map values are obtained from the Constraints or
-     *                          Restrictions. The first positional parameter index
-     *                          starts at qlParamCount, which is updated by this
-     *                          method when JPQL parameters for repository method
-     *                          special parameters are added.
-     * @param pageReq       PageRequest, if supplied to the repository method.
-     * @param sortsOverride If present, sorts to use instead of the sorts from source.
-     *                          A value is supplied when the repostiory method has
-     *                          Order or Sort parameters. Otherwise null.
+     * @param source          QueryInfo from which to copy.
+     * @param constraints     map of method parameter index (0-based) to deferred
+     *                            Constraint at the position. Empty if none.
+     * @param restriction     Restriction value that was supplied to the repository method.
+     *                            Otherwise null.
+     * @param reqJPQLParams   map of JPQL parameter name/index to value to be
+     *                            populated for special parameters (Constraints and
+     *                            Restrictions) that are always required. Map values
+     *                            are obtained from the Constraint or Restriction.
+     *                            The first positional parameter index starts at
+     *                            qlParamCount, which is updated by this method when
+     *                            JPQL parameters for Constraints and Restrictions
+     *                            are added.
+     * @param orderJPQLParams map of JPQL parameter name/index to be populated for
+     *                            expressions found in Order/Sort and for controlling
+     *                            cursor pagination. The map is null when only the
+     *                            OrderBy annotation or keyword is used
+     * @param pageReq         PageRequest, if supplied to the repository method.
+     * @param sortsOverride   If present, sorts to use instead of the sorts from source.
+     *                            A value is supplied when the repostiory method has
+     *                            Order or Sort parameters. Otherwise null.
      * @return the new query information.
      */
     private QueryInfo copy(Map<Integer, Object> constraints,
                            Object restriction,
-                           Map<Object, Object> jpqlParams,
+                           Map<Object, Object> reqJPQLParams,
+                           Map<Object, Object> orderJPQLParams,
                            PageRequest pageReq,
                            List<Sort<Object>> sortsOverride) {
         DataVersionCompatibility compat = entityInfo.factory.provider.compat;
@@ -965,12 +938,7 @@ public abstract class QueryInfo {
 
                 q.append(info.hasWhere ? "AND " : "WHERE ");
                 info.hasWhere = true;
-
-                info.qlParamCount = generateRestrictions(q,
-                                                         restriction,
-                                                         info.qlParamCount,
-                                                         info.qlParamNames,
-                                                         jpqlParams);
+                info.generateRestrictions(q, restriction, reqJPQLParams);
 
                 if (info.restrictAt >= 0 && info.restrictAt < len) {
                     int newPosition = q.length();
@@ -985,16 +953,12 @@ public abstract class QueryInfo {
             boolean countPages = Page.class.equals(multiType) ||
                                  CursoredPage.class.equals(multiType);
 
-            q = info.initQueryByParameters(countPages, constraints, jpqlParams);
+            q = info.initQueryByParameters(countPages, constraints, reqJPQLParams);
 
             if (restriction != null) {
                 q.append(info.hasWhere ? " AND " : " WHERE ");
                 info.hasWhere = true;
-                info.qlParamCount = generateRestrictions(q,
-                                                         restriction,
-                                                         info.qlParamCount,
-                                                         info.qlParamNames,
-                                                         jpqlParams);
+                info.generateRestrictions(q, restriction, reqJPQLParams);
             }
 
             // If there are no overrides from Order/Sort parameters, keep the
@@ -1012,7 +976,7 @@ public abstract class QueryInfo {
                 order = order == null //
                                 ? new StringBuilder(100).append(" ORDER BY ") //
                                 : order.append(", ");
-                info.generateSort(order, sort, forward, jpqlParams);
+                info.generateSort(order, sort, forward, orderJPQLParams);
             }
 
         if (pageReq == null ||
@@ -1027,7 +991,8 @@ public abstract class QueryInfo {
             info.ql = null;
             info.generateCursorQueries(q,
                                        forward ? order : null,
-                                       forward ? null : order);
+                                       forward ? null : order,
+                                       orderJPQLParams);
         }
 
         return info;
@@ -1151,16 +1116,19 @@ public abstract class QueryInfo {
         boolean requiresNewQuery = restriction != null ||
                                    !deferredConstraints.isEmpty();
 
-        // Map of named parameter name or positional parameter index to value
+        // Maps of named parameter name or positional parameter index to value
         // for values corresponding to repository method special parameters.
-        // The first positional parameter index to add starts at qlParamCount,
-        // which is updated as entries for additional JPQL parameters are added.
-        Map<Object, Object> addedJPQLParams = null;
+        // JPQL parameters for Restrictions and Constraints are always required:
+        Map<Object, Object> requiredJPQLParams = null;
+        // JPQL parameters for expressions (omitted from count) in Order/Sort
+        // and for controlling cursor pagination:
+        Map<Object, Object> orderJPQLParams = null;
 
         QueryInfo queryInfo = requiresNewQuery //
                         ? copy(deferredConstraints, //
                                restriction, //
-                               addedJPQLParams = new LinkedHashMap<>(), //
+                               requiredJPQLParams = new LinkedHashMap<>(), //
+                               orderJPQLParams = new LinkedHashMap<>(), //
                                null, //
                                null) //
                         : this;
@@ -1174,7 +1142,11 @@ public abstract class QueryInfo {
         if (trace && tc.isDebugEnabled())
             Tr.debug(this, tc, "created query " + query);
 
-        setParameters(query, args, deferredConstraints, addedJPQLParams);
+        setParameters(query,
+                      args,
+                      deferredConstraints,
+                      requiredJPQLParams,
+                      orderJPQLParams);
         return query;
     }
 
@@ -1673,16 +1645,19 @@ public abstract class QueryInfo {
             requiresNewQuery = true;
         }
 
-        // Map of named parameter name or positional parameter index to value
-        // for values corresponding to repository method special parameters.
-        // The first positional parameter index to add starts at qlParamCount,
-        // which is updated as entries for additional JPQL parameters are added.
-        Map<Object, Object> addedJPQLParams = null;
+        // Maps of named parameter name or positional parameter index to value
+        // for values corresponding to special parameters and cursor pagination.
+        // JPQL parameters for Restrictions and Constraints are always required:
+        Map<Object, Object> requiredJPQLParams = null;
+        // JPQL parameters for expressions (omitted from count) in Order/Sort
+        // and for controlling cursor pagination:
+        Map<Object, Object> orderJPQLParams = null;
 
         QueryInfo queryInfo = requiresNewQuery //
                         ? copy(deferredConstraints, //
                                qc.restriction(), //
-                               addedJPQLParams = new LinkedHashMap<>(), //
+                               requiredJPQLParams = new LinkedHashMap<>(), //
+                               orderJPQLParams = new LinkedHashMap<>(), //
                                qc.pageRequest(), //
                                qc.sorts()) //
                         : this;
@@ -1692,7 +1667,8 @@ public abstract class QueryInfo {
                                             txStatus,
                                             args,
                                             deferredConstraints,
-                                            addedJPQLParams);
+                                            requiredJPQLParams,
+                                            orderJPQLParams);
 
         if (isOptional) {
             returnValue = returnValue == null
@@ -1726,9 +1702,10 @@ public abstract class QueryInfo {
      * @param args                method parameters.
      * @param deferredConstraints map of method parameter index to non-Literal
      *                                Constraints that are supplied at execution time.
-     * @param addedJPQLParams     map of JPQL parameter names/indices and values that
-     *                                are added due to repository special parameters.
-     *                                Null indicates none are added.
+     * @param requiredJPQLParams  map of JPQL parameter name/index to value for
+     *                                Constraints/Restrictions. Null indicates none
+     * @param orderJPQLParams     map of JPQL parameter name/index to value for
+     *                                expressions in Order/Sort. Null indicates none
      * @return results, before wrapping in an Optional or CompletionStage.
      * @throws Exception if an error occurs.
      */
@@ -1738,14 +1715,18 @@ public abstract class QueryInfo {
                         int txStatus,
                         Object[] args,
                         Map<Integer, Object> deferredConstraints,
-                        Map<Object, Object> addedJPQLParams) throws Exception {
+                        Map<Object, Object> requiredJPQLParams,
+                        Map<Object, Object> orderJPQLParams) throws Exception {
         final boolean trace = TraceComponent.isAnyTracingEnabled();
         if (trace && tc.isEntryEnabled())
             Tr.entry(this, tc, "find",
                      "non-literal Constraints at: " + deferredConstraints.keySet(),
-                     "added JPQL params: " + (addedJPQLParams == null //
+                     "required JPQL params: " + (requiredJPQLParams == null //
                                      ? null //
-                                     : addedJPQLParams.keySet()));
+                                     : requiredJPQLParams.keySet()),
+                     "order JPQL params: " + (orderJPQLParams == null //
+                                     ? null //
+                                     : orderJPQLParams.keySet()));
 
         Limit limit = qc.limit();
         int max = qc.maxResults();
@@ -1759,7 +1740,8 @@ public abstract class QueryInfo {
                             pageReq, //
                             args, //
                             deferredConstraints, //
-                            addedJPQLParams);
+                            requiredJPQLParams, //
+                            orderJPQLParams);
         } else if (Page.class.equals(multiType)) {
             PageRequest req = limit == null ? pageReq : toPageRequest(limit);
             returnValue = new PageImpl<>(//
@@ -1768,7 +1750,8 @@ public abstract class QueryInfo {
                             req, //
                             args, //
                             deferredConstraints, //
-                            addedJPQLParams);
+                            requiredJPQLParams, //
+                            orderJPQLParams);
         } else if (pageReq != null &&
                    !PageRequest.Mode.OFFSET.equals(pageReq.mode())) {
             throw Fail.pageModeIncompatible(this, pageReq);
@@ -1781,7 +1764,11 @@ public abstract class QueryInfo {
             TypedQuery<?> query = ehCreateTypedQuery(entityHandler,
                                                      ql,
                                                      Object.class);
-            setParameters(query, args, deferredConstraints, addedJPQLParams);
+            setParameters(query,
+                          args,
+                          deferredConstraints,
+                          requiredJPQLParams,
+                          orderJPQLParams);
 
             if (type == FIND_AND_DELETE)
                 query.setLockMode(LockModeType.PESSIMISTIC_WRITE);
@@ -2214,27 +2201,17 @@ public abstract class QueryInfo {
     /**
      * Appends JPQL to the partially built query to represent a Constraint.
      *
-     * @param q              partially built query to which to append JPQL
-     *                           representing the Constraint.
-     * @param constraint     the Constraint for which to generate JPQL.
-     * @param jpqlParamCount number of named or positional parameters identified
-     *                           up to this point for the JPQL.
-     * @param jpqlParamNames names of named parameters in the partially built
-     *                           query. Empty if the query uses positional
-     *                           parameters or has none. If using named parameters,
-     *                           this method should add any that are generated.
-     * @param jpqlParams     list for this method to populate with the name of
-     *                           named parameters or index of positional parameters,
-     *                           mapped to value, for each value obtained from the
-     *                           processed Restriction(s).
-     * @return the new count of named or positional parameters, including any that
-     *         were generated for the Constraint.
+     * @param q          partially built query to which to append JPQL
+     *                       representing the Constraint.
+     * @param constraint the Constraint for which to generate JPQL.
+     * @param jpqlParams list for this method to populate with the name of
+     *                       named parameters or index of positional parameters,
+     *                       mapped to value, for each value obtained from the
+     *                       processed Restriction(s).
      */
-    protected abstract int generateConstraint(StringBuilder q,
-                                              Object constraint,
-                                              int jpqlParamCount,
-                                              Set<String> jpqlParamNames,
-                                              Map<Object, Object> jpqlParams);
+    protected abstract void generateConstraint(StringBuilder q,
+                                               Object constraint,
+                                               Map<Object, Object> jpqlParams);
 
     /**
      * Generates a query to select the COUNT of all entities matching the
@@ -2267,18 +2244,27 @@ public abstract class QueryInfo {
      * _ OR (o.lastName = ?5 AND o.firstName > ?6)
      * _ OR (o.lastName = ?5 AND o.firstName = ?6 AND o.ssn > ?7) )
      *
-     * @param q    query up to the WHERE clause, if present
-     * @param fwd  ORDER BY clause in forward page direction.
-     *                 Null if forward page direction is not needed.
-     * @param prev ORDER BY clause in previous page direction.
-     *                 Null if previous page direction is not needed.
+     * @param q               query up to the WHERE clause, if present
+     * @param fwd             ORDER BY clause in forward page direction.
+     *                            Null if forward page direction is not needed.
+     * @param prev            ORDER BY clause in previous page direction.
+     *                            Null if previous page direction is not needed.
+     * @param orderJPQLParams map of JPQL parameter name/value for Order/Sort
+     *                            into which to also add mappings for expression
+     *                            values for controlling cursor pagination.
+     *                            Map values are obtained from the Sort expression.
+     *                            The map is null when only the OrderBy annotation
+     *                            or keyword is used
      */
     private void generateCursorQueries(StringBuilder q,
                                        StringBuilder fwd,
-                                       StringBuilder prev) {
+                                       StringBuilder prev,
+                                       Map<Object, Object> orderJPQLParams) {
         int numSorts = sorts.size();
+        int totalParamCount = qlParamCount + numSorts;
         boolean positionalParams = qlParamNames.isEmpty();
         String[] paramNames = positionalParams ? null : new String[numSorts];
+        List<String> elementExpressions = new ArrayList<>(numSorts * 5);
         StringBuilder a = fwd == null //
                         ? null //
                         : new StringBuilder(200).append(hasWhere ? " AND (" : " WHERE (");
@@ -2286,6 +2272,23 @@ public abstract class QueryInfo {
                         ? null //
                         : new StringBuilder(200).append(hasWhere ? " AND (" : " WHERE (");
         for (int i = 0; i < numSorts; i++) {
+            // Compute the representation of each cursor element
+            Sort<?> sort = sorts.get(i);
+            StringBuilder expression = new StringBuilder();
+            if (sort.property() == null) {
+                if (sort.ignoreCase())
+                    expression.append('(');
+                totalParamCount = generateExpression(expression,
+                                                     getExpression(sort),
+                                                     totalParamCount,
+                                                     orderJPQLParams);
+                if (sort.ignoreCase())
+                    expression.append(')');
+            } else {
+                appendAttributeName(sort.property(), expression);
+            }
+            elementExpressions.add(expression.toString());
+
             if (!positionalParams)
                 paramNames[i] = generateNamedParameterName("cursor",
                                                            qlParamCount + i + 1);
@@ -2294,14 +2297,13 @@ public abstract class QueryInfo {
             if (b != null)
                 b.append(i == 0 ? "(" : " OR (");
             for (int s = 0; s <= i; s++) {
-                Sort<?> sort = sorts.get(s);
+                sort = sorts.get(s);
                 boolean asc = sort.isAscending();
                 boolean lower = sort.ignoreCase();
-                String name = sort.property();
                 if (a != null)
                     if (lower) {
                         a.append(s == 0 ? "LOWER(" : " AND LOWER(");
-                        appendAttributeName(name, a);
+                        a.append(elementExpressions.get(s));
                         a.append(')');
                         a.append(s < i ? '=' : (asc ? '>' : '<'));
                         a.append("LOWER(");
@@ -2312,7 +2314,7 @@ public abstract class QueryInfo {
                         a.append(')');
                     } else {
                         a.append(s == 0 ? "" : " AND ");
-                        appendAttributeName(name, a);
+                        a.append(elementExpressions.get(s));
                         a.append(s < i ? '=' : (asc ? '>' : '<'));
                         if (positionalParams)
                             a.append('?').append(qlParamCount + s + 1);
@@ -2322,7 +2324,7 @@ public abstract class QueryInfo {
                 if (b != null)
                     if (lower) {
                         b.append(s == 0 ? "LOWER(" : " AND LOWER(");
-                        appendAttributeName(name, b);
+                        b.append(elementExpressions.get(s));
                         b.append(')');
                         b.append(s < i ? '=' : (asc ? '<' : '>'));
                         b.append("LOWER(");
@@ -2333,7 +2335,7 @@ public abstract class QueryInfo {
                         b.append(')');
                     } else {
                         b.append(s == 0 ? "" : " AND ");
-                        appendAttributeName(name, b);
+                        b.append(elementExpressions.get(s));
                         b.append(s < i ? '=' : (asc ? '<' : '>'));
                         if (positionalParams)
                             b.append('?').append(qlParamCount + s + 1);
@@ -2352,7 +2354,9 @@ public abstract class QueryInfo {
             jpqlBeforeCursor = new StringBuilder(q).append(b).append(')').append(prev).toString();
 
         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
-            Tr.debug(this, tc, "forward & previous cursor queries", jpqlAfterCursor, jpqlBeforeCursor);
+            Tr.debug(this, tc, "forward & previous cursor queries",
+                     jpqlAfterCursor,
+                     jpqlBeforeCursor);
     }
 
     /**
@@ -2431,6 +2435,31 @@ public abstract class QueryInfo {
     }
 
     /**
+     * Appends JPQL to the partially built query to represent an Expression
+     * parameter of a Constraint or Restriction.
+     *
+     * Unlike other generate methods, this one does NOT update the qlParamCount,
+     * instead returning the new value so that the caller can decide whether or
+     * not to update it. This is done so that parameters added for expressions
+     * generated for cursor-based pagination do not interfere.
+     *
+     * @param q              partially built query ending with the WHERE clause.
+     * @param expression     the Expression for which to generate JPQL.
+     * @param jpqlParamCount number of named or positional parameters in the
+     *                           partially built query.
+     * @param xprParams      list for this method to populate with the name of
+     *                           named parameters or index of positional parameters,
+     *                           mapped to value, for values (if any) obtained from
+     *                           the Expression.
+     * @return the new count of named or positional parameters, including any that
+     *         were generated for the Expression.
+     */
+    protected abstract int generateExpression(StringBuilder q,
+                                              Object expression,
+                                              int jpqlParamCount,
+                                              Map<Object, Object> xprParams);
+
+    /**
      * Generates the name of a named parameter with the given prefix and number
      * which is not already in use (as represented by qlParamNames). This method
      * ensures a unique name by appending the _ character after the number until
@@ -2481,7 +2510,7 @@ public abstract class QueryInfo {
         }
 
         if (needsCursorQueries) {
-            generateCursorQueries(q, fwd, prev);
+            generateCursorQueries(q, fwd, prev, null);
             q.append(fwd);
         }
     }
@@ -2569,29 +2598,21 @@ public abstract class QueryInfo {
 
         // p is the repository method parameter number (0-based)
         // qp is the JPQL query parameter number (1-based)
-        int numJPQLParams = 0;
+        qlParamCount = 0;
         for (int p = 0; p < numConstraints; p++) {
-            numPreviousJPQLParams[p] = numJPQLParams;
+            numPreviousJPQLParams[p] = qlParamCount;
 
             Object constraint = constraints.get(p);
             if (constraint == null) {
-                numJPQLParams = inspectMethodParam(p,
-                                                   paramTypes[p],
-                                                   annosForAllParams[p],
-                                                   attrNames,
-                                                   attrConstraints,
-                                                   updateOps,
-                                                   numJPQLParams);
-                if (numJPQLParams < 0)
-                    Fail.methodParamAnnoConflict(this, numJPQLParams, p,
-                                                 paramTypes[p], annosForAllParams[p]);
+                inspectMethodParam(p,
+                                   paramTypes[p],
+                                   annosForAllParams[p],
+                                   attrNames,
+                                   attrConstraints,
+                                   updateOps);
             } else {
                 constraintJPQL[p] = new StringBuilder(50);
-                numJPQLParams = generateConstraint(constraintJPQL[p],
-                                                   constraint,
-                                                   numJPQLParams,
-                                                   qlParamNames,
-                                                   jpqlParams);
+                generateConstraint(constraintJPQL[p], constraint, jpqlParams);
             }
 
             // Determine the entity attribute name, first from @By or an assignment
@@ -2617,7 +2638,7 @@ public abstract class QueryInfo {
             attrNames[p] = getAttributeName(name, true);
         }
 
-        numPreviousJPQLParams[numConstraints] = numJPQLParams;
+        numPreviousJPQLParams[numConstraints] = qlParamCount;
 
         // Write new JPQL, starting with SELECT or UPDATE
         if (q == null && type == FIND) { // SELECT
@@ -2732,8 +2753,6 @@ public abstract class QueryInfo {
                 boolean isCollection = entityInfo.collectionElementTypes //
                                 .containsKey(name);
 
-                qlParamCount += numPreviousJPQLParams[p + 1] - numPreviousJPQLParams[p];
-
                 if (constraintJPQL[p] == null) {
                     appendConstraint(q,
                                      o_,
@@ -2769,27 +2788,16 @@ public abstract class QueryInfo {
      * Appends JPQL to the partially built query to implement a Restriction
      * parameter of a repository method.
      *
-     * @param q              partially built query ending with the WHERE clause.
-     * @param restriction    value of Restriction parameter. Otherwise null.
-     * @param jpqlParamCount number of named or positional parameters in the
-     *                           partially built query.
-     * @param jpqlParamNames names of named parameters in the partially bulit
-     *                           query. Empty if the query uses positional
-     *                           parameeters or has none. If using named parameters,
-     *                           this method should add any that are generated for
-     *                           the restriction part of the query.
-     * @param jpqlParams     list for this method to populate with the name of
-     *                           named parameters or index of positional parameters,
-     *                           mapped to value, for each value obtained from the
-     *                           processed Restriction(s).
-     * @return the new count of named or positional parameters, including any that
-     *         were generated for the Restriction(s).
+     * @param q           partially built query ending with the WHERE clause.
+     * @param restriction value of Restriction parameter. Otherwise null.
+     * @param jpqlParams  list for this method to populate with the name of
+     *                        named parameters or index of positional parameters,
+     *                        mapped to value, for each value obtained from the
+     *                        processed Restriction(s).
      */
-    protected abstract int generateRestrictions(StringBuilder q,
-                                                Object restriction,
-                                                int jpqlParamCount,
-                                                Set<String> jpqlParamNames,
-                                                Map<Object, Object> jpqlParams);
+    protected abstract void generateRestrictions(StringBuilder q,
+                                                 Object restriction,
+                                                 Map<Object, Object> jpqlParams);
 
     /**
      * Generates the SELECT clause of the JPQL.
@@ -2953,7 +2961,11 @@ public abstract class QueryInfo {
 
         String attributeName = sort.property();
         if (attributeName == null)
-            appendExpression(sort, q, jpqlParams);
+            // TODO do the extra JPQL parameters interfere with the count query?
+            qlParamCount = generateExpression(q,
+                                              getExpression(sort),
+                                              qlParamCount,
+                                              jpqlParams);
         else
             appendAttributeName(attributeName, q);
 
@@ -3206,6 +3218,16 @@ public abstract class QueryInfo {
     public final EntityInfo getEntityInfo() {
         return entityInfo;
     }
+
+    /**
+     * Returns the expression() field of the Sort criterion.
+     * Null if the Sort does not have an expression, which is
+     * always the case prior to Data 1.1.
+     *
+     * @param sort sort criterion that has an expression
+     * @return jakarta.data.expression.ComparableExpression (or subtype) or null
+     */
+    protected abstract Object getExpression(Sort<?> sort);
 
     /**
      * Looks for mutually exclusive annotations (Delete, Find, Query, ...)
@@ -4246,29 +4268,25 @@ public abstract class QueryInfo {
      * Find/Delete/Update method to determine its meaning. Based on the meaning,
      * updates one or more of (attrNames, constraints, updateOps) at position p.
      *
-     * @param p                 repository method parameter index (0-based).
-     * @param paramType         class of the repository method parameter at index p.
-     *                              When generating the query upfront, this is from
-     *                              the repository method signature. When generating
-     *                              the query at invocation time and a Constraint
-     *                              subtype is supplied, this is the class of the
-     *                              supplied instance.
-     * @param paramAnnos        annotations on the repository method parameter at
-     *                              index p.
-     * @param attrNames         the implementer can update this at position p to
-     *                              supply the entity attribute name from the value
-     *                              of an assignment annotation.
-     * @param constraints       the implementer can update this at position p to
-     *                              supply the constraint type indicated by the
-     *                              Is annotation or by a Constraint-typed method
-     *                              parameter.
-     * @param updateOps         the implementer can update this at position p to
-     *                              supply the update operation indicated by an
-     *                              assignment annotation.
-     * @param prevNumJPQLParams count of JQPL query parameters required for
-     *                              repository method parameters up to, but not
-     *                              including, the current repository method
-     *                              parameter being inspected.
+     * @param p           repository method parameter index (0-based).
+     * @param paramType   class of the repository method parameter at index p.
+     *                        When generating the query upfront, this is from
+     *                        the repository method signature. When generating
+     *                        the query at invocation time and a Constraint
+     *                        subtype is supplied, this is the class of the
+     *                        supplied instance.
+     * @param paramAnnos  annotations on the repository method parameter at
+     *                        index p.
+     * @param attrNames   the implementer can update this at position p to
+     *                        supply the entity attribute name from the value
+     *                        of an assignment annotation.
+     * @param constraints the implementer can update this at position p to
+     *                        supply the constraint type indicated by the
+     *                        Is annotation or by a Constraint-typed method
+     *                        parameter.
+     * @param updateOps   the implementer can update this at position p to
+     *                        supply the update operation indicated by an
+     *                        assignment annotation.
      * @return count of JPQL query parameters required for repository method
      *         parameters up to and including the current one. Otherwise returns
      *         an error code: PARAM_ANNO_CONFLICTS_WITH_CONSTRAINT or
@@ -4279,8 +4297,7 @@ public abstract class QueryInfo {
                                               Annotation[] paramAnnos,
                                               String[] attrNames,
                                               AttributeConstraint[] constraints,
-                                              char[] updateOps,
-                                              int prevNumJPQLParams);
+                                              char[] updateOps);
 
     /**
      * Write information about this instance to the introspection file for
@@ -4650,7 +4667,7 @@ public abstract class QueryInfo {
             if (mightHaveUpdateCount) {
                 query = ehCreateNativeStatement(entityHandler);
 
-                setParameters(query, args, Collections.emptyMap(), null);
+                setParameters(query, args, Collections.emptyMap(), null, null);
 
                 returnValue = toReturnValue(query.executeUpdate(),
                                             singleType);
@@ -4675,7 +4692,7 @@ public abstract class QueryInfo {
                     query.setFirstResult(startAt);
                 }
 
-                setParameters(query, args, Collections.emptyMap(), null);
+                setParameters(query, args, Collections.emptyMap(), null, null);
 
                 returnValue = getQueryResults(entityHandler, qc, query, txStatus);
             }
@@ -5800,14 +5817,19 @@ public abstract class QueryInfo {
      * @param args                repository method arguments
      * @param deferredConstraints map of method parameter index to non-Literal
      *                                Constraints that are supplied at execution time.
-     * @param addedJPQLParams     map of JPQL parameter names/indices and values
-     *                                for repository method special parameters.
+     * @param requiredJPQLParams  map of JPQL parameter name/index to value for
+     *                                special parameters that are always required
+     *                                (Constraints/Restrictions). Null indicates none
+     * @param orderJPQLParams     map of JPQL parameter name/index to value for
+     *                                expressions in Order/Sort and values needed to
+     *                                control cursor pagination. Null indicates none
      */
     @Trivial // avoid logging customer data
     void setParameters(jakarta.persistence.Query query,
                        Object[] args,
                        Map<Integer, Object> deferredConstraints,
-                       Map<Object, Object> addedJPQLParams) {
+                       Map<Object, Object> requiredJPQLParams,
+                       Map<Object, Object> orderJPQLParams) {
         final boolean trace = TraceComponent.isAnyTracingEnabled();
         final int numArgs = args == null ? 0 : args.length;
 
@@ -5816,26 +5838,26 @@ public abstract class QueryInfo {
             checkForNamedParameters(query);
 
         if (trace && tc.isDebugEnabled()) {
-            Object addedLoggable = loggable(addedJPQLParams);
+            Object req = loggable(requiredJPQLParams);
+            Object ord = loggable(orderJPQLParams);
             Tr.debug(this, tc, "setParameters",
                      numArgs + " method args",
                      "first special param at 0-based index " + specialParamsStartAt,
                      qlParamNames,
-                     addedLoggable == addedJPQLParams //
-                                     ? addedLoggable //
-                                     : addedJPQLParams.keySet());
+                     req == requiredJPQLParams ? req : requiredJPQLParams.keySet(),
+                     ord == orderJPQLParams ? ord : orderJPQLParams.keySet());
         }
 
         if (qlParamNames.isEmpty()) { // positional parameters
             int paramNum = 1;
             for (int a = 0; a < specialParamsStartAt; a++) {
                 Object value;
-                while (addedJPQLParams != null &&
-                       (value = addedJPQLParams.getOrDefault(paramNum, NONE)) != NONE) {
+                while (requiredJPQLParams != null &&
+                       (value = requiredJPQLParams.getOrDefault(paramNum, NONE)) != NONE) {
                     // Positional parameter generated at execution time from an
                     // Expression within a Restriction or Constraint
                     if (trace && tc.isDebugEnabled())
-                        Tr.debug(this, tc, "[X] set ?" + paramNum + ' ' + loggable(value));
+                        Tr.debug(this, tc, "[r] set ?" + paramNum + ' ' + loggable(value));
                     query.setParameter(paramNum++, value);
                 }
                 if (deferredConstraints.containsKey(a))
@@ -5846,21 +5868,31 @@ public abstract class QueryInfo {
                 Object[] constraintValues = toConstraintValues(value);
                 if (constraintValues == null) { // Normal positional parameter
                     if (trace && tc.isDebugEnabled())
-                        Tr.debug(this, tc, "[M] set ?" + paramNum + ' ' + loggable(value));
+                        Tr.debug(this, tc, "[q] set ?" + paramNum + ' ' + loggable(value));
                     query.setParameter(paramNum++, value);
                 } else { // Literal Expression from a Constraint
                     for (Object cvalue : constraintValues) {
                         if (trace && tc.isDebugEnabled())
-                            Tr.debug(this, tc, "[L] set ?" + paramNum + ' ' + loggable(cvalue));
+                            Tr.debug(this, tc, "[c] set ?" + paramNum + ' ' + loggable(cvalue));
                         query.setParameter(paramNum++, cvalue);
                     }
                 }
             }
-            // Additional generated positional parameters (might be for cursor pagination)
-            for (Object value; addedJPQLParams != null &&
-                               (value = addedJPQLParams.getOrDefault(paramNum, NONE)) != NONE;) {
+
+            // Additional generated positional parameters
+            for (Object value; requiredJPQLParams != null &&
+                               (value = requiredJPQLParams.getOrDefault(paramNum, NONE)) != NONE;) {
                 if (trace && tc.isDebugEnabled())
-                    Tr.debug(this, tc, "[a] set ?" + paramNum + ' ' + loggable(value));
+                    Tr.debug(this, tc, "[r] set ?" + paramNum + ' ' + loggable(value));
+                query.setParameter(paramNum++, value);
+            }
+
+            // Generated positional parameters for expressions in Order/Sort
+            // and values needed to control cursor pagination
+            for (Object value; orderJPQLParams != null &&
+                               (value = orderJPQLParams.getOrDefault(paramNum, NONE)) != NONE;) {
+                if (trace && tc.isDebugEnabled())
+                    Tr.debug(this, tc, "[o] set ?" + paramNum + ' ' + loggable(value));
                 query.setParameter(paramNum++, value);
             }
         } else { // named parameters
@@ -5873,16 +5905,28 @@ public abstract class QueryInfo {
                     throw Fail.extraMethodParams(this, a + 1, specialParamsStartAt + 1);
                 String paramName = paramNames.next();
                 if (trace && tc.isDebugEnabled())
-                    Tr.debug(this, tc, "[m] set :" + paramName + ' ' + loggable(args[a]));
+                    Tr.debug(this, tc, "[q] set :" + paramName + ' ' + loggable(args[a]));
                 query.setParameter(paramName, args[a]);
             }
-            // Additional generated positional parameters (might be for cursor pagination)
-            if (addedJPQLParams != null)
-                for (Entry<Object, Object> entry : addedJPQLParams.entrySet()) {
+
+            // Additional generated named parameters
+            if (requiredJPQLParams != null)
+                for (Entry<Object, Object> entry : requiredJPQLParams.entrySet()) {
                     String paramName = (String) entry.getKey();
                     Object value = entry.getValue();
                     if (trace && tc.isDebugEnabled())
-                        Tr.debug(this, tc, "[a] set :" + paramName + ' ' + loggable(value));
+                        Tr.debug(this, tc, "[r] set :" + paramName + ' ' + loggable(value));
+                    query.setParameter(paramName, value);
+                }
+
+            // Generated named parameters for expressions in Order/Sort
+            // and values needed to control cursor pagination
+            if (orderJPQLParams != null)
+                for (Entry<Object, Object> entry : orderJPQLParams.entrySet()) {
+                    String paramName = (String) entry.getKey();
+                    Object value = entry.getValue();
+                    if (trace && tc.isDebugEnabled())
+                        Tr.debug(this, tc, "[o] set :" + paramName + ' ' + loggable(value));
                     query.setParameter(paramName, value);
                 }
         }

--- a/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/v1_0/QueryInfo_1_0.java
+++ b/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/v1_0/QueryInfo_1_0.java
@@ -22,7 +22,6 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.util.Collections;
 import java.util.Map;
-import java.util.Set;
 
 import com.ibm.websphere.ras.annotation.Trivial;
 
@@ -112,14 +111,6 @@ public class QueryInfo_1_0 extends QueryInfo {
 
     @Override
     @Trivial
-    protected void appendExpression(Sort<?> sort,
-                                    StringBuilder q,
-                                    Map<Object, Object> jpqlParams) {
-        throw new IllegalArgumentException(sort.toString());
-    }
-
-    @Override
-    @Trivial
     protected <T> Sort<T> createSort(String expression, OrderBy orderBy) {
         return new Sort<T>( //
                         expression, //
@@ -190,20 +181,24 @@ public class QueryInfo_1_0 extends QueryInfo {
     }
 
     @Override
-    protected int generateConstraint(StringBuilder q,
-                                     Object constraint,
-                                     int jpqlParamCount,
-                                     Set<String> jpqlParamNames,
-                                     Map<Object, Object> jpqlParams) {
+    protected void generateConstraint(StringBuilder q,
+                                      Object constraint,
+                                      Map<Object, Object> jpqlParams) {
         throw new UnsupportedOperationException("jakarta.data.constraint.Constraint");
     }
 
     @Override
-    protected int generateRestrictions(StringBuilder q,
-                                       Object restriction,
-                                       int jpqlParamCount,
-                                       Set<String> jpqlParamNames,
-                                       Map<Object, Object> jpqlParams) {
+    protected int generateExpression(StringBuilder q,
+                                     Object expression,
+                                     int jpqlParamCount,
+                                     Map<Object, Object> xprParams) {
+        throw new IllegalArgumentException("Sort: " + expression.toString());
+    }
+
+    @Override
+    protected void generateRestrictions(StringBuilder q,
+                                        Object restriction,
+                                        Map<Object, Object> jpqlParams) {
         throw new UnsupportedOperationException("jakarta.data.restrict.Restriction");
     }
 
@@ -212,6 +207,12 @@ public class QueryInfo_1_0 extends QueryInfo {
     protected Map<Integer, Object> getDeferredConstraints(boolean alwaysDefer,
                                                           Object[] methodParams) {
         return Collections.emptyMap();
+    }
+
+    @Override
+    @Trivial
+    protected Object getExpression(Sort<?> sort) {
+        return null;
     }
 
     @Override
@@ -251,11 +252,10 @@ public class QueryInfo_1_0 extends QueryInfo {
                                   Annotation[] paramAnnos,
                                   String[] attrNames,
                                   AttributeConstraint[] constraints,
-                                  char[] updateOps,
-                                  int prevNumJPQLParams) {
+                                  char[] updateOps) {
         // In Data 1.0, all constraints are the equality condition
         constraints[p] = AttributeConstraint.Equal;
-        return prevNumJPQLParams + 1;
+        return ++qlParamCount;
     }
 
     @Override

--- a/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/v1_1/QueryInfo_1_1.java
+++ b/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/v1_1/QueryInfo_1_1.java
@@ -41,6 +41,7 @@ import com.ibm.websphere.ras.annotation.Trivial;
 import com.ibm.ws.ffdc.annotation.FFDCIgnore;
 
 import io.openliberty.data.internal.AttributeConstraint;
+import io.openliberty.data.internal.Fail;
 import io.openliberty.data.internal.QueryInfo;
 import io.openliberty.data.internal.QueryType;
 import io.openliberty.data.internal.Util;
@@ -200,7 +201,7 @@ public class QueryInfo_1_1 extends QueryInfo {
      * @param jpqlParamCount parameter number to include in the generated name.
      * @param jpqlParamNames list of named parameter names to which to add the
      *                           generated name, which must not already be in the list.
-     * @return
+     * @return generated name
      */
     @Trivial
     private String addExpressionParam(int jpqlParamCount, Set<String> jpqlParamNames) {
@@ -336,19 +337,6 @@ public class QueryInfo_1_1 extends QueryInfo {
         }
 
         return q;
-    }
-
-    @Override
-    @Trivial
-    protected void appendExpression(Sort<?> sort,
-                                    StringBuilder q,
-                                    Map<Object, Object> jpqlParams) {
-        qlParamCount = generateExpression(q,
-                                          entityVar_,
-                                          sort.expression(),
-                                          qlParamCount,
-                                          qlParamNames,
-                                          jpqlParams);
     }
 
     /**
@@ -648,30 +636,20 @@ public class QueryInfo_1_1 extends QueryInfo {
     /**
      * Appends JPQL to the partially built query to represent a Constraint.
      *
-     * @param q              partially built query to which to append JPQL
-     *                           representing the Constraint.
-     * @param entityVar_     entity identifier variable name and . character.
-     * @param constraint     the Constraint for which to generate JPQL.
-     * @param jpqlParamCount number of named or positional parameters identified
-     *                           up to this point for the JPQL.
-     * @param jpqlParamNames names of named parameters in the partially built
-     *                           query. Empty if the query uses positional
-     *                           parameeters or has none. If using named parameters,
-     *                           this method should add any that are generated.
-     * @param jpqlParams     list for this method to populate with the name of
-     *                           named parameters or index of positional parameters,
-     *                           mapped to value, for each value obtained from the
-     *                           processed Restriction(s).
-     * @return the new count of named or positional parameters, including any that
-     *         were generated for the Constraint.
+     * @param q          partially built query to which to append JPQL
+     *                       representing the Constraint.
+     * @param entityVar_ entity identifier variable name and . character.
+     * @param constraint the Constraint for which to generate JPQL.
+     * @param jpqlParams list for this method to populate with the name of
+     *                       named parameters or index of positional parameters,
+     *                       mapped to value, for each value obtained from the
+     *                       processed Restriction(s).
      */
     @Override
     // TODO @Trivial // avoid tracing values found in Expression.toString()
-    protected int generateConstraint(StringBuilder q,
-                                     Object constraint,
-                                     int jpqlParamCount,
-                                     Set<String> jpqlParamNames,
-                                     Map<Object, Object> jpqlParams) {
+    protected void generateConstraint(StringBuilder q,
+                                      Object constraint,
+                                      Map<Object, Object> jpqlParams) {
 
         Expression<?, ?> exp1 = null;
         Expression<?, ?> exp2 = null;
@@ -730,12 +708,10 @@ public class QueryInfo_1_1 extends QueryInfo {
         q.append(c.operator());
 
         if (exp1 != null) {
-            jpqlParamCount = generateExpression(q,
-                                                entityVar_,
-                                                exp1,
-                                                jpqlParamCount,
-                                                jpqlParamNames,
-                                                jpqlParams);
+            qlParamCount = generateExpression(q,
+                                              exp1,
+                                              qlParamCount,
+                                              jpqlParams);
 
             if (exp2 != null) {
                 if (c == AttributeConstraint.LikeEscaped ||
@@ -748,12 +724,10 @@ public class QueryInfo_1_1 extends QueryInfo {
                     throw new IllegalArgumentException("Constraint: " +
                                                        constraint.getClass().getName());
 
-                jpqlParamCount = generateExpression(q,
-                                                    entityVar_,
-                                                    exp2,
-                                                    jpqlParamCount,
-                                                    jpqlParamNames,
-                                                    jpqlParams);
+                qlParamCount = generateExpression(q,
+                                                  exp2,
+                                                  qlParamCount,
+                                                  jpqlParams);
             }
         } else if (exps != null) { // IN or NOT IN
             q.append('(');
@@ -761,56 +735,31 @@ public class QueryInfo_1_1 extends QueryInfo {
                 if (i != 0)
                     q.append(", ");
 
-                jpqlParamCount = generateExpression(q,
-                                                    entityVar_,
-                                                    exps.get(i),
-                                                    jpqlParamCount,
-                                                    jpqlParamNames,
-                                                    jpqlParams);
+                qlParamCount = generateExpression(q,
+                                                  exps.get(i),
+                                                  qlParamCount,
+                                                  jpqlParams);
             }
             q.append(')');
         }
-
-        return jpqlParamCount;
     }
 
-    /**
-     * Appends JPQL to the partially built query to represent an Expression
-     * parameter of a Constraint or Restriction.
-     *
-     * @param q              partially built query ending with the WHERE clause.
-     * @param entityVar_     entity identifier variable name and . character.
-     * @param expression     the Expression for which to generate JPQL.
-     * @param jpqlParamCount number of named or positional parameters in the
-     *                           partially built query.
-     * @param jpqlParamNames names of named parameters in the partially built
-     *                           query. Empty if the query uses positional
-     *                           parameeters or has none. If using named parameters,
-     *                           this method should add any that are generated.
-     * @param xprParams      list for this method to populate with the name of
-     *                           named parameters or index of positional parameters,
-     *                           mapped to value, for values (if any) obtained from
-     *                           the Expression.
-     * @return the new count of named or positional parameters, including any that
-     *         were generated for the Expression.
-     */
+    @Override
     @Trivial // avoid tracing values found in Expression.toString()
-    private int generateExpression(StringBuilder q,
-                                   String entityVar_,
-                                   Expression<?, ?> expression,
-                                   int jpqlParamCount,
-                                   Set<String> jpqlParamNames,
-                                   Map<Object, Object> xprParams) {
+    protected int generateExpression(StringBuilder q,
+                                     Object expression,
+                                     int jpqlParamCount,
+                                     Map<Object, Object> xprParams) {
         if (expression instanceof Attribute<?> attr) {
             q.append(entityVar_).append(attr.name());
         } else if (expression instanceof Literal<?> literal) {
             jpqlParamCount++;
-            boolean positionalParams = jpqlParamNames.isEmpty();
+            boolean positionalParams = qlParamNames.isEmpty();
             if (positionalParams) {
                 q.append('?').append(jpqlParamCount);
                 xprParams.put(jpqlParamCount, literal.value());
             } else {
-                String paramName = addExpressionParam(jpqlParamCount, jpqlParamNames);
+                String paramName = addExpressionParam(jpqlParamCount, qlParamNames);
                 q.append(':').append(paramName);
                 xprParams.put(paramName, literal.value());
             }
@@ -857,10 +806,8 @@ public class QueryInfo_1_1 extends QueryInfo {
             }
             // first argument:
             jpqlParamCount = generateExpression(q,
-                                                entityVar_,
                                                 args.get(0),
                                                 jpqlParamCount,
-                                                jpqlParamNames,
                                                 xprParams);
             // between first and second arguments:
             switch (name) {
@@ -878,10 +825,8 @@ public class QueryInfo_1_1 extends QueryInfo {
                 case TextFunctionExpression.LEFT:
                 case TextFunctionExpression.RIGHT:
                     jpqlParamCount = generateExpression(q,
-                                                        entityVar_,
                                                         args.get(1),
                                                         jpqlParamCount,
-                                                        jpqlParamNames,
                                                         xprParams);
                     break;
             }
@@ -901,19 +846,15 @@ public class QueryInfo_1_1 extends QueryInfo {
             String typeName = cast.type().getSimpleName();
             q.append("CAST (");
             jpqlParamCount = generateExpression(q,
-                                                entityVar_,
                                                 cast.expression(),
                                                 jpqlParamCount,
-                                                jpqlParamNames,
                                                 xprParams);
             q.append(" AS ").append(typeName).append(')');
         } else if (expression instanceof NumericOperatorExpression<?, ?> op) {
             q.append('(');
             jpqlParamCount = generateExpression(q,
-                                                entityVar_,
                                                 op.left(),
                                                 jpqlParamCount,
-                                                jpqlParamNames,
                                                 xprParams);
             q.append(switch (op.operator()) {
                 case PLUS -> " + ";
@@ -922,10 +863,8 @@ public class QueryInfo_1_1 extends QueryInfo {
                 case DIVIDE -> " / ";
             });
             jpqlParamCount = generateExpression(q,
-                                                entityVar_,
                                                 op.right(),
                                                 jpqlParamCount,
-                                                jpqlParamNames,
                                                 xprParams);
             q.append(')');
         } else if (expression instanceof TemporalExpression<?, ?> temporal) {
@@ -949,43 +888,25 @@ public class QueryInfo_1_1 extends QueryInfo {
      * Appends JPQL to the partially built query to implement a Restriction
      * parameter of a repository method.
      *
-     * @param q              partially built query ending with the WHERE clause.
-     * @param restriction    value of Restriction parameter. Otherwise null.
-     * @param jpqlParamCount number of named or positional parameters in the
-     *                           partially built query.
-     * @param jpqlParamNames names of named parameters in the partially bulit
-     *                           query. Empty if the query uses positional
-     *                           parameters or has none. If using named parameters,
-     *                           this method should add any that are generated for
-     *                           the restriction part of the query.
-     * @param qrParams       initially empty list for this method to populate
-     *                           with the name of named parameters or index of
-     *                           positional parameters, mapped to value, for each
-     *                           value obtained from the processed Restriction(s).
-     * @return the new count of named or positional parameters, including any that
-     *         were generated for the Restriction(s).
+     * @param q           partially built query ending with the WHERE clause.
+     * @param restriction value of Restriction parameter. Otherwise null.
+     * @param qrParams    initially empty list for this method to populate
+     *                        with the name of named parameters or index of
+     *                        positional parameters, mapped to value, for each
+     *                        value obtained from the processed Restriction(s).
      */
     @Override
     // TODO @Trivial // avoid tracing values found in Restriction.toString()
-    public int generateRestrictions(StringBuilder q,
-                                    Object restriction,
-                                    int jpqlParamCount,
-                                    Set<String> jpqlParamNames,
-                                    Map<Object, Object> qrParams) {
+    public void generateRestrictions(StringBuilder q,
+                                     Object restriction,
+                                     Map<Object, Object> qrParams) {
 
         if (restriction instanceof BasicRestriction<?, ?> r) {
-            jpqlParamCount = generateExpression(q,
-                                                entityVar_,
-                                                r.expression(),
-                                                jpqlParamCount,
-                                                jpqlParamNames,
-                                                qrParams);
-
-            jpqlParamCount = generateConstraint(q,
-                                                r.constraint(),
-                                                jpqlParamCount,
-                                                jpqlParamNames,
-                                                qrParams);
+            qlParamCount = generateExpression(q,
+                                              r.expression(),
+                                              qlParamCount,
+                                              qrParams);
+            generateConstraint(q, r.constraint(), qrParams);
         } else if (restriction instanceof CompositeRestriction<?> r) {
             q.append(r.isNegated() ? "NOT (" : "(");
             boolean all = r.type() == CompositeRestriction.Type.ALL;
@@ -998,19 +919,13 @@ public class QueryInfo_1_1 extends QueryInfo {
                     if (i > 0)
                         q.append(all ? " AND " : " OR ");
 
-                    jpqlParamCount = generateRestrictions(q,
-                                                          rr.get(i),
-                                                          jpqlParamCount,
-                                                          jpqlParamNames,
-                                                          qrParams);
+                    generateRestrictions(q, rr.get(i), qrParams);
                 }
             q.append(')');
         } else {
             throw new IllegalArgumentException("Unsupported Restriction type: " +
                                                restriction.getClass().getName());
         }
-
-        return jpqlParamCount;
     }
 
     @Override
@@ -1041,6 +956,12 @@ public class QueryInfo_1_1 extends QueryInfo {
         if (trace && tc.isEntryEnabled())
             Tr.exit(this, tc, "getDeferredConstraints", deferred.keySet());
         return deferred;
+    }
+
+    @Override
+    @Trivial
+    protected Object getExpression(Sort<?> sort) {
+        return sort.expression();
     }
 
     @Override
@@ -1153,9 +1074,8 @@ public class QueryInfo_1_1 extends QueryInfo {
                                   Annotation[] paramAnnos,
                                   String[] attrNames,
                                   AttributeConstraint[] constraints,
-                                  char[] updateOps,
-                                  int prevNumJPQLParams) {
-        int numJPQLParams = prevNumJPQLParams;
+                                  char[] updateOps) {
+        int prevNumJPQLParams = qlParamCount;
 
         for (Annotation anno : paramAnnos)
             if (anno instanceof Is) {
@@ -1163,43 +1083,44 @@ public class QueryInfo_1_1 extends QueryInfo {
             } else if (anno instanceof Assign) {
                 attrNames[p] = ((Assign) anno).value();
                 updateOps[p] = '=';
-                numJPQLParams++;
+                qlParamCount++;
             } else if (anno instanceof Add) {
                 attrNames[p] = ((Add) anno).value();
                 updateOps[p] = '+';
-                numJPQLParams++;
+                qlParamCount++;
             } else if (anno instanceof Multiply) {
                 attrNames[p] = ((Multiply) anno).value();
                 updateOps[p] = '*';
-                numJPQLParams++;
+                qlParamCount++;
             } else if (anno instanceof Divide) {
                 attrNames[p] = ((Divide) anno).value();
                 updateOps[p] = '/';
-                numJPQLParams++;
+                qlParamCount++;
             } else if (anno instanceof SubtractFrom) {
                 attrNames[p] = ((SubtractFrom) anno).value();
                 updateOps[p] = '-';
-                numJPQLParams++;
+                qlParamCount++;
             }
 
         if (constraints[p] == null && Constraint.class.isAssignableFrom(paramType)) {
             constraints[p] = toAttributeConstraint(null, paramType);
         }
 
-        if (numJPQLParams == prevNumJPQLParams) {
+        if (qlParamCount == prevNumJPQLParams) {
             if (constraints[p] == null)
                 constraints[p] = AttributeConstraint.Equal;
 
             // no annotation indicating a constraint or update
-            numJPQLParams += constraints[p].numMethodParams();
-        } else if (numJPQLParams - prevNumJPQLParams > 1) {
+            qlParamCount += constraints[p].numMethodParams();
+        } else if (qlParamCount - prevNumJPQLParams > 1) {
             // TODO possibly allow a redundant Constraint that matches the Is annotation.
-            numJPQLParams = PARAM_ANNOS_CONFLICT;
+            throw Fail.methodParamAnnoConflict(this, false, p, paramType, paramAnnos);
         } else if (false) { // TODO 1.1 check if paramType is a Constraint
-            numJPQLParams = PARAM_ANNO_CONFLICTS_WITH_CONSTRAINT;
+            throw Fail.methodParamAnnoConflict(this, true, p, paramType, paramAnnos);
+            // TODO send in boolean for _CONFLICTS_WITH_CONSTRAINT
         }
 
-        return numJPQLParams;
+        return qlParamCount;
     }
 
     /**

--- a/dev/io.openliberty.data.internal_fat_1_1/test-applications/Data_1_1_App/src/test/jakarta/data/v1_1/web/Data_1_1_Servlet.java
+++ b/dev/io.openliberty.data.internal_fat_1_1/test-applications/Data_1_1_App/src/test/jakarta/data/v1_1/web/Data_1_1_Servlet.java
@@ -529,6 +529,350 @@ public class Data_1_1_Servlet extends FATServlet {
     }
 
     /**
+     * Obtain cursored pages for queries with sort criteria that includes
+     * expressions.
+     */
+    @Test
+    public void testExpressionAsCursorElement() {
+        // pages | # | denominator | proximity to 10 | 2nd char | name
+        // 1       1            18                 0          e   Ten Eighteenths
+        // 1       2            18                 1          l   Eleven Eighteenths
+        // 1       3            18                 1          i   Nine Eighteenths
+        // 1       4            18                 2          w   Twelve Eighteenths
+        // 1       5            18                 2          i   Eight Eighteenths
+        // 1       6            18                 3          h   Thirteen Eighteenths
+        // 1       7            18                 3          e   Seven Eighteenths
+        // 1       8            18                 4          o   Fourteen Eighteenths
+        // 1       9            18                 4          i   Six Eighteenths
+        // 1      10            18                 5          i   Fifteen Eighteenths
+        // 2      11            18                 5          i   Five Eighteenths
+        // 2      12            18                 6          o   Four Eighteenths
+        // 2      13            18                 6          i   Sixteen Eighteenths
+        // 2      14            18                 7          h   Three Eighteenths
+        // 2      15            18                 7          e   Seventeen Eighteenths
+        // 2      16            18                 8          w   Two Eighteenths
+        // 2      17            18                 9          n   One Eighteenth
+        // 2 3    18            19                 0          e   Ten Nineteenths
+        // 2 3    19            19                 1          l   Eleven Nineteenths
+        // 2 3    20            19                 1          i   Nine Nineteenths
+        //   3    21            19                 2          w   Twelve Nineteenths
+        //   3    22            19                 2          i   Eight Nineteenths
+        //   3    23            19                 3          h   Thirteen Nineteenths
+        //        24            19                 3          e   Seven Nineteenths
+        //        25            19                 4          o   Fourteen Nineteenths
+        //        26            19                 4          i   Six Nineteenths
+        //        27            19                 5          i   Fifteen Nineteenths
+        //        28            19                 5          i   Five Nineteenths
+        //        29            19                 6          o   Four Nineteenths
+        //        30            19                 6          i   Sixteen Nineteenths
+        //        31            19                 7          h   Three Eighteenths
+        //        32            19                 7          e   Seventeen Nineteenths
+        //        33            19                 8          w   Two Nineteenths
+        //        34            19                 8          i   Eighteen Nineteenths
+        //        35            19                 9          n   One Nineteenths
+
+        Order<Fraction> order = Order // also @OrderBy(_Fraction.DENOMINATOR) on method
+                        .by(_Fraction.numerator.subtractedFrom(10).abs().asc(),
+                            _Fraction.name.left(2).right(1).desc(), // 2nd char of name
+                            _Fraction.name.asc());
+
+        String pattern = "% _i__teenth%"; // Eighteenth(s), Nineteenth(s)
+
+        CursoredPage<Fraction> page1 = fractions.namedLike(pattern,
+                                                           order,
+                                                           PageRequest.ofSize(10));
+
+        assertEquals(List.of("Ten Eighteenths",
+                             "Eleven Eighteenths",
+                             "Nine Eighteenths",
+                             "Twelve Eighteenths",
+                             "Eight Eighteenths",
+                             "Thirteen Eighteenths",
+                             "Seven Eighteenths",
+                             "Fourteen Eighteenths",
+                             "Six Eighteenths",
+                             "Fifteen Eighteenths"),
+                     page1.stream()
+                                     .map(f -> f.name)
+                                     .toList());
+
+        assertEquals(true,
+                     page1.hasNext());
+        assertEquals(true,
+                     page1.hasTotals());
+        assertEquals(35L,
+                     page1.totalElements());
+        assertEquals(4L,
+                     page1.totalPages());
+
+        Fraction lastOnPage = page1.content().get(page1.numberOfElements() - 1);
+        Cursor lastOnPageCursor = Cursor.forKey(lastOnPage.denominator,
+                                                Math.abs(10 - lastOnPage.numerator),
+                                                lastOnPage.name.substring(1, 2),
+                                                lastOnPage.name);
+        PageRequest page2Req = PageRequest.ofSize(10).afterCursor(lastOnPageCursor);
+
+        CursoredPage<Fraction> page2 = fractions.namedLike(pattern,
+                                                           order,
+                                                           page2Req);
+
+        assertEquals(List.of("Five Eighteenths",
+                             "Four Eighteenths",
+                             "Sixteen Eighteenths",
+                             "Three Eighteenths",
+                             "Seventeen Eighteenths",
+                             "Two Eighteenths",
+                             "One Eighteenth",
+                             "Ten Nineteenths",
+                             "Eleven Nineteenths",
+                             "Nine Nineteenths"),
+                     page2.stream()
+                                     .map(f -> f.name)
+                                     .toList());
+
+        assertEquals(true,
+                     page2.hasNext());
+        assertEquals(true,
+                     page2.hasPrevious());
+        assertEquals(true,
+                     page2.hasTotals());
+        assertEquals(35L,
+                     page2.totalElements());
+        assertEquals(4L,
+                     page2.totalPages());
+
+        Cursor sevenNineteenthsCursor = Cursor //
+                        .forKey(19, 3, "e", "Seven Nineteenths");
+        PageRequest page3Req = PageRequest.ofSize(6)
+                        .beforeCursor(sevenNineteenthsCursor);
+
+        CursoredPage<Fraction> page3 = fractions.namedLike(pattern,
+                                                           order,
+                                                           page3Req);
+
+        assertEquals(true,
+                     page3.hasNext());
+        assertEquals(true,
+                     page3.hasPrevious());
+        assertEquals(true,
+                     page3.hasTotals());
+        assertEquals(35L,
+                     page3.totalElements());
+
+        assertEquals(List.of("Ten Nineteenths",
+                             "Eleven Nineteenths",
+                             "Nine Nineteenths",
+                             "Twelve Nineteenths",
+                             "Eight Nineteenths",
+                             "Thirteen Nineteenths"),
+                     page3.stream()
+                                     .map(f -> f.name)
+                                     .toList());
+    }
+
+    /**
+     * Obtain cursored pages for queries with sort criteria that includes
+     * expressions. The repository method also includes a Restriction
+     * with expressions of its own.
+     */
+    @Test
+    public void testExpressionsInCursorElementAndRestrictions() {
+        //             desc     asc      desc   asc
+        // pages | # | type | n * (d-1) | num / denom
+        // 1       1      T           3     1 /  4
+        // 1       2      T           4     1 /  5
+        // 1       3      T           7     1 /  8
+        // 1       4      T           8     2 /  5
+        // 1       5      T           9     1 / 10
+        // 1       6      T          21     3 /  8
+        // 1       7      T          27     3 / 10
+        // 1       8      T          35     5 /  8
+        // 1       9      T          63     7 / 10
+        // 1      10      T         105     7 / 16
+        // 1      11      T         135     9 / 16
+        // 2      12      R           5     1 /  6
+        // 2      13      R           6     1 /  7
+        // 2      14      R           8     1 /  9
+        // 2      15      R          10     1 / 11
+        // 2      16      R          12     2 /  7
+        // 2      17      R          16     2 /  9
+        // 2      18      R          18     3 /  7
+        // 2      19      R          20     2 / 11
+        //        20      R          24     4 /  7
+        //        21      R          30     3 / 11
+        //        22      R          32     4 /  9
+        //        23      R          36     3 / 13
+        //        24      R          40     5 /  9
+        // 3      25      R          40     4 / 11
+        // 3      26      R          48     4 / 13
+        // 3      27      R          50     5 / 11
+        // 3      28      R          55     5 / 12
+        // 3      29      R          60     6 / 11
+        // 4      30      R          60     5 / 13
+        // 4      31      R          65     5 / 14
+        // 4      32      R          70     7 / 11
+        // 4      33      R          72     6 / 13
+        // 4      34      R          77     7 / 12
+        // 4      35      R          80     8 / 11
+        // 4      36      R          98     7 / 15
+        // 4      37      R         108     9 / 13
+        // 4      38      R         112     8 / 15
+        //        39      R         112     7 / 17
+        //        40      R         117     9 / 14
+        //        41      R         128     8 / 17
+        //        42      R         162     9 / 19
+
+        Between<Integer> denominator3to10MoreThanNumerator = Between
+                        .bounds(_Fraction.numerator.plus(3),
+                                _Fraction.numerator.plus(10));
+
+        Restriction<Fraction> filter = Restrict
+                        .all(_Fraction.numerator.lessThanEqual(9),
+                             _Fraction.name.length().notEqualTo(17));
+
+        Order<Fraction> order = Order //
+                        .by(_Fraction.decimal_type.desc(),
+                            _Fraction.numerator
+                                            .times(_Fraction.denominator.minus(1))
+                                            .asc(),
+                            _Fraction.numerator.desc());
+
+        Cursor sevenSeventeenthsCursor = Cursor.forKey(Decimal.Type.REPEATING,
+                                                       7 * (17 - 1),
+                                                       7);
+        PageRequest page4Req = PageRequest.beforeCursor(sevenSeventeenthsCursor,
+                                                        4,
+                                                        9,
+                                                        true);
+
+        CursoredPage<Fraction> page4 = fractions
+                        .fetchCursored(denominator3to10MoreThanNumerator,
+                                       true, // reduced
+                                       filter,
+                                       order,
+                                       page4Req);
+
+        assertEquals(List.of("5/13",
+                             "5/14",
+                             "7/11",
+                             "6/13",
+                             "7/12",
+                             "8/11",
+                             "7/15",
+                             "9/13",
+                             "8/15"),
+                     page4.stream()
+                                     .map(f -> f.numerator + "/" + f.denominator)
+                                     .toList());
+
+        assertEquals(true,
+                     page4.hasNext());
+        assertEquals(true,
+                     page4.hasPrevious());
+        assertEquals(true,
+                     page4.hasTotals());
+        // TODO implement count queries when restriction is present
+        //assertEquals(42L,
+        //             page4.totalElements());
+
+        Fraction firstOnPage = page4.content().get(0);
+        Cursor firstOnPageCursor = Cursor
+                        .forKey(firstOnPage.decimal.type(),
+                                firstOnPage.numerator * (firstOnPage.denominator - 1),
+                                firstOnPage.numerator);
+        PageRequest page3Req = PageRequest.ofSize(5).beforeCursor(firstOnPageCursor);
+
+        CursoredPage<Fraction> page3 = fractions
+                        .fetchCursored(denominator3to10MoreThanNumerator,
+                                       true, // reduced
+                                       filter,
+                                       order,
+                                       page3Req);
+
+        assertEquals(List.of("4/11",
+                             "4/13",
+                             "5/11",
+                             "5/12",
+                             "6/11"),
+                     page3.stream()
+                                     .map(f -> f.numerator + "/" + f.denominator)
+                                     .toList());
+
+        assertEquals(true,
+                     page3.hasNext());
+        assertEquals(true,
+                     page3.hasPrevious());
+        assertEquals(true,
+                     page3.hasTotals());
+        // TODO implement count queries when restriction is present
+        //assertEquals(42L,
+        //             page3.totalElements());
+
+        CursoredPage<Fraction> page1 = fractions
+                        .fetchCursored(denominator3to10MoreThanNumerator,
+                                       true, // reduced
+                                       filter,
+                                       order,
+                                       PageRequest.ofSize(11));
+
+        assertEquals(true,
+                     page1.hasNext());
+        assertEquals(true,
+                     page1.hasTotals());
+        // TODO implement count queries when restriction is present
+        //assertEquals(42L,
+        //             page1.totalElements());
+        //assertEquals(4L,
+        //             page1.totalPages());
+
+        assertEquals(List.of("1/4",
+                             "1/5",
+                             "1/8",
+                             "2/5",
+                             "1/10",
+                             "3/8",
+                             "3/10",
+                             "5/8",
+                             "7/10",
+                             "7/16",
+                             "9/16"),
+                     page1.stream()
+                                     .map(f -> f.numerator + "/" + f.denominator)
+                                     .toList());
+
+        Fraction lastOnPage = page1.content().get(page1.numberOfElements() - 1);
+        Cursor lastOnPageCursor = Cursor
+                        .forKey(lastOnPage.decimal.type(),
+                                lastOnPage.numerator * (lastOnPage.denominator - 1),
+                                lastOnPage.numerator);
+        PageRequest page2Req = PageRequest.afterCursor(lastOnPageCursor, 2, 8, false);
+
+        CursoredPage<Fraction> page2 = fractions
+                        .fetchCursored(denominator3to10MoreThanNumerator,
+                                       true, // reduced
+                                       filter,
+                                       order,
+                                       page2Req);
+
+        assertEquals(List.of("1/6",
+                             "1/7",
+                             "1/9",
+                             "1/11",
+                             "2/7",
+                             "2/9",
+                             "3/7",
+                             "2/11"),
+                     page2.stream()
+                                     .map(f -> f.numerator + "/" + f.denominator)
+                                     .toList());
+
+        assertEquals(8,
+                     page2.numberOfElements());
+        assertEquals(false,
+                     page2.hasTotals());
+    }
+
+    /**
      * Tests a Find method with the First annotation specifying a value
      * larger than 1.
      */

--- a/dev/io.openliberty.data.internal_fat_1_1/test-applications/Data_1_1_App/src/test/jakarta/data/v1_1/web/Fractions.java
+++ b/dev/io.openliberty.data.internal_fat_1_1/test-applications/Data_1_1_App/src/test/jakarta/data/v1_1/web/Fractions.java
@@ -144,6 +144,14 @@ public interface Fractions {
      int exclusiveMax,
      Restriction<Fraction> filter);
 
+    @Find
+    CursoredPage<Fraction> fetchCursored //
+    (@By(_Fraction.DENOMINATOR) Between<Integer> denominatorRange,
+     @By(_Fraction.REDUCED) @Is(EqualTo.class) boolean isReduced,
+     Restriction<Fraction> filter,
+     Order<Fraction> order,
+     PageRequest pageReq);
+
     @First
     @NativeQuery("""
                     SELECT *


### PR DESCRIPTION
Implements cursor pagination when Sort expressions are supplied to a query. This is possible from the beginning of the data set or relative to a supplied cursor.  Adds testing, including when a Restriction is also present.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
