### PR TITLE
JAX-WS: Add message keys for unknown element config

### DIFF
--- a/dev/com.ibm.ws.jaxws.2.3.common/resources/com/ibm/ws/jaxws/internal/resources/JaxWsCommonMessages.nlsprops
+++ b/dev/com.ibm.ws.jaxws.2.3.common/resources/com/ibm/ws/jaxws/internal/resources/JaxWsCommonMessages.nlsprops
@@ -208,38 +208,38 @@ err.unsupported.jmx.operation.useraction=Do not run unsupported operation.
 
 # webService and webServiceClient config messages
 
-info.no.attributes.webservice=CWWKW0062I: The webService configuration element is enabled, but no configuration attributes are present.
-info.no.attributes.webservice.explanation=The webService configuration element was added to the server.xml but does not contain any attributes. No configuration will be applied.
-info.no.attributes.webservice.useraction=Add one or more configuration attributes to the webService element or remove it from the server.xml.
+info.no.attributes.webservice=CWWKW0062I: The webService configuration element is enabled, but has no configuration attributes.
+info.no.attributes.webservice.explanation=The webService configuration element was added to the server.xml file, but it does not contain any configuration attributes. Without attributes, no webService configuration options take effect and the server uses default behavior.
+info.no.attributes.webservice.useraction=Add one or more configuration attributes to the webService element, or remove the webService element from the server.xml file.
 
-info.no.attributes.webserviceclient=CWWKW0063I: The webServiceClient configuration element is enabled, but no configuration attributes are present.
-info.no.attributes.webserviceclient.explanation=The webServiceClient configuration element was added to the server.xml but does not contain any attributes. No configuration will be applied.
-info.no.attributes.webserviceclient.useraction=Add one or more configuration attributes to the webServiceClient element or remove it from the server.xml.
-
-#{0}=serviceName value
-info.ignore.unexpected.elements.client.named=CWWKW0064I: The ignoreUnexpectedElements attribute is enabled on JAX-WS client {0}. Unknown elements found in incoming SOAP responses for this client will be ignored.
-info.ignore.unexpected.elements.client.named.explanation=The webServiceClient configuration with serviceName {0} has ignoreUnexpectedElements set to true. JAXB will ignore unknown elements when unmarshalling incoming SOAP responses.
-info.ignore.unexpected.elements.client.named.useraction=No action required. To disable this behavior, set ignoreUnexpectedElements to false in the webServiceClient configuration.
-
-#{0}=portName value
-info.ignore.unexpected.elements.provider.named=CWWKW0065I: The ignoreUnexpectedElements attribute is enabled on JAX-WS provider {0}. Unknown elements found in incoming SOAP messages for this provider will be ignored.
-info.ignore.unexpected.elements.provider.named.explanation=The webService configuration with portName {0} has ignoreUnexpectedElements set to true. JAXB will ignore unknown elements when unmarshalling incoming SOAP requests.
-info.ignore.unexpected.elements.provider.named.useraction=No action required. To disable this behavior, set ignoreUnexpectedElements to false in the webService configuration.
-
-info.ignore.unexpected.elements.global=CWWKW0066I: The ignoreUnexpectedElements attribute is enabled. Unknown elements found during unmarshalling will be ignored.
-info.ignore.unexpected.elements.global.explanation=A global webServiceClient or webService configuration has ignoreUnexpectedElements set to true. JAXB will ignore unknown elements during unmarshalling.
-info.ignore.unexpected.elements.global.useraction=No action required. To disable this behavior, set ignoreUnexpectedElements to false in the configuration.
-
-info.schema.validation.global=CWWKW0067I: The enableSchemaValidation attribute is set to true. JAXB schema validation will be enabled during the unmarshalling of SOAP messages.
-info.schema.validation.global.explanation=A global webServiceClient or webService configuration has enableSchemaValidation set to true. JAXB will perform full schema validation when unmarshalling incoming SOAP messages.
-info.schema.validation.global.useraction=No action required. To disable schema validation, set enableSchemaValidation to false in the configuration.
+info.no.attributes.webserviceclient=CWWKW0063I: The webServiceClient configuration element is enabled, but has no configuration attributes.
+info.no.attributes.webserviceclient.explanation=The webServiceClient configuration element was added to the server.xml file, but it does not contain any configuration attributes. Without attributes, no webServiceClient configuration options take effect and the server uses default behavior.
+info.no.attributes.webserviceclient.useraction=Add one or more configuration attributes to the webServiceClient element, or remove the webServiceClient element from the server.xml file.
 
 #{0}=serviceName value
-info.schema.validation.client.named=CWWKW0068I: The enableSchemaValidation attribute is enabled on JAX-WS client {0}. JAXB schema validation will be enabled during the unmarshalling of SOAP messages.
-info.schema.validation.client.named.explanation=The webServiceClient configuration with serviceName {0} has enableSchemaValidation set to true. JAXB will perform full schema validation when unmarshalling incoming SOAP responses for this client.
-info.schema.validation.client.named.useraction=No action required. To disable schema validation, set enableSchemaValidation to false in the webServiceClient configuration.
+info.ignore.unexpected.elements.client.named=CWWKW0064I: The ignoreUnexpectedElements attribute is enabled on the {0} JAX-WS client. Unknown elements that are found in incoming SOAP responses for this client are ignored.
+info.ignore.unexpected.elements.client.named.explanation=The webServiceClient configuration with the {0} serviceName has the ignoreUnexpectedElements attribute set to true. When JAXB unmarshals incoming SOAP responses, JAXB ignores unknown elements.
+info.ignore.unexpected.elements.client.named.useraction=No action is required. To disable this behavior, set ignoreUnexpectedElements to false in the webServiceClient configuration.
 
 #{0}=portName value
-info.schema.validation.provider.named=CWWKW0069I: The enableSchemaValidation attribute is enabled on JAX-WS provider {0}. JAXB schema validation will be enabled during the unmarshalling of SOAP messages.
-info.schema.validation.provider.named.explanation=The webService configuration with portName {0} has enableSchemaValidation set to true. JAXB will perform full schema validation when unmarshalling incoming SOAP requests for this provider.
-info.schema.validation.provider.named.useraction=No action required. To disable schema validation, set enableSchemaValidation to false in the webService configuration.git ls-files '**/.classpath' '**/.settings/**' | xargs git checkout --
+info.ignore.unexpected.elements.provider.named=CWWKW0065I: The ignoreUnexpectedElements attribute is enabled on the {0} JAX-WS provider. Unknown elements that are found in incoming SOAP requests for this provider are ignored.
+info.ignore.unexpected.elements.provider.named.explanation=The webService configuration with the {0} portName has the ignoreUnexpectedElements attribute set to true. When JAXB unmarshals incoming SOAP requests, JAXB ignores unknown elements.
+info.ignore.unexpected.elements.provider.named.useraction=No action is required. To disable this behavior, set ignoreUnexpectedElements to false in the webService configuration.
+
+info.ignore.unexpected.elements.global=CWWKW0066I: The ignoreUnexpectedElements attribute is enabled. Unknown elements that are found during unmarshalling are ignored.
+info.ignore.unexpected.elements.global.explanation=A global webServiceClient or webService configuration has the ignoreUnexpectedElements attribute set to true. When JAXB unmarshals incoming SOAP messages, JAXB ignores unknown elements.
+info.ignore.unexpected.elements.global.useraction=No action is required. To disable this behavior, set ignoreUnexpectedElements to false in the configuration.
+
+info.schema.validation.global=CWWKW0067I: The enableSchemaValidation attribute is set to true. Incoming SOAP messages are validated against the schema before they are processed.
+info.schema.validation.global.explanation=A global webServiceClient or webService configuration has enableSchemaValidation set to true. When JAXB unmarshals incoming SOAP messages, JAXB performs full schema validation.
+info.schema.validation.global.useraction=No action is required. To disable schema validation, set enableSchemaValidation to false in the configuration.
+
+#{0}=serviceName value
+info.schema.validation.client.named=CWWKW0068I: The enableSchemaValidation attribute is enabled on the {0} JAX-WS client. Incoming SOAP responses for this client are validated against the schema before they are processed.
+info.schema.validation.client.named.explanation=The webServiceClient configuration with the {0} serviceName has enableSchemaValidation set to true. When JAXB unmarshals incoming SOAP responses for this client, JAXB performs full schema validation.
+info.schema.validation.client.named.useraction=No action is required. To disable schema validation, set enableSchemaValidation to false in the webServiceClient configuration.
+
+#{0}=portName value
+info.schema.validation.provider.named=CWWKW0069I: The enableSchemaValidation attribute is enabled on the {0} JAX-WS provider. Incoming SOAP requests for this provider are validated against the schema before they are processed.
+info.schema.validation.provider.named.explanation=The webService configuration with the {0} portName has enableSchemaValidation set to true. When JAXB unmarshals incoming SOAP requests for this provider, JAXB performs full schema validation.
+info.schema.validation.provider.named.useraction=No action is required. To disable schema validation, set enableSchemaValidation to false in the webService configuration.

--- a/dev/com.ibm.ws.jaxws.2.3.common/resources/com/ibm/ws/jaxws/internal/resources/JaxWsCommonMessages.nlsprops
+++ b/dev/com.ibm.ws.jaxws.2.3.common/resources/com/ibm/ws/jaxws/internal/resources/JaxWsCommonMessages.nlsprops
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2020 IBM Corporation and others.
+# Copyright (c) 2020, 2026 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -205,3 +205,41 @@ error.endpointinfo.validation.bindingtype.and.wsdl.mismatch.useraction=Update th
 err.unsupported.jmx.operation=CWWKW0059E: The operation {0} is not supported.
 err.unsupported.jmx.operation.explanation=The required operation is not allowed to be performed.
 err.unsupported.jmx.operation.useraction=Do not run unsupported operation.
+
+# webService and webServiceClient config messages
+
+info.no.attributes.webservice=CWWKW0062I: The webService configuration element is enabled, but no configuration attributes are present.
+info.no.attributes.webservice.explanation=The webService configuration element was added to the server.xml but does not contain any attributes. No configuration will be applied.
+info.no.attributes.webservice.useraction=Add one or more configuration attributes to the webService element or remove it from the server.xml.
+
+info.no.attributes.webserviceclient=CWWKW0063I: The webServiceClient configuration element is enabled, but no configuration attributes are present.
+info.no.attributes.webserviceclient.explanation=The webServiceClient configuration element was added to the server.xml but does not contain any attributes. No configuration will be applied.
+info.no.attributes.webserviceclient.useraction=Add one or more configuration attributes to the webServiceClient element or remove it from the server.xml.
+
+#{0}=serviceName value
+info.ignore.unexpected.elements.client.named=CWWKW0064I: The ignoreUnexpectedElements attribute is enabled on JAX-WS client {0}. Unknown elements found in incoming SOAP responses for this client will be ignored.
+info.ignore.unexpected.elements.client.named.explanation=The webServiceClient configuration with serviceName {0} has ignoreUnexpectedElements set to true. JAXB will ignore unknown elements when unmarshalling incoming SOAP responses.
+info.ignore.unexpected.elements.client.named.useraction=No action required. To disable this behavior, set ignoreUnexpectedElements to false in the webServiceClient configuration.
+
+#{0}=portName value
+info.ignore.unexpected.elements.provider.named=CWWKW0065I: The ignoreUnexpectedElements attribute is enabled on JAX-WS provider {0}. Unknown elements found in incoming SOAP messages for this provider will be ignored.
+info.ignore.unexpected.elements.provider.named.explanation=The webService configuration with portName {0} has ignoreUnexpectedElements set to true. JAXB will ignore unknown elements when unmarshalling incoming SOAP requests.
+info.ignore.unexpected.elements.provider.named.useraction=No action required. To disable this behavior, set ignoreUnexpectedElements to false in the webService configuration.
+
+info.ignore.unexpected.elements.global=CWWKW0066I: The ignoreUnexpectedElements attribute is enabled. Unknown elements found during unmarshalling will be ignored.
+info.ignore.unexpected.elements.global.explanation=A global webServiceClient or webService configuration has ignoreUnexpectedElements set to true. JAXB will ignore unknown elements during unmarshalling.
+info.ignore.unexpected.elements.global.useraction=No action required. To disable this behavior, set ignoreUnexpectedElements to false in the configuration.
+
+info.schema.validation.global=CWWKW0067I: The enableSchemaValidation attribute is set to true. JAXB schema validation will be enabled during the unmarshalling of SOAP messages.
+info.schema.validation.global.explanation=A global webServiceClient or webService configuration has enableSchemaValidation set to true. JAXB will perform full schema validation when unmarshalling incoming SOAP messages.
+info.schema.validation.global.useraction=No action required. To disable schema validation, set enableSchemaValidation to false in the configuration.
+
+#{0}=serviceName value
+info.schema.validation.client.named=CWWKW0068I: The enableSchemaValidation attribute is enabled on JAX-WS client {0}. JAXB schema validation will be enabled during the unmarshalling of SOAP messages.
+info.schema.validation.client.named.explanation=The webServiceClient configuration with serviceName {0} has enableSchemaValidation set to true. JAXB will perform full schema validation when unmarshalling incoming SOAP responses for this client.
+info.schema.validation.client.named.useraction=No action required. To disable schema validation, set enableSchemaValidation to false in the webServiceClient configuration.
+
+#{0}=portName value
+info.schema.validation.provider.named=CWWKW0069I: The enableSchemaValidation attribute is enabled on JAX-WS provider {0}. JAXB schema validation will be enabled during the unmarshalling of SOAP messages.
+info.schema.validation.provider.named.explanation=The webService configuration with portName {0} has enableSchemaValidation set to true. JAXB will perform full schema validation when unmarshalling incoming SOAP requests for this provider.
+info.schema.validation.provider.named.useraction=No action required. To disable schema validation, set enableSchemaValidation to false in the webService configuration.git ls-files '**/.classpath' '**/.settings/**' | xargs git checkout --

--- a/dev/com.ibm.ws.jaxws.2.3.common/src/com/ibm/ws/jaxws/client/LibertyWebServiceClientInInterceptor.java
+++ b/dev/com.ibm.ws.jaxws.2.3.common/src/com/ibm/ws/jaxws/client/LibertyWebServiceClientInInterceptor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 IBM Corporation and others.
+ * Copyright (c) 2024, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -22,13 +22,31 @@ import com.ibm.ws.jaxws.internal.WebServiceConfigConstants;
 import io.openliberty.jaxws.jaxb.IgnoreUnexpectedElementValidationEventHandler;
 
 /**
+ * A CXF-style inbound interceptor on the client-side that applies webServiceClient configuration
+ * from the Liberty server.xml at the RECEIVE phase of the interceptor chain.
  *
+ * <p>On each incoming SOAP response message it resolves the active configuration values
+ * (ignoreUnexpectedElements, enableSchemaValidation, enableDefaultValidation) for the
+ * calling service, then applies the corresponding CXF/JAXB message properties. Named
+ * configurations (matched by serviceName) take precedence over the global default.</p>
+ *
+ * <p>Info-level NLS messages are emitted once per JVM lifetime via static flags to avoid
+ * log flooding; subsequent activations are recorded at debug level only.</p>
  */
 public class LibertyWebServiceClientInInterceptor extends AbstractPhaseInterceptor<Message> {
 
     private static final TraceComponent tc = Tr.register(LibertyWebServiceClientInInterceptor.class);
 
+    /** Ensures CWWKW0064I / CWWKW0066I is logged only once across all requests. */
+    private static boolean issuedIgnoreUnexpectedElementsMessage = false;
 
+    /** Ensures CWWKW0067I / CWWKW0068I is logged only once across all requests. */
+    private static boolean issuedSchemaValidationMessage = false;
+
+    /**
+     * Registers this interceptor at the CXF RECEIVE phase so it runs as soon as
+     * an inbound message arrives, before unmarshalling.
+     */
     public LibertyWebServiceClientInInterceptor() {
         super(Phase.RECEIVE);
 
@@ -37,6 +55,19 @@ public class LibertyWebServiceClientInInterceptor extends AbstractPhaseIntercept
         }
     }
 
+    /**
+     * Applies webServiceClient configuration properties to the inbound CXF message.
+     *
+     * <p>Resolution order for each property:
+     * <ol>
+     *   <li>Named config matching the service name of the message</li>
+     *   <li>Global (default) config if no named match is found</li>
+     *   <li>No-op if neither exists</li>
+     * </ol>
+     *
+     * @param message the inbound CXF message
+     * @throws Fault if a CXF-level fault occurs
+     */
     @Override
     public void handleMessage(Message message) throws Fault {
         boolean debug = TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled();
@@ -62,12 +93,16 @@ public class LibertyWebServiceClientInInterceptor extends AbstractPhaseIntercept
         
         Object enableDefaultValidation = null;
 
+        boolean ignoreUnexpectedResolvedFromNamed = false;
+        boolean schemaValidationResolvedFromNamed = false;
+
         // if messageServiceName != null, try to get the values from configuration using it
         if (messageServiceName != null) {
             // if messageServiceName != null, try to get enableSchemaValidation value from configuration, if it's == null try it to get the default configuration value
             if(WebServicesClientConfigHolder.getEnableSchemaValidation(messageServiceName) != null) {
                 
                 enableSchemaValidation = WebServicesClientConfigHolder.getEnableSchemaValidation(messageServiceName);
+                schemaValidationResolvedFromNamed = true;
                 
             } else if (WebServicesClientConfigHolder.getEnableSchemaValidation(WebServiceConfigConstants.DEFAULT_PROP) != null) {
                 
@@ -80,6 +115,7 @@ public class LibertyWebServiceClientInInterceptor extends AbstractPhaseIntercept
             if(WebServicesClientConfigHolder.getIgnoreUnexpectedElements(messageServiceName) != null) {
                 
                 ignoreUnexpectedElements = WebServicesClientConfigHolder.getIgnoreUnexpectedElements(messageServiceName);
+                ignoreUnexpectedResolvedFromNamed = true;
                 
             } else if (WebServicesClientConfigHolder.getIgnoreUnexpectedElements(WebServiceConfigConstants.DEFAULT_PROP) != null) {
                 
@@ -122,12 +158,23 @@ public class LibertyWebServiceClientInInterceptor extends AbstractPhaseIntercept
         }
         
         // As long as property is non-null:
-        // Enable enhanced schema validation if true, or disable it along with default validation if false 
+        // Enable enhanced schema validation if true, or disable it along with default validation if false
         if ( enableSchemaValidation != null) {
             if ((boolean) enableSchemaValidation == true) {
-                // enable Schema Validation 
+                // enable Schema Validation
                 message.put("schema-validation-enabled", true);
-                
+
+                if (!issuedSchemaValidationMessage) {
+                    if (schemaValidationResolvedFromNamed) {
+                        Tr.info(tc, "info.schema.validation.client.named", messageServiceName); // CWWKW0068I
+                    } else {
+                        Tr.info(tc, "info.schema.validation.global"); // CWWKW0067I
+                    }
+                    issuedSchemaValidationMessage = true;
+                } else if (debug) {
+                    Tr.debug(tc, "enableSchemaValidation is active for service " + messageServiceName + " (message already issued)");
+                }
+
                 if (debug) {
                     Tr.debug(tc, "Set schema-validation-enabled to " + true);
 
@@ -158,7 +205,18 @@ public class LibertyWebServiceClientInInterceptor extends AbstractPhaseIntercept
 
             // Set our custom validation event handler
             IgnoreUnexpectedElementValidationEventHandler unexpectedElementValidationEventHandler = new IgnoreUnexpectedElementValidationEventHandler();
-            message.put(JAXBDataBinding.READER_VALIDATION_EVENT_HANDLER, unexpectedElementValidationEventHandler); 
+            message.put(JAXBDataBinding.READER_VALIDATION_EVENT_HANDLER, unexpectedElementValidationEventHandler);
+
+            if (!issuedIgnoreUnexpectedElementsMessage) {
+                if (ignoreUnexpectedResolvedFromNamed) {
+                    Tr.info(tc, "info.ignore.unexpected.elements.client.named", messageServiceName); // CWWKW0064I
+                } else {
+                    Tr.info(tc, "info.ignore.unexpected.elements.global"); // CWWKW0066I
+                }
+                issuedIgnoreUnexpectedElementsMessage = true;
+            } else if (debug) {
+                Tr.debug(tc, "ignoreUnexpectedElements is active for service " + messageServiceName + " (message already issued)");
+            }
 
             if (debug) {
                 Tr.debug(tc, "Set JAXBDataBinding.SET_VALIDATION_EVENT_HANDLER to  " + (boolean) ignoreUnexpectedElements + " for ignoreUnexpectedElements");

--- a/dev/com.ibm.ws.jaxws.2.3.common/src/com/ibm/ws/jaxws/client/LibertyWebServiceClientInInterceptor.java
+++ b/dev/com.ibm.ws.jaxws.2.3.common/src/com/ibm/ws/jaxws/client/LibertyWebServiceClientInInterceptor.java
@@ -158,7 +158,7 @@ public class LibertyWebServiceClientInInterceptor extends AbstractPhaseIntercept
         }
         
         // As long as property is non-null:
-        // Enable enhanced schema validation if true, or disable it along with default validation if false
+        // Enable enhanced schema validation if true, or disable it along with default validation if false 
         if ( enableSchemaValidation != null) {
             if ((boolean) enableSchemaValidation == true) {
                 // enable Schema Validation

--- a/dev/com.ibm.ws.jaxws.2.3.common/src/com/ibm/ws/jaxws/client/WebServiceClientConfigImpl.java
+++ b/dev/com.ibm.ws.jaxws.2.3.common/src/com/ibm/ws/jaxws/client/WebServiceClientConfigImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 IBM Corporation and others.
+ * Copyright (c) 2024, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -43,9 +43,16 @@ public class WebServiceClientConfigImpl extends WebServiceConfig {
         propertiesToRemove.add(WebServiceConfigConstants.SERVICE_NAME_PROP);
     }
     
-    // Flag tells us if the message for a call to a beta method has been issued
+    /** Ensures the beta-edition info message is logged only once per class. */
     private static boolean issuedBetaMessage = false;
-    
+
+    /**
+     * Guards all lifecycle methods against invocation outside of a beta Liberty edition.
+     * Throws {@link UnsupportedOperationException} on non-beta builds; logs a one-time
+     * debug message on beta builds.
+     *
+     * @throws UnsupportedOperationException if not running a beta edition
+     */
     private void betaFenceCheck() throws UnsupportedOperationException {
         // Not running beta edition, throw exception
         if (!ProductInfo.getBetaEdition()) { 
@@ -61,6 +68,14 @@ public class WebServiceClientConfigImpl extends WebServiceConfig {
 
     
     
+    /**
+     * OSGi DS activation constructor. Called when a {@code <webServiceClient>} element
+     * is added to the server.xml. Validates the properties, filters them to only the
+     * recognised config attributes, and registers them with {@link WebServicesClientConfigHolder}
+     * keyed by serviceName (or the global default key if no serviceName is specified).
+     *
+     * @param properties the component properties supplied by OSGi config admin
+     */
     @Deprecated
     @Activate
     public WebServiceClientConfigImpl(Map<String, Object> properties) {
@@ -76,14 +91,26 @@ public class WebServiceClientConfigImpl extends WebServiceConfig {
         
         String serviceName = getServiceName(properties); // find serviceName
         
-        // Add config for serviceName
-        WebServicesClientConfigHolder.addConfig(this.toString(), serviceName,
-                                                filterProps(properties));
+        // Add info message for config without any attribute set
+        Map<String, Object> filteredProperties = filterProps(properties);
+        if (filteredProperties.isEmpty()) {
+            Tr.info(tc, "info.no.attributes.webserviceclient");
+        }
+
+         // Add config for serviceName
+        WebServicesClientConfigHolder.addConfig(this.toString(), serviceName, filteredProperties);
     }
     
+    /**
+     * OSGi DS modification callback. Called when an existing {@code <webServiceClient>}
+     * element in the server.xml is changed. Removes the previous registration and
+     * re-registers with the updated properties.
+     *
+     * @param properties the updated component properties supplied by OSGi config admin
+     */
     @Deprecated
     @Modified
-    protected void modified(Map<String, Object> properties) {        
+    protected void modified(Map<String, Object> properties) {
 
         betaFenceCheck();
         
@@ -99,10 +126,22 @@ public class WebServiceClientConfigImpl extends WebServiceConfig {
         
         // Re-add modfied config
         String serviceName = getServiceName(properties);
-        WebServicesClientConfigHolder.addConfig(this.toString(), serviceName,
-                                                filterProps(properties));
+
+        // Add info message for config without any attribute set
+        Map<String, Object> filteredProperties = filterProps(properties);
+        if (filteredProperties.isEmpty()) {
+            Tr.info(tc, "info.no.attributes.webserviceclient");
+        }
+
+         // Add config for serviceName
+        WebServicesClientConfigHolder.addConfig(this.toString(), serviceName, filteredProperties);
     }
 
+    /**
+     * OSGi DS deactivation callback. Called when the {@code <webServiceClient>} element
+     * is removed from the server.xml. Removes the registration from
+     * {@link WebServicesClientConfigHolder}.
+     */
     @Deprecated
     @Deactivate
     protected void deactivate() {
@@ -176,7 +215,12 @@ public class WebServiceClientConfigImpl extends WebServiceConfig {
         }
     }
 
-    // For test purposes
+    /**
+     * Returns whether any webServiceClient configuration has been registered.
+     * Exposed for unit test use only.
+     *
+     * @return {@code true} if at least one configuration entry exists
+     */
     protected boolean isConfigExists() {
         return WebServicesClientConfigHolder.isConfigExists();
     }

--- a/dev/com.ibm.ws.jaxws.2.3.common/src/com/ibm/ws/jaxws/endpoint/AbstractJaxWsWebEndpoint.java
+++ b/dev/com.ibm.ws.jaxws.2.3.common/src/com/ibm/ws/jaxws/endpoint/AbstractJaxWsWebEndpoint.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019,2024 IBM Corporation and others.
+ * Copyright (c) 2019, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -93,6 +93,18 @@ public abstract class AbstractJaxWsWebEndpoint implements JaxWsWebEndpoint {
     // Flag tells us if the message for a call to a beta method has been issued
     private static boolean issuedBetaMessage = false;
 
+    /** Ensures CWWKW0065I / CWWKW0066I is logged only once across all endpoint invocations. */
+    private static boolean issuedIgnoreUnexpectedElementsMessage = false;
+
+    /** Ensures CWWKW0067I / CWWKW0069I is logged only once across all endpoint invocations. */
+    private static boolean issuedSchemaValidationMessage = false;
+
+    /**
+     * Constructs the endpoint with the Liberty endpoint metadata and module runtime data.
+     *
+     * @param endpointInfo        Liberty metadata describing the JAX-WS endpoint
+     * @param jaxWsModuleMetaData runtime metadata for the JAX-WS module (classloader, bus, etc.)
+     */
     public AbstractJaxWsWebEndpoint(EndpointInfo endpointInfo, JaxWsModuleMetaData jaxWsModuleMetaData) {
         this.endpointInfo = endpointInfo;
         this.jaxWsModuleMetaData = jaxWsModuleMetaData;
@@ -282,7 +294,15 @@ public abstract class AbstractJaxWsWebEndpoint implements JaxWsWebEndpoint {
     }
 
     /**
-     * 
+     * Applies webService configuration from the Liberty server.xml to the CXF endpoint.
+     *
+     * <p>Called on each request invocation (within the beta fence in {@link #invoke}).
+     * Resolves configuration values in order: named config matching the endpoint's portName
+     * first, falling back to the global default. Applies the resolved values as CXF
+     * endpoint properties controlling JAXB validation behaviour.</p>
+     *
+     * <p>Info-level NLS messages are emitted once per JVM lifetime via static flags;
+     * subsequent activations are recorded at debug level only.</p>
      */
     private void configureWebServicesConfig() {
         
@@ -312,13 +332,17 @@ public abstract class AbstractJaxWsWebEndpoint implements JaxWsWebEndpoint {
         Object ignoreUnexpectedElements = null;
 
         Object enableDefaultValidation = null;
-                
+
+        boolean ignoreUnexpectedResolvedFromNamed = false;
+        boolean schemaValidationResolvedFromNamed = false;
+
         // if portName != null, try to get the values from configuration using it
         if (portName != null) {
             // if portName != null, try to get enableSchemaValidation value from configuration, if it's == null try it to get the default configuration value
             if(WebServicesConfigHolder.getEnableSchemaValidation(portName) != null) {
                 
                 enableSchemaValidation = WebServicesConfigHolder.getEnableSchemaValidation(portName);
+                schemaValidationResolvedFromNamed = true;
                 
             } else if (WebServicesConfigHolder.getEnableSchemaValidation(WebServiceConfigConstants.DEFAULT_PROP) != null) {
                 
@@ -331,6 +355,7 @@ public abstract class AbstractJaxWsWebEndpoint implements JaxWsWebEndpoint {
             if(WebServicesConfigHolder.getIgnoreUnexpectedElements(portName) != null) {
                 
                 ignoreUnexpectedElements = WebServicesConfigHolder.getIgnoreUnexpectedElements(portName);
+                ignoreUnexpectedResolvedFromNamed = true;
                 
             } else if (WebServicesConfigHolder.getIgnoreUnexpectedElements(WebServiceConfigConstants.DEFAULT_PROP) != null) {
                 
@@ -370,6 +395,17 @@ public abstract class AbstractJaxWsWebEndpoint implements JaxWsWebEndpoint {
         if ( enableSchemaValidation != null) {
             cxfEndpointInfo.setProperty("schema-validation-enabled",  enableSchemaValidation);
 
+            if ((boolean) enableSchemaValidation == true && !issuedSchemaValidationMessage) {
+                if (schemaValidationResolvedFromNamed) {
+                    Tr.info(tc, "info.schema.validation.provider.named", portName); // CWWKW0069I
+                } else {
+                    Tr.info(tc, "info.schema.validation.global"); // CWWKW0067I
+                }
+                issuedSchemaValidationMessage = true;
+            } else if ((boolean) enableSchemaValidation == true && debug) {
+                Tr.debug(tc, "enableSchemaValidation is active for port " + portName + " (message already issued)");
+            }
+
             if (debug) {
                 Tr.debug(tc, "Set schema-validation-enabled to " + enableSchemaValidation);
 
@@ -390,7 +426,18 @@ public abstract class AbstractJaxWsWebEndpoint implements JaxWsWebEndpoint {
             
             // Set our custom validation event handler
             IgnoreUnexpectedElementValidationEventHandler unexpectedElementValidationEventHandler = new IgnoreUnexpectedElementValidationEventHandler();
-            cxfEndpointInfo.setProperty(JAXBDataBinding.READER_VALIDATION_EVENT_HANDLER, unexpectedElementValidationEventHandler); 
+            cxfEndpointInfo.setProperty(JAXBDataBinding.READER_VALIDATION_EVENT_HANDLER, unexpectedElementValidationEventHandler);
+
+            if (!issuedIgnoreUnexpectedElementsMessage) {
+                if (ignoreUnexpectedResolvedFromNamed) {
+                    Tr.info(tc, "info.ignore.unexpected.elements.provider.named", portName); // CWWKW0065I
+                } else {
+                    Tr.info(tc, "info.ignore.unexpected.elements.global"); // CWWKW0066I
+                }
+                issuedIgnoreUnexpectedElementsMessage = true;
+            } else if (debug) {
+                Tr.debug(tc, "ignoreUnexpectedElements is active for port " + portName + " (message already issued)");
+            }
 
             if (debug) {
                 Tr.debug(tc, "Set JAXBDataBinding.SET_VALIDATION_EVENT_HANDLER to  " + ignoreUnexpectedElements);

--- a/dev/com.ibm.ws.jaxws.2.3.common/src/com/ibm/ws/jaxws/endpoint/WebServiceConfigImpl.java
+++ b/dev/com.ibm.ws.jaxws.2.3.common/src/com/ibm/ws/jaxws/endpoint/WebServiceConfigImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024, 2025 IBM Corporation and others.
+ * Copyright (c) 2024, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.jaxws.2.3.common/src/com/ibm/ws/jaxws/endpoint/WebServiceConfigImpl.java
+++ b/dev/com.ibm.ws.jaxws.2.3.common/src/com/ibm/ws/jaxws/endpoint/WebServiceConfigImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 IBM Corporation and others.
+ * Copyright (c) 2024, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -43,9 +43,16 @@ public class WebServiceConfigImpl extends WebServiceConfig {
         propertiesToRemove.add(WebServiceConfigConstants.PORT_NAME_PROP);
     }
     
-    // Flag tells us if the message for a call to a beta method has been issued
+    /** Ensures the beta-edition info message is logged only once per class. */
     private static boolean issuedBetaMessage = false;
-    
+
+    /**
+     * Guards all lifecycle methods against invocation outside of a beta Liberty edition.
+     * Throws {@link UnsupportedOperationException} on non-beta builds; logs a one-time
+     * debug message on beta builds.
+     *
+     * @throws UnsupportedOperationException if not running a beta edition
+     */
     private void betaFenceCheck() throws UnsupportedOperationException {
         // Not running beta edition, throw exception
         if (!ProductInfo.getBetaEdition()) { 
@@ -61,6 +68,14 @@ public class WebServiceConfigImpl extends WebServiceConfig {
 
     
     
+    /**
+     * OSGi DS activation constructor. Called when a {@code <webService>} element
+     * is added to the server.xml. Validates the properties, filters them to only the
+     * recognised config attributes, and registers them with {@link WebServicesConfigHolder}
+     * keyed by portName (or the global default key if no portName is specified).
+     *
+     * @param properties the component properties supplied by OSGi config admin
+     */
     @Deprecated
     @Activate
     public WebServiceConfigImpl(Map<String, Object> properties) {
@@ -76,14 +91,27 @@ public class WebServiceConfigImpl extends WebServiceConfig {
         
         String portName = getPortName(properties); // find portName
         
+        // Add info message for config without any attribute set
+        Map<String, Object> filteredProperties = filterProps(properties);
+        if (filteredProperties.isEmpty()) {
+            Tr.info(tc, "info.no.attributes.webservice");
+        }
+
         // Add config for portName
         WebServicesConfigHolder.addConfig(this.toString(), portName,
-                                                filterProps(properties));
+                                                filteredProperties);
     }
     
+    /**
+     * OSGi DS modification callback. Called when an existing {@code <webService>}
+     * element in the server.xml is changed. Removes the previous registration and
+     * re-registers with the updated properties.
+     *
+     * @param properties the updated component properties supplied by OSGi config admin
+     */
     @Deprecated
     @Modified
-    protected void modified(Map<String, Object> properties) {        
+    protected void modified(Map<String, Object> properties) {
 
         betaFenceCheck();
         
@@ -105,10 +133,20 @@ public class WebServiceConfigImpl extends WebServiceConfig {
         
         // Re-add modfied config
         String portName = getPortName(properties);
-        WebServicesConfigHolder.addConfig(this.toString(), portName,
-                                                filterProps(properties));
+
+        // Add info message for config without any attribute set
+        Map<String, Object> filteredProperties = filterProps(properties);
+        if (filteredProperties.isEmpty()) {
+            Tr.info(tc, "info.no.attributes.webservice");
+        }
+        WebServicesConfigHolder.addConfig(this.toString(), portName, filteredProperties);
     }
 
+    /**
+     * OSGi DS deactivation callback. Called when the {@code <webService>} element
+     * is removed from the server.xml. Removes the registration from
+     * {@link WebServicesConfigHolder}.
+     */
     @Deprecated
     @Deactivate
     protected void deactivate() {

--- a/dev/com.ibm.ws.jaxws.2.3.common/src/com/ibm/ws/jaxws/internal/ConfigHolder.java
+++ b/dev/com.ibm.ws.jaxws.2.3.common/src/com/ibm/ws/jaxws/internal/ConfigHolder.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 IBM Corporation and others.
+ * Copyright (c) 2024, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -292,6 +292,13 @@ public class ConfigHolder {
         return tc.isDebugEnabled() && TraceComponent.isAnyTracingEnabled();
     }
     
+    /**
+     * Validates that the provided properties map is non-null and non-empty, updating
+     * the internal {@code configExists} flag accordingly.
+     *
+     * @param properties the OSGi component properties to validate
+     * @return {@code true} if properties are present and non-empty; {@code false} otherwise
+     */
     public static boolean checkConfig(Map<String, Object> properties) {
         if (properties == null || properties.isEmpty()) {
             if (tc.isDebugEnabled() && TraceComponent.isAnyTracingEnabled()) {
@@ -303,8 +310,30 @@ public class ConfigHolder {
         }
         return configExists;
     }
-    
+
+    /**
+     * Returns whether any configuration has been registered with this holder.
+     * Used as a fast-path guard in interceptors and endpoints to skip processing
+     * when no webService/webServiceClient config is present.
+     *
+     * @return {@code true} if at least one configuration entry has been registered
+     */
     public static boolean isConfigExists() {
         return configExists;
+    }
+
+    /**
+     * Returns true if any named (non-default) configuration exists.
+     * Used to distinguish "no named config registered" from "named config exists but name doesn't match".
+     */
+    public static boolean hasNamedConfig() {
+        synchronized (ConfigHolder.class) {
+            for (String key : configInfo.keySet()) {
+                if (!key.equals(WebServiceConfigConstants.DEFAULT_PROP)) {
+                    return true;
+                }
+            }
+            return false;
+        }
     }
 }


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

This PR add the message keys that were missing from the original implementation, but were missing from the design document. By adding these message keys, we should be able to finish out the rest of the process for [#25265](https://github.com/OpenLiberty/open-liberty/issues/25265)
