### PR TITLE
Add branch coupling support flag for Postgres

### DIFF
--- a/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/PostgreSQLHelper.java
+++ b/dev/com.ibm.ws.jdbc/src/com/ibm/ws/rsadapter/impl/PostgreSQLHelper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019,2021 IBM Corporation and others.
+ * Copyright (c) 2019, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -19,10 +19,12 @@ import java.util.HashMap;
 import java.util.Map;
 
 import javax.resource.ResourceException;
+import javax.transaction.xa.XAResource;
 
 import com.ibm.ejs.cm.logger.TraceWriter;
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.ws.resource.ResourceRefInfo;
 import com.ibm.ws.rsadapter.AdapterUtil;
 
 /**
@@ -132,5 +134,24 @@ public class PostgreSQLHelper extends DatabaseHelper {
     @Override
     public boolean supportsSubjectDoAsForKerberos() {
         return true;
+    }
+
+    /**
+     * Returns the XA start flag for the specified branch coupling type.
+     *
+     * PostgreSQL has no proprietary XA branch coupling flags. LOOSE coupling is the
+     * natural behavior of the PostgreSQL XA implementation (each enlistment gets its
+     * own independent branch), so BRANCH_COUPLING_LOOSE maps to XAResource.TMNOFLAGS.
+     * TIGHT coupling is not supported.
+     *
+     * @param couplingType branch coupling type
+     * @return XAResource.TMNOFLAGS for LOOSE; -1 (not supported) for TIGHT
+     */
+    @Override
+    public int branchCouplingSupported(int couplingType) {
+        if (couplingType == ResourceRefInfo.BRANCH_COUPLING_LOOSE)
+            return XAResource.TMNOFLAGS;
+        // -1 indicates the JDBC driver has no support for this branch coupling type
+        return -1;
     }
 }


### PR DESCRIPTION
Adds branchCouplingSupported method to PostgreSQLHelper. Postgres's uses loosely coupled transaction branches, and doesn't support tight, so this allows specifiying LOOSE for Postgres to work, while still rejecting TIGHT.

This allows the recently updated XARecovery test to continue to work on Postgres.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".