### PR TITLE
Improve performance for the logged out cookie cache

### DIFF
--- a/dev/com.ibm.ws.kernel.service/src/com/ibm/ws/common/crypto/MessageDigestUtils.java
+++ b/dev/com.ibm.ws.kernel.service/src/com/ibm/ws/common/crypto/MessageDigestUtils.java
@@ -1,0 +1,122 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package com.ibm.ws.common.crypto;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicReference;
+
+import com.ibm.websphere.ras.Tr;
+import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.websphere.ras.annotation.Sensitive;
+import com.ibm.websphere.ras.annotation.Trivial;
+import com.ibm.ws.common.encoder.Base64Coder;
+import com.ibm.ws.ffdc.annotation.FFDCIgnore;
+import com.ibm.ws.kernel.service.util.ConcurrentObjectPool;
+
+public class MessageDigestUtils {
+
+    private static final TraceComponent tc = Tr.register(MessageDigestUtils.class);
+
+    private static class MessageDigestProcessor {
+        private final MessageDigest CLONEABLE_MESSAGE_DIGEST;
+        private final String algorithm;
+        private final ConcurrentObjectPool<MessageDigest> messageDigestPool = new ConcurrentObjectPool<>(50);
+
+        MessageDigestProcessor(String algorithm) throws NoSuchAlgorithmException {
+            this.algorithm = algorithm;
+            CLONEABLE_MESSAGE_DIGEST = MessageDigest.getInstance(algorithm);
+        }
+
+        String getHashedValue(@Sensitive String originalValue) throws NoSuchAlgorithmException {
+            byte[] valueBytes = originalValue.getBytes(StandardCharsets.UTF_8);
+
+            MessageDigest md = getMessageDigest();
+
+            byte[] hashedBytes = md.digest(valueBytes);
+
+            // If an exception happens we are not putting it back into the pool in case the
+            // MessageDigest is not in a healthy state
+            messageDigestPool.put(md);
+
+            return Base64Coder.base64EncodeToString(hashedBytes);
+        }
+
+        /**
+         * Use clone() to get a new instance as its approximately 50% faster (as
+         * seen in empirical testing), if we can. Worst case scenario is we will
+         * create a new one each time.
+         *
+         * @return A MessageDigest instance, possibly a pooled entry
+         * @throws NoSuchAlgorithmException
+         */
+        @Trivial
+        @FFDCIgnore({ CloneNotSupportedException.class })
+        private MessageDigest getMessageDigest() throws NoSuchAlgorithmException {
+
+            MessageDigest pooledDigest = messageDigestPool.get();
+
+            if (pooledDigest != null) {
+                return pooledDigest;
+            }
+
+            /*
+             * Try to clone the parent. If we can't, then we'll ignore the FFDC and create a
+             * new instance. If the clone fails, which is REALLY unlikely, as we
+             * know the SHA MessageDigest is cloneable on IBM and Sun JDKs
+             */
+            try {
+                return (MessageDigest) CLONEABLE_MESSAGE_DIGEST.clone();
+            } catch (CloneNotSupportedException cnse) {
+                if (tc.isDebugEnabled()) {
+                    Tr.debug(tc, "CloneNotSupportedException caught while trying to clone MessageDigest with algorithm " + algorithm
+                                 + ". This is pretty unlikely, and we need to get details about the JDK which is in use.",
+                             cnse);
+                }
+                return MessageDigest.getInstance(algorithm);
+            }
+        }
+    }
+
+    private static Map<String, MessageDigestProcessor> messageDigestProcessors = new ConcurrentHashMap<>();
+
+    /**
+     * Converts a String to its hashed value based off of a MessageDigest for the provided
+     * algorithm.
+     *
+     * @param originalValue String value which may be a password so is marked Sensitive
+     * @param algorithm     MessageDigest algorithm to use
+     * @return
+     * @throws NoSuchAlgorithmException
+     */
+    public static String getHashedValue(@Sensitive String originalValue, String algorithm) throws NoSuchAlgorithmException {
+        MessageDigestProcessor mdProcessor = messageDigestProcessors.get(algorithm);
+
+        if (mdProcessor == null) {
+            AtomicReference<NoSuchAlgorithmException> caughtExc = new AtomicReference<>();
+            mdProcessor = messageDigestProcessors.computeIfAbsent(algorithm, (k) -> {
+                try {
+                    return new MessageDigestProcessor(k);
+                } catch (NoSuchAlgorithmException e) {
+                    caughtExc.set(e);
+                    return null;
+                }
+            });
+            if (mdProcessor == null) {
+                throw caughtExc.get();
+            }
+        }
+
+        return mdProcessor.getHashedValue(originalValue);
+    }
+}

--- a/dev/com.ibm.ws.security.authentication.builtin/src/com/ibm/ws/security/authentication/internal/cache/keyproviders/BasicAuthCacheKeyProvider.java
+++ b/dev/com.ibm.ws.security.authentication.builtin/src/com/ibm/ws/security/authentication/internal/cache/keyproviders/BasicAuthCacheKeyProvider.java
@@ -6,13 +6,9 @@
  * http://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package com.ibm.ws.security.authentication.internal.cache.keyproviders;
 
-import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Collections;
 import java.util.HashSet;
@@ -22,9 +18,8 @@ import java.util.Set;
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.websphere.ras.annotation.Sensitive;
-import com.ibm.websphere.ras.annotation.Trivial;
 import com.ibm.websphere.security.cred.WSCredential;
-import com.ibm.ws.common.encoder.Base64Coder;
+import com.ibm.ws.common.crypto.MessageDigestUtils;
 import com.ibm.ws.ffdc.annotation.FFDCIgnore;
 import com.ibm.ws.security.authentication.cache.AuthCacheConfig;
 import com.ibm.ws.security.authentication.cache.CacheContext;
@@ -41,8 +36,6 @@ public class BasicAuthCacheKeyProvider implements CacheKeyProvider {
     private static final String KEY_SEPARATOR = ":";
 
     private static final String SHA_512 = "SHA-512";
-    private static MessageDigest CLONEABLE_MESSAGE_DIGEST = null;
-    private static final Object SYNC_OBJECT = new Object();
 
     /** {@inheritDoc} */
     @Override
@@ -179,49 +172,8 @@ public class BasicAuthCacheKeyProvider implements CacheKeyProvider {
         return lookupKey;
     }
 
-    /**
-     * Use clone() to get a new instance as its approximately 50% faster (as
-     * seen in empirical testing), if we can. Worst case scenario is we will
-     * create a new one each time.
-     *
-     * @return
-     * @throws NoSuchAlgorithmException
-     */
-    @Trivial
-    @FFDCIgnore(CloneNotSupportedException.class)
-    private static MessageDigest getMessageDigest() throws NoSuchAlgorithmException {
-        /*
-         * If we've never been asked for a MessageDigest, create the parent of
-         * our clones.
-         */
-        if (CLONEABLE_MESSAGE_DIGEST == null) {
-            synchronized (SYNC_OBJECT) {
-                if (CLONEABLE_MESSAGE_DIGEST == null) {
-                    CLONEABLE_MESSAGE_DIGEST = MessageDigest.getInstance(SHA_512);
-                }
-            }
-        }
-
-        /*
-         * Try to clone the parent. If we can't, then we'll ignore the FFDC and create a
-         * new instance. If the clone fails, which is REALLY unlikely, as we
-         * know the SHA MessageDigest is cloneable on IBM and Sun JDKs
-         */
-        try {
-            return (MessageDigest) CLONEABLE_MESSAGE_DIGEST.clone();
-        } catch (CloneNotSupportedException cnse) {
-            //Since implementation of clone is optional in Java, if the clone does not work, just return a new instance.
-            return MessageDigest.getInstance(SHA_512);
-        }
-    }
-
     private static String getHashedPassword(@Sensitive String password) throws NoSuchAlgorithmException {
-        String hashedPassword = null;
-        if (password != null) {
-            MessageDigest messageDigest = getMessageDigest();
-            hashedPassword = Base64Coder.base64EncodeToString(messageDigest.digest(Base64Coder.getBytes(password)));
-        }
-        return hashedPassword;
+        return password == null ? null : MessageDigestUtils.getHashedValue(password, SHA_512);
     }
 
 }

--- a/dev/com.ibm.ws.webcontainer.security/src/com/ibm/ws/webcontainer/security/LoggedOutCookieCacheHelper.java
+++ b/dev/com.ibm.ws.webcontainer.security/src/com/ibm/ws/webcontainer/security/LoggedOutCookieCacheHelper.java
@@ -6,23 +6,15 @@
  * http://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package com.ibm.ws.webcontainer.security;
 
+import java.security.NoSuchAlgorithmException;
+
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
-import com.ibm.websphere.ras.annotation.Trivial;
 import com.ibm.ws.common.crypto.CryptoUtils;
-import com.ibm.ws.common.encoder.Base64Coder;
-import com.ibm.ws.ffdc.annotation.FFDCIgnore;
-import com.ibm.ws.webcontainer.security.internal.StringUtil;
-
-import java.nio.charset.StandardCharsets;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
+import com.ibm.ws.common.crypto.MessageDigestUtils;
 
 /**
  * Utility 'helper' class to get the singleton {@link LoggedOutCookieCache}
@@ -34,11 +26,9 @@ public class LoggedOutCookieCacheHelper {
     private static final TraceComponent tc = Tr.register(LoggedOutCookieCacheHelper.class, "LoggedOutCookieCache");
 
     private static LoggedOutCookieCache cookieCacheService = null;
-    
+
     public static final String LOGOUT_KEY_PREFIX = "LOGOUT:";
     private static final String SHA_512 = CryptoUtils.MESSAGE_DIGEST_ALGORITHM_SHA_512;
-    private static final Object SYNC_OBJECT = new Object();
-    private static MessageDigest CLONEABLE_MESSAGE_DIGEST = null;
 
     /**
      * Get the singleton {@link LoggedOutCookieCache} instance.
@@ -68,71 +58,30 @@ public class LoggedOutCookieCacheHelper {
      * @return Hash string with LOGOUT: prefix, or null if error
      */
     public static String generateTokenHashKey(String tokenString) {
-        if (tc.isEntryEnabled()) Tr.entry(tc, "generateTokenHashKey()", tokenString);
+        if (tc.isEntryEnabled())
+            Tr.entry(tc, "generateTokenHashKey()", tokenString);
 
         if (tokenString == null || tokenString.isEmpty()) {
-            if (tc.isEntryEnabled()) Tr.exit(tc, "generateTokenHashKey()", "null or empty token");
+            if (tc.isEntryEnabled())
+                Tr.exit(tc, "generateTokenHashKey()", "null or empty token");
             return null;
         }
 
-        MessageDigest md = getCloneableMessageDigest();
-        if (md == null) {
-            if (tc.isDebugEnabled()) Tr.debug(tc, "MessageDigest unavailable; token hash cannot be generated. Logout tracking is disabled.");
-            if (tc.isEntryEnabled()) Tr.exit(tc, "generateTokenHashKey()", null);
-            return null;
-        }
-        
-        md.update(tokenString.getBytes(StandardCharsets.UTF_8));
-        String hashKey = LOGOUT_KEY_PREFIX + Base64Coder.base64EncodeToString(md.digest());
-        
-        if (tc.isEntryEnabled()) Tr.exit(tc, "generateTokenHashKey()", hashKey);
-        return hashKey;
-    }
-
-    /**
-     * Get a MessageDigest instance using clone() for better performance.
-     * Uses SHA-512 algorithm. Approximately 50% faster than creating new instances.
-     *
-     * @return A MessageDigest instance, or null if unavailable
-     */
-    @Trivial
-    @FFDCIgnore({ CloneNotSupportedException.class, NoSuchAlgorithmException.class })
-    private static MessageDigest getCloneableMessageDigest() {
-        /*
-         * If we've never been asked for a MessageDigest, create the parent of
-         * our clones.
-         */
-        if (CLONEABLE_MESSAGE_DIGEST == null) {
-            synchronized (SYNC_OBJECT) {
-                if (CLONEABLE_MESSAGE_DIGEST == null) {
-                    try {
-                        CLONEABLE_MESSAGE_DIGEST = MessageDigest.getInstance(SHA_512);
-                    } catch (NoSuchAlgorithmException nsae) {
-                        // Not possible. SHA-512 is required by all JREs.
-                    }
-                }
-            }
-        }
-
-        /*
-         * Try to clone the parent. If we can't, then we'll ignore the FFDC and create a
-         * new instance. If the clone fails, which is REALLY unlikely, as we
-         * know the SHA MessageDigest is cloneable on IBM and Sun JDKs
-         */
+        String hashedToken = null;
         try {
-            return (MessageDigest) CLONEABLE_MESSAGE_DIGEST.clone();
-        } catch (CloneNotSupportedException cnse) {
-            if (tc.isDebugEnabled()) {
-                Tr.debug(tc, "CloneNotSupportedException caught while trying to clone MessageDigest with algorithm " + SHA_512
-                             + ". This is pretty unlikely, and we need to get details about the JDK which is in use.",
-                         cnse);
-            }
-            try {
-                return MessageDigest.getInstance(SHA_512);
-            } catch (NoSuchAlgorithmException nsae) {
-                // Not possible. SHA-512 is required by all JREs.
-                return null;
-            }
+            hashedToken = MessageDigestUtils.getHashedValue(tokenString, SHA_512);
+        } catch (NoSuchAlgorithmException nsae) {
+            if (tc.isDebugEnabled())
+                Tr.debug(tc, "MessageDigest unavailable; token hash cannot be generated. Logout tracking is disabled.");
+            if (tc.isEntryEnabled())
+                Tr.exit(tc, "generateTokenHashKey()", null);
+            return null;
         }
+
+        String hashKey = LOGOUT_KEY_PREFIX + hashedToken;
+
+        if (tc.isEntryEnabled())
+            Tr.exit(tc, "generateTokenHashKey()", hashKey);
+        return hashKey;
     }
 }


### PR DESCRIPTION
- With the introduction of #35096, there is a performance impact.  This was narrowed down to how we do MessageDigest processing in the LoggedOutCookieCacheHelper where we clone() the MessageDigest on every request.  In other places we have a single MessageDigest and we use a lock object to control concurrency on it.
- With this change, LoggedOutCookieCacheHelper is updated to use an Object pool to keep a pool of MessageDigests instead of making a new clone on every operation.
- During analysis of the performance profiles, noticed that BasicAuthCacheKeyProvider also does the same patter.  As such extracted the common code into a utility class for both LoggedOutCookedCacheHelper and BasicAuthCacheKeyProvider to use.  Made it extensible to support other algorithms than SHA-512 that other code could make use of this common utility to get a performance benefit.

Fixes: #35355 

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
