### PR TITLE
Micrometer update version

### DIFF
--- a/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
+++ b/dev/cnf/dependabot/check_this_in_if_it_changes/pom.xml
@@ -548,8 +548,23 @@
     </dependency>
     <dependency>
       <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-commons</artifactId>
+      <version>1.15.12</version>
+    </dependency>
+    <dependency>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-core</artifactId>
+      <version>1.15.12</version>
+    </dependency>
+    <dependency>
+      <groupId>io.micrometer</groupId>
       <artifactId>micrometer-core</artifactId>
       <version>1.9.3</version>
+    </dependency>
+    <dependency>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-registry-prometheus-simpleclient</artifactId>
+      <version>1.15.12</version>
     </dependency>
     <dependency>
       <groupId>io.micrometer</groupId>
@@ -1223,8 +1238,18 @@
     </dependency>
     <dependency>
       <groupId>io.prometheus</groupId>
+      <artifactId>simpleclient</artifactId>
+      <version>0.16.0</version>
+    </dependency>
+    <dependency>
+      <groupId>io.prometheus</groupId>
       <artifactId>simpleclient_common</artifactId>
       <version>0.15.0</version>
+    </dependency>
+    <dependency>
+      <groupId>io.prometheus</groupId>
+      <artifactId>simpleclient_common</artifactId>
+      <version>0.16.0</version>
     </dependency>
     <dependency>
       <groupId>io.prometheus</groupId>
@@ -1233,13 +1258,28 @@
     </dependency>
     <dependency>
       <groupId>io.prometheus</groupId>
+      <artifactId>simpleclient_tracer_common</artifactId>
+      <version>0.16.0</version>
+    </dependency>
+    <dependency>
+      <groupId>io.prometheus</groupId>
       <artifactId>simpleclient_tracer_otel</artifactId>
       <version>0.15.0</version>
     </dependency>
     <dependency>
       <groupId>io.prometheus</groupId>
+      <artifactId>simpleclient_tracer_otel</artifactId>
+      <version>0.16.0</version>
+    </dependency>
+    <dependency>
+      <groupId>io.prometheus</groupId>
       <artifactId>simpleclient_tracer_otel_agent</artifactId>
       <version>0.15.0</version>
+    </dependency>
+    <dependency>
+      <groupId>io.prometheus</groupId>
+      <artifactId>simpleclient_tracer_otel_agent</artifactId>
+      <version>0.16.0</version>
     </dependency>
     <dependency>
       <groupId>io.reactivex.rxjava2</groupId>

--- a/dev/cnf/oss_dependencies.maven
+++ b/dev/cnf/oss_dependencies.maven
@@ -105,7 +105,10 @@ io.jaegertracing:jaeger-thrift:0.34.0
 io.jaegertracing:jaeger-thrift:1.6.0
 io.jaegertracing:jaeger-tracerresolver:0.34.0
 io.jaegertracing:jaeger-tracerresolver:1.6.0
+io.micrometer:micrometer-commons:1.15.12
+io.micrometer:micrometer-core:1.15.12
 io.micrometer:micrometer-core:1.9.3
+io.micrometer:micrometer-registry-prometheus-simpleclient:1.15.12
 io.micrometer:micrometer-registry-prometheus:1.9.3
 io.netty:netty-buffer:4.2.13.Final
 io.netty:netty-codec-base:4.2.13.Final
@@ -240,10 +243,15 @@ io.projectreactor:reactor-core:3.4.19
 io.projectreactor:reactor-core:3.5.16
 io.projectreactor:reactor-core:3.8.0-M5
 io.prometheus:simpleclient:0.15.0
+io.prometheus:simpleclient:0.16.0
 io.prometheus:simpleclient_common:0.15.0
+io.prometheus:simpleclient_common:0.16.0
 io.prometheus:simpleclient_tracer_common:0.15.0
+io.prometheus:simpleclient_tracer_common:0.16.0
 io.prometheus:simpleclient_tracer_otel:0.15.0
+io.prometheus:simpleclient_tracer_otel:0.16.0
 io.prometheus:simpleclient_tracer_otel_agent:0.15.0
+io.prometheus:simpleclient_tracer_otel_agent:0.16.0
 io.reactivex.rxjava2:rxjava:2.2.19
 io.reactivex:rxjava:1.3.8
 io.smallrye.common:smallrye-common-annotation:1.6.0

--- a/dev/io.openliberty.io.micrometer/bnd.bnd
+++ b/dev/io.openliberty.io.micrometer/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2022 IBM Corporation and others.
+# Copyright (c) 2022, 2026 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -21,39 +21,43 @@ javac.source: 11
 javac.target: 11
 
 Require-Capability: osgi.ee; filter:="(&(osgi.ee=JavaSE)(version=11))"
+
+
 Import-Package: \
-	io.micrometer.core.*;version=1.9.3,\
-	io.micrometer.prometheus;version=1.9.3,\
-	org.LatencyUtils;version=2.0.3,\
+    io.micrometer.core.*;version=1.15.12,\
+    io.micrometer.common.*;version=1.15.12,\
+    io.micrometer.prometheus.*;version=1.15.12,\
+    org.LatencyUtils;version=2.0.3,\
     org.HdrHistogram.*;version=2.1.12,\
-    io.prometheus.*;version=0.15.0,\
+    io.prometheus.*;version=0.16.0,\
     com.ibm.*,\
     org.osgi.*
 
-# do not import all
 
 Export-Package: \
-    io.micrometer.prometheus;version=1.8.5,\
-	io.micrometer.core.*;version=1.8.5,\
-	org.LatencyUtils;version=2.0.3,\
+    io.micrometer.prometheus;version=1.15.12,\
+    io.micrometer.core.*;version=1.15.12,\
+    io.micrometer.common.*;version=1.15.12,\
+    org.LatencyUtils;version=2.0.3,\
     org.HdrHistogram.*;version=2.1.12,\
-    io.prometheus.*;version=0.15.0
+    io.prometheus.*;version=0.16.0
 
 publish.wlp.jar.suffix: lib
 
 -buildpath: \
     com.ibm.ws.logging;version=latest,\
     com.ibm.websphere.org.osgi.service.component;version=latest,\
-	com.ibm.wsspi.org.osgi.service.component.annotations;version=latest,\
-	com.ibm.ws.org.osgi.annotation.versioning;version=latest,\
-	com.ibm.ws.container.service.compat;version=latest,\
-	com.ibm.ws.container.service;version=latest,\
-	io.micrometer:micrometer-core;version=1.9.3,\
-    io.micrometer:micrometer-registry-prometheus;version=1.9.3,\
+    com.ibm.wsspi.org.osgi.service.component.annotations;version=latest,\
+    com.ibm.ws.org.osgi.annotation.versioning;version=latest,\
+    com.ibm.ws.container.service.compat;version=latest,\
+    com.ibm.ws.container.service;version=latest,\
+    io.micrometer:micrometer-core;version=1.15.12,\
+    io.micrometer:micrometer-commons;version=1.15.12,\
+    io.micrometer:micrometer-registry-prometheus-simpleclient;version=1.15.12,\
     org.hdrhistogram:HdrHistogram;version=2.1.12,\
     org.latencyutils:LatencyUtils;version=2.0.3,\
-    io.prometheus:simpleclient_common;version=0.15.0,\
-    io.prometheus:simpleclient;version=0.15.0,\
-    io.prometheus:simpleclient_tracer_otel;version=0.15.0,\
-	io.prometheus:simpleclient_tracer_otel_agent;version=0.15.0,\
-	io.prometheus:simpleclient_tracer_common;version=0.15.0
+    io.prometheus:simpleclient_common;version=0.16.0,\
+    io.prometheus:simpleclient;version=0.16.0,\
+    io.prometheus:simpleclient_tracer_otel;version=0.16.0,\
+    io.prometheus:simpleclient_tracer_otel_agent;version=0.16.0,\
+    io.prometheus:simpleclient_tracer_common;version=0.16.0

--- a/dev/io.openliberty.microprofile.metrics.5.0.internal/bnd.bnd
+++ b/dev/io.openliberty.microprofile.metrics.5.0.internal/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2022, 2025 IBM Corporation and others.
+# Copyright (c) 2022, 2026 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at 	

--- a/dev/io.openliberty.microprofile.metrics.5.0.internal/bnd.bnd
+++ b/dev/io.openliberty.microprofile.metrics.5.0.internal/bnd.bnd
@@ -64,6 +64,8 @@ WS-TraceGroup: METRICS
 
 -buildpath: \
     org.eclipse.osgi;version=latest,\
+    com.ibm.ws.kernel.metatype.helper;version=latest,\
+    com.ibm.ws.artifact;version=latest.\
 	com.ibm.websphere.org.osgi.core;version=latest,\
 	com.ibm.ws.app.manager.wab.jakarta;version=latest,\
 	com.ibm.ws.container.service;version=latest,\

--- a/dev/io.openliberty.microprofile.metrics.5.0.internal/src/io/openliberty/microprofile/metrics50/internal/SmallryeMetricsCDIMetadata.java
+++ b/dev/io.openliberty.microprofile.metrics.5.0.internal/src/io/openliberty/microprofile/metrics50/internal/SmallryeMetricsCDIMetadata.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2022, 2023 IBM Corporation and others.
+ * Copyright (c) 2022, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -18,6 +18,7 @@ import java.security.CodeSource;
 import java.security.ProtectionDomain;
 import java.security.cert.Certificate;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -43,6 +44,7 @@ import com.ibm.ws.kernel.provisioning.ContentBasedLocalBundleRepository;
 import com.ibm.wsspi.classloading.ClassLoaderConfiguration;
 import com.ibm.wsspi.classloading.ClassLoaderIdentity;
 import com.ibm.wsspi.classloading.ClassLoadingService;
+import com.ibm.wsspi.config.Fileset;
 import com.ibm.wsspi.library.Library;
 
 import io.openliberty.cdi.spi.CDIExtensionMetadata;
@@ -72,6 +74,15 @@ public class SmallryeMetricsCDIMetadata implements CDIExtensionMetadata {
             + "$Responder";
     private static final String APPLICATION_NAME_RESOLVER_CLASSNAME = "io.smallrye.metrics.setup.ApplicationNameResolver";
 
+    /*
+     * As of Micrometer version 1.13.x and up the Micrometer Prometheus Registry
+     * will package it as `io.micrometer.prometheusmetrics.*` on top of downstream
+     * dependency behaviour changes (i.e. Prometheus Java Client). However, we will
+     * use their back-wards compatible Micrometer Prometheus Registry Simple Client
+     * which retains the old naming convention and subsequent behaviour. Context:
+     * MPR at 1.13.x and up switches from Prometheus Simple client to Prometheus
+     * Java Client v1.x which alters scrape and quantiles + bucket co-existence.
+     */
     private static final String FQ_PROMETHEUSCONFIG_PATH = "io.micrometer.prometheus.PrometheusConfig";
 
     private ClassLoadingService classLoadingService;
@@ -107,6 +118,8 @@ public class SmallryeMetricsCDIMetadata implements CDIExtensionMetadata {
     @Activate
     protected void activate(ComponentContext context, Map<String, Object> properties) throws Exception {
         File smallRyeMetricsJarFile;
+        boolean isSharedLibAvailable = (sharedLib != null);
+
         try {
             smallRyeMetricsJarFile = resolveSmallRyeMetricsJar();
         } catch (FileNotFoundException e) {
@@ -116,8 +129,6 @@ public class SmallryeMetricsCDIMetadata implements CDIExtensionMetadata {
 
         List<File> classPath = new ArrayList<File>();
         classPath.add(smallRyeMetricsJarFile);
-
-        boolean isSharedLibAvailable = (sharedLib != null);
 
         /*
          * No Library Reference detected. Will use default embedded Micrometer
@@ -204,6 +215,88 @@ public class SmallryeMetricsCDIMetadata implements CDIExtensionMetadata {
     protected void setSharedLib(Library ref) throws Exception {
         sharedLib = ref;
         Tr.audit(tc, "libraryRefConfigured.info.CWMMC0014I", sharedLib.id());
+        validateSharedLibraryJars(sharedLib);
+    }
+
+    /**
+     * Checks on Micrometer core version and if Promethues Registry is used. If
+     * v1.13+ is in effect, we expect Promtheus registry simple client to be used.
+     *
+     * @param sharedLib
+     */
+    private void validateSharedLibraryJars(Library sharedLib) {
+        List<File> allFiles = new ArrayList<File>();
+        Collection<Fileset> filesets = sharedLib.getFilesets();
+        if (filesets == null) {
+            if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                Tr.debug(tc, "No file sets founds", null);
+            }
+            return;
+        }
+
+        for (Fileset fileset : filesets) {
+            Collection<File> files = fileset.getFileset();
+            if (files == null) {
+                if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                    Tr.debug(tc, "No files found in fileset: " + fileset, null);
+                }
+                continue;
+            }
+            for (File file : files) {
+                allFiles.add(file);
+            }
+        }
+
+        // Parse version from micrometer-registry-prometheus JAR
+        boolean foundPre1_13 = false;
+        boolean found1_13OrAbove = false;
+
+        for (File file : allFiles) {
+            String fileName = file.getName();
+            if (fileName.startsWith("micrometer-core-") && fileName.endsWith(".jar")) {
+
+                String versionString = fileName.substring("micrometer-core-".length(), fileName.length() - 4);
+                // Parse major and minor version
+                String[] versionParts = versionString.split("\\.");
+                if (versionParts.length >= 2) {
+                    try {
+                        int major = Integer.parseInt(versionParts[0]);
+                        int minor = Integer.parseInt(versionParts[1]);
+
+                        if (major == 1 && minor >= 9 && minor <= 12) {
+                            foundPre1_13 = true;
+                        } else if (major == 1 && minor >= 13) {
+                            found1_13OrAbove = true;
+                        } else if (major > 1) {
+                            found1_13OrAbove = true;
+                        }
+                    } catch (NumberFormatException e) {
+                        // Skip if version parsing fails
+                    }
+                }
+            }
+
+            /*
+             * Check if micrometer-registry-prometheus is used when using v1.13+
+             */
+            if (fileName.startsWith("micrometer-registry-prometheus-")
+                    && !fileName.startsWith("micrometer-registry-prometheus-simpleclient-") && found1_13OrAbove) {
+
+                // Use generic error - Requires trace to be used.
+                Tr.error(tc, "internal.error.CWMMC0006E", null);
+
+                if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                    Tr.debug(tc, String.format(
+                            "Error: The runtime has detected that micrometer-core v1.13+[%s] has been used with micrometer-registry-prometheus."
+                                    + "At v1.13+ the micrometer-registry-prometheus-simpleclient must be used backwards compatability."));
+                }
+
+                // MUST indicate failure of activation.
+                isSuccessfulActivation = false;
+
+            }
+        }
+
     }
 
     protected void unsetSharedLib(Library ref) {

--- a/dev/io.openliberty.microprofile.metrics.5.0.internal/src/io/openliberty/microprofile/metrics50/internal/SmallryeMetricsCDIMetadata.java
+++ b/dev/io.openliberty.microprofile.metrics.5.0.internal/src/io/openliberty/microprofile/metrics50/internal/SmallryeMetricsCDIMetadata.java
@@ -229,7 +229,7 @@ public class SmallryeMetricsCDIMetadata implements CDIExtensionMetadata {
         Collection<Fileset> filesets = sharedLib.getFilesets();
         if (filesets == null) {
             if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-                Tr.debug(tc, "No file sets founds", null);
+                Tr.debug(tc, "No file sets found in shared library", null);
             }
             return;
         }
@@ -247,7 +247,12 @@ public class SmallryeMetricsCDIMetadata implements CDIExtensionMetadata {
             }
         }
 
-        // Parse version from micrometer-registry-prometheus JAR
+        /*
+         * Parse version from micrometer-core and identify if
+         * micrometer-registry-prometheus or if
+         * micrometer-registry-prometheus-simpleclient is used (if 1.13.x+)
+         *
+         */
         boolean foundPre1_13 = false;
         boolean found1_13OrAbove = false;
 
@@ -272,6 +277,10 @@ public class SmallryeMetricsCDIMetadata implements CDIExtensionMetadata {
                         }
                     } catch (NumberFormatException e) {
                         // Skip if version parsing fails
+                        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                            Tr.debug(tc, String.format("The version parsed is in an unexpected fomat for the file: %s ",
+                                    fileName));
+                        }
                     }
                 }
             }

--- a/dev/io.openliberty.microprofile.metrics.5.0.internal/src/io/openliberty/microprofile/metrics50/internal/SmallryeMetricsCDIMetadata.java
+++ b/dev/io.openliberty.microprofile.metrics.5.0.internal/src/io/openliberty/microprofile/metrics50/internal/SmallryeMetricsCDIMetadata.java
@@ -235,16 +235,7 @@ public class SmallryeMetricsCDIMetadata implements CDIExtensionMetadata {
         }
 
         for (Fileset fileset : filesets) {
-            Collection<File> files = fileset.getFileset();
-            if (files == null) {
-                if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-                    Tr.debug(tc, "No files found in fileset: " + fileset, null);
-                }
-                continue;
-            }
-            for (File file : files) {
-                allFiles.add(file);
-            }
+            allFiles.addAll(fileset.getFileset());
         }
 
         /*


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

################################################################################################

Bumps `micrometer-core` and `micrometer-prometheus-registry` from `1.9.3` to `1.15.12`. With this change, we have now switched to `micrometer-prometheus-registry-simpleclient` for back-wards compatability due to breaking changes in 1.13.x for the `micrometer-prometheus-registry`.

