### PR TITLE
Refresh to latest from Jakarta Data 1467, 1482, 1505

### DIFF
--- a/dev/io.openliberty.data.internal_fat_1_1/test-applications/Data_1_1_App/src/test/jakarta/data/v1_1/web/Data_1_1_Servlet.java
+++ b/dev/io.openliberty.data.internal_fat_1_1/test-applications/Data_1_1_App/src/test/jakarta/data/v1_1/web/Data_1_1_Servlet.java
@@ -64,8 +64,8 @@ import jakarta.transaction.UserTransaction;
 import org.junit.Test;
 
 import componenttest.annotation.AllowedFFDC;
-import componenttest.app.FATServlet;
 import componenttest.annotation.SkipIfSysProp;
+import componenttest.app.FATServlet;
 import test.jakarta.data.v1_1.web.Fraction.Decimal;
 import test.jakarta.data.v1_1.web.Fraction.Decimal.Type;
 
@@ -546,7 +546,7 @@ public class Data_1_1_Servlet extends FATServlet {
      * Use the QueryOptions annotation on a Find method to supply a load graph
      * that overrides loading of an ElementCollection to make it eager rather
      * than lazily loaded.
-     * 
+     *
      * Applies scaling due to Oracle stripping trailing 0s
      */
     @Test
@@ -555,25 +555,25 @@ public class Data_1_1_Servlet extends FATServlet {
                              BigDecimal.valueOf(310, 3), // nearest hundreth
                              BigDecimal.valueOf(313, 3)), // nearest thousandth
                      fractions.of(5, 16).orElseThrow().rounded
-                                        .stream()
-                                        .map(bd -> bd.setScale(3))
-                                        .toList());
+                                     .stream()
+                                     .map(bd -> bd.setScale(3))
+                                     .toList());
 
         assertEquals(List.of(BigDecimal.valueOf(900, 3), // nearest tenth
                              BigDecimal.valueOf(860, 3), // nearest hundreth
                              BigDecimal.valueOf(857, 3)), // nearest thousandth
                      fractions.of(6, 7).orElseThrow().rounded
-                                       .stream()
-                                       .map(bd -> bd.setScale(3))
-                                       .toList());
+                                     .stream()
+                                     .map(bd -> bd.setScale(3))
+                                     .toList());
 
         assertEquals(List.of(BigDecimal.valueOf(600, 3), // nearest tenth
                              BigDecimal.valueOf(620, 3), // nearest hundreth
                              BigDecimal.valueOf(615, 3)), // nearest thousandth
                      fractions.of(8, 13).orElseThrow().rounded
-                                        .stream()
-                                        .map(bd -> bd.setScale(3))
-                                        .toList());
+                                     .stream()
+                                     .map(bd -> bd.setScale(3))
+                                     .toList());
     }
 
     /**
@@ -1450,6 +1450,44 @@ public class Data_1_1_Servlet extends FATServlet {
     }
 
     /**
+     * Tests a Limit that has an offset from the first result.
+     */
+    @Test
+    public void testLimitAfterOffset() {
+
+        assertEquals(List.of("Thirteen Sixteenths",
+                             "Thirteen Twentieths",
+                             "Three Eighteenths",
+                             "Three Eighths",
+                             "Three Elevenths"),
+                     fractions.named(Like.pattern("T%"),
+                                     Order.by(Sort.asc(_Fraction.NAME)),
+                                     Limit.of(5, 15))); // results 16..20
+
+        assertEquals(List.of("Three Fifteenths",
+                             "Three Fifths",
+                             "Three Fourteenths",
+                             "Three Fourths",
+                             "Three Nineteenths"),
+                     fractions.named(Like.pattern("T%"),
+                                     Order.by(Sort.asc(_Fraction.NAME)),
+                                     Limit.of(5, 20))); // results 21..25
+
+        assertEquals(List.of("Ten Eighteenths"),
+                     fractions.named(Like.pattern("T%"),
+                                     Order.by(Sort.asc(_Fraction.NAME)),
+                                     Limit.of(1, 0))); // first result
+
+        assertEquals(List.of("Two Thirds",
+                             "Two Thirteenths",
+                             "Two Twelfths",
+                             "Two Twentieths"),
+                     fractions.named(Like.pattern("T%"),
+                                     Order.by(Sort.asc(_Fraction.NAME)),
+                                     Limit.of(5, 56))); // results 57..61
+    }
+
+    /**
      * Use the QueryOptions annotation to establish pessimistic locking and
      * a query timeout on a repository method annotated JakartaQuery.
      */
@@ -1943,7 +1981,8 @@ public class Data_1_1_Servlet extends FATServlet {
         try {
             assertEquals(BigDecimal.valueOf(6090L, 4),
                          fractions.roundedUp(14, 23)
-                                         .orElseThrow().setScale(4));
+                                         .orElseThrow()
+                                         .setScale(4));
 
             System.out.println("Update 14/23");
 
@@ -2271,7 +2310,7 @@ public class Data_1_1_Servlet extends FATServlet {
      * supplied to a repository method.
      */
     // Oracle doesn't do integer division, it always returns a floating point number
-    @SkipIfSysProp(SkipIfSysProp.DB_Oracle) 
+    @SkipIfSysProp(SkipIfSysProp.DB_Oracle)
     @Test
     public void testPlusAndDivide() {
 
@@ -2897,7 +2936,7 @@ public class Data_1_1_Servlet extends FATServlet {
                                                      .minus(_Fraction.name.length())
                                                      .plus(3)
                                                      .abs()
-                                                     .asc(),  
+                                                     .asc(),
                                               _Fraction.reduced.asc(),
                                               _Fraction.name.left(4).desc(),
                                               _Fraction.decimal.navigate(_Decimal.digits)

--- a/dev/io.openliberty.data.internal_fat_1_1/test-applications/Data_1_1_App/src/test/jakarta/data/v1_1/web/Data_1_1_Servlet.java
+++ b/dev/io.openliberty.data.internal_fat_1_1/test-applications/Data_1_1_App/src/test/jakarta/data/v1_1/web/Data_1_1_Servlet.java
@@ -1214,7 +1214,7 @@ public class Data_1_1_Servlet extends FATServlet {
 
         PageRequest page2Req = PageRequest.ofSize(5)
                         .afterCursor(threeFifths)
-                        .page(2)
+                        .pageNumber(2)
                         .withoutTotal();
 
         CursoredPage<Fraction> page2 = fractions.namedLike("%fths",

--- a/dev/io.openliberty.jakarta.data.1.1/resources/jakarta/data/messages/DataMessages.nlsprops
+++ b/dev/io.openliberty.jakarta.data.1.1/resources/jakarta/data/messages/DataMessages.nlsprops
@@ -42,3 +42,8 @@
  identify the entity class that declares the attribute. For static metamodel \
  classes, use an .of method that is defined on an Attribute subtype to supply \
  the entity class and entity attribute type.
+013.arg.invalid=The {0} argument cannot be {1}
+014.mode.disallows.offset=A page cannot be requested to have an offset \
+ and a mode of {0}
+015.cursor.uncomputable=The requested operation is not available because a \
+ cursor cannot be computed from sort criteria that includes an expression.

--- a/dev/io.openliberty.jakarta.data.1.1/resources/jakarta/data/messages/DataMessages.properties
+++ b/dev/io.openliberty.jakarta.data.1.1/resources/jakarta/data/messages/DataMessages.properties
@@ -33,3 +33,8 @@
  identify the entity class that declares the attribute. For static metamodel \
  classes, use an .of method that is defined on an Attribute subtype to supply \
  the entity class and entity attribute type.
+013.arg.invalid=The {0} argument cannot be {1}
+014.mode.disallows.offset=A page cannot be requested to have an offset \
+ and a mode of {0}
+015.cursor.uncomputable=The requested operation is not available because a \
+ cursor cannot be computed from sort criteria that includes an expression.

--- a/dev/io.openliberty.jakarta.data.1.1/src/jakarta/data/Limit.java
+++ b/dev/io.openliberty.jakarta.data.1.1/src/jakarta/data/Limit.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022,2023 IBM Corporation and others.
+ * Copyright (c) 2022,2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -11,6 +11,8 @@
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package jakarta.data;
+
+import jakarta.data.messages.Messages;
 
 /**
  * Method signatures are copied from the jakarta.data.repository.Limit from the Jakarta Data repo.
@@ -29,12 +31,28 @@ public record Limit(int maxResults,
         return new Limit(maxResults, 1L);
     }
 
+    public static Limit of(int maxResults, long offset) {
+        if (offset < 0)
+            throw new IllegalArgumentException(Messages.get("004.arg.negative",
+                                                            "offset"));
+
+        if (offset == Long.MAX_VALUE)
+            throw new IllegalArgumentException(Messages.get("013.arg.invalid",
+                                                            "offset",
+                                                            offset));
+
+        return new Limit(maxResults, offset + 1);
+    }
+
     public static Limit range(long startAt, long endAt) {
         if (startAt > endAt)
-            throw new IllegalArgumentException("startAt: " + startAt + ", endAt: " + endAt);
+            throw new IllegalArgumentException("startAt: " + startAt +
+                                               ", endAt: " + endAt);
 
         if (Integer.MAX_VALUE <= endAt - startAt)
-            throw new IllegalArgumentException("startAt: " + startAt + ", endAt: " + endAt + ", maxResults > " + Integer.MAX_VALUE);
+            throw new IllegalArgumentException("startAt: " + startAt +
+                                               ", endAt: " + endAt +
+                                               ", maxResults > " + Integer.MAX_VALUE);
 
         return new Limit(1 + (int) (endAt - startAt), startAt);
     }

--- a/dev/io.openliberty.jakarta.data.1.1/src/jakarta/data/page/PageRequest.java
+++ b/dev/io.openliberty.jakarta.data.1.1/src/jakarta/data/page/PageRequest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022,2025 IBM Corporation and others.
+ * Copyright (c) 2022,2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -15,8 +15,11 @@ package jakarta.data.page;
 import java.util.List;
 import java.util.Optional;
 
+import jakarta.data.messages.Messages;
+
 /**
- * Method signatures are copied from jakarta.data.repository.PageRequest from the Jakarta Data repo.
+ * Method signatures are copied from jakarta.data.page.PageRequest
+ * from the Jakarta Data repo.
  */
 public interface PageRequest {
     public static enum Mode {
@@ -63,9 +66,30 @@ public interface PageRequest {
 
     public Mode mode();
 
-    public long page();
+    public default long page() {
+        return pageNumber();
+    }
 
-    public PageRequest page(long pageNum);
+    public long pageNumber();
+
+    public PageRequest pageNumber(long pageNum);
+
+    public default PageRequest pageOffset(long offset) {
+        if (mode() != Mode.OFFSET)
+            throw new IllegalStateException(Messages.get("014.mode.disallows.offset",
+                                                         mode()));
+
+        if (offset < 0)
+            throw new IllegalArgumentException(Messages.get("004.arg.negative",
+                                                            "offset"));
+
+        if (offset == Long.MAX_VALUE)
+            throw new IllegalArgumentException(Messages.get("013.arg.invalid",
+                                                            "offset",
+                                                            offset));
+
+        return pageNumber(offset + 1);
+    }
 
     public boolean requestTotal();
 

--- a/dev/io.openliberty.jakarta.data.1.1/src/jakarta/data/page/Pagination.java
+++ b/dev/io.openliberty.jakarta.data.1.1/src/jakarta/data/page/Pagination.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022,2025 IBM Corporation and others.
+ * Copyright (c) 2022,2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -17,9 +17,10 @@ import java.util.Optional;
 import jakarta.data.messages.Messages;
 
 /**
- * Method signatures are copied from jakarta.data.repository.PageRequest from the Jakarta Data repo.
+ * Method signatures are copied from jakarta.data.page.PageRequest from the
+ * Jakarta Data repo.
  */
-record Pagination(long page,
+record Pagination(long pageNumber,
                 int size,
                 Mode mode,
                 Cursor type,
@@ -27,8 +28,8 @@ record Pagination(long page,
                 implements PageRequest {
 
     Pagination {
-        if (page < 1)
-            throw new IllegalArgumentException("pageNumber: " + page);
+        if (pageNumber < 1)
+            throw new IllegalArgumentException("pageNumber: " + pageNumber);
         if (size < 1)
             throw new IllegalArgumentException("maxPageSize: " + size);
         if (mode != Mode.OFFSET && (type == null || type.size() == 0))
@@ -37,12 +38,12 @@ record Pagination(long page,
 
     @Override
     public PageRequest afterCursor(PageRequest.Cursor cursor) {
-        return new Pagination(page, size, Mode.CURSOR_NEXT, cursor, requestTotal);
+        return new Pagination(pageNumber, size, Mode.CURSOR_NEXT, cursor, requestTotal);
     }
 
     @Override
     public PageRequest beforeCursor(PageRequest.Cursor cursor) {
-        return new Pagination(page, size, Mode.CURSOR_PREVIOUS, cursor, requestTotal);
+        return new Pagination(pageNumber, size, Mode.CURSOR_PREVIOUS, cursor, requestTotal);
     }
 
     @Override
@@ -51,18 +52,19 @@ record Pagination(long page,
     }
 
     @Override
-    public PageRequest page(long pageNum) {
+    public PageRequest pageNumber(long pageNum) {
         return new Pagination(pageNum, size, mode, type, requestTotal);
     }
 
     @Override
     public Pagination size(int maxPageSize) {
-        return new Pagination(page, maxPageSize, mode, type, requestTotal);
+        return new Pagination(pageNumber, maxPageSize, mode, type, requestTotal);
     }
 
     @Override
     public String toString() {
-        StringBuilder b = new StringBuilder("PageRequest{page=").append(page) //
+        StringBuilder b = new StringBuilder("PageRequest{pageNumber=") //
+                        .append(pageNumber) //
                         .append(", size=").append(size) //
                         .append(", mode=").append(mode);
 
@@ -76,12 +78,12 @@ record Pagination(long page,
 
     @Override
     public PageRequest withoutTotal() {
-        return new Pagination(page, size, mode, type, false);
+        return new Pagination(pageNumber, size, mode, type, false);
     }
 
     @Override
     public PageRequest withTotal() {
-        return new Pagination(page, size, mode, type, true);
+        return new Pagination(pageNumber, size, mode, type, true);
     }
 
 }

--- a/dev/io.openliberty.jakarta.data.1.1/src/jakarta/data/page/impl/CursoredPageRecord.java
+++ b/dev/io.openliberty.jakarta.data.1.1/src/jakarta/data/page/impl/CursoredPageRecord.java
@@ -58,11 +58,13 @@ public record CursoredPageRecord<T>(
              totalElements, //
              pageRequest, //
              last ? null : PageRequest.afterCursor(cursors.get(cursors.size() - 1),
-                                                   1L + pageRequest.page(),
+                                                   1L + pageRequest.pageNumber(),
                                                    pageRequest.size(),
                                                    pageRequest.requestTotal()), //
              first ? null : PageRequest.beforeCursor(cursors.get(0),
-                                                     pageRequest.page() == 1 ? 1 : pageRequest.page() - 1,
+                                                     pageRequest.pageNumber() == 1 //
+                                                                     ? 1 //
+                                                                     : pageRequest.page() - 1,
                                                      pageRequest.size(),
                                                      pageRequest.requestTotal()));
     }

--- a/dev/io.openliberty.jakarta.data.1.1/src/jakarta/data/page/impl/CursoredPageRecord.java
+++ b/dev/io.openliberty.jakarta.data.1.1/src/jakarta/data/page/impl/CursoredPageRecord.java
@@ -71,6 +71,10 @@ public record CursoredPageRecord<T>(
 
     @Override
     public Cursor cursor(int i) {
+        if (cursors.isEmpty())
+            throw new UnsupportedOperationException(Messages //
+                            .get("015.cursor.uncomputable"));
+
         return cursors.get(i);
     }
 
@@ -101,7 +105,10 @@ public record CursoredPageRecord<T>(
 
     @Override
     public PageRequest nextPageRequest() {
-        if (nextPageRequest == null)
+        if (cursors.isEmpty())
+            throw new UnsupportedOperationException(Messages //
+                            .get("015.cursor.uncomputable"));
+        else if (nextPageRequest == null)
             throw new NoSuchElementException();
         else
             return nextPageRequest;
@@ -114,7 +121,10 @@ public record CursoredPageRecord<T>(
 
     @Override
     public PageRequest previousPageRequest() {
-        if (previousPageRequest == null)
+        if (cursors.isEmpty())
+            throw new UnsupportedOperationException(Messages //
+                            .get("015.cursor.uncomputable"));
+        else if (previousPageRequest == null)
             throw new NoSuchElementException();
         else
             return previousPageRequest;

--- a/dev/io.openliberty.jakarta.data.1.1/src/jakarta/data/page/impl/PageRecord.java
+++ b/dev/io.openliberty.jakarta.data.1.1/src/jakarta/data/page/impl/PageRecord.java
@@ -45,7 +45,8 @@ public record PageRecord<T>(PageRequest pageRequest,
         this(req, //
              content, //
              total, //
-             content.size() == req.size() && (total < 0 || req.page() * req.size() < total));
+             content.size() == req.size() && //
+                    (total < 0 || req.pageNumber() * req.size() < total));
     }
 
     @Override
@@ -60,7 +61,7 @@ public record PageRecord<T>(PageRequest pageRequest,
 
     @Override
     public boolean hasPrevious() {
-        return pageRequest.page() > 1;
+        return pageRequest.pageNumber() > 1;
     }
 
     @Override
@@ -76,7 +77,9 @@ public record PageRecord<T>(PageRequest pageRequest,
     @Override
     public PageRequest nextPageRequest() {
         if (hasNext())
-            return PageRequest.ofPage(pageRequest.page() + 1L, pageRequest.size(), pageRequest.requestTotal());
+            return PageRequest.ofPage(pageRequest.pageNumber() + 1L,
+                                      pageRequest.size(),
+                                      pageRequest.requestTotal());
         else
             throw new NoSuchElementException();
     }
@@ -89,7 +92,9 @@ public record PageRecord<T>(PageRequest pageRequest,
     @Override
     public PageRequest previousPageRequest() {
         if (hasPrevious())
-            return PageRequest.ofPage(pageRequest.page() - 1L, pageRequest.size(), pageRequest.requestTotal());
+            return PageRequest.ofPage(pageRequest.pageNumber() - 1L,
+                                      pageRequest.size(),
+                                      pageRequest.requestTotal());
         else
             throw new NoSuchElementException();
     }

--- a/dev/io.openliberty.jakarta.data.1.1/src/jakarta/data/spi/expression/function/CurrentDate.java
+++ b/dev/io.openliberty.jakarta.data.1.1/src/jakarta/data/spi/expression/function/CurrentDate.java
@@ -23,12 +23,15 @@ public interface CurrentDate<T> extends TemporalExpression<T, LocalDate> {
 
     @SuppressWarnings("unchecked")
     static <T> CurrentDate<T> now() {
-        return (CurrentDate<T>) CurrentDateImpl.INSTANCE;
+        return (CurrentDate<T>) CurrentDateInstance.instance;
     }
 }
 
-class CurrentDateImpl<T> implements CurrentDate<T> {
-    static final CurrentDate<?> INSTANCE = new CurrentDateImpl<>();
+class CurrentDateInstance implements CurrentDate<Object> {
+    static final CurrentDate<?> instance = new CurrentDateInstance();
+
+    private CurrentDateInstance() {
+    }
 
     @Override
     public String toString() {

--- a/dev/io.openliberty.jakarta.data.1.1/src/jakarta/data/spi/expression/function/CurrentDateTime.java
+++ b/dev/io.openliberty.jakarta.data.1.1/src/jakarta/data/spi/expression/function/CurrentDateTime.java
@@ -23,12 +23,15 @@ public interface CurrentDateTime<T> extends TemporalExpression<T, LocalDateTime>
 
     @SuppressWarnings("unchecked")
     static <T> CurrentDateTime<T> now() {
-        return (CurrentDateTime<T>) CurrentDateTimeImpl.INSTANCE;
+        return (CurrentDateTime<T>) CurrentDateTimeInstance.instance;
     }
 }
 
-class CurrentDateTimeImpl<T> implements CurrentDateTime<T> {
-    static final CurrentDateTime<?> INSTANCE = new CurrentDateTimeImpl<>();
+class CurrentDateTimeInstance implements CurrentDateTime<Object> {
+    static final CurrentDateTime<?> instance = new CurrentDateTimeInstance();
+
+    private CurrentDateTimeInstance() {
+    }
 
     @Override
     public String toString() {

--- a/dev/io.openliberty.jakarta.data.1.1/src/jakarta/data/spi/expression/function/CurrentTime.java
+++ b/dev/io.openliberty.jakarta.data.1.1/src/jakarta/data/spi/expression/function/CurrentTime.java
@@ -23,12 +23,15 @@ public interface CurrentTime<T> extends TemporalExpression<T, LocalTime> {
 
     @SuppressWarnings("unchecked")
     static <T> CurrentTime<T> now() {
-        return (CurrentTime<T>) CurrentTimeImpl.INSTANCE;
+        return (CurrentTime<T>) CurrentTimeInstance.instance;
     }
 }
 
-class CurrentTimeImpl<T> implements CurrentTime<T> {
-    static final CurrentTime<?> INSTANCE = new CurrentTimeImpl<>();
+class CurrentTimeInstance implements CurrentTime<Object> {
+    static final CurrentTime<?> instance = new CurrentTimeInstance();
+
+    private CurrentTimeInstance() {
+    }
 
     @Override
     public String toString() {


### PR DESCRIPTION
Refreshes our copy of Data 1.1 code to the latest from Jakarta Data PRs 1467, 1482, 1505

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
