### PR TITLE
count of total elements across pages when restriction is present

### DIFF
--- a/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/QueryInfo.java
+++ b/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/QueryInfo.java
@@ -495,11 +495,12 @@ public abstract class QueryInfo {
      *
      * @param restrictions represented as a WHERE clause, or otherwise as an
      *                         AND clause to append to the query's WHERE clause
+     * @return the new count query that is assigned to jpqlCount
      */
-    private void appendCountRestrictions(String restrictions) {
+    private String appendCountRestrictions(String restrictions) {
         int countLen = jpqlCount.length() + 1 + restrictions.length();
 
-        jpqlCount = new StringBuilder(countLen) //
+        return jpqlCount = new StringBuilder(countLen) //
                         .append(jpqlCount) //
                         .append(' ') //
                         .append(restrictions) //

--- a/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/QueryInfo.java
+++ b/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/QueryInfo.java
@@ -490,6 +490,23 @@ public abstract class QueryInfo {
                                                       Annotation[] annos);
 
     /**
+     * Appends restrictions to the query (jpqlCount) that selects the
+     * COUNT of all matching entities.
+     *
+     * @param restrictions represented as a WHERE clause, or otherwise as an
+     *                         AND clause to append to the query's WHERE clause
+     */
+    private void appendCountRestrictions(String restrictions) {
+        int countLen = jpqlCount.length() + 1 + restrictions.length();
+
+        jpqlCount = new StringBuilder(countLen) //
+                        .append(jpqlCount) //
+                        .append(' ') //
+                        .append(restrictions) //
+                        .toString();
+    }
+
+    /**
      * Asks the Jakarta Persistence provider whether the given query uses named
      * parameters. The API for this is optional, but supported by Hibernate.
      * If the API is not supported, assume named parameters are not permitted.
@@ -925,7 +942,7 @@ public abstract class QueryInfo {
             info.specialParamsStartAt = specialParamsStartAt;
 
             if (restriction == null) {
-                // no Constraints deferred or Restriction
+                // no Constraints deferred and no Restriction
                 q = new StringBuilder(ql);
             } else {
                 // has Restriction, but no Constraints deferred
@@ -936,9 +953,15 @@ public abstract class QueryInfo {
                 else
                     q.append(ql).append(' ');
 
+                int restrictAtForCount = jpqlCount == null || jpqlCount.length() < //
+                                Util.MIN_COUNT_QUERY_LENGTH ? -1 : q.length();
+
                 q.append(info.hasWhere ? "AND " : "WHERE ");
                 info.hasWhere = true;
                 info.generateRestrictions(q, restriction, reqJPQLParams);
+
+                if (restrictAtForCount >= 0)
+                    info.appendCountRestrictions(q.substring(restrictAtForCount));
 
                 if (info.restrictAt >= 0 && info.restrictAt < len) {
                     int newPosition = q.length();
@@ -956,9 +979,15 @@ public abstract class QueryInfo {
             q = info.initQueryByParameters(countPages, constraints, reqJPQLParams);
 
             if (restriction != null) {
+                int restrictAtForCount = jpqlCount == null || jpqlCount.length() < //
+                                Util.MIN_COUNT_QUERY_LENGTH ? -1 : q.length();
+
                 q.append(info.hasWhere ? " AND " : " WHERE ");
                 info.hasWhere = true;
                 info.generateRestrictions(q, restriction, reqJPQLParams);
+
+                if (restrictAtForCount >= 0)
+                    info.appendCountRestrictions(q.substring(restrictAtForCount));
             }
 
             // If there are no overrides from Order/Sort parameters, keep the
@@ -2222,11 +2251,13 @@ public abstract class QueryInfo {
      */
     private void generateCount(String where) {
         String o = entityVar;
-        StringBuilder q = new StringBuilder(21 + 2 * o.length() +
-                                            entityInfo.name.length() +
-                                            (where == null ? 0 : where.length())) //
-                                                            .append("SELECT COUNT(").append(o).append(") FROM ") //
-                                                            .append(entityInfo.name);
+        int len = 21 + 2 * o.length() +
+                  entityInfo.name.length() +
+                  (where == null ? 0 : where.length());
+
+        StringBuilder q = new StringBuilder(len) //
+                        .append("SELECT COUNT(").append(o).append(") FROM ") //
+                        .append(entityInfo.name);
         if (o != THIS)
             q.append(' ').append(o);
 

--- a/dev/io.openliberty.data.internal_fat_1_1/test-applications/Data_1_1_App/src/test/jakarta/data/v1_1/web/Data_1_1_Servlet.java
+++ b/dev/io.openliberty.data.internal_fat_1_1/test-applications/Data_1_1_App/src/test/jakarta/data/v1_1/web/Data_1_1_Servlet.java
@@ -2459,6 +2459,11 @@ public class Data_1_1_Servlet extends FATServlet {
                                      .collect(Collectors.toList()));
     }
 
+    /**
+     * Request offset pagination from a query by method name that accepts a
+     * Restriction parameter, and specify a restriction.
+     * Verify the total count of elements and pages is computed correctly.
+     */
     @Test
     public void testQueryByMethodNameWithRestriction() {
         Page<Fraction> page1 = fractions//

--- a/dev/io.openliberty.data.internal_fat_1_1/test-applications/Data_1_1_App/src/test/jakarta/data/v1_1/web/Data_1_1_Servlet.java
+++ b/dev/io.openliberty.data.internal_fat_1_1/test-applications/Data_1_1_App/src/test/jakarta/data/v1_1/web/Data_1_1_Servlet.java
@@ -504,6 +504,44 @@ public class Data_1_1_Servlet extends FATServlet {
     }
 
     /**
+     * Request cursor pagination from a repository method that accepts a
+     * Restriction parameter, but specify the unrestricted restriction.
+     * Verify the total count of elements and pages is computed correctly.
+     */
+    @Test
+    public void testCursoredPageCountWithEmptyRestriction() {
+
+        Between<Integer> denominators5to10 = Between.bounds(5, 10);
+
+        Order<Fraction> order = Order.by(_Fraction.denominator.asc(),
+                                         _Fraction.numerator.asc());
+
+        Cursor fourSeventhsCursor = Cursor.forKey(7, 4);
+        PageRequest page3Req = PageRequest.ofSize(5)
+                        .pageNumber(3)
+                        .afterCursor(fourSeventhsCursor);
+
+        CursoredPage<Fraction> page3 = fractions
+                        .fetchCursored(denominators5to10,
+                                       true, // reduced
+                                       Restrict.unrestricted(),
+                                       order,
+                                       page3Req);
+
+        assertEquals(26L,
+                     page3.totalElements());
+
+        assertEquals(List.of("5/7",
+                             "6/7",
+                             "1/8",
+                             "3/8",
+                             "5/8"),
+                     page3.stream()
+                                     .map(f -> f.numerator + "/" + f.denominator)
+                                     .toList());
+    }
+
+    /**
      * Use a stateful repository to find an entity. Use a detach operation to
      * make the entity unmanaged. Make updates to the entity. After committing,
      * verify that updates made after the detach operation are not written to
@@ -2419,6 +2457,61 @@ public class Data_1_1_Servlet extends FATServlet {
                      fractions.where(restriction)
                                      .map(f -> f.name)
                                      .collect(Collectors.toList()));
+    }
+
+    @Test
+    public void testQueryByMethodNameWithRestriction() {
+        Page<Fraction> page1 = fractions//
+                        .findPageByDenominatorInAndNumeratorBetweenOrderByNumerator //
+                        (List.of(12, 20, 16),
+                         3,
+                         17,
+                         _Fraction.denominator.desc(),
+                         _Fraction.reduced.isTrue(),
+                         PageRequest.ofSize(6));
+
+        assertEquals(List.of("3/20",
+                             "3/16",
+                             "5/16",
+                             "5/12",
+                             "7/20",
+                             "7/16"),
+                     page1.stream()
+                                     .map(f -> f.numerator + "/" + f.denominator)
+                                     .toList());
+
+        assertEquals(16L,
+                     page1.totalElements());
+        assertEquals(3L,
+                     page1.totalPages());
+
+        assertEquals(true,
+                     page1.hasNext());
+
+        Page<Fraction> page2 = fractions//
+                        .findPageByDenominatorInAndNumeratorBetweenOrderByNumerator //
+                        (List.of(12, 20, 16),
+                         3,
+                         17,
+                         _Fraction.denominator.desc(),
+                         _Fraction.reduced.isTrue(),
+                         page1.nextPageRequest());
+
+        assertEquals(List.of("7/12",
+                             "9/20",
+                             "9/16",
+                             "11/20",
+                             "11/16",
+                             "11/12"),
+                     page2.stream()
+                                     .map(f -> f.numerator + "/" + f.denominator)
+                                     .toList());
+
+        assertEquals(16L,
+                     page2.totalElements());
+        assertEquals(3L,
+                     page2.totalPages());
+
     }
 
     /**

--- a/dev/io.openliberty.data.internal_fat_1_1/test-applications/Data_1_1_App/src/test/jakarta/data/v1_1/web/Data_1_1_Servlet.java
+++ b/dev/io.openliberty.data.internal_fat_1_1/test-applications/Data_1_1_App/src/test/jakarta/data/v1_1/web/Data_1_1_Servlet.java
@@ -759,26 +759,25 @@ public class Data_1_1_Servlet extends FATServlet {
         //        20      R          24     4 /  7
         //        21      R          30     3 / 11
         //        22      R          32     4 /  9
-        //        23      R          36     3 / 13
-        //        24      R          40     5 /  9
-        // 3      25      R          40     4 / 11
-        // 3      26      R          48     4 / 13
-        // 3      27      R          50     5 / 11
-        // 3      28      R          55     5 / 12
-        // 3      29      R          60     6 / 11
-        // 4      30      R          60     5 / 13
-        // 4      31      R          65     5 / 14
-        // 4      32      R          70     7 / 11
-        // 4      33      R          72     6 / 13
-        // 4      34      R          77     7 / 12
-        // 4      35      R          80     8 / 11
-        // 4      36      R          98     7 / 15
-        // 4      37      R         108     9 / 13
-        // 4      38      R         112     8 / 15
-        //        39      R         112     7 / 17
-        //        40      R         117     9 / 14
-        //        41      R         128     8 / 17
-        //        42      R         162     9 / 19
+        //        23      R          40     5 /  9
+        // 3      24      R          40     4 / 11
+        // 3      25      R          48     4 / 13
+        // 3      26      R          50     5 / 11
+        // 3      27      R          55     5 / 12
+        // 3      28      R          60     6 / 11
+        // 4      29      R          60     5 / 13
+        // 4      30      R          65     5 / 14
+        // 4      31      R          70     7 / 11
+        // 4      32      R          72     6 / 13
+        // 4      33      R          77     7 / 12
+        // 4      34      R          80     8 / 11
+        // 4      35      R          98     7 / 15
+        // 4      36      R         108     9 / 13
+        // 4      37      R         112     8 / 15
+        //        38      R         112     7 / 17
+        //        39      R         117     9 / 14
+        //        40      R         128     8 / 17
+        //        41      R         162     9 / 19
 
         Between<Integer> denominator3to10MoreThanNumerator = Between
                         .bounds(_Fraction.numerator.plus(3),
@@ -829,9 +828,8 @@ public class Data_1_1_Servlet extends FATServlet {
                      page4.hasPrevious());
         assertEquals(true,
                      page4.hasTotals());
-        // TODO implement count queries when restriction is present
-        //assertEquals(42L,
-        //             page4.totalElements());
+        assertEquals(41L,
+                     page4.totalElements());
 
         Fraction firstOnPage = page4.content().get(0);
         Cursor firstOnPageCursor = Cursor
@@ -862,9 +860,8 @@ public class Data_1_1_Servlet extends FATServlet {
                      page3.hasPrevious());
         assertEquals(true,
                      page3.hasTotals());
-        // TODO implement count queries when restriction is present
-        //assertEquals(42L,
-        //             page3.totalElements());
+        assertEquals(41L,
+                     page3.totalElements());
 
         CursoredPage<Fraction> page1 = fractions
                         .fetchCursored(denominator3to10MoreThanNumerator,
@@ -877,11 +874,10 @@ public class Data_1_1_Servlet extends FATServlet {
                      page1.hasNext());
         assertEquals(true,
                      page1.hasTotals());
-        // TODO implement count queries when restriction is present
-        //assertEquals(42L,
-        //             page1.totalElements());
-        //assertEquals(4L,
-        //             page1.totalPages());
+        assertEquals(41L,
+                     page1.totalElements());
+        assertEquals(4L,
+                     page1.totalPages());
 
         assertEquals(List.of("1/4",
                              "1/5",
@@ -2258,6 +2254,53 @@ public class Data_1_1_Servlet extends FATServlet {
                                                  Sort.asc(_Fraction.NUMERATOR)) //
                                      .map(f -> f.name)
                                      .collect(Collectors.toList()));
+    }
+
+    /**
+     * Request offset pagination from a repository method that accepts a
+     * Restriction parameter. Verify the total count of elements and pages
+     * takes into account the given Restriction value.
+     */
+    @Test
+    public void testOffsetPageCountWithRestrictions() {
+        @SuppressWarnings("unchecked")
+        Page<Fraction> page1 = fractions //
+                        .fetchOffsetPage(12,
+                                         _Fraction.reduced.isTrue(),
+                                         PageRequest.ofSize(9),
+                                         _Fraction.name.asc());
+        assertEquals(45,
+                     page1.totalElements());
+        assertEquals(5,
+                     page1.totalPages());
+
+        @SuppressWarnings("unchecked")
+        Page<Fraction> page3 = fractions //
+                        .fetchOffsetPage(12,
+                                         _Fraction.reduced.isTrue(),
+                                         PageRequest.ofSize(9).pageNumber(3),
+                                         _Fraction.name.asc());
+        assertEquals(45,
+                     page3.totalElements());
+        assertEquals(5,
+                     page3.totalPages());
+
+        Restriction<Fraction> restriction = Restrict //
+                        .any(_Fraction.reduced.isTrue(),
+                             _Fraction.numerator.equalTo(3),
+                             _Fraction.name.length().equalTo(10));
+
+        @SuppressWarnings("unchecked")
+        Page<Fraction> page2 = fractions //
+                        .fetchOffsetPage(12,
+                                         restriction,
+                                         PageRequest.ofSize(8).pageNumber(2),
+                                         _Fraction.numerator.asc(),
+                                         _Fraction.denominator.desc());
+        assertEquals(52,
+                     page2.totalElements());
+        assertEquals(7,
+                     page2.totalPages());
     }
 
     /**

--- a/dev/io.openliberty.data.internal_fat_1_1/test-applications/Data_1_1_App/src/test/jakarta/data/v1_1/web/Fractions.java
+++ b/dev/io.openliberty.data.internal_fat_1_1/test-applications/Data_1_1_App/src/test/jakarta/data/v1_1/web/Fractions.java
@@ -160,6 +160,14 @@ public interface Fractions {
      PageRequest pageReq,
      Sort<Fraction>... sorts);
 
+    Page<Fraction> findPageByDenominatorInAndNumeratorBetweenOrderByNumerator //
+    (List<Integer> denominators,
+     int minNumerator,
+     int maxNumerator,
+     Sort<Fraction> sort,
+     Restriction<Fraction> filter,
+     PageRequest pageReq);
+
     @First
     @NativeQuery("""
                     SELECT *

--- a/dev/io.openliberty.data.internal_fat_1_1/test-applications/Data_1_1_App/src/test/jakarta/data/v1_1/web/Fractions.java
+++ b/dev/io.openliberty.data.internal_fat_1_1/test-applications/Data_1_1_App/src/test/jakarta/data/v1_1/web/Fractions.java
@@ -152,6 +152,14 @@ public interface Fractions {
      Order<Fraction> order,
      PageRequest pageReq);
 
+    @Find
+    @SuppressWarnings("unchecked")
+    Page<Fraction> fetchOffsetPage //
+    (@By(_Fraction.DENOMINATOR) @Is(AtMost.class) int maxDenominator,
+     Restriction<Fraction> filter,
+     PageRequest pageReq,
+     Sort<Fraction>... sorts);
+
     @First
     @NativeQuery("""
                     SELECT *


### PR DESCRIPTION
Generate count queries for cursor-based and offset-based pagination to include Restrictions when present. Add automated testing.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #xFILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
