### PR TITLE
Adjust MCP Tool arg processing for new API

### DIFF
--- a/dev/io.openliberty.mcp.internal/resources/io/openliberty/mcp/internal/resources/CWMCM.nlsprops
+++ b/dev/io.openliberty.mcp.internal/resources/io/openliberty/mcp/internal/resources/CWMCM.nlsprops
@@ -59,13 +59,6 @@ CWMCM0006E.duplicate.special.arguments.explanation=One or more special arguments
 CWMCM0006E.duplicate.special.arguments.useraction=Remove the extra instances.
 
 # Used for server logging
-# {0} = The fully qualified method name
-# {1} = The parameter type simple name
-CWMCM0007E.invalid.arguments=CWMCM0007E: The {0} MCP Tool has a parameter of type {1} which is not a recognized special argument type and does not have a `@ToolArg` annotation.
-CWMCM0007E.invalid.arguments.explanation=One or more parameters were not annotated as tool arguments and are not recognized special argument types.
-CWMCM0007E.invalid.arguments.useraction=Check whether you have the correct class imported for your argument, or you meant to include @ToolArg.
-
-# Used for server logging
 # do not translate MCP
 # {0} = The MCP server endpoint URL
 CWMCM0008I.mcp.endpoint.url=CWMCM0008I: The MCP server endpoint: {0}

--- a/dev/io.openliberty.mcp.internal/src/io/openliberty/mcp/internal/McpCdiExtension.java
+++ b/dev/io.openliberty.mcp.internal/src/io/openliberty/mcp/internal/McpCdiExtension.java
@@ -14,6 +14,7 @@ import static io.openliberty.mcp.internal.encoders.EncoderRegistry.DEFAULT_ENCOD
 import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -156,8 +157,7 @@ public class McpCdiExtension implements Extension {
             error |= reportOnInvalidToolNames(afterDeploymentValidation, toolRegistry) |
                      reportOnDuplicateTools(afterDeploymentValidation, toolRegistry) |
                      reportOnToolArgEdgeCases(afterDeploymentValidation, toolRegistry) |
-                     reportOnDuplicateSpecialArguments(afterDeploymentValidation, toolRegistry) |
-                     reportOnInvalidSpecialArguments(afterDeploymentValidation, toolRegistry);
+                     reportOnDuplicateSpecialArguments(afterDeploymentValidation, toolRegistry);
         }
 
         if (error) {
@@ -349,44 +349,20 @@ public class McpCdiExtension implements Extension {
                 continue;
             }
             MethodMetadata methodMetadata = tool.methodMetadata().get();
-            Map<SpecialArgumentType.Resolution, Integer> resultCountMap = new HashMap<>();
+            Map<SpecialArgumentType, Integer> argCountMap = new EnumMap<>(SpecialArgumentType.class);
             for (SpecialArgumentMetadata specialArgument : methodMetadata.specialArguments()) {
-                SpecialArgumentType.Resolution specialArgumentTypeResolution = specialArgument.typeResolution();
-                if (specialArgumentTypeResolution.specialArgsType() == SpecialArgumentType.UNSUPPORTED) {
-                    continue;
-                }
-                resultCountMap.merge(specialArgumentTypeResolution, 1, Integer::sum);
-
+                SpecialArgumentType specialArgumentType = specialArgument.type();
+                argCountMap.merge(specialArgumentType, 1, Integer::sum);
             }
-            resultCountMap.forEach((k, v) -> {
-                if (v > 1) {
+            argCountMap.forEach((type, count) -> {
+                if (count > 1) {
                     error.set(true);
                     Tr.error(tc, "CWMCM0006E.duplicate.special.arguments", tool.getToolQualifiedName(),
-                             k.actualClass().getSimpleName());
-
+                             type.getTypeClass().getSimpleName());
                 }
-
             });
         }
         return error.get();
-
-    }
-
-    private boolean reportOnInvalidSpecialArguments(AfterDeploymentValidation afterDeploymentValidation, ToolRegistry tools) {
-        boolean error = false;
-        for (ToolMetadata tool : tools.getAllTools()) {
-            if (tool.methodMetadata().isEmpty()) {
-                continue;
-            }
-            for (SpecialArgumentMetadata specialArgument : tool.methodMetadata().get().specialArguments()) {
-                if (specialArgument.typeResolution().specialArgsType() == SpecialArgumentType.UNSUPPORTED) {
-                    error = true;
-                    Tr.error(tc, "CWMCM0007E.invalid.arguments", tool.getToolQualifiedName(),
-                             specialArgument.typeResolution());
-                }
-            }
-        }
-        return error;
     }
 
     private void registerTool(Tool tool, Bean<?> bean, AnnotatedMethod<?> method, BeanManager beanManager) {

--- a/dev/io.openliberty.mcp.internal/src/io/openliberty/mcp/internal/SpecialArgumentType.java
+++ b/dev/io.openliberty.mcp.internal/src/io/openliberty/mcp/internal/SpecialArgumentType.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2025, 2026 IBM Corporation and others.
+ * Copyright (c) 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -9,7 +9,13 @@
  *******************************************************************************/
 package io.openliberty.mcp.internal;
 
+import static java.util.stream.Collectors.toMap;
+
 import java.lang.reflect.Type;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Stream;
 
 import org.mcpjava.server.Cancellation;
 import org.mcpjava.server.McpRequest;
@@ -18,8 +24,14 @@ import org.mcpjava.server.progress.Progress;
 public enum SpecialArgumentType {
     CANCELLATION(Cancellation.class),
     REQUEST(McpRequest.class),
-    PROGRESS(Progress.class),
-    UNSUPPORTED(Object.class);
+    PROGRESS(Progress.class);
+
+    private static final Map<Class<?>, SpecialArgumentType> typeByClass;
+
+    static {
+        typeByClass = Stream.of(SpecialArgumentType.values())
+                            .collect(toMap(SpecialArgumentType::getTypeClass, Function.identity()));
+    }
 
     private final Class<?> typeClass;
 
@@ -27,33 +39,11 @@ public enum SpecialArgumentType {
         this.typeClass = typeClass;
     }
 
-    public static Resolution fromClass(Type type) {
-        Class<?> clazz = extractClass(type);
-        if (clazz == null) {
-            return new Resolution(UNSUPPORTED, Object.class);
-        }
-        for (SpecialArgumentType specialArgType : values()) {
-            if (specialArgType.typeClass.equals(clazz)) {
-                return new Resolution(specialArgType, clazz);
-            }
-        }
-        return new Resolution(UNSUPPORTED, clazz);
+    public static Optional<SpecialArgumentType> fromClass(Type type) {
+        return Optional.ofNullable(typeByClass.get(type));
     }
 
-    private static Class<?> extractClass(Type type) {
-        if (type instanceof Class<?> clazz) {
-            return clazz;
-        }
-        return null;
-    }
-
-    public record Resolution(SpecialArgumentType specialArgsType, Class<?> actualClass) {
-        @Override
-        public String toString() {
-            if (specialArgsType == UNSUPPORTED) {
-                return "UNSUPPORTED(" + actualClass.getName() + ")";
-            }
-            return specialArgsType.name() + "(" + actualClass.getName() + ")";
-        }
+    public Class<?> getTypeClass() {
+        return typeClass;
     }
 }

--- a/dev/io.openliberty.mcp.internal/src/io/openliberty/mcp/internal/ToolMetadata.java
+++ b/dev/io.openliberty.mcp.internal/src/io/openliberty/mcp/internal/ToolMetadata.java
@@ -86,7 +86,7 @@ public record ToolMetadata(String name,
 
     public record ToolMethodArgument(AnnotatedParameter<?> parameter, ToolArgument argument) {}
 
-    public record SpecialArgumentMetadata(SpecialArgumentType.Resolution typeResolution, int index) {}
+    public record SpecialArgumentMetadata(SpecialArgumentType type, int index) {}
 
     public ToolMetadata {
         arguments = ((arguments == null) ? Collections.emptyList() : arguments);
@@ -252,31 +252,35 @@ public record ToolMetadata(String name,
      * ToolArg.defaultValue is set, or
      * the argument return type is optional
      */
-    private static boolean isArgumentRequired(boolean requiredArgAnnotation, String defaultValue, Type argumentType) {
-        if (!defaultValue.isEmpty()) {
+    private static boolean isArgumentRequired(ToolArg argAnnotation, Type argumentType) {
+        if (argAnnotation != null && !argAnnotation.defaultValue().isEmpty()) {
             return false;
         }
         if (DefaultValueResolver.isOptionalType(argumentType)) {
             return false;
         }
-        return requiredArgAnnotation;
-
+        return argAnnotation != null ? argAnnotation.required() : true;
     }
 
     private static void addArgumentMetadata(AnnotatedParameter<?> param, Type argumentType, List<ToolMethodArgument> result) {
-        ToolArg argAnnotation = param.getAnnotation(ToolArg.class);
 
-        if (argAnnotation != null) {
-            String argName = resolveArgumentName(param, argAnnotation);
-            boolean required = isArgumentRequired(argAnnotation.required(), argAnnotation.defaultValue(), param.getBaseType());
-            result.add(new ToolMethodArgument(param,
-                                              new ToolArgument(argName,
-                                                               argAnnotation.description(),
-                                                               required,
-                                                               argumentType,
-                                                               argAnnotation.defaultValue())));
+        if (SpecialArgumentType.fromClass(argumentType).isPresent()) {
+            // This parameter is a special argument
+            return;
         }
 
+        ToolArg argAnnotation = param.getAnnotation(ToolArg.class);
+        String argName = resolveArgumentName(param, argAnnotation);
+        String description = argAnnotation != null ? argAnnotation.description() : "";
+        boolean required = isArgumentRequired(argAnnotation, param.getBaseType());
+        String defaultValue = argAnnotation != null ? argAnnotation.defaultValue() : "";
+
+        result.add(new ToolMethodArgument(param,
+                                          new ToolArgument(argName,
+                                                           description,
+                                                           required,
+                                                           argumentType,
+                                                           defaultValue)));
     }
 
     private static boolean hasUnresolvableTypeVariables(Type baseType, Map<TypeVariable<?>, Type> genericMap) {
@@ -315,10 +319,12 @@ public record ToolMetadata(String name,
     }
 
     private static String resolveArgumentName(AnnotatedParameter<?> param, ToolArg argAnnotation) {
-        String argAnnotationName = argAnnotation.name();
+        if (argAnnotation != null) {
+            String argAnnotationName = argAnnotation.name();
 
-        if (!argAnnotationName.equals(ToolArg.ELEMENT_NAME)) {
-            return argAnnotationName;
+            if (!argAnnotationName.equals(ToolArg.ELEMENT_NAME)) {
+                return argAnnotationName;
+            }
         }
 
         if (param.getJavaParameter().isNamePresent()) {
@@ -332,11 +338,9 @@ public record ToolMetadata(String name,
     private static List<SpecialArgumentMetadata> getSpecialArgumentList(AnnotatedMethod<?> method) {
         List<SpecialArgumentMetadata> result = new ArrayList<>();
         for (AnnotatedParameter<?> p : method.getParameters()) {
-            ToolArg pInfo = p.getAnnotation(ToolArg.class);
-            if (pInfo == null) {
-                SpecialArgumentMetadata pData = new SpecialArgumentMetadata(SpecialArgumentType.fromClass(p.getBaseType()), p.getPosition());
-                result.add(pData);
-            }
+            SpecialArgumentType.fromClass(p.getBaseType()).ifPresent(type -> {
+                result.add(new SpecialArgumentMetadata(type, p.getPosition()));
+            });
         }
         return Collections.unmodifiableList(result);
     }

--- a/dev/io.openliberty.mcp.internal/src/io/openliberty/mcp/internal/tools/BeanMethodHandler.java
+++ b/dev/io.openliberty.mcp.internal/src/io/openliberty/mcp/internal/tools/BeanMethodHandler.java
@@ -98,11 +98,10 @@ public abstract class BeanMethodHandler<RESPONSE> implements Function<ToolArgume
         }
 
         for (SpecialArgumentMetadata specArg : method.specialArguments()) {
-            argsArray[specArg.index()] = switch (specArg.typeResolution().specialArgsType()) {
+            argsArray[specArg.index()] = switch (specArg.type()) {
                 case CANCELLATION -> t.cancellation();
                 case REQUEST -> t.request();
                 case PROGRESS -> t.progress();
-                default -> throw new RuntimeException("Unknown arg"); //TODO FIX - possibly we can guarantee this is validated earlier
             };
         }
         return argsArray;

--- a/dev/io.openliberty.mcp.internal_fat/fat/resources/io/openliberty/mcp/internal/fat/tool/expected-tools-list-response.json
+++ b/dev/io.openliberty.mcp.internal_fat/fat/resources/io/openliberty/mcp/internal/fat/tool/expected-tools-list-response.json
@@ -1880,6 +1880,33 @@
                                             "properties": {},
                                             "required": []
                                         }
+                                    },
+                                    {
+                                        "name": "unannotatedArgTool",
+                                        "inputSchema": {
+                                            "type": "object",
+                                            "properties": {
+                                                "name": {
+                                                    "type": "string"
+                                                },
+                                                "count": {
+                                                    "type": "integer"
+                                                }
+                                            },
+                                            "required": ["name", "count"]
+                                        }
+                                    },
+                                    {
+                                        "name": "echoNoParamName",
+                                        "inputSchema": {
+                                            "type": "object",
+                                            "properties": {
+                                                "input": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": ["input"]
+                                        }
                                     }
                                 ]
                             },

--- a/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/tool/DeploymentProblemTest.java
+++ b/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/tool/DeploymentProblemTest.java
@@ -93,13 +93,6 @@ public class DeploymentProblemTest extends FATServletClient {
     }
 
     @Test
-    public void testInvalidSpecialArgsTestCase() throws Exception {
-        String expectedErrorHeader = "The (.+?) MCP Tool has a parameter of type (.+?) which is not a recognized special argument type and does not have a `@ToolArg` annotation.";
-        List<String> expectedErrorList = List.of("io.openliberty.mcp.internal.fat.tool.deploymentErrorApps.InvalidSpecialArgsErrorTest.invalidSpecialArgumentTool");
-        ExpectedAppFailureValidator.findAndAssertExpectedErrorsInLogs("Invalid Special Args: ", expectedErrorHeader, expectedErrorList, server);
-    }
-
-    @Test
     public void testGenericArgsTestCase() throws Exception {
         String expectedErrorHeader = "The (.+?) argument of the (.+?) MCP tool method contains unsupported components such as TypeVariable, Wildcard, GenericArrayType.";
         List<String> expectedErrorList = List.of("io.openliberty.mcp.internal.fat.tool.deploymentErrorApps.ToolArgValidationTest.addGenericToGenericArray");

--- a/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/tool/NoParamNameTest.java
+++ b/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/tool/NoParamNameTest.java
@@ -46,4 +46,11 @@ public class NoParamNameTest extends FATServletClient {
         List<String> expectedErrorList = List.of("io.openliberty.mcp.internal.fat.noparamtool.NoParamTools.missingToolArgNameTool");
         ExpectedAppFailureValidator.findAndAssertExpectedErrorsInLogs("Missing arguments found in MCP Tool: ", expectedErrorHeader, expectedErrorList, server);
     }
+
+    @Test
+    public void missingToolArgAnnotation() throws Exception {
+        String expectedErrorHeader = "CWMCM0003E: The (.+?) MCP tool method has one or more arguments without a name specified.";
+        List<String> expectedErrorList = List.of("io.openliberty.mcp.internal.fat.noparamtool.NoParamTools.missingToolArgAnnotation");
+        ExpectedAppFailureValidator.findAndAssertExpectedErrorsInLogs("Missing arguments found in MCP Tool: ", expectedErrorHeader, expectedErrorList, server);
+    }
 }

--- a/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/tool/ToolTest.java
+++ b/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/tool/ToolTest.java
@@ -2978,4 +2978,75 @@ public class ToolTest extends FATServletClient {
         JSONAssert.assertEquals(expectedFragment, response, false);
     }
 
+    @Test
+    public void testUnannotatedToolArgs() throws Exception {
+        String request = """
+                          {
+                          "jsonrpc": "2.0",
+                          "id": "2",
+                          "method": "tools/call",
+                          "params": {
+                            "name": "unannotatedArgTool",
+                            "arguments": {
+                              "name": "fred",
+                              "count": 3
+                            }
+                          }
+                        }
+                        """;
+
+        String response = client.callMCP(request);
+        String expectedResponse = """
+                        {
+                          "id":"2",
+                          "jsonrpc":"2.0",
+                          "result": {
+                            "content": [
+                              {
+                                "type":"text",
+                                "text":"hello hello hello fred of FAT Test Client"
+                              }
+                            ],
+                            "isError": false
+                          }
+                        }
+                        """;
+        JSONAssert.assertEquals(expectedResponse, response, JSONCompareMode.STRICT);
+    }
+
+    @Test
+    public void testNoParamNameTool() throws Exception {
+        String request = """
+                          {
+                          "jsonrpc": "2.0",
+                          "id": "2",
+                          "method": "tools/call",
+                          "params": {
+                            "name": "echoNoParamName",
+                            "arguments": {
+                              "input": "test1"
+                            }
+                          }
+                        }
+                        """;
+
+        String response = client.callMCP(request);
+        String expectedResponse = """
+                        {
+                          "id":"2",
+                          "jsonrpc":"2.0",
+                          "result": {
+                            "content": [
+                              {
+                                "type":"text",
+                                "text":"test1"
+                              }
+                            ],
+                            "isError": false
+                          }
+                        }
+                        """;
+        JSONAssert.assertEquals(expectedResponse, response, JSONCompareMode.STRICT);
+    }
+
 }

--- a/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/tool/basicToolApp/BasicTools.java
+++ b/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/tool/basicToolApp/BasicTools.java
@@ -649,6 +649,17 @@ public class BasicTools {
                       .orElse("No Session ID");
     }
 
+    @Tool
+    public String unannotatedArgTool(String name, int count, McpRequest req) {
+        StringBuilder result = new StringBuilder();
+        for (int i = 0; i < count; i++) {
+            result.append("hello ");
+        }
+        result.append(name);
+        result.append(" of ").append(req.clientInfo().title());
+        return result.toString();
+    }
+
     /**
      * Run a callable and translate any exceptions or assertion errors into a String
      */

--- a/dev/io.openliberty.mcp.internal_fat/noParamNames/io/openliberty/mcp/internal/fat/noparamtool/NoParamTools.java
+++ b/dev/io.openliberty.mcp.internal_fat/noParamNames/io/openliberty/mcp/internal/fat/noparamtool/NoParamTools.java
@@ -11,6 +11,7 @@ package io.openliberty.mcp.internal.fat.noparamtool;
 
 import org.mcpjava.server.tools.Tool;
 import org.mcpjava.server.tools.ToolArg;
+
 import jakarta.enterprise.context.ApplicationScoped;
 
 @ApplicationScoped
@@ -18,6 +19,11 @@ public class NoParamTools {
 
     @Tool(name = "missingToolArgNameTool", title = "missing ToolArgName Tool", description = "ToolArgName is missing so app wont start")
     public String missingToolArgNameTool(@ToolArg(description = "input to echo") String input) {
+        return input;
+    }
+
+    @Tool
+    public String missingToolArgAnnotation(String input) {
         return input;
     }
 }

--- a/dev/io.openliberty.mcp.internal_fat/noParamNames/io/openliberty/mcp/internal/fat/tool/basicToolApp/BasicToolsNoParamNames.java
+++ b/dev/io.openliberty.mcp.internal_fat/noParamNames/io/openliberty/mcp/internal/fat/tool/basicToolApp/BasicToolsNoParamNames.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2025 IBM Corporation and others.
+ * Copyright (c) 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -7,19 +7,21 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  *******************************************************************************/
-package io.openliberty.mcp.internal.fat.tool.deploymentErrorApps;
+package io.openliberty.mcp.internal.fat.tool.basicToolApp;
 
 import org.mcpjava.server.tools.Tool;
+import org.mcpjava.server.tools.ToolArg;
+
 import jakarta.enterprise.context.ApplicationScoped;
 
+/**
+ * More basic tools for ToolTest, compiled without parameter names included
+ */
 @ApplicationScoped
-public class InvalidSpecialArgsErrorTest {
+public class BasicToolsNoParamNames {
 
-    ///////////////////
-    //// Invalid Special Argument Tool
-    @Tool(name = "invalidSpecialArgumentTool")
-    public void invalidSpecialArgumentTool(InvalidSpecialVariable invalidArgs) {}
-
-    public record InvalidSpecialVariable() {}
-
+    @Tool
+    public String echoNoParamName(@ToolArg(name = "input") String input) {
+        return input;
+    }
 }


### PR DESCRIPTION
The new API [specifies how tool arguments are processed](https://www.javadoc.io/doc/org.mcpjava/mcp-server-api/latest/org/mcpjava/server/tools/Tool.html) slightly differently to the existing implementation.

Any parameters not detected as special arguments are assumed to be tool arguments, even if they don't have the `ToolArg` annotation. The name can be generated from the parameter name if the class was compiled with -parameters, otherwise it's a tool argument with no name.

You can no longer have an "unrecognised special argument" as this is now interpreted as a tool argument without a name defined. As such the `UNSUPPORTED` special argument type, validation method and message are all removed.

Removing `UNSUPPORTED` also means we no longer need `SpecialArgumentType.Resolution`, since we no longer need to store an actual type separately from the special argument type.

Add tests for arguments without `ToolArg`.

Remove tests for invalid special arguments.


- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

Fixes #35217 