### PR TITLE
Additional handling for edge case with transaction timeout on a slow system

### DIFF
--- a/dev/com.ibm.ws.jdbc_fat_v41/fat/src/com/ibm/ws/jdbc/fat/v41/JDBC41Test.java
+++ b/dev/com.ibm.ws.jdbc_fat_v41/fat/src/com/ibm/ws/jdbc/fat/v41/JDBC41Test.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017,2023 IBM Corporation and others.
+ * Copyright (c) 2017,2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.jdbc_fat_v41/fat/src/com/ibm/ws/jdbc/fat/v41/JDBC41Test.java
+++ b/dev/com.ibm.ws.jdbc_fat_v41/fat/src/com/ibm/ws/jdbc/fat/v41/JDBC41Test.java
@@ -56,6 +56,7 @@ public class JDBC41Test extends FATServletClient {
         server.stopServer("J2CA0081E.*slowDS", // expected by testNetworkTimeoutSimple
                           "J2CA0026E.*RollbackException", // from testTransactionTimeoutAbort when transaction times out before enlist
                           "J2CA0027E", // expected by testTransactionTimeoutAbort - XAds removed because it does not appear on the same line as the message ID in every language
+                          "J2CA0030E", // from testTransactionTimeoutAbort when transaction times out before enlist
                           "DSRA0302E.*XAException*", // expected by testTransactionTimeoutAbort
                           "DSRA0304E.*XAException*", // expected by testTransactionTimeoutAbort
                           "DSRA9400E.*addSync", // from testTransactionTimeoutAbort when transaction times out before enlist

--- a/dev/com.ibm.ws.jdbc_fat_v41/test-applications/basicfat/src/jdbc/fat/v41/web/BasicTestServlet.java
+++ b/dev/com.ibm.ws.jdbc_fat_v41/test-applications/basicfat/src/jdbc/fat/v41/web/BasicTestServlet.java
@@ -1550,6 +1550,7 @@ public class BasicTestServlet extends FATDatabaseServlet {
     @Test
     @SkipIfDataSourceProperties({ SYBASE, INFORMIX_JDBC }) // no 4.1 sybase or ifx driver
     @AllowedFFDC({
+                   "java.sql.SQLException", // wraps RollbackException when transaction times out before enlist
                    "javax.resource.ResourceException", // times out before enlistment
                    "javax.transaction.RollbackException", // times out before enlistment
                    "javax.transaction.xa.XAException", "java.lang.NullPointerException", "oracle.jdbc.xa.OracleXAException",

--- a/dev/com.ibm.ws.jdbc_fat_v41/test-applications/basicfat/src/jdbc/fat/v41/web/BasicTestServlet.java
+++ b/dev/com.ibm.ws.jdbc_fat_v41/test-applications/basicfat/src/jdbc/fat/v41/web/BasicTestServlet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017,2023 IBM Corporation and others.
+ * Copyright (c) 2017,2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at


### PR DESCRIPTION
This edge case is mentioned in the test already, where a transaction can time out before enlist on a slow system. The Rollback and Resource Exceptions are already handled, but a SQLException FFDC is also created, so that needs to be covered as well.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

