### PR TITLE
Fix LoggingTest.testFeatureLog failure on dynamic port

### DIFF
--- a/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat/test-applications/helloServer/src/com/ibm/ws/jaxws/test/wsr/servlet/LoggingTestServlet.java
+++ b/dev/com.ibm.ws.jaxws.2.2.webcontainer_fat/test-applications/helloServer/src/com/ibm/ws/jaxws/test/wsr/servlet/LoggingTestServlet.java
@@ -23,6 +23,7 @@ import javax.servlet.http.HttpServletResponse;
 import javax.xml.namespace.QName;
 import javax.xml.transform.Source;
 import javax.xml.transform.stream.StreamSource;
+import javax.xml.ws.BindingProvider;
 import javax.xml.ws.Dispatch;
 import javax.xml.ws.Service;
 import javax.xml.ws.WebServiceRef;
@@ -40,7 +41,7 @@ public class LoggingTestServlet extends HttpServlet {
 
     private static Logger log = Logger.getLogger(LoggingTestServlet.class.getName());
 
-    @WebServiceRef(name = "services/PeopleService", wsdlLocation = "http://localhost:8010/helloApp/PeopleService?wsdl")
+    @WebServiceRef(name = "services/PeopleService", value = PeopleService.class)
     PeopleService serviceWithREF;
 
     public LoggingTestServlet() {
@@ -82,6 +83,9 @@ public class LoggingTestServlet extends HttpServlet {
                 break;
             case "wsref":
                 People billRef = serviceWithREF.getBillPort();
+                ((BindingProvider) billRef).getRequestContext().put(
+                    BindingProvider.ENDPOINT_ADDRESS_PROPERTY,
+                    "http://" + req.getLocalAddr() + ":" + req.getLocalPort() + "/helloApp/PeopleService");
                 result = billRef.hello("World");
                 break;
         }


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [ ] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

---

## Summary

`LoggingTest.testFeatureLog` was failing with 404 on `?WSType=proxy` across all platforms and JDK versions. Root cause was a hardcoded port in `@WebServiceRef.wsdlLocation`.

## Root Cause

`LoggingTestServlet` declared:
```java
@WebServiceRef(name = "services/PeopleService", wsdlLocation = "http://localhost:8010/helloApp/PeopleService?wsdl")
PeopleService serviceWithREF;
```

When another test server held port 8010, `LoggingServer` was allocated port 8011. Liberty's JAX-WS injection attempted to fetch the WSDL from the hardcoded `localhost:8010` at servlet init time — either failing (connection refused) or hitting a different server. The servlet failed to initialise, causing **all** requests (including `WSType=proxy` which doesn't even use the injected ref) to return 404 for the full 5-second retry window.

## Changes

- `com.ibm.ws.jaxws.2.2.webcontainer_fat/test-applications/helloServer/src/com/ibm/ws/jaxws/test/wsr/servlet/LoggingTestServlet.java`
  - Replace hardcoded `wsdlLocation = "http://localhost:8010/..."` with `value = PeopleService.class` in `@WebServiceRef`
  - Override `ENDPOINT_ADDRESS_PROPERTY` at request time using `req.getLocalAddr()` + `req.getLocalPort()` + correct context root
