### PR TITLE
Revert "Upgrading surefire to avoid testng error"

### DIFF
--- a/dev/com.ibm.ws.concurrent.mp.1.2_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.concurrent.mp.1.2_fat_tck/publish/tckRunner/tck/pom.xml
@@ -163,7 +163,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.5.6</version> <!-- Any changes to the surefire version must be tested against ZOS -->
+                <version>2.17</version> <!-- Any changes to the surefire version must be tested against ZOS -->
                 <configuration>
                     <argLine>-Dfile.encoding=${project.build.sourceEncoding} -Dcom.ibm.tools.attach.enable=yes</argLine> <!-- Needed for ZOS. sourceEncoding is needed because Arquillian calls string.getBtytes(). Attach is needed because Arquillian uses com.sun.tools.attach to find VMs -->
                     <systemPropertyVariables>

--- a/dev/com.ibm.ws.concurrent.mp.1.3_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.concurrent.mp.1.3_fat_tck/publish/tckRunner/tck/pom.xml
@@ -171,7 +171,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.5.6</version> <!-- Any changes to the surefire version must be tested against ZOS -->
+                <version>2.17</version> <!-- Any changes to the surefire version must be tested against ZOS -->
                 <configuration>
                     <argLine>-Dfile.encoding=${project.build.sourceEncoding} -Dcom.ibm.tools.attach.enable=yes</argLine> <!-- Needed for ZOS. sourceEncoding is needed because Arquillian calls string.getBtytes(). Attach is needed because Arquillian uses com.sun.tools.attach to find VMs -->
                     <systemPropertyVariables>

--- a/dev/com.ibm.ws.concurrent.mp_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.concurrent.mp_fat_tck/publish/tckRunner/tck/pom.xml
@@ -152,7 +152,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.5.6</version> <!-- Any changes to the surefire version must be tested against ZOS -->
+                <version>2.17</version> <!-- Any changes to the surefire version must be tested against ZOS -->
                 <configuration>
                     <argLine>-Dfile.encoding=${project.build.sourceEncoding} -Dcom.ibm.tools.attach.enable=yes</argLine> <!-- Needed for ZOS. sourceEncoding is needed because Arquillian calls string.getBtytes(). Attach is needed because Arquillian uses com.sun.tools.attach to find VMs -->
                     <systemPropertyVariables>

--- a/dev/io.openliberty.jakarta.concurrency.3.0_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.jakarta.concurrency.3.0_fat_tck/publish/tckRunner/tck/pom.xml
@@ -178,7 +178,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.5.6</version> <!-- Any changes to the surefire version must be tested against ZOS -->
+                <version>2.17</version> <!-- Any changes to the surefire version must be tested against ZOS -->
                 <configuration>
                     <argLine>-Dfile.encoding=${project.build.sourceEncoding} -Dcom.ibm.tools.attach.enable=yes</argLine> <!-- Needed for ZOS. sourceEncoding is needed becuase arquillian calls string.getBtytes(). Attach is needed becuase because arquillian uses com.sun.tools.attach to find VMs -->
                     <systemPropertyVariables>


### PR DESCRIPTION
Reverts OpenLiberty/open-liberty#35281

it is causing a hard break in z/os java 8 builds.