### PR TITLE
Replace `computeIfAbsent` with `compute` for HAM Tracking

### DIFF
--- a/dev/com.ibm.ws.security.javaeesec.cdi/src/com/ibm/ws/security/javaeesec/cdi/extensions/HttpAuthenticationMechanismsTracker.java
+++ b/dev/com.ibm.ws.security.javaeesec.cdi/src/com/ibm/ws/security/javaeesec/cdi/extensions/HttpAuthenticationMechanismsTracker.java
@@ -42,7 +42,7 @@ public class HttpAuthenticationMechanismsTracker {
             // atomic operation required on concurrent hash map as multiple CDI extensions
             //   can now use initialize and use moduleMapsPerApplication without
             //   that the initialize comes first
-            moduleMapsPerApplication.computeIfAbsent(applicationName, key -> createInitializedWebModuleMap());
+            moduleMapsPerApplication.compute(applicationName, (key, value) -> createInitializedWebModuleMap());
         }
     }
 


### PR DESCRIPTION
Originally we were removing and then creating a new sub-map on application initialization. with `computeIfAbsent` we were now maintaining the submap with its contents, so when we change a WAR within an application to use a different HAM, the old HAM was still in the list.

By replacing with `compute` we maintain the new atomicity, but means when we initialise for an existing application we do so with a clean the slate. instead of maintaining any potential stale data.

Fixes [#311126](https://wasrtc.hursley.ibm.com:9443/jazz/web/projects/WS-CD#action=com.ibm.team.workitem.viewWorkItem&id=311126)
Addresses issue introduced by https://github.com/OpenLiberty/open-liberty/pull/34819

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".