### PR TITLE
Adding datasource to use during init that specifies the h2 datasource

### DIFF
--- a/dev/com.ibm.ws.jdbc_fat_h2/test-applications/H2TestApp/src/test/jdbc/h2/web/H2TestServlet.java
+++ b/dev/com.ibm.ws.jdbc_fat_h2/test-applications/H2TestApp/src/test/jdbc/h2/web/H2TestServlet.java
@@ -52,6 +52,11 @@ import org.junit.Test;
 import componenttest.annotation.SkipIfSysProp;
 import componenttest.app.FATServlet;
 
+@DataSourceDefinition(name = "java:app/jdbc/H2JdbcDataSource",
+                      className = "org.h2.jdbcx.JdbcDataSource",
+                      url = "jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1",
+                      user = "dbuser1",
+                      password = "dbpwd1")
 @DataSourceDefinition(name = "java:app/jdbc/H2ConnectionPoolDataSource",
                       className = "javax.sql.ConnectionPoolDataSource",
                       url = "jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1",
@@ -75,6 +80,9 @@ import componenttest.app.FATServlet;
 @SuppressWarnings("serial")
 @WebServlet("/*")
 public class H2TestServlet extends FATServlet {
+    @Resource(lookup = "java:app/jdbc/H2JdbcDataSource")
+    DataSource h2initDataSource;
+
     @Resource(lookup = "java:app/jdbc/H2ConnectionPoolDataSource")
     DataSource h2cpDataSource;
 
@@ -107,7 +115,7 @@ public class H2TestServlet extends FATServlet {
 
     @Override
     public void init(ServletConfig config) throws ServletException {
-        try (Connection con = h2cpDataSource.getConnection()) {
+        try (Connection con = h2initDataSource.getConnection()) {
             Statement stmt = con.createStatement();
             stmt.execute("""
                             CREATE TABLE COMPOUNDS (


### PR DESCRIPTION
… class to avoid tests using h2.properties failing on iSeries

Co-authored-by-AI: IBM Bob 2.0.2


- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
