### PR TITLE
Uncomment wait to allow server to complete wsoc calls

### DIFF
--- a/dev/io.openliberty.wsoc.internal_fat/fat/src/io/openliberty/wsoc/tests/all/MultiClientTest.java
+++ b/dev/io.openliberty.wsoc.internal_fat/fat/src/io/openliberty/wsoc/tests/all/MultiClientTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2014 IBM Corporation and others.
+ * Copyright (c) 2013, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -90,7 +90,7 @@ public class MultiClientTest {
                                                                                         .getSession()
                                                                                         .getBasicRemote()
                                                                                         .sendText(textValues[x]);
-                                                                        //java.lang.Thread.sleep(25);
+                                                                        java.lang.Thread.sleep(25);
                                                                     } catch (Exception e) {
                                                                         e.printStackTrace();
                                                                     }

--- a/dev/io.openliberty.wsoc.internal_fat/fat/src/io/openliberty/wsoc/tests/all/TraceEnabledTest.java
+++ b/dev/io.openliberty.wsoc.internal_fat/fat/src/io/openliberty/wsoc/tests/all/TraceEnabledTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2021 IBM Corporation and others.
+ * Copyright (c) 2014, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -178,7 +178,7 @@ public class TraceEnabledTest {
                                                                               for (int x = 0; x < textValues.length; x++) {
                                                                                   try {
                                                                                       getMultiTestContext().getPublisher().getSession().getBasicRemote().sendText(textValues[x]);
-                                                                                      //java.lang.Thread.sleep(25);
+                                                                                      java.lang.Thread.sleep(25);
                                                                                   } catch (Exception e) {
                                                                                       e.printStackTrace();
                                                                                   }


### PR DESCRIPTION
- [ ] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [ ] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

Attempt to reduce defect 311048 

```
testSSCSinglePublisherMultipleReciverTextSuccess_EE11_FEATURES:com.ibm.ws.fat.util.browser.WebBrowserException: 2026-07-12-15:21:46:251 The body of Web Browser 274 Response 1 does not contain: SuccessfulTest - Response body: java.lang.AssertionError: array lengths differed, expected.length=6 actual.length=5
    at io.openliberty.wsoc.tests.all.MultiClientTest.testSinglePublisherMultipleReciverTextSuccess(MultiClientTest.java:109)
    at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
    at io.openliberty.wsoc.common.SingleRequestClientTestRunner.doGet(SingleRequestClientTestRunner.java:75)
    at jakarta.servlet.http.HttpServlet.service(HttpServlet.java:633)
```