### PR TITLE
Fix timing issue in EJB quiesce test

### DIFF
--- a/dev/com.ibm.ws.ejbcontainer.quiesce_fat/fat/src/com/ibm/ws/ejbcontainer/quiesce/fat/tests/MdbQuiesceTest.java
+++ b/dev/com.ibm.ws.ejbcontainer.quiesce_fat/fat/src/com/ibm/ws/ejbcontainer/quiesce/fat/tests/MdbQuiesceTest.java
@@ -203,7 +203,7 @@ public class MdbQuiesceTest extends FATServletClient {
             // Verify all three message sequences are present in order
             verifyMessagesInOrder(expectedJcaDeactivation, actualJcaDeactivation, "JCA Deactivation", 4);
             verifyMessagesInOrder(expectedEjbDeactivation, actualEjbDeactivation, "EJB Deactivation", 4);
-            verifyMessagesInOrder(expectedPreDestroy, actualPreDestroy, "PreDestroy", 8);
+            verifyMessagesInOrder(expectedPreDestroy, actualPreDestroy, "PreDestroy", 7);
 
         } finally {
             if (mdbServer.isStarted()) {

--- a/dev/com.ibm.ws.ejbcontainer.quiesce_fat/fat/src/com/ibm/ws/ejbcontainer/quiesce/fat/tests/MdbQuiesceTest.java
+++ b/dev/com.ibm.ws.ejbcontainer.quiesce_fat/fat/src/com/ibm/ws/ejbcontainer/quiesce/fat/tests/MdbQuiesceTest.java
@@ -175,8 +175,7 @@ public class MdbQuiesceTest extends FATServletClient {
             ("CWWKE1100I", // waiting for server quiesce
              "PreDestroy:MdbQuiesceApp:MdbQuiesceWeb:StartupSingletonQuiesceBnd:",
              "PreDestroy:MdbQuiesceApp:MdbQuiesceEjb:StartupSingletonQuiesceBnd:",
-             "CWWKO0220I", // standard quiesce listener defaultHttpEndpoint
-             "CWWKO0220I", // standard quiesce listener JMS Endpoint
+             "CWWKO0220I: TCP Channel defaultHttpEndpoint", // standard quiesce listener defaultHttpEndpoint
              "CWWKE1101I", // server quiesce complete
              "PreDestroy:MdbQuiesceApp:MdbQuiesceWeb:StartupSingletonQuiesceDefault:",
              "PreDestroy:MdbQuiesceApp:MdbQuiesceEjb:StartupSingletonQuiesceDefault:",
@@ -198,7 +197,7 @@ public class MdbQuiesceTest extends FATServletClient {
                                                                                       mdbServer.getDefaultLogFile());
 
             // Find PreDestroy messages
-            List<String> actualPreDestroy = mdbServer.findStringsInLogsUsingMark(".*CWWKE1100I|CWWKO0220I|CWWKE1101I|PreDestroy:MdbQuiesceApp|CWWKZ0009I.*",
+            List<String> actualPreDestroy = mdbServer.findStringsInLogsUsingMark(".*CWWKE1100I|CWWKO0220I:.*defaultHttpEndpoint|CWWKE1101I|PreDestroy:MdbQuiesceApp|CWWKZ0009I.*",
                                                                                  mdbServer.getDefaultLogFile());
 
             // Verify all three message sequences are present in order


### PR DESCRIPTION
Test only needs to validate the quiesce message for the defaultHttpEndpoint is after some EJB pre-quiesce messages, so remove checking for the jms quiesce message as it is not relavant to success of test and order of it varies.

for #34898

Co-authored-by-AI: IBM Bob 2.0.0

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".