### PR TITLE
Add `?application=<name>` query parameter support to the `/openapi` endpoint

### DIFF
--- a/dev/io.openliberty.microprofile.openapi.2.0.internal.servlet/src/io/openliberty/microprofile/openapi20/internal/servlet/ApplicationServlet.java
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal.servlet/src/io/openliberty/microprofile/openapi20/internal/servlet/ApplicationServlet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2024 IBM Corporation and others.
+ * Copyright (c) 2020, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -87,11 +87,27 @@ public class ApplicationServlet extends OpenAPIServletBase {
             /*
              * Retrieve the current provider and get the OpenAPI model for it. If there is no current provider then
              * generate a default (empty) OpenAPI model.
+             *
+             * If the client supplied ?application=<name>, return documentation only for that application.
+             * If the named application is not found, return 404 Not Found.
              */
             ApplicationRegistry appRegistry = appRegistryTracker.getService();
             OpenAPIProvider currentProvider = null;
             if (appRegistry != null) {
-                currentProvider = appRegistry.getOpenAPIProvider();
+                String applicationParam = request.getParameter(Constants.APPLICATION_PARAM_NAME);
+                if (applicationParam != null) {
+                    currentProvider = appRegistry.getOpenAPIProvider(applicationParam);
+                    if (currentProvider == null) {
+                        // The application name was supplied but doesn't match any deployed application
+                        if (LoggingUtils.isEventEnabled(tc)) {
+                            Tr.event(this, tc, "application query parameter did not match a deployed application: " + applicationParam);
+                        }
+                        writeResponse(response, null, Status.NOT_FOUND, contentType);
+                        return;
+                    }
+                } else {
+                    currentProvider = appRegistry.getOpenAPIProvider();
+                }
             }
             final String document;
             if (currentProvider != null) {

--- a/dev/io.openliberty.microprofile.openapi.2.0.internal/src/io/openliberty/microprofile/openapi20/internal/ApplicationRegistryImpl.java
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal/src/io/openliberty/microprofile/openapi20/internal/ApplicationRegistryImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2025 IBM Corporation and others.
+ * Copyright (c) 2020, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -261,6 +261,29 @@ public class ApplicationRegistryImpl implements ApplicationRegistry, OpenAPIAppC
                 Tr.event(this, tc, "Finished creating OpenAPI provider");
             }
             return result;
+        }
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public OpenAPIProvider getOpenAPIProvider(String applicationName) {
+        synchronized (this) {
+            ApplicationRecord record = applications.get(applicationName);
+            if (record == null) {
+                if (LoggingUtils.isDebugEnabled(tc)) {
+                    Tr.debug(this, tc, "getOpenAPIProvider(String): application not found: " + applicationName);
+                }
+                return null;
+            }
+
+            List<OpenAPIProvider> providers = record.providers;
+            if (providers.isEmpty()) {
+                return null;
+            } else if (providers.size() == 1) {
+                return providers.get(0);
+            } else {
+                return mergeProcessor.mergeDocuments(providers);
+            }
         }
     }
 

--- a/dev/io.openliberty.microprofile.openapi.2.0.internal/src/io/openliberty/microprofile/openapi20/internal/services/ApplicationRegistry.java
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal/src/io/openliberty/microprofile/openapi20/internal/services/ApplicationRegistry.java
@@ -1,3 +1,15 @@
+/*******************************************************************************
+ * Copyright (c) 2020, 2026 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
 package io.openliberty.microprofile.openapi20.internal.services;
 
 import com.ibm.ws.container.service.app.deploy.ApplicationInfo;
@@ -40,5 +52,18 @@ public interface ApplicationRegistry {
      * @return an {@code OpenAPIProvider} holding an OpenAPI model or {@code null} if there are no OpenAPI providers
      */
     OpenAPIProvider getOpenAPIProvider();
+
+    /**
+     * Finds the models for the named application only, merges its web modules if necessary, and returns them.
+     * <p>
+     * This is used when the client supplies an {@code ?application=} query parameter on the {@code /openapi} endpoint
+     * to request the OpenAPI document for a single deployed application.
+     *
+     * @param applicationName
+     *     The deployment name of the application (matches the {@code name} attribute from {@code server.xml}).
+     * @return an {@code OpenAPIProvider} holding an OpenAPI model for the named application,
+     *         or {@code null} if the application is not known or has no OpenAPI providers
+     */
+    OpenAPIProvider getOpenAPIProvider(String applicationName);
 
 }

--- a/dev/io.openliberty.microprofile.openapi.2.0.internal/src/io/openliberty/microprofile/openapi20/internal/utils/Constants.java
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal/src/io/openliberty/microprofile/openapi20/internal/utils/Constants.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2021 IBM Corporation and others.
+ * Copyright (c) 2020, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -128,6 +128,9 @@ public class Constants {
     public static final String FORMAT_PARAM_NAME = "format";
     public static final String FORMAT_PARAM_VALUE_JSON = "json";
     public static final String FORMAT_PARAM_VALUE_YAML = "yaml";
+
+    // Application Query Parameter Constants
+    public static final String APPLICATION_PARAM_NAME = "application";
 
     // Regular expression constants
     public static final Pattern REGEX_COMPONENT_KEY_PATTERN = Pattern.compile("^[a-zA-Z0-9\\.\\-_]+$");

--- a/dev/io.openliberty.microprofile.openapi.2.0.internal_fat/fat/src/io/openliberty/microprofile/openapi20/fat/FATSuite.java
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal_fat/fat/src/io/openliberty/microprofile/openapi20/fat/FATSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2025 IBM Corporation and others.
+ * Copyright (c) 2017, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -25,6 +25,7 @@ import io.openliberty.microprofile.openapi20.fat.deployments.MergeConfigServerXM
 import io.openliberty.microprofile.openapi20.fat.deployments.MergeConfigTest;
 import io.openliberty.microprofile.openapi20.fat.deployments.MergeTest;
 import io.openliberty.microprofile.openapi20.fat.deployments.MergeWithServletTest;
+import io.openliberty.microprofile.openapi20.fat.deployments.SingleAppQueryParamTest;
 import io.openliberty.microprofile.openapi20.fat.deployments.StartupWarningMessagesTest;
 import io.openliberty.microprofile.openapi20.fat.deployments.ZOSConnectExtensionTest;
 import io.openliberty.microprofile.openapi20.fat.shutdown.ShutdownTest;
@@ -40,6 +41,7 @@ import io.openliberty.microprofile.openapi20.fat.version.OpenAPIVersionTest;
     MergeConfigBothTest.class,
     MergeTest.class,
     MergeWithServletTest.class,
+    SingleAppQueryParamTest.class,
     OpenAPIVersionTest.class,
     ShutdownTest.class,
     StartupWarningMessagesTest.class,

--- a/dev/io.openliberty.microprofile.openapi.2.0.internal_fat/fat/src/io/openliberty/microprofile/openapi20/fat/deployments/SingleAppQueryParamTest.java
+++ b/dev/io.openliberty.microprofile.openapi.2.0.internal_fat/fat/src/io/openliberty/microprofile/openapi20/fat/deployments/SingleAppQueryParamTest.java
@@ -1,0 +1,201 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.microprofile.openapi20.fat.deployments;
+
+import static com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions.DISABLE_VALIDATION;
+import static com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions.SERVER_ONLY;
+import static org.junit.Assert.assertNotNull;
+
+import java.net.HttpURLConnection;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.ibm.websphere.simplicity.ShrinkHelper;
+
+import componenttest.annotation.Server;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.custom.junit.runner.Mode;
+import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.rules.repeater.RepeatTests;
+import componenttest.topology.impl.LibertyServer;
+import io.openliberty.microprofile.openapi20.fat.FATSuite;
+import io.openliberty.microprofile.openapi20.fat.deployments.test1.DeploymentTestApp;
+import io.openliberty.microprofile.openapi20.fat.deployments.test1.DeploymentTestResource;
+import io.openliberty.microprofile.openapi20.fat.utils.OpenAPIConnection;
+import io.openliberty.microprofile.openapi20.fat.utils.OpenAPITestUtil;
+
+/**
+ * Tests for the {@code ?application=<name>} query parameter on the {@code /openapi} endpoint.
+ * <p>
+ * The parameter was added to allow clients to retrieve the OpenAPI document for a single named
+ * application rather than the merged document for all deployed applications.
+ */
+@RunWith(FATRunner.class)
+public class SingleAppQueryParamTest {
+
+    private static final String SERVER_NAME = "OpenAPIMergeTestServer";
+
+    @Server(SERVER_NAME)
+    public static LibertyServer server;
+
+    @ClassRule
+    public static RepeatTests r = FATSuite.repeatDefault(SERVER_NAME);
+
+    private final List<String> deployedApps = new ArrayList<>();
+
+    @BeforeClass
+    public static void setupServer() throws Exception {
+        server.setAdditionalSystemProperties(
+                                             Collections.singletonMap("mp_openapi_extensions_liberty_merged_include", "all"));
+        server.startServer();
+    }
+
+    @AfterClass
+    public static void shutdownServer() throws Exception {
+        server.stopServer();
+    }
+
+    @After
+    public void cleanup() throws Exception {
+        server.setMarkToEndOfLog();
+        server.deleteAllDropinApplications();
+
+        List<String> failedToStop = new ArrayList<>();
+        for (String app : deployedApps) {
+            if (server.waitForStringInLogUsingMark("CWWKZ0009I:.*" + app) == null) {
+                failedToStop.add(app);
+            }
+        }
+        deployedApps.clear();
+
+        if (!failedToStop.isEmpty()) {
+            throw new AssertionError("The following apps failed to stop: " + failedToStop);
+        }
+    }
+
+    /**
+     * With a single deployed app, {@code ?application=<name>} returns the document for that app.
+     */
+    @Test
+    public void testApplicationParamSingleApp() throws Exception {
+        WebArchive war1 = ShrinkWrap.create(WebArchive.class, "test1.war")
+                                    .addClasses(DeploymentTestApp.class, DeploymentTestResource.class);
+        deployApp(war1);
+
+        String doc = OpenAPIConnection.openAPIDocsConnection(server, false)
+                                      .queryParam("application", "test1")
+                                      .download();
+        JsonNode openapiNode = OpenAPITestUtil.readYamlTree(doc);
+        OpenAPITestUtil.checkPaths(openapiNode, 1, "/test1/test");
+    }
+
+    /**
+     * With two deployed apps, {@code ?application=<name>} returns only that app's document,
+     * while omitting the parameter still returns the merged document.
+     */
+    @Test
+    public void testApplicationParamOneOfMultipleApps() throws Exception {
+        WebArchive war1 = ShrinkWrap.create(WebArchive.class, "test1.war")
+                                    .addClasses(DeploymentTestApp.class, DeploymentTestResource.class);
+        WebArchive war2 = ShrinkWrap.create(WebArchive.class, "test2.war")
+                                    .addClasses(DeploymentTestApp.class, DeploymentTestResource.class);
+        deployApp(war1);
+        deployApp(war2);
+
+        // No parameter: merged document from both apps
+        String mergedDoc = OpenAPIConnection.openAPIDocsConnection(server, false).download();
+        JsonNode mergedNode = OpenAPITestUtil.readYamlTree(mergedDoc);
+        OpenAPITestUtil.checkPaths(mergedNode, 2, "/test1/test", "/test2/test");
+
+        // ?application=test1: only test1's paths
+        String app1Doc = OpenAPIConnection.openAPIDocsConnection(server, false)
+                                          .queryParam("application", "test1")
+                                          .download();
+        JsonNode app1Node = OpenAPITestUtil.readYamlTree(app1Doc);
+        OpenAPITestUtil.checkPaths(app1Node, 1, "/test1/test");
+
+        // ?application=test2: only test2's paths
+        String app2Doc = OpenAPIConnection.openAPIDocsConnection(server, false)
+                                          .queryParam("application", "test2")
+                                          .download();
+        JsonNode app2Node = OpenAPITestUtil.readYamlTree(app2Doc);
+        OpenAPITestUtil.checkPaths(app2Node, 1, "/test2/test");
+    }
+
+    /**
+     * An unrecognised application name must return HTTP 404 Not Found.
+     */
+    @Test
+    public void testApplicationParamNotFound() throws Exception {
+        WebArchive war1 = ShrinkWrap.create(WebArchive.class, "test1.war")
+                                    .addClasses(DeploymentTestApp.class, DeploymentTestResource.class);
+        deployApp(war1);
+
+        OpenAPIConnection.openAPIDocsConnection(server, false)
+                         .queryParam("application", "doesNotExist")
+                         .expectedResponseCode(HttpURLConnection.HTTP_NOT_FOUND)
+                         .download();
+    }
+
+    /**
+     * For a multi-module EAR, {@code ?application=<ear-name>} returns the document with paths
+     * from all web modules within that EAR merged together.
+     */
+    @Test
+    @Mode(TestMode.FULL)
+    public void testApplicationParamMultiModuleEar() throws Exception {
+        WebArchive war1 = ShrinkWrap.create(WebArchive.class, "test1.war")
+                                    .addClasses(DeploymentTestApp.class, DeploymentTestResource.class);
+        WebArchive war2 = ShrinkWrap.create(WebArchive.class, "test2.war")
+                                    .addClasses(DeploymentTestApp.class, DeploymentTestResource.class);
+        EnterpriseArchive ear = ShrinkWrap.create(EnterpriseArchive.class, "test.ear")
+                                          .addAsModules(war1, war2);
+        deployApp(ear);
+
+        // The EAR is registered under the name "test"; its two WAR modules should be merged
+        String doc = OpenAPIConnection.openAPIDocsConnection(server, false)
+                                      .queryParam("application", "test")
+                                      .download();
+        JsonNode openapiNode = OpenAPITestUtil.readYamlTree(doc);
+        OpenAPITestUtil.checkPaths(openapiNode, 2, "/test1/test", "/test2/test");
+    }
+
+    // --- helpers ---
+
+    private void deployApp(Archive<?> archive) throws Exception {
+        server.setMarkToEndOfLog();
+        server.setTraceMarkToEndOfDefaultTrace();
+        ShrinkHelper.exportDropinAppToServer(server, archive, SERVER_ONLY, DISABLE_VALIDATION);
+        assertNotNull(server.waitForStringInLogUsingMark("CWWKZ0001I:.*" + getName(archive)));
+        deployedApps.add(getName(archive));
+    }
+
+    private String getName(Archive<?> archive) {
+        String name = archive.getName();
+        int dot = name.lastIndexOf('.');
+        return dot != -1 ? name.substring(0, dot) : name;
+    }
+}


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [ ] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

## Add `?application=<name>` query parameter support to the `/openapi` endpoint

### Summary

This PR adds support for an `?application=<name>` query parameter on the `/openapi` endpoint. When supplied, the endpoint returns the OpenAPI document for the single named application rather than the merged document for all deployed applications. If the named application is not found, the endpoint returns HTTP 404 Not Found.

### Changes

#### New Feature: Per-application OpenAPI document retrieval

- **`Constants.java`**: Added a new constant `APPLICATION_PARAM_NAME = "application"` to define the query parameter name.

- **`ApplicationRegistry.java`**: Added a new method `getOpenAPIProvider(String applicationName)` to the `ApplicationRegistry` interface. This method finds the OpenAPI providers for a named application, merges web modules if necessary, and returns the result. Returns `null` if the application is not known or has no OpenAPI providers. Also added missing copyright header.

- **`ApplicationRegistryImpl.java`**: Implemented the new `getOpenAPIProvider(String applicationName)` method. It looks up the application by name in the registry and merges its providers if the application has multiple web modules (e.g., a multi-module EAR).

- **`ApplicationServlet.java`**: Updated the servlet to read the `?application=` query parameter from the incoming request. If the parameter is present:
  - Delegates to the new `getOpenAPIProvider(String)` method.
  - If no matching application is found, logs an event and writes an HTTP 404 response.
  - If the parameter is absent, falls back to the existing `getOpenAPIProvider()` behaviour (merged document for all apps).

### Tests

- **`SingleAppQueryParamTest.java`** (new FAT test class): Covers the following scenarios:
  - `testApplicationParamSingleApp`: With one deployed WAR, `?application=<name>` returns that app's document.
  - `testApplicationParamOneOfMultipleApps`: With two deployed WARs, the parameter selects one app's document; omitting the parameter still returns the merged document.
  - `testApplicationParamNotFound`: An unrecognised application name returns HTTP 404.
  - `testApplicationParamMultiModuleEar` (FULL mode): For a multi-module EAR, `?application=<ear-name>` returns the merged document across all web modules within that EAR.

- **`FATSuite.java`**: Registered `SingleAppQueryParamTest` in the FAT suite.

### Behavior Change Consideration

This change is purely additive. The new `?application=` query parameter was not previously interpreted, so existing clients that do not supply it are unaffected. Clients that happen to pass `?application=` with an unrecognised value will now receive a 404 instead of the full merged document, which is a new and intentional behaviour.

---
Co-authored-by-AI: IBM Bob 2.0.0.
