### PR TITLE
Fix references and location of the MCP Java jar

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/public/mcpServer-1.0/io.openliberty.mcpServer-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/mcpServer-1.0/io.openliberty.mcpServer-1.0.feature
@@ -23,8 +23,8 @@ Subsystem-Name: Model Context Protocol Server 1.0
 -features=io.openliberty.mcpServer1.0.ee-10.0;ibm.tolerates:="11.0, 12.0"
 -bundles=io.openliberty.mcp; location:="dev/api/ibm/,lib/", \
  io.openliberty.mcp.internal, \
- io.openliberty.org.mcp-java.mcp-server-api; location:="dev/api/stable/,lib/"; mavenCoordinates="org.mcpjava:mcp-server-api:1.0.0", \
- io.openliberty.org.mcp-java.mcp-server-api.fragment
+ io.openliberty.org.mcpjava.mcp-server-api; location:="dev/api/stable/,lib/"; mavenCoordinates="org.mcpjava:mcp-server-api:1.0.0", \
+ io.openliberty.org.mcpjava.mcp-server-api.fragment
 -files=dev/api/ibm/javadoc/io.openliberty.mcp_1.0-javadoc.zip
 kind=beta
 edition=core

--- a/dev/io.openliberty.org.mcpjava.mcp-server-api/bnd.bnd
+++ b/dev/io.openliberty.org.mcpjava.mcp-server-api/bnd.bnd
@@ -13,6 +13,8 @@ bVersion=1.0
 
 Bundle-SymbolicName: io.openliberty.org.mcpjava.mcp-server-api; singleton:=true
 
+publish.wlp.jar.suffix: dev/api/stable
+
 Require-Capability: osgi.ee; filter:="(&(osgi.ee=JavaSE)(version=17))"
 
 javac.source: 17


### PR DESCRIPTION
- Publish the jar to `dev/api/stable`
- Update the bundle name in the feature file

The first problem was only checked in the build. I think the second issue got through because I updated the feature files and didn't clean my workspace, so the file with the old name was still present and allowed the server to start.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

Fixes #35289 