### PR TITLE
Match the exception type being chosen for the 1.1 spec

### DIFF
--- a/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/Fail.java
+++ b/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/Fail.java
@@ -356,14 +356,16 @@ public class Fail {
     }
 
     /**
-     * Raise a new MappingException for the error where some operations are not
-     * available because a Sort expression was used to request a cursored page.
+     * Raise a new UnsupportedOperationException for the error where some
+     * operations are not available because a Sort expression was used
+     * to request a cursored page.
      *
      * @param info query information for the repository method
      * @param sort the sort criterion
-     * @throws the MappingException
+     * @throws the UnsupportedOperationException
      */
-    static MappingException incompatibleSort(QueryInfo info, Sort<?> sort) {
+    static UnsupportedOperationException incompatibleSort(QueryInfo info,
+                                                          Sort<?> sort) {
         String attrName = sort.property();
         throw exc(MappingException.class,
                   "CWWKD1123.sort.incompat.with.cursor",


### PR DESCRIPTION
Spec language proposed for Jakarta Data 1505 includes raising UnsupportedOperationException for methods that directly or indirectly require the Jakarta Data provider to create a cursor based on sort criteria that includes expressions rather than entity attributes.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
