### PR TITLE
Upgrading to Hibernate 7.4.4 for JPA FATs and configurig L2 cache for testing

### DIFF
--- a/dev/com.ibm.ws.jpa.tests.jpa_31_fat/build.gradle
+++ b/dev/com.ibm.ws.jpa.tests.jpa_31_fat/build.gradle
@@ -14,7 +14,7 @@
 apply from: '../wlp-gradle/subprojects/maven-central-mirror.gradle'
 
 ext {
-  hibernateVersion = '7.3.3.Final'
+  hibernateVersion = '7.4.4.Final'
 }
 
 configurations {

--- a/dev/com.ibm.ws.jpa.tests.jpa_31_fat/publish/shared/config/hibernate32-cfg.xml
+++ b/dev/com.ibm.ws.jpa.tests.jpa_31_fat/publish/shared/config/hibernate32-cfg.xml
@@ -30,19 +30,18 @@
 
     <!-- START: Hibernate permissions -->
     <javaPermission className="java.security.AllPermission" codebase="${shared.resource.dir}/jpa_fat_jpa32_hibernate/antlr4-runtime-4.13.2.jar"/>
-    <javaPermission className="java.security.AllPermission" codebase="${shared.resource.dir}/jpa_fat_jpa32_hibernate/angus-activation-2.0.2.jar"/>
+    <javaPermission className="java.security.AllPermission" codebase="${shared.resource.dir}/jpa_fat_jpa32_hibernate/angus-activation-2.0.3.jar"/>
     <javaPermission className="java.security.AllPermission" codebase="${shared.resource.dir}/jpa_fat_jpa32_hibernate/antlr4-runtime-4.13.2.jar"/>
     <javaPermission className="java.security.AllPermission" codebase="${shared.resource.dir}/jpa_fat_jpa32_hibernate/byte-buddy-1.18.8.jar"/>
-    <javaPermission className="java.security.AllPermission" codebase="${shared.resource.dir}/jpa_fat_jpa32_hibernate/classmate-1.7.0.jar"/>
-    <javaPermission className="java.security.AllPermission" codebase="${shared.resource.dir}/jpa_fat_jpa32_hibernate/hibernate-community-dialects-7.3.3.Final.jar"/>
-    <javaPermission className="java.security.AllPermission" codebase="${shared.resource.dir}/jpa_fat_jpa32_hibernate/hibernate-core-7.3.3.Final.jar"/>
+    <javaPermission className="java.security.AllPermission" codebase="${shared.resource.dir}/jpa_fat_jpa32_hibernate/hibernate-community-dialects-7.4.4.Final.jar"/>
+    <javaPermission className="java.security.AllPermission" codebase="${shared.resource.dir}/jpa_fat_jpa32_hibernate/hibernate-core-7.4.4.Final.jar"/>
     <javaPermission className="java.security.AllPermission" codebase="${shared.resource.dir}/jpa_fat_jpa32_hibernate/hibernate-models-1.1.1.jar"/>
-    <javaPermission className="java.security.AllPermission" codebase="${shared.resource.dir}/jpa_fat_jpa32_hibernate/hibernate-scan-jandex-7.3.3.Final.jar"/>
+    <javaPermission className="java.security.AllPermission" codebase="${shared.resource.dir}/jpa_fat_jpa32_hibernate/hibernate-scan-jandex-7.4.4.Final.jar"/>
     <javaPermission className="java.security.AllPermission" codebase="${shared.resource.dir}/jpa_fat_jpa32_hibernate/istack-commons-runtime-4.1.2.jar"/>
-    <javaPermission className="java.security.AllPermission" codebase="${shared.resource.dir}/jpa_fat_jpa32_hibernate/jandex-3.3.0.jar"/>
-    <javaPermission className="java.security.AllPermission" codebase="${shared.resource.dir}/jpa_fat_jpa32_hibernate/jaxb-core-4.0.6.jar"/>
-    <javaPermission className="java.security.AllPermission" codebase="${shared.resource.dir}/jpa_fat_jpa32_hibernate/jaxb-runtime-4.0.6.jar"/>
+    <javaPermission className="java.security.AllPermission" codebase="${shared.resource.dir}/jpa_fat_jpa32_hibernate/jandex-3.3.2.jar"/>
+    <javaPermission className="java.security.AllPermission" codebase="${shared.resource.dir}/jpa_fat_jpa32_hibernate/jaxb-core-4.0.7.jar"/>
+    <javaPermission className="java.security.AllPermission" codebase="${shared.resource.dir}/jpa_fat_jpa32_hibernate/jaxb-runtime-4.0.7.jar"/>
     <javaPermission className="java.security.AllPermission" codebase="${shared.resource.dir}/jpa_fat_jpa32_hibernate/jboss-logging-3.6.1.Final.jar"/>
-    <javaPermission className="java.security.AllPermission" codebase="${shared.resource.dir}/jpa_fat_jpa32_hibernate/txw2-4.0.6.jar"/>
+    <javaPermission className="java.security.AllPermission" codebase="${shared.resource.dir}/jpa_fat_jpa32_hibernate/txw2-4.0.7.jar"/>
     <!-- END: Hibernate permissions -->
 </server>

--- a/dev/com.ibm.ws.jpa.tests.jpa_32_fat/build.gradle
+++ b/dev/com.ibm.ws.jpa.tests.jpa_32_fat/build.gradle
@@ -14,7 +14,7 @@
 apply from: '../wlp-gradle/subprojects/maven-central-mirror.gradle'
 
 ext {
-  hibernateVersion = '7.3.3.Final'
+  hibernateVersion = '7.4.4.Final'
 }
 
 configurations {
@@ -41,6 +41,22 @@ dependencies {
   hibernateJPA32 "org.hibernate.orm:hibernate-core:${hibernateVersion}", withoutJakartaAPI
   hibernateJPA32 "org.hibernate.orm:hibernate-community-dialects:${hibernateVersion}", withoutJakartaAPI
   hibernateJPA32 "org.hibernate.orm:hibernate-scan-jandex:${hibernateVersion}", withoutJakartaAPI
+  hibernateJPA32("org.hibernate.orm:hibernate-jcache:${hibernateVersion}") {
+    exclude group: 'org.hibernate.orm', module: 'hibernate-core'
+    exclude group: 'org.jboss.logging', module: 'jboss-logging'
+  }
+  hibernateJPA32("org.ehcache:ehcache:3.10.8:jakarta") {
+    transitive = false
+  }
+  hibernateJPA32("javax.cache:cache-api:1.1.1") {
+    transitive = false
+  }
+  hibernateJPA32("org.slf4j:slf4j-api:1.7.36") {
+    transitive = false
+  }
+  hibernateJPA32("org.slf4j:slf4j-simple:1.7.36") {
+    transitive = false
+  }
 }
 
 task addJPAFATTools (type: Copy) {

--- a/dev/com.ibm.ws.jpa.tests.jpa_32_fat/publish/shared/config/hibernate32-cfg.xml
+++ b/dev/com.ibm.ws.jpa.tests.jpa_32_fat/publish/shared/config/hibernate32-cfg.xml
@@ -28,20 +28,24 @@
     <javaPermission className="java.lang.RuntimePermission" name="getenv.TURN_OFF_LR_LOOP_ENTRY_BRANCH_OPT"/>
 
     <!-- START: Hibernate permissions -->
+    <javaPermission className="java.security.AllPermission" codebase="${shared.resource.dir}/jpa_fat_jpa32_hibernate/cache-api-1.1.1.jar"/>
+    <javaPermission className="java.security.AllPermission" codebase="${shared.resource.dir}/jpa_fat_jpa32_hibernate/ehcache-3.10.8-jakarta.jar"/>
+    <javaPermission className="java.security.AllPermission" codebase="${shared.resource.dir}/jpa_fat_jpa32_hibernate/hibernate-jcache-7.4.4.Final.jar"/>
+    <javaPermission className="java.security.AllPermission" codebase="${shared.resource.dir}/jpa_fat_jpa32_hibernate/slf4j-api-1.7.36.jar"/>
+    <javaPermission className="java.security.AllPermission" codebase="${shared.resource.dir}/jpa_fat_jpa32_hibernate/slf4j-simple-1.7.36.jar"/>
     <javaPermission className="java.security.AllPermission" codebase="${shared.resource.dir}/jpa_fat_jpa32_hibernate/antlr4-runtime-4.13.2.jar"/>
-    <javaPermission className="java.security.AllPermission" codebase="${shared.resource.dir}/jpa_fat_jpa32_hibernate/angus-activation-2.0.2.jar"/>
+    <javaPermission className="java.security.AllPermission" codebase="${shared.resource.dir}/jpa_fat_jpa32_hibernate/angus-activation-2.0.3.jar"/>
     <javaPermission className="java.security.AllPermission" codebase="${shared.resource.dir}/jpa_fat_jpa32_hibernate/antlr4-runtime-4.13.2.jar"/>
     <javaPermission className="java.security.AllPermission" codebase="${shared.resource.dir}/jpa_fat_jpa32_hibernate/byte-buddy-1.18.8.jar"/>
-    <javaPermission className="java.security.AllPermission" codebase="${shared.resource.dir}/jpa_fat_jpa32_hibernate/classmate-1.7.0.jar"/>
-    <javaPermission className="java.security.AllPermission" codebase="${shared.resource.dir}/jpa_fat_jpa32_hibernate/hibernate-community-dialects-7.3.3.Final.jar"/>
-    <javaPermission className="java.security.AllPermission" codebase="${shared.resource.dir}/jpa_fat_jpa32_hibernate/hibernate-core-7.3.3.Final.jar"/>
+    <javaPermission className="java.security.AllPermission" codebase="${shared.resource.dir}/jpa_fat_jpa32_hibernate/hibernate-community-dialects-7.4.4.Final.jar"/>
+    <javaPermission className="java.security.AllPermission" codebase="${shared.resource.dir}/jpa_fat_jpa32_hibernate/hibernate-core-7.4.4.Final.jar"/>
     <javaPermission className="java.security.AllPermission" codebase="${shared.resource.dir}/jpa_fat_jpa32_hibernate/hibernate-models-1.1.1.jar"/>
-    <javaPermission className="java.security.AllPermission" codebase="${shared.resource.dir}/jpa_fat_jpa32_hibernate/hibernate-scan-jandex-7.3.3.Final.jar"/>
+    <javaPermission className="java.security.AllPermission" codebase="${shared.resource.dir}/jpa_fat_jpa32_hibernate/hibernate-scan-jandex-7.4.4.Final.jar"/>
     <javaPermission className="java.security.AllPermission" codebase="${shared.resource.dir}/jpa_fat_jpa32_hibernate/istack-commons-runtime-4.1.2.jar"/>
-    <javaPermission className="java.security.AllPermission" codebase="${shared.resource.dir}/jpa_fat_jpa32_hibernate/jandex-3.3.0.jar"/>
-    <javaPermission className="java.security.AllPermission" codebase="${shared.resource.dir}/jpa_fat_jpa32_hibernate/jaxb-core-4.0.6.jar"/>
-    <javaPermission className="java.security.AllPermission" codebase="${shared.resource.dir}/jpa_fat_jpa32_hibernate/jaxb-runtime-4.0.6.jar"/>
+    <javaPermission className="java.security.AllPermission" codebase="${shared.resource.dir}/jpa_fat_jpa32_hibernate/jandex-3.3.2.jar"/>
+    <javaPermission className="java.security.AllPermission" codebase="${shared.resource.dir}/jpa_fat_jpa32_hibernate/jaxb-core-4.0.7.jar"/>
+    <javaPermission className="java.security.AllPermission" codebase="${shared.resource.dir}/jpa_fat_jpa32_hibernate/jaxb-runtime-4.0.7.jar"/>
     <javaPermission className="java.security.AllPermission" codebase="${shared.resource.dir}/jpa_fat_jpa32_hibernate/jboss-logging-3.6.1.Final.jar"/>
-    <javaPermission className="java.security.AllPermission" codebase="${shared.resource.dir}/jpa_fat_jpa32_hibernate/txw2-4.0.6.jar"/>
+    <javaPermission className="java.security.AllPermission" codebase="${shared.resource.dir}/jpa_fat_jpa32_hibernate/txw2-4.0.7.jar"/>
     <!-- END: Hibernate permissions -->	
 </server>

--- a/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartadata/src/io/openliberty/jpa/data/tests/web/JakartaDataRecreateServlet.java
+++ b/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartadata/src/io/openliberty/jpa/data/tests/web/JakartaDataRecreateServlet.java
@@ -49,6 +49,7 @@ import java.util.stream.Stream;
 import org.junit.Ignore;
 import org.junit.Test;
 
+import componenttest.annotation.SkipForRepeat;
 import componenttest.annotation.SkipIfSysProp;
 import componenttest.app.FATServlet;
 import io.openliberty.jpa.data.tests.models.Account;
@@ -138,37 +139,6 @@ public class JakartaDataRecreateServlet extends FATServlet {
         return repeatPhase != null && repeatPhase.contains("hibernate");
     }
 
-    /**
-     * Skip test if running with Hibernate and log the reason.
-     * Usage: if (skipTestIfHibernate("reason")) return;
-     *
-     * @param reason the reason for skipping (error type or description)
-     * @return true if test should be skipped (running with Hibernate), false otherwise
-     */
-    private boolean skipTestIfHibernate(String reason) {
-        if (isRunningWithHibernate()) {
-            System.out.println("SKIPPING TEST - Running with Hibernate");
-            System.out.println("REASON: " + reason);
-            return true;
-        }
-        return false;
-    }
-
-    /**
-     * Skip test if running with Hibernate on SQL Server and log the reason.
-     * Usage: if (skipTestIfHibernateOnSQLServer("reason")) return;
-     *
-     * @param reason the reason for skipping (error type or description)
-     * @return true if test should be skipped, false otherwise
-     */
-    private boolean skipTestIfHibernateOnSQLServer(String reason) {
-        if (isRunningWithHibernate() && isSQLServer()) {
-            System.out.println("SKIPPING TEST - Running with Hibernate on SQL Server");
-            System.out.println("REASON: " + reason);
-            return true;
-        }
-        return false;
-    }
 
     @Test
     public void alwaysPasses() {
@@ -421,10 +391,9 @@ public class JakartaDataRecreateServlet extends FATServlet {
     }
 
     @Test //Original issue: https://github.com/OpenLiberty/open-liberty/issues/28920
+    @SkipForRepeat("JPA32_HIBERNATE")
     @Ignore("Additional issue: https://github.com/OpenLiberty/open-liberty/issues/28874")
     public void testOLGH28920() throws Exception {
-        if (skipTestIfHibernate("Hibernate fails when using constructor query"))
-            return;
         Rebate r1 = Rebate.of(10.00, "testOLGH28920", LocalTime.now().minusHours(1), LocalDate.now(), Status.SUBMITTED,
                               LocalDateTime.now(), 1);
         Rebate r2 = Rebate.of(12.00, "testOLGH28920", LocalTime.now().minusHours(1), LocalDate.now(), Status.PAID,
@@ -714,10 +683,9 @@ public class JakartaDataRecreateServlet extends FATServlet {
     }
 
     @Test
+    @SkipForRepeat("JPA32_HIBERNATE")
     // "Reference issue: https://github.com/OpenLiberty/open-liberty/issues/30093"
     public void testOLGH30093() throws Exception {
-        if (skipTestIfHibernate("ClassCastException: PersistentBag incompatible with ArrayList"))
-            return;
         deleteAllEntities(Prime.class); // Cleanup any left over entities
 
         Prime two = Prime.of(2, "II", "two");
@@ -768,10 +736,9 @@ public class JakartaDataRecreateServlet extends FATServlet {
     }
 
     @Test
+    @SkipForRepeat("JPA32_HIBERNATE")
     @SkipIfSysProp(DB_Oracle) //Reference issue: https://github.com/OpenLiberty/open-liberty/issues/28545
     public void testOLGH28545_1() throws Exception {
-        if (skipTestIfHibernate("SQLGrammarException: Syntax error with 'for update with rs'"))
-            return;
         deleteAllEntities(Package.class); // Cleanup any left over entities
 
         Package p1 = Package.of(1, 1.0f, 1.0f, 1.0f, "testOLGH28545-1");
@@ -819,10 +786,9 @@ public class JakartaDataRecreateServlet extends FATServlet {
     }
 
     @Test
+    @SkipForRepeat("JPA32_HIBERNATE")
     @SkipIfSysProp(DB_Oracle) //Reference issue: https://github.com/OpenLiberty/open-liberty/issues/28545
     public void testOLGH28545_2() throws Exception {
-        if (skipTestIfHibernate("SQLGrammarException: Syntax error with 'for update with rs'"))
-            return;
         deleteAllEntities(Package.class); // Cleanup any left over entities
 
         Package p1 = Package.of(1, 1.0f, 1.0f, 1.0f, "testOLGH28545-1");
@@ -872,10 +838,9 @@ public class JakartaDataRecreateServlet extends FATServlet {
     }
 
     @Test
+    @SkipForRepeat("JPA32_HIBERNATE")
     //Reference issue : https://github.com/OpenLiberty/open-liberty/issues/30444
     public void testOLGH30444() throws Exception {
-        if (skipTestIfHibernate("SQLGrammarException: Syntax error with 'for update with rs'"))
-            return;
         deleteAllEntities(Package.class);
 
         Package p1 = Package.of(1, 1.0f, 1.0f, 1.0f, "testOLGH28545-1");
@@ -906,10 +871,9 @@ public class JakartaDataRecreateServlet extends FATServlet {
     }
 
     @Test //Reference issue: https://github.com/OpenLiberty/open-liberty/issues/28545
+    @SkipForRepeat("JPA32_HIBERNATE")
     @SkipIfSysProp({ DB_Postgres, DB_Oracle })
     public void testOLGH28545_3() throws Exception {
-        if (skipTestIfHibernate("ClassCastException: PersistentBag incompatible with ArrayList"))
-            return;
         deleteAllEntities(Prime.class);
 
         Prime two = Prime.of(2, "II", "two");
@@ -970,9 +934,9 @@ public class JakartaDataRecreateServlet extends FATServlet {
     }
 
     @Test
+    @SkipForRepeat("JPA32_HIBERNATE")
     // @Ignore("Reference issue: https://github.com/OpenLiberty/open-liberty/issues/29073")
     public void testOLGH29073() throws Exception {
-        if (skipTestIfHibernateOnSQLServer("Foreign key constraint violation with collection tables")) return;
         
         deleteAllEntities(City.class);
 
@@ -1012,9 +976,9 @@ public class JakartaDataRecreateServlet extends FATServlet {
     }
 
     @Test
+    @SkipForRepeat("JPA32_HIBERNATE")
     //Reference issue: https://github.com/OpenLiberty/open-liberty/issues/29073
     public void testOLGH29073_WHERECLAUSE() throws Exception {
-        if (skipTestIfHibernateOnSQLServer("Foreign key constraint violation with collection tables")) return;
         
         deleteAllEntities(City.class);
 
@@ -1356,10 +1320,9 @@ public class JakartaDataRecreateServlet extends FATServlet {
     }
 
     @Test // Reference issue: https://github.com/OpenLiberty/open-liberty/issues/28737
+    @SkipForRepeat("JPA32_HIBERNATE")
     @SkipIfSysProp({ DB_Postgres, DB_SQLServer })
     public void testOLGH28737() throws Exception {
-        if (skipTestIfHibernate("EntityExistsException: A different object with the same identifier was already associated"))
-            return;
         deleteAllEntities(Box.class);
 
         Box cube = Box.of("testOLGH28737", 1, 1, 1);
@@ -1398,11 +1361,10 @@ public class JakartaDataRecreateServlet extends FATServlet {
     }
 
     @Test //Reference issue: https://github.com/OpenLiberty/open-liberty/issues/28289
+    @SkipForRepeat("JPA32_HIBERNATE")
     @SkipIfSysProp({ DB_Oracle })
     // DB2 resolved (Oracle outstanding): https://github.com/eclipse-ee4j/eclipselink/issues/2282
     public void testOLGH28289() throws Exception {
-        if (skipTestIfHibernate("SQLGrammarException: Syntax error with 'for update with rs'"))
-            return;
         deleteAllEntities(Package.class);
 
         Package p1 = Package.of(70071, 17.0f, 17.1f, 7.7f, "testOLGH28289#70071"); // tallest and smallest length
@@ -1699,6 +1661,7 @@ public class JakartaDataRecreateServlet extends FATServlet {
     }
 
     @Test //Reference issue: https://github.com/OpenLiberty/open-liberty/issues/29440
+    @SkipForRepeat("JPA32_HIBERNATE")
     @SkipIfSysProp({ DB_Postgres, DB_Oracle })
     public void testOLGH29440() throws Exception {
         deleteAllEntities(DemographicInfo.class);
@@ -1892,8 +1855,6 @@ public class JakartaDataRecreateServlet extends FATServlet {
     @Ignore("Reference issue: https://github.com/OpenLiberty/open-liberty/issues/30501")
     //Issue closed. Error is valid and now provides a meaningful message
     public void testOLGH30501() throws Exception {
-        if (skipTestIfHibernate("Hibernate fails when using constructor query"))
-            return;
         deleteAllEntities(Prime.class);
 
         List<RomanNumeral> result;
@@ -1922,8 +1883,6 @@ public class JakartaDataRecreateServlet extends FATServlet {
     //Original issue: https://github.com/OpenLiberty/open-liberty/issues/29475
     @Ignore("Additional issue: https://github.com/OpenLiberty/open-liberty/issues/28589")
     public void testOLGH29475() throws Exception {
-        if (skipTestIfHibernate("Hibernate fails when using constructor query"))
-            return;
         Rating.Reviewer jimmy = Rating.Reviewer.of("Jimothy", "Scramble", "J.Scramble@example.com");
         Rating.Item blueBerry = Rating.Item.of("BlueBerry 10", 299.99f);
         Rating rating = Rating.of(1001, blueBerry, 4, jimmy,
@@ -1978,10 +1937,9 @@ public class JakartaDataRecreateServlet extends FATServlet {
     }
 
     @Test
+    @SkipForRepeat("JPA32_HIBERNATE")
     //Reference issue: https://github.com/OpenLiberty/open-liberty/issues/29475 .This test includes issues in ElementCollection
     public void test_29475_ElementCollection() throws Exception {
-        if (skipTestIfHibernate("ClassCastException: PersistentBag incompatible with ArrayList"))
-            return;
         ECEntity e1 = new ECEntity();
         e1.setId("EC1");
         e1.setIntArray(new int[] { 14, 12, 1 });
@@ -2147,9 +2105,8 @@ public class JakartaDataRecreateServlet extends FATServlet {
     }
 
     @Test //Reference issue: https://github.com/OpenLiberty/open-liberty/issues/29460
+    @SkipForRepeat("JPA32_HIBERNATE")
     public void testOLGH29460() throws Exception {
-        if (skipTestIfHibernate("EntityExistsException: Detached entity passed to persist"))
-            return;
         // Setup test data using the factory method
         Participant p1 = Participant.of("John", "Doe", 1);
         Participant p2 = Participant.of("Jane", "Smith", 2);
@@ -2397,10 +2354,9 @@ public class JakartaDataRecreateServlet extends FATServlet {
     }
 
     @Test
+    @SkipForRepeat("JPA32_HIBERNATE")
     //Reference issue: https://github.com/OpenLiberty/open-liberty/issues/31558
     public void testOLGH31558() throws Exception {
-        if (skipTestIfHibernate("PropertyAccessException: Could not set value of PersistentBag"))
-            return;
         deleteCollectionTable("ShippingAddress_RECIPIENTINFO");
         deleteAllEntities(ShippingAddress.class);
 
@@ -2588,10 +2544,9 @@ public class JakartaDataRecreateServlet extends FATServlet {
     }
 
     @Test
+    @SkipForRepeat("JPA32_HIBERNATE")
     //Reference issue: https://github.com/OpenLiberty/open-liberty/issues/32867
     public void testOLGH32867() throws Exception {
-        if (skipTestIfHibernate("Hibernate fails when using constructor query"))
-            return;
         deleteAllEntities(Showtime.class);
 
         Showtime t1 = Showtime.of("Spiderman", LocalDateTime.now(),

--- a/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartapersistence/resources/jpa-3.2/web/WEB-INF/classes/META-INF/persistence.xml
+++ b/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartapersistence/resources/jpa-3.2/web/WEB-INF/classes/META-INF/persistence.xml
@@ -29,6 +29,8 @@
             <property name="hibernate.cache.use_second_level_cache" value="true"/>
             <property name="hibernate.cache.region.factory_class" value="org.hibernate.cache.jcache.internal.JCacheRegionFactory"/>
             <property name="hibernate.javax.cache.missing_cache_strategy" value="create"/>
+            <!-- ORA-43853: disable SecureFiles LOB syntax for non-ASSM tablespaces (e.g. SYSTEM) -->
+            <property name="hibernate.dialect.oracle.value_lob_enabled" value="false"/>
         </properties>
     </persistence-unit>
 </persistence>

--- a/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartapersistence/resources/jpa-3.2/web/WEB-INF/classes/META-INF/persistence.xml
+++ b/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartapersistence/resources/jpa-3.2/web/WEB-INF/classes/META-INF/persistence.xml
@@ -19,11 +19,16 @@
         version="3.2">
 
     <persistence-unit name="JakartaPersistenceUnit">
-    	<properties>
-   <!-- Drop and recreate the database schema automatically for clean test runs -->
-   <property name="jakarta.persistence.schema-generation.database.action" value="drop-and-create" />
-			<property name="eclipselink.logging.parameters" value="true"/>
-			<property name="hibernate.show_sql" value="true"/>
-		</properties>
+        <shared-cache-mode>ENABLE_SELECTIVE</shared-cache-mode>
+        <properties>
+            <!-- Drop and recreate the database schema automatically for clean test runs -->
+            <property name="jakarta.persistence.schema-generation.database.action" value="drop-and-create" />
+            <property name="eclipselink.logging.parameters" value="true"/>
+            <property name="hibernate.show_sql" value="true"/>
+            <!-- L2 cache via JCache/EHCache -->
+            <property name="hibernate.cache.use_second_level_cache" value="true"/>
+            <property name="hibernate.cache.region.factory_class" value="org.hibernate.cache.jcache.internal.JCacheRegionFactory"/>
+            <property name="hibernate.javax.cache.missing_cache_strategy" value="create"/>
+        </properties>
     </persistence-unit>
 </persistence>

--- a/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartapersistence/src/io/openliberty/jpa/persistence/tests/models/PersistenceUnitEntity.java
+++ b/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartapersistence/src/io/openliberty/jpa/persistence/tests/models/PersistenceUnitEntity.java
@@ -9,9 +9,11 @@
  *******************************************************************************/
 package io.openliberty.jpa.persistence.tests.models;
 
+import jakarta.persistence.Cacheable;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 
+@Cacheable
 @Entity
 public class PersistenceUnitEntity {
     @Id

--- a/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartapersistence/src/io/openliberty/jpa/persistence/tests/web/JakartaPersistenceServlet.java
+++ b/dev/com.ibm.ws.jpa.tests.jpa_32_fat/test-applications/jakartapersistence/src/io/openliberty/jpa/persistence/tests/web/JakartaPersistenceServlet.java
@@ -31,6 +31,7 @@ import static org.junit.Assert.assertTrue;
 import org.junit.Test;
 
 import componenttest.annotation.OnlyIfSysProp;
+import componenttest.annotation.SkipForRepeat;
 import static componenttest.annotation.OnlyIfSysProp.DB_Not_Default;
 import componenttest.annotation.SkipIfSysProp;
 import static componenttest.annotation.SkipIfSysProp.DB_DB2;
@@ -90,33 +91,6 @@ public class JakartaPersistenceServlet extends FATServlet {
     @Resource
     private UserTransaction tx;
     
-    /**
-     * Method to check if the test is running with Hibernate.
-     * Reads the 'repeat_phase' environment variable set in the test setup.
-     *
-     * @return true if running with Hibernate, false otherwise
-     */
-    private boolean isRunningWithHibernate() {
-        String repeatPhase = System.getenv("repeat_phase");
-        return repeatPhase != null && repeatPhase.contains("hibernate");
-    }
-
-    /**
-     * Skip test if running with Hibernate and log the reason.
-     * Usage: if (skipTestIfHibernate("reason")) return;
-     *
-     * @param reason the reason for skipping (error type or description)
-     * @return true if test should be skipped (running with Hibernate), false otherwise
-     */
-    private boolean skipTestIfHibernate(String reason) {
-        if (isRunningWithHibernate()) {
-            System.out.println("SKIPPING TEST - Running with Hibernate");
-            System.out.println("REASON: " + reason);
-            return true;
-        }
-        return false;
-    }
-
     @Test
     public void testGetNameReturnsPersistenceUnitName() {
         EntityManagerFactory emf = em.getEntityManagerFactory();
@@ -516,8 +490,8 @@ public class JakartaPersistenceServlet extends FATServlet {
     }
   
     @Test
+    @SkipForRepeat("JPA32_HIBERNATE")
     public void testRecordAsEmbeddable_NoMatchAndOrdering() throws Exception {
-        if (skipTestIfHibernate("EntityExistsException: Detached entity passed to persist")) return;
         // Clean up any existing data
         deleteAllEntities(Participant.class);
 
@@ -554,9 +528,9 @@ public class JakartaPersistenceServlet extends FATServlet {
     }
 
     @Test
+    @SkipForRepeat("JPA32_HIBERNATE")
     @SkipIfSysProp(DB_Oracle)
     public void testRecordAsEmbeddable_NullEdgeCaseAndOrdering() throws Exception {
-        if (skipTestIfHibernate("EntityExistsException: Detached entity passed to persist")) return;
         deleteAllEntities(Participant.class);
         
         // Setup test data with null, empty, and edge case values
@@ -1010,12 +984,12 @@ public class JakartaPersistenceServlet extends FATServlet {
     }
     
     @Test
+    @SkipForRepeat("JPA32_HIBERNATE")
     @SkipIfSysProp({
         DB_SQLServer, //Reference issue: https://github.com/OpenLiberty/open-liberty/issues/32957
         DB_Oracle //Oracle DB doesn't have any conversion function into TIME so whole TIMESTAMP is returned and result is converted to time in EclipseLink/Java
     })
     public void testExtractTimeFromLocalData() throws Exception {
-        if (skipTestIfHibernate("Hibernate fails when using constructor query")) return;
         deleteAllEntities(DateTimeEntity.class);
         DateTimeEntity q1 = new DateTimeEntity(1, "q1", LocalDate.of(2023, 3, 15), LocalTime.of(9, 30), LocalDateTime.of(2023, 3, 15, 9, 30));
         DateTimeEntity q2 = new DateTimeEntity(2, "q2", LocalDate.of(2022, 8, 22), LocalTime.of(14, 45), LocalDateTime.of(2022, 8, 22, 14, 45));
@@ -1050,8 +1024,8 @@ public class JakartaPersistenceServlet extends FATServlet {
     }
     
     @Test
+    @SkipForRepeat("JPA32_HIBERNATE")
     public void testExtractDateFromLocalData() throws Exception {
-        if (skipTestIfHibernate("Hibernate fails when using constructor query")) return;
         deleteAllEntities(DateTimeEntity.class);
         DateTimeEntity q1 = new DateTimeEntity(1, "q1", LocalDate.of(2023, 3, 15), LocalTime.of(9, 30), LocalDateTime.of(2023, 3, 15, 9, 30));
         DateTimeEntity q2 = new DateTimeEntity(2, "q2", LocalDate.of(2022, 8, 22), LocalTime.of(14, 45), LocalDateTime.of(2022, 8, 22, 14, 45));
@@ -1087,8 +1061,8 @@ public class JakartaPersistenceServlet extends FATServlet {
     }
 
     @Test
+    @SkipForRepeat("JPA32_HIBERNATE")
     public void testExtractWeekFromLocalData() throws Exception {
-        if (skipTestIfHibernate("Hibernate fails when using constructor query")) return;
         deleteAllEntities(DateTimeEntity.class);
         // Using dates that fall in the same ISO week
         DateTimeEntity q1 = new DateTimeEntity(1, "q1", LocalDate.of(2024, 1, 8), LocalTime.of(10, 15), LocalDateTime.of(2024, 1, 8, 10, 15));   // Week 2 of 2024
@@ -1125,8 +1099,8 @@ public class JakartaPersistenceServlet extends FATServlet {
     }
 
     @Test
+    @SkipForRepeat("JPA32_HIBERNATE")
     public void testExtractQuarterFromLocalDataWithJPQL() throws Exception {
-        if (skipTestIfHibernate("Hibernate fails when using constructor query")) return;
         deleteAllEntities(DateTimeEntity.class);
         DateTimeEntity q1 = new DateTimeEntity(1, "q1", LocalDate.of(2023, 2, 15), LocalTime.of(8, 30), LocalDateTime.of(2023, 2, 15, 8, 30));   // Q1
         DateTimeEntity q2 = new DateTimeEntity(2, "q2", LocalDate.of(2023, 7, 20), LocalTime.of(14, 15), LocalDateTime.of(2023, 7, 20, 14, 15)); // Q3
@@ -1162,8 +1136,8 @@ public class JakartaPersistenceServlet extends FATServlet {
     }
     
     @Test
+    @SkipForRepeat("JPA32_HIBERNATE")
     public void testExtractMonthFromLocalData() throws Exception {
-        if (skipTestIfHibernate("Hibernate fails when using constructor query")) return;
         deleteAllEntities(DateTimeEntity.class);
         DateTimeEntity q1 = new DateTimeEntity(1, "q1", LocalDate.of(2023, 03, 15), LocalTime.of(9, 30), LocalDateTime.of(2023, 03, 15, 9, 30));
         DateTimeEntity q2 = new DateTimeEntity(2, "q2", LocalDate.of(2022, 8, 22), LocalTime.of(14, 45), LocalDateTime.of(2022, 8, 22, 14, 45));
@@ -1197,8 +1171,8 @@ public class JakartaPersistenceServlet extends FATServlet {
     }
     
     @Test
+    @SkipForRepeat("JPA32_HIBERNATE")
     public void testExtractYearFromLocalDataWithJPQL() throws Exception {
-        if (skipTestIfHibernate("Hibernate fails when using constructor query")) return;
         deleteAllEntities(DateTimeEntity.class);
         DateTimeEntity q1 = new DateTimeEntity(1, "q1", LocalDate.of(2023, 4, 18), LocalTime.of(10, 45), LocalDateTime.of(2023, 4, 18, 10, 45));
         DateTimeEntity q2 = new DateTimeEntity(2, "q2", LocalDate.of(2022, 6, 25), LocalTime.of(16, 20), LocalDateTime.of(2022, 6, 25, 16, 20));
@@ -1233,8 +1207,8 @@ public class JakartaPersistenceServlet extends FATServlet {
     }
     
     @Test
+    @SkipForRepeat("JPA32_HIBERNATE")
     public void testExtractDayFromLocalData() throws Exception {
-        if (skipTestIfHibernate("Hibernate fails when using constructor query")) return;
         deleteAllEntities(DateTimeEntity.class);
         DateTimeEntity q1 = new DateTimeEntity(1, "q1", LocalDate.of(2023, 3, 25), LocalTime.of(9, 30), LocalDateTime.of(2023, 3, 25, 9, 30));
         DateTimeEntity q2 = new DateTimeEntity(2, "q2", LocalDate.of(2022, 8, 12), LocalTime.of(14, 45), LocalDateTime.of(2022, 8, 12, 14, 45));
@@ -1269,8 +1243,8 @@ public class JakartaPersistenceServlet extends FATServlet {
     }
 
     @Test
+    @SkipForRepeat("JPA32_HIBERNATE")
     public void testExtractHourFromLocalData() throws Exception {
-        if (skipTestIfHibernate("Hibernate fails when using constructor query")) return;
         deleteAllEntities(DateTimeEntity.class);
         DateTimeEntity q1 = new DateTimeEntity(1, "q1", LocalDate.of(2023, 5, 10), LocalTime.of(14, 30), LocalDateTime.of(2023, 5, 10, 14, 30));
         DateTimeEntity q2 = new DateTimeEntity(2, "q2", LocalDate.of(2022, 7, 15), LocalTime.of(9, 45), LocalDateTime.of(2022, 7, 15, 9, 45));
@@ -1305,8 +1279,8 @@ public class JakartaPersistenceServlet extends FATServlet {
     }
 
     @Test
+    @SkipForRepeat("JPA32_HIBERNATE")
     public void testExtractMinuteFromLocalData() throws Exception {
-        if (skipTestIfHibernate("Hibernate fails when using constructor query")) return;
         deleteAllEntities(DateTimeEntity.class);
         DateTimeEntity q1 = new DateTimeEntity(1, "q1", LocalDate.of(2023, 4, 18), LocalTime.of(10, 45), LocalDateTime.of(2023, 4, 18, 10, 45));
         DateTimeEntity q2 = new DateTimeEntity(2, "q2", LocalDate.of(2022, 6, 25), LocalTime.of(16, 20), LocalDateTime.of(2022, 6, 25, 16, 20));
@@ -1341,8 +1315,8 @@ public class JakartaPersistenceServlet extends FATServlet {
     }
 
     @Test
+    @SkipForRepeat("JPA32_HIBERNATE")
     public void testExtractSecondFromLocalData() throws Exception {
-        if (skipTestIfHibernate("Hibernate fails when using constructor query")) return;
         deleteAllEntities(DateTimeEntity.class);
         DateTimeEntity q1 = new DateTimeEntity(1, "q1", LocalDate.of(2023, 2, 14), LocalTime.of(13, 25, 30), LocalDateTime.of(2023, 2, 14, 13, 25, 30));
         DateTimeEntity q2 = new DateTimeEntity(2, "q2", LocalDate.of(2022, 11, 8), LocalTime.of(17, 50, 15), LocalDateTime.of(2022, 11, 8, 17, 50, 15));
@@ -1444,7 +1418,6 @@ public class JakartaPersistenceServlet extends FATServlet {
     
     @Test
     public void testCacheRetrieveMode_EMLevel_Use_Default() throws Exception {
-        if (skipTestIfHibernate("Assertion failure: null value returned")) return;
         deleteAllEntities(PersistenceUnitEntity.class);
         String id = "testCacheRetrieveMode_EMLevel_Use_Default";
 
@@ -1452,6 +1425,7 @@ public class JakartaPersistenceServlet extends FATServlet {
         em.persist(PersistenceUnitEntity.of(id, 222));
         em.flush();
         tx.commit();
+        em.clear();
 
         tx.begin();
         PersistenceUnitEntity entity;
@@ -1463,11 +1437,9 @@ public class JakartaPersistenceServlet extends FATServlet {
             update.setParameter(1, id);
             update.executeUpdate();
             
-            Query query = em.createQuery("FROM PersistenceUnitEntity WHERE id = ?1");
-            query.setParameter(1, id);
-            entity = (PersistenceUnitEntity) query.getSingleResult();
-
+            entity = em.find(PersistenceUnitEntity.class, id);
             tx.commit();
+
         } catch (Exception e) {
             tx.rollback();
             throw e;
@@ -1479,7 +1451,6 @@ public class JakartaPersistenceServlet extends FATServlet {
     @Test
     //Reference issue: https://github.com/OpenLiberty/open-liberty/issues/33189
     public void testCacheRetrieveMode_QueryLevel_Bypass() throws Exception {
-        if (skipTestIfHibernate("NullPointerException: Cannot invoke getCacheMode()")) return;
         deleteAllEntities(PersistenceUnitEntity.class);
         String id = "testCacheRetrieveMode_QueryLevel_Bypass";
 
@@ -1511,8 +1482,8 @@ public class JakartaPersistenceServlet extends FATServlet {
     }
     
     @Test
+    @SkipForRepeat("JPA32_HIBERNATE")
     public void testCacheRetrieveMode_QueryLevel_Use_Default() throws Exception {
-        if (skipTestIfHibernate("Assertion failure: null value returned")) return;
         deleteAllEntities(PersistenceUnitEntity.class);
         String id = "testCacheRetrieveMode_QueryLevel_Use_Default";
 
@@ -1520,6 +1491,7 @@ public class JakartaPersistenceServlet extends FATServlet {
         em.persist(PersistenceUnitEntity.of(id, 222));
         em.flush();
         tx.commit();
+        em.clear();
 
         tx.begin();
         PersistenceUnitEntity entity;
@@ -1544,9 +1516,9 @@ public class JakartaPersistenceServlet extends FATServlet {
     }
 
     @Test
+    @SkipForRepeat("JPA32_HIBERNATE")
     //Reference issue: https://github.com/OpenLiberty/open-liberty/issues/33189
     public void testCacheRetrieveMode_QueryOverridesEM_UseOverridesBypass() throws Exception {
-        if (skipTestIfHibernate("NullPointerException: Cannot invoke getCacheMode()")) return;
         deleteAllEntities(PersistenceUnitEntity.class);
         String id = "testCacheRetrieveMode_QueryOverridesEM_UseOverridesBypass";
 
@@ -1554,6 +1526,7 @@ public class JakartaPersistenceServlet extends FATServlet {
         em.persist(PersistenceUnitEntity.of(id, 222));
         em.flush();
         tx.commit();
+        em.clear();
 
         tx.begin();
         PersistenceUnitEntity entity;
@@ -1584,7 +1557,6 @@ public class JakartaPersistenceServlet extends FATServlet {
     @Test
     //Reference issue: https://github.com/OpenLiberty/open-liberty/issues/33189
     public void testCacheRetrieveMode_QueryOverridesEM_BypassOverridesUse() throws Exception {
-        if (skipTestIfHibernate("NullPointerException: Cannot invoke getCacheMode()")) return;
         deleteAllEntities(PersistenceUnitEntity.class);
         String id = "testCacheRetrieveMode_QueryOverridesEM_BypassOverridesUse";
 
@@ -1651,7 +1623,6 @@ public class JakartaPersistenceServlet extends FATServlet {
     @Test
     //Reference issue: https://github.com/OpenLiberty/open-liberty/issues/33189
     public void testCacheStoreMode_EMLevel_Use_Default() throws Exception {
-        if (skipTestIfHibernate("Assertion failure: null value returned")) return;
         deleteAllEntities(PersistenceUnitEntity.class);
         String id = "testCacheStoreMode_EMLevel_Use_Default";
 
@@ -1682,7 +1653,6 @@ public class JakartaPersistenceServlet extends FATServlet {
     @Test
     //Reference issue: https://github.com/OpenLiberty/open-liberty/issues/33189
     public void testCacheStoreMode_QueryLevel_Bypass() throws Exception {
-        if (skipTestIfHibernate("NullPointerException: Cannot invoke getCacheMode()")) return;
         deleteAllEntities(PersistenceUnitEntity.class);
         String id = "testCacheStoreMode_QueryLevel_Bypass";
 
@@ -1711,7 +1681,6 @@ public class JakartaPersistenceServlet extends FATServlet {
     
     @Test
     public void testCacheStoreMode_QueryLevel_Use_default() throws Exception {
-        if (skipTestIfHibernate("Assertion failure: null value returned")) return;
         deleteAllEntities(PersistenceUnitEntity.class);
         String id = "testCacheStoreMode_QueryLevel_Use_default";
 
@@ -1743,7 +1712,6 @@ public class JakartaPersistenceServlet extends FATServlet {
     @Test
     //Reference issue: https://github.com/OpenLiberty/open-liberty/issues/33189
     public void testCacheStoreMode_QueryOverridesEM_UseOverridesBypass() throws Exception {
-        if (skipTestIfHibernate("NullPointerException: Cannot invoke getCacheMode()")) return;
         deleteAllEntities(PersistenceUnitEntity.class);
         String id = "testCacheStoreMode_QueryOverridesEM_UseOverridesBypass";
 
@@ -1776,7 +1744,6 @@ public class JakartaPersistenceServlet extends FATServlet {
     @Test
     //Reference issue: https://github.com/OpenLiberty/open-liberty/issues/33189
     public void testCacheStoreMode_QueryOverridesEM_BypassOverridesUse() throws Exception {
-        if (skipTestIfHibernate("NullPointerException: Cannot invoke getCacheMode()")) return;
         deleteAllEntities(PersistenceUnitEntity.class);
         String id = "testCacheStoreMode_QueryOverridesEM_BypassOverridesUse";
         
@@ -1807,7 +1774,6 @@ public class JakartaPersistenceServlet extends FATServlet {
     @Test
     //Reference issue: https://github.com/OpenLiberty/open-liberty/issues/33189
     public void testCacheStoreMode_EMLevel_Refresh() throws Exception {
-        if (skipTestIfHibernate("Assertion failure: null value returned")) return;
         deleteAllEntities(PersistenceUnitEntity.class);
         String id = "testCacheStoreMode_EMLevel_Refresh";
 
@@ -1840,7 +1806,6 @@ public class JakartaPersistenceServlet extends FATServlet {
     @Test
     //Reference issue: https://github.com/OpenLiberty/open-liberty/issues/33189
     public void testCacheStoreMode_QueryLevel_Refresh() throws Exception {
-        if (skipTestIfHibernate("NullPointerException: Cannot invoke getCacheMode()")) return;
         deleteAllEntities(PersistenceUnitEntity.class);
         String id = "testCacheStoreMode_QueryLevel_Refresh";
 
@@ -1870,7 +1835,6 @@ public class JakartaPersistenceServlet extends FATServlet {
     @Test
     //Reference issue: https://github.com/OpenLiberty/open-liberty/issues/33189
     public void testCacheStoreMode_QueryOverridesEM_RefreshOverridesBypass() throws Exception {
-        if (skipTestIfHibernate("NullPointerException: Cannot invoke getCacheMode()")) return;
         deleteAllEntities(PersistenceUnitEntity.class);
         String id = "testCacheStoreMode_QueryOverridesEM_RefreshOverridesBypass";
 
@@ -1904,7 +1868,6 @@ public class JakartaPersistenceServlet extends FATServlet {
     @Test
     //Reference issue: https://github.com/OpenLiberty/open-liberty/issues/33189
     public void testCacheStoreMode_QueryOverridesEM_BypassOverridesRefresh() throws Exception {
-        if (skipTestIfHibernate("NullPointerException: Cannot invoke getCacheMode()")) return;
         deleteAllEntities(PersistenceUnitEntity.class);
         String id = "testCacheStoreMode_QueryOverridesEM_BypassOverridesRefresh";
 
@@ -1969,8 +1932,8 @@ public class JakartaPersistenceServlet extends FATServlet {
     }
     
     @Test
+    @SkipForRepeat("JPA32_HIBERNATE")
     public void testYearConversionError() throws Exception {
-        if (skipTestIfHibernate("SemanticException: Could not interpret path expression 'YEARVALUE'")) return;
         PartialDateEntity entity2022 = new PartialDateEntity();
         entity2022.setYear(Year.of(2022));
         entity2022.setBestDay(MonthDay.of(12, 25));
@@ -2019,8 +1982,8 @@ public class JakartaPersistenceServlet extends FATServlet {
     }
 
     @Test
+    @SkipForRepeat("JPA32_HIBERNATE")
     public void testConstructorExpressionWithCasePrimitiveLong() throws Exception {
-        if (skipTestIfHibernate("Hibernate fails when using constructor query")) return;
         deleteAllEntities(SimpleEmployee.class);
 
         SimpleEmployee emp1 = new SimpleEmployee("Tony", 35000L);


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

Upgraded Hibernate version to 7.4.4.Final which fixes the error with JPA 3.2 methods — `setCacheStoreMode` and `setCacheRetrieveMode` . Also configured L2 cache in JPA 3.2 FAT using JCache/Ehcache.
Replaced condition based return strategy for skipping tests with annotation `@SkipForRepeat("JPA32_HIBERNATE")`