### PR TITLE
test for annotations on repository bean methods

### DIFF
--- a/dev/io.openliberty.data.internal_fat_1_1/test-applications/Data_1_1_App/src/test/jakarta/data/v1_1/web/Data_1_1_Servlet.java
+++ b/dev/io.openliberty.data.internal_fat_1_1/test-applications/Data_1_1_App/src/test/jakarta/data/v1_1/web/Data_1_1_Servlet.java
@@ -2847,7 +2847,7 @@ public class Data_1_1_Servlet extends FATServlet {
         Method alter = sectors.getClass().getMethod("alter", Sector.class);
         RolesAllowed rolesForMethod = alter.getAnnotation(RolesAllowed.class);
         assertNotNull("Repository bean method " + alter +
-                      " lacks the RollsAllowed annotation",
+                      " lacks the RolesAllowed annotation",
                       rolesForMethod);
 
         assertEquals(List.of("operator"),

--- a/dev/io.openliberty.data.internal_fat_1_1/test-applications/Data_1_1_App/src/test/jakarta/data/v1_1/web/Data_1_1_Servlet.java
+++ b/dev/io.openliberty.data.internal_fat_1_1/test-applications/Data_1_1_App/src/test/jakarta/data/v1_1/web/Data_1_1_Servlet.java
@@ -16,6 +16,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
 
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.time.LocalDate;
@@ -34,6 +36,9 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import jakarta.annotation.Resource;
+import jakarta.annotation.security.DenyAll;
+import jakarta.annotation.security.PermitAll;
+import jakarta.annotation.security.RolesAllowed;
 import jakarta.data.Limit;
 import jakarta.data.Order;
 import jakarta.data.Sort;
@@ -84,6 +89,9 @@ public class Data_1_1_Servlet extends FATServlet {
 
     @Inject
     Fractions fractions;
+
+    @Inject
+    Sectors sectors; // has security roles that will eventually be enforced
 
     @Inject
     StatefulFractionRepository statefulFractionRepo;
@@ -2821,6 +2829,99 @@ public class Data_1_1_Servlet extends FATServlet {
                                                      fifteenTimesInverseDesc))
                                      .map(f -> f.name)
                                      .toList());
+    }
+
+    /**
+     * Annotations from the jakarta.annotation.security package that are
+     * found on a repository interface methods are automatically copied to the
+     * respective method on the repository bean instance/proxy.
+     * Data PR 1507 would like to add class level annotations as well, but
+     * Weld does not preserve them on bean proxies/interceptor proxies.
+     * This test case enforces that the current behavior is not regressed.
+     */
+    @Test
+    public void testSecurityAnnotationsTransferedToBeanMethods() throws Exception {
+
+        // repository bean method: alter(Sector)
+
+        Method alter = sectors.getClass().getMethod("alter", Sector.class);
+        RolesAllowed rolesForMethod = alter.getAnnotation(RolesAllowed.class);
+        assertNotNull("Repository bean method " + alter +
+                      " lacks the RollsAllowed annotation",
+                      rolesForMethod);
+
+        assertEquals(List.of("operator"),
+                     List.of(rolesForMethod.value()));
+
+        for (Annotation anno : alter.getAnnotations())
+            if (RolesAllowed.class.getPackageName()
+                            .equals(anno.annotationType().getPackageName())
+                &&
+                !RolesAllowed.class.equals(anno.annotationType()))
+                fail("Unexpected security annotation on repository bean method: " +
+                     anno);
+
+        // repository bean method: byLabel(String)
+
+        Method byLabel = sectors.getClass().getMethod("byLabel", String.class);
+        assertNotNull(byLabel.getAnnotation(PermitAll.class));
+
+        for (Annotation anno : byLabel.getAnnotations())
+            if (PermitAll.class.getPackageName()
+                            .equals(anno.annotationType().getPackageName())
+                &&
+                !PermitAll.class.equals(anno.annotationType()))
+                fail("Unexpected security annotation on repository bean method: " +
+                     anno);
+
+        // repository bean method: create(Sector)
+
+        Method create = sectors.getClass().getMethod("create", Sector.class);
+
+        for (Annotation anno : create.getAnnotations())
+            if (PermitAll.class.getPackageName()
+                            .equals(anno.annotationType().getPackageName()))
+                fail("Unexpected security annotation on repository bean method: " +
+                     anno);
+
+        // repository bean method: destroy(Sector)
+
+        Method destroy = sectors.getClass().getMethod("destroy", Sector.class);
+
+        for (Annotation anno : destroy.getAnnotations())
+            if (PermitAll.class.getPackageName()
+                            .equals(anno.annotationType().getPackageName()))
+                fail("Unexpected security annotation on repository bean method: " +
+                     anno);
+
+        // repository bean method: eraseEverything()
+
+        Method eraseEverything = sectors.getClass().getMethod("eraseEverything");
+        assertNotNull(eraseEverything.getAnnotation(DenyAll.class));
+
+        for (Annotation anno : eraseEverything.getAnnotations())
+            if (DenyAll.class.getPackageName()
+                            .equals(anno.annotationType().getPackageName())
+                &&
+                !DenyAll.class.equals(anno.annotationType()))
+                fail("Unexpected security annotation on repository bean method: " +
+                     anno);
+
+        // repository bean class
+
+        RolesAllowed rolesForClass = //
+                        sectors.getClass().getAnnotation(RolesAllowed.class);
+        // The Weld proxy for the bean does not include class-level annotations.
+        // Jakarta Security would need to define these annotations as interceptor
+        // bindings to have them to apply to CDI beans.
+
+        for (Annotation anno : sectors.getClass().getAnnotations())
+            if (RolesAllowed.class.getPackageName()
+                            .equals(anno.annotationType().getPackageName())
+                &&
+                !RolesAllowed.class.equals(anno.annotationType()))
+                fail("Unexpected security annotation on repository bean: " + anno);
+
     }
 
     /**

--- a/dev/io.openliberty.data.internal_fat_1_1/test-applications/Data_1_1_App/src/test/jakarta/data/v1_1/web/Data_1_1_Servlet.java
+++ b/dev/io.openliberty.data.internal_fat_1_1/test-applications/Data_1_1_App/src/test/jakarta/data/v1_1/web/Data_1_1_Servlet.java
@@ -2914,6 +2914,7 @@ public class Data_1_1_Servlet extends FATServlet {
         // The Weld proxy for the bean does not include class-level annotations.
         // Jakarta Security would need to define these annotations as interceptor
         // bindings to have them to apply to CDI beans.
+        // TODO add test based on changes made during EE 12
 
         for (Annotation anno : sectors.getClass().getAnnotations())
             if (RolesAllowed.class.getPackageName()

--- a/dev/io.openliberty.data.internal_fat_1_1/test-applications/Data_1_1_App/src/test/jakarta/data/v1_1/web/Sector.java
+++ b/dev/io.openliberty.data.internal_fat_1_1/test-applications/Data_1_1_App/src/test/jakarta/data/v1_1/web/Sector.java
@@ -1,0 +1,83 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package test.jakarta.data.v1_1.web;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+
+/**
+ * Entity to use in repository that is annotated with jakarta.annotation.security
+ * annotations.
+ */
+@Entity
+public class Sector {
+
+    @Column(nullable = false)
+    float centralAngle; // in degrees, from initial side to terminal side
+
+    @Column(nullable = false)
+    float initialSideAngle; // from 0 degrees to initial side
+
+    @Column(nullable = false)
+    @Id
+    String label;
+
+    @Column(nullable = false)
+    float radius; // length of initial side and terminal side of the sector
+
+    @Column(nullable = false)
+    int x; // of point at center of circle to which the sector belongs
+
+    @Column(nullable = false)
+    int y; // of point at center of circle to which the sector belongs
+
+    public static Sector of(String label,
+                            int x,
+                            int y,
+                            float radius,
+                            float centralAngle,
+                            float initialSideAngle) {
+        Sector s = new Sector();
+        s.centralAngle = centralAngle;
+        s.initialSideAngle = initialSideAngle;
+        s.label = label;
+        s.radius = radius;
+        s.x = x;
+        s.y = y;
+        return s;
+    }
+
+    /**
+     * Textual description. For example:
+     *
+     * Sector#1 (3,8) radius 10 @120˚ with central angle 60˚
+     */
+    @Override
+    public String toString() {
+        return new StringBuilder("Sector#")
+                        .append(label)
+                        .append('(')
+                        .append(x)
+                        .append(',')
+                        .append(y)
+                        .append(") radius ")
+                        .append(radius)
+                        .append(" @")
+                        .append(initialSideAngle)
+                        .append("˚ with central angle ")
+                        .append(centralAngle)
+                        .append('˚')
+                        .toString();
+    }
+}

--- a/dev/io.openliberty.data.internal_fat_1_1/test-applications/Data_1_1_App/src/test/jakarta/data/v1_1/web/Sectors.java
+++ b/dev/io.openliberty.data.internal_fat_1_1/test-applications/Data_1_1_App/src/test/jakarta/data/v1_1/web/Sectors.java
@@ -1,0 +1,54 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package test.jakarta.data.v1_1.web;
+
+import static jakarta.data.repository.By.ID;
+
+import java.util.Optional;
+
+import jakarta.annotation.security.DenyAll;
+import jakarta.annotation.security.PermitAll;
+import jakarta.annotation.security.RolesAllowed;
+import jakarta.data.repository.By;
+import jakarta.data.repository.Delete;
+import jakarta.data.repository.Find;
+import jakarta.data.repository.Insert;
+import jakarta.data.repository.Repository;
+import jakarta.data.repository.Update;
+
+/**
+ * Repository with annotations from the jakarta.annotation.security package
+ */
+@Repository(dataStore = "MyDataStore")
+@RolesAllowed({ "admin", "dba" })
+public interface Sectors {
+
+    @RolesAllowed("operator")
+    @Update
+    void alter(Sector s);
+
+    @Find
+    @PermitAll
+    Optional<Sector> byLabel(@By(ID) String label);
+
+    @Insert
+    void create(Sector s);
+
+    @Delete
+    void destroy(Sector s);
+
+    @Delete
+    @DenyAll
+    void eraseEverything();
+
+}


### PR DESCRIPTION
Test case of current behavior for security annotations on repository methods.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
