### PR TITLE
Concurrency tck

### DIFF
--- a/dev/com.ibm.ws.concurrent.mp.1.2_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.concurrent.mp.1.2_fat_tck/publish/tckRunner/tck/pom.xml
@@ -176,6 +176,7 @@
                         <suiteXmlFile>${suiteXmlFile}</suiteXmlFile>
                     </suiteXmlFiles>
                     <testSourceDirectory>${basedir}${file.separarator}src${file.separarator}main${file.separarator}java${file.separarator}</testSourceDirectory>
+                    <forkNode implementation="org.apache.maven.plugin.surefire.extensions.SurefireForkNodeFactory" /> <!-- Use TCP/IP instead of process pipes for ZOS -->
                 </configuration>
             </plugin>
         </plugins>

--- a/dev/com.ibm.ws.concurrent.mp.1.2_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.concurrent.mp.1.2_fat_tck/publish/tckRunner/tck/pom.xml
@@ -163,7 +163,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.17</version> <!-- Any changes to the surefire version must be tested against ZOS -->
+                <version>3.5.6</version> <!-- Any changes to the surefire version must be tested against ZOS -->
                 <configuration>
                     <argLine>-Dfile.encoding=${project.build.sourceEncoding} -Dcom.ibm.tools.attach.enable=yes</argLine> <!-- Needed for ZOS. sourceEncoding is needed because Arquillian calls string.getBtytes(). Attach is needed because Arquillian uses com.sun.tools.attach to find VMs -->
                     <systemPropertyVariables>

--- a/dev/com.ibm.ws.concurrent.mp.1.3_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.concurrent.mp.1.3_fat_tck/publish/tckRunner/tck/pom.xml
@@ -171,7 +171,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.17</version> <!-- Any changes to the surefire version must be tested against ZOS -->
+                <version>3.5.6</version> <!-- Any changes to the surefire version must be tested against ZOS -->
                 <configuration>
                     <argLine>-Dfile.encoding=${project.build.sourceEncoding} -Dcom.ibm.tools.attach.enable=yes</argLine> <!-- Needed for ZOS. sourceEncoding is needed because Arquillian calls string.getBtytes(). Attach is needed because Arquillian uses com.sun.tools.attach to find VMs -->
                     <systemPropertyVariables>

--- a/dev/com.ibm.ws.concurrent.mp.1.3_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.concurrent.mp.1.3_fat_tck/publish/tckRunner/tck/pom.xml
@@ -184,6 +184,7 @@
                         <suiteXmlFile>${suiteXmlFile}</suiteXmlFile>
                     </suiteXmlFiles>
                     <testSourceDirectory>${basedir}${file.separarator}src${file.separarator}main${file.separarator}java${file.separarator}</testSourceDirectory>
+                    <forkNode implementation="org.apache.maven.plugin.surefire.extensions.SurefireForkNodeFactory" /> <!-- Use TCP/IP instead of process pipes for ZOS -->
                 </configuration>
             </plugin>
         </plugins>

--- a/dev/com.ibm.ws.concurrent.mp_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.concurrent.mp_fat_tck/publish/tckRunner/tck/pom.xml
@@ -152,7 +152,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.17</version> <!-- Any changes to the surefire version must be tested against ZOS -->
+                <version>3.5.6</version> <!-- Any changes to the surefire version must be tested against ZOS -->
                 <configuration>
                     <argLine>-Dfile.encoding=${project.build.sourceEncoding} -Dcom.ibm.tools.attach.enable=yes</argLine> <!-- Needed for ZOS. sourceEncoding is needed because Arquillian calls string.getBtytes(). Attach is needed because Arquillian uses com.sun.tools.attach to find VMs -->
                     <systemPropertyVariables>

--- a/dev/com.ibm.ws.concurrent.mp_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.concurrent.mp_fat_tck/publish/tckRunner/tck/pom.xml
@@ -165,6 +165,7 @@
                         <suiteXmlFile>${suiteXmlFile}</suiteXmlFile>
                     </suiteXmlFiles>
                     <testSourceDirectory>${basedir}${file.separarator}src${file.separarator}main${file.separarator}java${file.separarator}</testSourceDirectory>
+                    <forkNode implementation="org.apache.maven.plugin.surefire.extensions.SurefireForkNodeFactory" /> <!-- Use TCP/IP instead of process pipes for ZOS -->
                 </configuration>
             </plugin>
         </plugins>

--- a/dev/io.openliberty.jakarta.concurrency.3.0_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.jakarta.concurrency.3.0_fat_tck/publish/tckRunner/tck/pom.xml
@@ -193,6 +193,7 @@
                     </suiteXmlFiles>
                     <reportNameSuffix>${jakarta.tck.platform}</reportNameSuffix>
                     <testSourceDirectory>${basedir}${file.separarator}src${file.separarator}main${file.separarator}java${file.separarator}</testSourceDirectory>
+                    <forkNode implementation="org.apache.maven.plugin.surefire.extensions.SurefireForkNodeFactory" /> <!-- Use TCP/IP instead of process pipes for ZOS -->
                 </configuration>
             </plugin>
         </plugins>

--- a/dev/io.openliberty.jakarta.concurrency.3.0_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.jakarta.concurrency.3.0_fat_tck/publish/tckRunner/tck/pom.xml
@@ -178,7 +178,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.17</version> <!-- Any changes to the surefire version must be tested against ZOS -->
+                <version>3.5.6</version> <!-- Any changes to the surefire version must be tested against ZOS -->
                 <configuration>
                     <argLine>-Dfile.encoding=${project.build.sourceEncoding} -Dcom.ibm.tools.attach.enable=yes</argLine> <!-- Needed for ZOS. sourceEncoding is needed becuase arquillian calls string.getBtytes(). Attach is needed becuase because arquillian uses com.sun.tools.attach to find VMs -->
                     <systemPropertyVariables>


### PR DESCRIPTION
Upgrade surefire version to avoid testng issue. Use SurefireForkNodeFactory to avoid encoding issues on z/os

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
