### PR TITLE
Skip tests on Db2/Hibernate that pass but are not correctly testing functionality

### DIFF
--- a/dev/io.openliberty.data.internal_fat_1_1/test-applications/Data_1_1_App/src/test/jakarta/data/v1_1/web/Data_1_1_Servlet.java
+++ b/dev/io.openliberty.data.internal_fat_1_1/test-applications/Data_1_1_App/src/test/jakarta/data/v1_1/web/Data_1_1_Servlet.java
@@ -111,6 +111,16 @@ public class Data_1_1_Servlet extends FATServlet {
     }
 
     /**
+     * Indicates if testing with the DB2 database.
+     *
+     * @return true if testing with the DB2 database.
+     */
+    static final boolean isDB2() {
+        String jdbcJarName = System.getenv().getOrDefault("DB_DRIVER", "UNKNOWN");
+        return jdbcJarName.startsWith("jcc");
+    }
+
+    /**
      * Indicates if testing with the Derby database.
      *
      * @return true if testing with the Derby database.
@@ -1466,6 +1476,10 @@ public class Data_1_1_Servlet extends FATServlet {
                    "jakarta.resource.ResourceException" }) // caused by the above during connection re-association
     @Test
     public void testLockModeAndQueryTimeoutAsQueryOptions() throws Exception {
+        // Hibernate does not honor the query timeout on native queries with DB2.
+        if (isDB2() && isHibernatePersistence())
+            return;
+
         // Populate with 18/23.
         // Ensure deletion in the finally block.
         fractions.supply(List.of(Fraction.of(18, 23)));
@@ -2369,8 +2383,9 @@ public class Data_1_1_Servlet extends FATServlet {
                    "jakarta.resource.ResourceException" }) // caused by the above during connection re-association
     @Test
     public void testQueryTimeoutAsQueryOptionOnNativeQuery() throws Exception {
-        // Derby ignores query timeout and the lock timeout ends up applying instead
-        if (isDerby())
+        // Derby ignores query timeout and the lock timeout ends up applying instead.
+        // Hibernate does not honor the query timeout on native queries with DB2.
+        if (isDerby() || (isDB2() && isHibernatePersistence()))
             return;
 
         CountDownLatch locked = new CountDownLatch(1);


### PR DESCRIPTION
Co-authored-by-AI: IBM Bob 2.0.1

Had a CI build hit the wrong FFDC, but the real issue here is these test hit the JTA timeout, not the QueryTimeout, when using Db2/Hibernate so they should be disabled until that is corrected, which saves us almost 4 minutes per build.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".