### PR TITLE
Adding maximum java version to fat 

### DIFF
--- a/dev/com.ibm.ws.jpa.tests.jpa_31_fat/fat/src/com/ibm/ws/jpa/jpa31/AsmServiceTest.java
+++ b/dev/com.ibm.ws.jpa.tests.jpa_31_fat/fat/src/com/ibm/ws/jpa/jpa31/AsmServiceTest.java
@@ -40,6 +40,7 @@ import com.ibm.ws.jpa.jpa31.AbstractFATSuite;
 import com.ibm.ws.testtooling.vehicle.web.JPAFATServletClient;
 
 import componenttest.annotation.MinimumJavaLevel;
+import componenttest.annotation.MaximumJavaLevel;
 import componenttest.annotation.Server;
 import componenttest.annotation.SkipForRepeat;
 import componenttest.custom.junit.runner.FATRunner;
@@ -55,6 +56,7 @@ import junit.framework.Assert;
 @RunWith(FATRunner.class)
 @Mode(TestMode.LITE)
 @MinimumJavaLevel(javaLevel = 11)
+@MaximumJavaLevel(javaLevel = 25) 
 @SkipForRepeat("JPA32_HIBERNATE")
 public class AsmServiceTest extends JPAFATServletClient {
     private final static String CONTEXT_ROOT = "eclAsmService";

--- a/dev/com.ibm.ws.jpa.tests.jpa_31_fat/fat/src/com/ibm/ws/jpa/jpa31/JPA31Test.java
+++ b/dev/com.ibm.ws.jpa.tests.jpa_31_fat/fat/src/com/ibm/ws/jpa/jpa31/JPA31Test.java
@@ -34,6 +34,7 @@ import com.ibm.ws.jpa.jpa31.AbstractFATSuite;
 import com.ibm.ws.testtooling.vehicle.web.JPAFATServletClient;
 
 import componenttest.annotation.MinimumJavaLevel;
+import componenttest.annotation.MaximumJavaLevel;
 import componenttest.annotation.Server;
 import componenttest.annotation.TestServlet;
 import componenttest.annotation.TestServlets;
@@ -54,6 +55,7 @@ import io.openliberty.jpa.tests.jpa31.web.TestUUIDEntityIDServlet;
 @RunWith(FATRunner.class)
 @Mode(TestMode.LITE)
 @MinimumJavaLevel(javaLevel = 11)
+@MaximumJavaLevel(javaLevel = 25) 
 public class JPA31Test extends JPAFATServletClient {
     private final static String CONTEXT_ROOT = "JPA31";
     private final static String RESOURCE_ROOT = "test-applications/jpa31/";

--- a/dev/com.ibm.ws.jpa.tests.jpa_31_fat/fat/src/com/ibm/ws/jpa/jpa31/JPABootstrapTest.java
+++ b/dev/com.ibm.ws.jpa.tests.jpa_31_fat/fat/src/com/ibm/ws/jpa/jpa31/JPABootstrapTest.java
@@ -26,6 +26,8 @@ import org.testcontainers.containers.JdbcDatabaseContainer;
 import com.ibm.websphere.simplicity.ShrinkHelper;
 
 import componenttest.annotation.MinimumJavaLevel;
+import componenttest.annotation.MaximumJavaLevel;
+
 import componenttest.annotation.Server;
 import componenttest.annotation.SkipForRepeat;
 import componenttest.annotation.TestServlet;
@@ -47,6 +49,7 @@ import jpabootstrap.web.TestJPABootstrapServlet;
 @RunWith(FATRunner.class)
 @Mode(TestMode.LITE)
 @MinimumJavaLevel(javaLevel = 11)
+@MaximumJavaLevel(javaLevel = 25) 
 @SkipForRepeat("JPA32_HIBERNATE")
 public class JPABootstrapTest extends FATServletClient {
     public static final String APP_NAME = "jpabootstrap";

--- a/dev/com.ibm.ws.jpa.tests.jpa_31_fat/fat/src/com/ibm/ws/jpa/jpa31/JPAJSONTest.java
+++ b/dev/com.ibm.ws.jpa.tests.jpa_31_fat/fat/src/com/ibm/ws/jpa/jpa31/JPAJSONTest.java
@@ -34,6 +34,7 @@ import com.ibm.ws.jpa.jpa31.AbstractFATSuite;
 import com.ibm.ws.testtooling.vehicle.web.JPAFATServletClient;
 
 import componenttest.annotation.MinimumJavaLevel;
+import componenttest.annotation.MaximumJavaLevel;
 import componenttest.annotation.Server;
 import componenttest.annotation.SkipForRepeat;
 import componenttest.annotation.TestServlet;
@@ -50,6 +51,7 @@ import io.openliberty.jpa.tests.jpa31.json.web.JPAJSONTestServlet;
 @RunWith(FATRunner.class)
 @Mode(TestMode.LITE)
 @MinimumJavaLevel(javaLevel = 11)
+@MaximumJavaLevel(javaLevel = 25) 
 @SkipForRepeat("JPA32_HIBERNATE")
 public class JPAJSONTest extends JPAFATServletClient {
     private final static String CONTEXT_ROOT = "jpajson";

--- a/dev/com.ibm.ws.jpa.tests.jpa_32_fat/fat/src/com/ibm/ws/jpa/jpa32/JPABootstrapTest.java
+++ b/dev/com.ibm.ws.jpa.tests.jpa_32_fat/fat/src/com/ibm/ws/jpa/jpa32/JPABootstrapTest.java
@@ -32,6 +32,7 @@ import com.ibm.websphere.simplicity.config.ServerConfiguration;
 import com.ibm.ws.jpa.FATSuite;
 
 import componenttest.annotation.MinimumJavaLevel;
+import componenttest.annotation.MaximumJavaLevel;
 import componenttest.annotation.Server;
 import componenttest.annotation.TestServlet;
 import componenttest.annotation.TestServlets;
@@ -52,6 +53,7 @@ import jpabootstrap.web.TestJPABootstrapServlet;
 @RunWith(FATRunner.class)
 @Mode(TestMode.LITE)
 @MinimumJavaLevel(javaLevel = 17)
+@MaximumJavaLevel(javaLevel = 25)  // Hibernate ByteBuddy limitation
 public class JPABootstrapTest extends FATServletClient {
     public static final String APP_NAME = "jpabootstrap";
     public static final String SERVLET = "TestJPABootstrap";

--- a/dev/com.ibm.ws.jpa.tests.jpa_32_fat/fat/src/com/ibm/ws/jpa/jpa32/JPACDIIntegrationTest.java
+++ b/dev/com.ibm.ws.jpa.tests.jpa_32_fat/fat/src/com/ibm/ws/jpa/jpa32/JPACDIIntegrationTest.java
@@ -24,6 +24,7 @@ import com.ibm.websphere.simplicity.ShrinkHelper;
 import com.ibm.ws.jpa.FATSuite;
 
 import componenttest.annotation.MinimumJavaLevel;
+import componenttest.annotation.MaximumJavaLevel;
 import componenttest.annotation.Server;
 import componenttest.annotation.TestServlet;
 import componenttest.custom.junit.runner.FATRunner;
@@ -40,6 +41,7 @@ import io.openliberty.jpa.jpacdiintegration.tests.web.JPACDIIntegrationServlet;
 
 @RunWith(FATRunner.class)
 @MinimumJavaLevel(javaLevel = 17)
+@MaximumJavaLevel(javaLevel = 25)  // Hibernate ByteBuddy limitation
 public class JPACDIIntegrationTest {
     public static final String APP_NAME = "jpacdiintegration";
     public static final String SERVLET = "JPACDI32";

--- a/dev/com.ibm.ws.jpa.tests.jpa_32_fat/fat/src/com/ibm/ws/jpa/jpa32/JakartaDataRecreateTest.java
+++ b/dev/com.ibm.ws.jpa.tests.jpa_32_fat/fat/src/com/ibm/ws/jpa/jpa32/JakartaDataRecreateTest.java
@@ -30,6 +30,7 @@ import com.ibm.ws.testtooling.database.DatabaseVendor;
 import com.ibm.ws.jpa.FATSuite;
 
 import componenttest.annotation.MinimumJavaLevel;
+import componenttest.annotation.MaximumJavaLevel;
 import componenttest.annotation.Server;
 import componenttest.annotation.TestServlet;
 import componenttest.custom.junit.runner.FATRunner;
@@ -47,6 +48,7 @@ import io.openliberty.jpa.data.tests.web.JakartaDataRecreateServlet;
  */
 @RunWith(FATRunner.class)
 @MinimumJavaLevel(javaLevel = 17)
+@MaximumJavaLevel(javaLevel = 25)  // Hibernate ByteBuddy limitation
 public class JakartaDataRecreateTest {
     public static final String APP_NAME = "jakartadata";
     public static final String SERVLET = "JakartaDataRecreate";

--- a/dev/com.ibm.ws.jpa.tests.jpa_32_fat/fat/src/com/ibm/ws/jpa/jpa32/JakartaPersistenceDataRecreateTest.java
+++ b/dev/com.ibm.ws.jpa.tests.jpa_32_fat/fat/src/com/ibm/ws/jpa/jpa32/JakartaPersistenceDataRecreateTest.java
@@ -30,6 +30,7 @@ import com.ibm.websphere.simplicity.config.ServerConfiguration;
 import com.ibm.ws.jpa.FATSuite;
 
 import componenttest.annotation.MinimumJavaLevel;
+import componenttest.annotation.MaximumJavaLevel;
 import componenttest.annotation.Server;
 import componenttest.annotation.TestServlet;
 import componenttest.custom.junit.runner.FATRunner;
@@ -45,6 +46,7 @@ import io.openliberty.jpa.persistence.tests.web.JakartaPersistenceDataRecreateSe
 
 @RunWith(FATRunner.class)
 @MinimumJavaLevel(javaLevel = 17)
+@MaximumJavaLevel(javaLevel = 25)  // Hibernate ByteBuddy limitation
 public class JakartaPersistenceDataRecreateTest {
 
     public static final String APP_NAME = "jakartapersistence";

--- a/dev/com.ibm.ws.jpa.tests.jpa_32_fat/fat/src/com/ibm/ws/jpa/jpa32/JakartaPersistenceTest.java
+++ b/dev/com.ibm.ws.jpa.tests.jpa_32_fat/fat/src/com/ibm/ws/jpa/jpa32/JakartaPersistenceTest.java
@@ -30,6 +30,7 @@ import com.ibm.websphere.simplicity.config.ServerConfiguration;
 import com.ibm.ws.jpa.FATSuite;
 
 import componenttest.annotation.MinimumJavaLevel;
+import componenttest.annotation.MaximumJavaLevel;
 import componenttest.annotation.Server;
 import componenttest.annotation.TestServlet;
 import componenttest.custom.junit.runner.FATRunner;
@@ -45,6 +46,7 @@ import io.openliberty.jpa.persistence.tests.web.JakartaPersistenceServlet;
 
 @RunWith(FATRunner.class)
 @MinimumJavaLevel(javaLevel = 17)
+@MaximumJavaLevel(javaLevel = 25)  // Hibernate ByteBuddy limitation
 public class JakartaPersistenceTest {
 
     public static final String APP_NAME = "jakartapersistence";


### PR DESCRIPTION
- [X] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [X] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [X] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

################################################################################################

Adding maximum java version to JPA31 and JPA32 fat to prevent issue with byte buddy when running the fat using hibernate. Fixes 2 test defect [310929](https://wasrtc.hursley.ibm.com:9443/jazz/web/projects/WS-CD#action=com.ibm.team.workitem.viewWorkItem&id=310929) and [310927](https://wasrtc.hursley.ibm.com:9443/jazz/web/projects/WS-CD#action=com.ibm.team.workitem.viewWorkItem&id=310927)
