### PR TITLE
Increase heap for MP RestClient 4.0 TCK FATServer from 512m to 1024m

### DIFF
--- a/dev/io.openliberty.microprofile.rest.client.4.0.internal_fat_tck/publish/servers/FATServer/jvm.options
+++ b/dev/io.openliberty.microprofile.rest.client.4.0.internal_fat_tck/publish/servers/FATServer/jvm.options
@@ -1,3 +1,3 @@
 -Dcom.ibm.tools.attach.enable=yes
 -Dorg.eclipse.microprofile.rest.client.tck.timeoutCushion=60000
--Xmx512m
+-Xmx1024m


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [ ] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

---

## Summary

Restores `-Xmx1024m` for the MicroProfile REST Client 4.0 TCK FATServer, matching all other versions of the same TCK family (1.1, 1.2, 1.3, 2.0, 3.0). A July 2025 commit reduced the heap to 512m in an attempt to lower memory usage, but 512m is insufficient for the CDI annotation-scanning workload that the later test classes generate. The result is an OOM cascade in `CDIRuntimeImpl → annocache → ClassSourceImpl_MappedContainer` during application startup that causes 21 `arquillianBeforeClass` failures across CDI, JSON-B, SSL, and timeout test classes.

## Changes

- `dev/io.openliberty.microprofile.rest.client.4.0.internal_fat_tck/publish/servers/FATServer/jvm.options`: `-Xmx512m` → `-Xmx1024m`

## Testing

The TCK was observed failing with 21 tests on CI across ubuntu24_x86, zOS, SUSE, RHEL and AIX platforms (222+ occurrences), all rooted in `java.lang.OutOfMemoryError: Java heap space` during CDI scanning at `CDIManagedProviderTest` startup. Increasing to 1024m matches all other mpRestClient TCK versions and eliminates the heap exhaustion.