### PR TITLE
Fix reference to MCP API project

### DIFF
--- a/dev/io.openliberty.mcp.internal_fat/bnd.bnd
+++ b/dev/io.openliberty.mcp.internal_fat/bnd.bnd
@@ -39,7 +39,7 @@ tested.features: \
 	io.openliberty.mcp;version=latest,\
 	io.openliberty.mcp.monitor;version=latest,\
 	com.ibm.websphere.appserver.api.monitor;version=latest,\
-	io.openliberty.org.mcp-java.mcp-server-api;version=latest,\
+	io.openliberty.org.mcpjava.mcp-server-api;version=latest,\
 	org.json:json;version=20080701,\
 	org.skyscreamer:jsonassert,\
 	com.ibm.ws.logging;version=latest,\


### PR DESCRIPTION
Looks like this was accidentally broken during a merge.

The feature branch is broken without this change.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".