### PR TITLE
Fix the featureUtility archive to extract the features properly

### DIFF
--- a/dev/com.ibm.ws.install.featureUtility_fat/build.gradle
+++ b/dev/com.ibm.ws.install.featureUtility_fat/build.gradle
@@ -20,7 +20,7 @@ configurations {
 dependencies {
   usrFeatures 'test.featureUtility_fat:userFeature:1.0@zip'
   usrEsa 'test.featureUtility_fat:usertest.with.api:1.0@esa'
-  features1 'test.featureUtility_fat:Archive:3.0@zip'
+  features1 'test.featureUtility_fat:Archive:1.0@zip'
   features2 'test.featureUtility_fat:Archive:2.0@zip'
 }
 

--- a/dev/com.ibm.ws.install.featureUtility_fat/fat/src/com/ibm/ws/install/featureUtility/fat/FATSuite.java
+++ b/dev/com.ibm.ws.install.featureUtility_fat/fat/src/com/ibm/ws/install/featureUtility/fat/FATSuite.java
@@ -39,8 +39,8 @@ public class FATSuite extends TestContainerSuite {
     public static void beforeSuite() throws Exception {
 	FeatureUtilityToolTest.setupEnv();
 	FeatureUtilityToolTest.constructLocalMavenRepo(Paths.get("publish/repo/").toAbsolutePath().toString(),Paths.get("publish/repo/userFeature/userFeature-1.0.zip"));
-	FeatureUtilityToolTest.constructLocalMavenRepo(Paths.get("publish/repo/").toAbsolutePath().toString(),Paths.get("publish/repo/archive1/Archive-3.0.zip"));
-	FeatureUtilityToolTest.constructLocalMavenRepo(Paths.get("publish/servers/staticWebServer/apps/staticWebApp.war").toAbsolutePath().toString(),Paths.get("publish/repo/archive1/Archive-3.0.zip"));
+	FeatureUtilityToolTest.constructLocalMavenRepo(Paths.get("publish/repo/").toAbsolutePath().toString(),Paths.get("publish/repo/archive1/Archive-1.0.zip"));
+	FeatureUtilityToolTest.constructLocalMavenRepo(Paths.get("publish/servers/staticWebServer/apps/staticWebApp.war").toAbsolutePath().toString(),Paths.get("publish/repo/archive1/Archive-1.0.zip"));
 	FeatureUtilityToolTest.constructLocalMavenRepo(Paths.get("publish/repo2/").toAbsolutePath().toString(),Paths.get("publish/repo/archive2/Archive-2.0.zip")); //New repo has versionless features
     }
 

--- a/dev/com.ibm.ws.install.featureUtility_fat/fat/src/com/ibm/ws/install/featureUtility/fat/FeatureUtilityToolTest.java
+++ b/dev/com.ibm.ws.install.featureUtility_fat/fat/src/com/ibm/ws/install/featureUtility/fat/FeatureUtilityToolTest.java
@@ -509,7 +509,7 @@ public abstract class FeatureUtilityToolTest {
 	String output = po.getStdout();
 
 	    if (errorCode != null) {
-		assertTrue(String.format("Should contain %s", errorCode), output.contains(errorCode));
+		assertTrue(String.format("Should contain %s. Error output: %s", errorCode, output), output.contains(errorCode));
 	    }
 	    if (filesList != null) {
 		assertFilesExist(filesList);

--- a/dev/com.ibm.ws.install.featureUtility_fat/fat/src/com/ibm/ws/install/featureUtility/fat/InstallFeatureTest.java
+++ b/dev/com.ibm.ws.install.featureUtility_fat/fat/src/com/ibm/ws/install/featureUtility/fat/InstallFeatureTest.java
@@ -180,7 +180,7 @@ public class InstallFeatureTest extends FeatureUtilityToolTest {
             // add the liberty server as the maven central mirror
             writeToProps(minifiedRoot + "/etc/featureUtility.properties",
                     "mavenCentralMirror.url",
-                    String.format("http://%s:%s/staticWebApp/Archive-3.0/",
+                    String.format("http://%s:%s/staticWebApp/",
                             server.getHostname(),
                             server.getHttpDefaultPort()));
 


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

Realized that when we uploaded Archive-3.0 and modified the tests to use it, it was not constructed properly. Because of this there were some intermittent build breaks.. not sure why we didn't catch that in personal and release builds. But this should have the fix once this is uploaded to DHE and Artifactory.