### PR TITLE
Fix intermittent timing failure in RestMetricsTest

### DIFF
--- a/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/RestMetricsTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/RestMetricsTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2024 IBM Corporation and others.
+ * Copyright (c) 2019, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -85,7 +85,7 @@ public class RestMetricsTest {
 
     private final String MAPPEDURI = getBaseTestUri(METRICSWAR, "rest", "restmetrics");
 
-    private static final int BUFFER = 2000; // margin or error in ms for response times.
+    private static final int BUFFER = 3500; // margin of error in ms for response times.
 
     private static final int EXPECTEDRT = 200; // Expected min. response time for a single request.
 


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [ ] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

---

## Summary

`RestMetricsTest` was failing intermittently with a timing assertion error — the MicroProfile Metrics accumulated elapsed time exceeded the expected upper bound (`EXPECTEDRT * count + BUFFER`) on loaded CI machines. The `BUFFER` of 2000ms was too tight; a macOS CI runner under heavy load produced an elapsed time of 2823ms against a ceiling of 2200ms.

## Changes

- `dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/RestMetricsTest.java` — increased `BUFFER` from 2000ms to 3500ms; updated copyright year to 2026.
