### PR TITLE
PasswordUtil.encode() misinterprets {algo} plaintext as ciphertext

### DIFF
--- a/dev/com.ibm.ws.crypto.passwordutil/src/com/ibm/websphere/crypto/PasswordUtil.java
+++ b/dev/com.ibm.ws.crypto.passwordutil/src/com/ibm/websphere/crypto/PasswordUtil.java
@@ -264,12 +264,17 @@ public class PasswordUtil {
 
         String current_crypto_algorithm = getCryptoAlgorithm(decoded_string);
 
-        if ((current_crypto_algorithm != null && current_crypto_algorithm.startsWith(crypto_algorithm)) || isHashed(decoded_string)) {
-            // don't accept encoded password
+        if ((current_crypto_algorithm != null && isValidCryptoAlgorithm(current_crypto_algorithm)
+             && current_crypto_algorithm.startsWith(crypto_algorithm)) || isHashed(decoded_string)) {
+            // don't accept already-encoded password
             throw new InvalidPasswordEncodingException();
-        } else if (current_crypto_algorithm != null) {
+        } else if (current_crypto_algorithm != null && isValidCryptoAlgorithm(current_crypto_algorithm)) {
+            // password is encoded with a different valid algorithm — decode it first, then re-encode
             decoded_string = passwordDecode(decoded_string);
         }
+        // If current_crypto_algorithm is non-null but NOT a valid crypto algorithm, the input string
+        // merely starts with a {something} pattern (e.g. a vault-generated password like "{abc}def").
+        // In that case we treat the entire string as literal plaintext and fall through to encode it.
         if (properties == null || !properties.containsKey(PROPERTY_NO_TRIM) || !"true".equalsIgnoreCase(properties.get(PROPERTY_NO_TRIM))) {
             decoded_string = decoded_string.trim();
         }

--- a/dev/com.ibm.ws.crypto.passwordutil/src/com/ibm/websphere/crypto/PasswordUtil.java
+++ b/dev/com.ibm.ws.crypto.passwordutil/src/com/ibm/websphere/crypto/PasswordUtil.java
@@ -263,18 +263,33 @@ public class PasswordUtil {
         }
 
         String current_crypto_algorithm = getCryptoAlgorithm(decoded_string);
+        // Exclude empty algorithm ("{}prefix") from isValidCurrentAlgorithm — an empty tag is not
+        // a real encoding, so a password like "{}testtest" must be treated as literal plaintext
+        // and encoded in full, preserving the {} characters in the round-trip.
+        boolean isValidCurrentAlgorithm = current_crypto_algorithm != null
+                                          && !current_crypto_algorithm.isEmpty()
+                                          && isValidCryptoAlgorithm(current_crypto_algorithm);
 
-        if ((current_crypto_algorithm != null && isValidCryptoAlgorithm(current_crypto_algorithm)
-             && current_crypto_algorithm.startsWith(crypto_algorithm)) || isHashed(decoded_string)) {
-            // don't accept already-encoded password
+        if (isHashed(decoded_string)) {
+            // Reject already-hashed passwords
             throw new InvalidPasswordEncodingException();
-        } else if (current_crypto_algorithm != null && isValidCryptoAlgorithm(current_crypto_algorithm)) {
+        }
+
+        if (isValidCurrentAlgorithm && current_crypto_algorithm.startsWith(crypto_algorithm)) {
+            // Reject passwords already encoded with the target algorithm
+            throw new InvalidPasswordEncodingException();
+        }
+
+        if (isValidCurrentAlgorithm) {
             // password is encoded with a different valid algorithm — decode it first, then re-encode
             decoded_string = passwordDecode(decoded_string);
         }
-        // If current_crypto_algorithm is non-null but NOT a valid crypto algorithm, the input string
-        // merely starts with a {something} pattern (e.g. a vault-generated password like "{abc}def").
-        // In that case we treat the entire string as literal plaintext and fall through to encode it.
+        // If current_crypto_algorithm is non-null but isValidCurrentAlgorithm is false, the input
+        // string merely starts with a {something} pattern (e.g. a vault-generated password like
+        // "{abc}def"). In that case we treat the entire string as literal plaintext and fall through
+        // to encode it. Note: {custom} and {custom:alias} are recognised by isValidCryptoAlgorithm()
+        // when the CustomPasswordEncryption OSGi service is active, so they correctly take the
+        // decode-then-re-encode path above.
         if (properties == null || !properties.containsKey(PROPERTY_NO_TRIM) || !"true".equalsIgnoreCase(properties.get(PROPERTY_NO_TRIM))) {
             decoded_string = decoded_string.trim();
         }

--- a/dev/com.ibm.ws.crypto.passwordutil/test/com/ibm/websphere/crypto/PasswordUtilTest.java
+++ b/dev/com.ibm.ws.crypto.passwordutil/test/com/ibm/websphere/crypto/PasswordUtilTest.java
@@ -182,6 +182,20 @@ public class PasswordUtilTest {
         } catch (InvalidPasswordEncodingException e) {
             // expected
         }
+
+        // Reviewer-suggested patterns — all 5 must encode and round-trip correctly as literal plaintext.
+        //
+        // "{}"   — getCryptoAlgorithm returns "" → isEmpty() guard → isValidCurrentAlgorithm=false → plaintext
+        // "{}a"  — same as above
+        // "{a}"  — getCryptoAlgorithm returns "a" → not a valid algorithm → plaintext
+        // "{a}b" — getCryptoAlgorithm returns "a" → not a valid algorithm → plaintext
+        // "a{}"  — does not start with '{' → getCryptoAlgorithm returns null → plaintext
+        String[] reviewerPatterns = new String[] { "{}", "{}a", "{a}", "{a}b", "a{}" };
+        for (String plain : reviewerPatterns) {
+            String encoded = PasswordUtil.encode(plain, "xor");
+            assertTrue("Pattern '" + plain + "' should encode to {xor}...: " + encoded, encoded.startsWith("{xor}"));
+            assertEquals("Pattern '" + plain + "' must round-trip correctly", plain, PasswordUtil.decode(encoded));
+        }
     }
 
     /**

--- a/dev/com.ibm.ws.crypto.passwordutil/test/com/ibm/websphere/crypto/PasswordUtilTest.java
+++ b/dev/com.ibm.ws.crypto.passwordutil/test/com/ibm/websphere/crypto/PasswordUtilTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009, 2025 IBM Corporation and others.
+ * Copyright (c) 2009, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -145,6 +145,59 @@ public class PasswordUtilTest {
         } catch (Throwable t) {
             outputMgr.failWithThrowable("testUtil", t);
         }
+    }
+
+    /**
+     * TS022437211 - Passwords that begin with a {something} pattern (e.g. vault/PIM-generated
+     * passphrases like "{abc}def" or "{redacted}***{/redacted}") must be treated as literal
+     * plaintext and encoded successfully rather than misinterpreted as pre-encoded ciphertext.
+     *
+     * Before the fix, encode() would either:
+     *   (a) silently return a truncated/empty result (XOR case observed by Keith), or
+     *   (b) throw NullPointerException from decoded_string.trim() after passwordDecode() returned null.
+     */
+    @Test
+    public void testEncodePasswordStartingWithCurlyBracePattern() throws Exception {
+        // Simple {something}value pattern — must encode to a valid {xor}... string and round-trip correctly
+        String plain1 = "{abc}def";
+        String encoded1 = PasswordUtil.encode(plain1, "xor");
+        assertTrue("Encoded password should start with {xor}: " + encoded1, encoded1.startsWith("{xor}"));
+        assertEquals("Round-trip decode must return the original plaintext", plain1, PasswordUtil.decode(encoded1));
+
+        // Pattern that triggered NPE in the customer's environment: {redacted}...{/redacted}
+        String plain2 = "{redacted}************{/redacted}";
+        String encoded2 = PasswordUtil.encode(plain2, "xor");
+        assertTrue("Encoded password should start with {xor}: " + encoded2, encoded2.startsWith("{xor}"));
+        assertEquals("Round-trip decode must return the original plaintext", plain2, PasswordUtil.decode(encoded2));
+
+        // Same patterns encoded with AES
+        String encoded3 = PasswordUtil.encode(plain1, "aes");
+        assertTrue("Encoded password should start with {aes}: " + encoded3, encoded3.startsWith("{aes}"));
+        assertEquals("Round-trip AES decode must return the original plaintext", plain1, PasswordUtil.decode(encoded3));
+
+        // Verify that a genuinely already-encoded password still correctly throws InvalidPasswordEncodingException
+        try {
+            PasswordUtil.encode("{xor}CDo9Hgw=", "xor");
+            fail("Should have thrown InvalidPasswordEncodingException for an already-xor-encoded password");
+        } catch (InvalidPasswordEncodingException e) {
+            // expected
+        }
+    }
+
+    /**
+     * TS022437211 - Verify that encode() with an explicit crypto key also handles passwords
+     * starting with {something} correctly (three-argument overload used by the customer).
+     */
+    @Test
+    public void testEncodeWithKeyPasswordStartingWithCurlyBracePattern() throws Exception {
+        String cryptoKey = "MyCustomEncryptionKey123!";
+
+        // Reproduces the exact customer scenario from the support case
+        String plain = "{mySecretPassword123}";
+        String encoded = PasswordUtil.encode(plain, "xor", cryptoKey);
+        assertFalse("Encoded result must not be just {xor} with empty payload: " + encoded, "{xor}".equals(encoded));
+        assertTrue("Encoded password should start with {xor}: " + encoded, encoded.startsWith("{xor}"));
+        assertEquals("Round-trip decode must return the original plaintext", plain, PasswordUtil.decode(encoded));
     }
 
     @Test


### PR DESCRIPTION
- [X] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [X] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [X] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

## Overview 
Passwords starting with a {something} pattern (e.g. vault/PIM-generated passphrases like '{abc}def' or '{redacted}***{/redacted}') were being misinterpreted as already-encoded values by PasswordUtil.encode().

## Root cause:
In encode(String, String, Map), getCryptoAlgorithm() returns a non-null token for any string matching the {.*} pattern at the start. The code then unconditionally attempted to decode the string before re-encoding, without first checking whether the extracted token is actually a valid crypto algorithm (xor, aes, hash, or custom).

This caused two failure modes:
1. NullPointerException: passwordDecode() returned null when the bogus algorithm caused decipher to fail, and decoded_string.trim() at line 274 threw NPE. Seen with '{redacted}***{/redacted}' inputs.
2. Silent data loss: for XOR, the internal decode returned an empty string, producing '{xor}' with no ciphertext payload. Confirmed by Keith Jabcuga's recreation program

## Fix:
Add isValidCryptoAlgorithm() guards to both the throw-on-already-encoded branch and the decode-then-re-encode branch. A {something} pattern in the input is now only acted upon when 'something' is a known algorithm. Literal plaintext passwords with curly-brace patterns fall through and are encoded directly as plaintext, which is the correct behaviour.

## Existing behaviour is preserved:
- Already-encoded passwords still throw InvalidPasswordEncodingException.
- Passwords encoded with a different valid algorithm are still decoded and re-encoded as before.

## Tests added in PasswordUtilTest:
- testEncodePasswordStartingWithCurlyBracePattern
- testEncodeWithKeyPasswordStartingWithCurlyBracePattern

Fixes #35243