### PR TITLE
fixing issue Co-authored-by-AI: IBM Bob 2.0.0

### DIFF
--- a/dev/com.ibm.ws.ui.tool.explore/resources/WEB-CONTENT/jsExplore/resources/_notifications/pushNotifications.js
+++ b/dev/com.ibm.ws.ui.tool.explore/resources/WEB-CONTENT/jsExplore/resources/_notifications/pushNotifications.js
@@ -1,3 +1,5 @@
+dev/com.ibm.ws.ui.tool.explore/resources/WEB-CONTENT/jsExplore/resources/_notifications/pushNotifications.js
+
 /*******************************************************************************
  * Copyright (c) 2015 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
@@ -37,7 +39,7 @@ define([ 'dojo/Deferred', '../_topicUtil' ], function(Deferred, topicUtil) {
     start: function() {
       console.log("Attempting to start the push notification mechanism. This relies on websockets, which may not be enabled on the Admin Center server");
       connectionAttempt = new Deferred();
-      var websocket = createWebSocket(createNotifyURL());
+      websocket = createWebSocket(createNotifyURL());
       // IE9 fix
       if (websocket !== null && websocket !== undefined) {
         console.log('Created WebSocket for URL: ' + websocket.url, websocket);
@@ -107,6 +109,16 @@ define([ 'dojo/Deferred', '../_topicUtil' ], function(Deferred, topicUtil) {
     var i;
     for (i = 0; i < updates.length; i++) {
       var update = updates[i];
+      // Ensure getTopic() can resolve appOnServer / appOnCluster topics.
+      // The WS payload may carry flat ids; reconstruct the nested form expected by _topicUtil.
+      if (update.type === 'appOnServer' && update.serverId && !update.server) {
+        update.server = { id: update.serverId };
+      }
+      if ((update.type === 'appOnCluster' || update.type === 'appsOnCluster' ||
+           update.type === 'serversOnCluster' || update.type === 'appInstancesByCluster') &&
+           update.clusterId && !update.cluster) {
+        update.cluster = { id: update.clusterId };
+      }
       topicUtil.publish(topicUtil.getTopic(update), update);
     }
   }

--- a/dev/com.ibm.ws.ui.tool.explore/resources/WEB-CONTENT/jsExplore/resources/_notifications/pushNotifications.js
+++ b/dev/com.ibm.ws.ui.tool.explore/resources/WEB-CONTENT/jsExplore/resources/_notifications/pushNotifications.js
@@ -1,5 +1,3 @@
-dev/com.ibm.ws.ui.tool.explore/resources/WEB-CONTENT/jsExplore/resources/_notifications/pushNotifications.js
-
 /*******************************************************************************
  * Copyright (c) 2015 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials

--- a/dev/com.ibm.ws.ui.tool.explore/resources/WEB-CONTENT/jsExplore/resources/_notifications/uclCommon.js
+++ b/dev/com.ibm.ws.ui.tool.explore/resources/WEB-CONTENT/jsExplore/resources/_notifications/uclCommon.js
@@ -71,6 +71,11 @@ define([ ], function() {
      * @return {Object} Returns an Object with an added and removed field or null if the array contents are the same
      */
     compareTwoLists: function(cachedList, nowList) {
+      // Guard against undefined inputs (e.g. stale cache after WS session)
+      if (!cachedList || !nowList) {
+       return null;
+      }
+
       var addedRemoved = { added: [], removed: [] };
 
       // First, find things that were 'added'
@@ -105,6 +110,11 @@ define([ ], function() {
      *                  or null if the IDs of the elements in the arrays of objects are the same.
      */
     compareTwoListsById: function(cachedList, nowList) {
+      // Guard against undefined inputs (e.g. stale cache after WS session)
+      if (!cachedList || !nowList) {
+       return null;
+      }
+
       var addedRemoved = { added: [], removed: [] };
 
       // First, find things that were 'added'


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).

Fixes #293545 and Fixes #295185 which have been intermittent issues since the original version of the Admin Center. (Hopefully)

**Changes in pushNotifications.js** - 
Root cause. pushNotifications.js:110 calls topicUtil.getTopic(update) where update is the
raw WS payload. For appOnServer the topic builder at _topicUtil.js:175-176 requires
resource.server.id, and for appOnCluster it requires resource.cluster.id. If the server's WS
push payload instead carries a flat serverId / clusterId field (or the nesting is absent), those
branches fall through to the else at line 191 which calls __getTopicByType(resource.type,
resource.id) — producing a topic like /explore/apps/myApp instead of
/explore/servers/host,/wlp/,server1/apps/myApp. No subscriber is listening on the wrong
topic; the event is silently discarded

Previously the var declaration created a function-scoped shadow, so the module-level websocket
stayed null, making stop() unable to close the socket and allowing multiple orphaned sockets to
accumulate across reconnect cycles.

**uclCommon.js**
Fix — guard in compareTwoLists
The simplest, most defensive fix is a null-guard at the top of the shared utility

