### PR TITLE
Convert io.openliberty.data.internal_fat_jpa_hibernate bucket from Derby to H2

### DIFF
--- a/dev/io.openliberty.data.internal_fat_jpa_hibernate/build.gradle
+++ b/dev/io.openliberty.data.internal_fat_jpa_hibernate/build.gradle
@@ -163,7 +163,7 @@ addRequiredLibraries.dependsOn copyTestContainers
 addRequiredLibraries.dependsOn copyJdbcDriversJava17Plus
 
 addRequiredLibraries.dependsOn addHibernateJPA32
-addRequiredLibraries.dependsOn addDerbyJava17Plus
+addRequiredLibraries.dependsOn addH2
 
 jar.dependsOn addHibernatePermissions
 

--- a/dev/io.openliberty.data.internal_fat_jpa_hibernate/cognitiveMetadata.yml
+++ b/dev/io.openliberty.data.internal_fat_jpa_hibernate/cognitiveMetadata.yml
@@ -4,3 +4,4 @@
 # description: Uncomment this field and add a description to give some notes about this bucket.
 # triageNotes: Uncomment this field if there are some short notes you would like Pipeline Monitors to see when triaging this bucket.
 functionalArea: Jakarta Data
+description: Migrated from derby to h2

--- a/dev/io.openliberty.data.internal_fat_jpa_hibernate/fat/src/test/jakarta/data/jpa/hibernate/DataJPAHibernateIntegrationTest.java
+++ b/dev/io.openliberty.data.internal_fat_jpa_hibernate/fat/src/test/jakarta/data/jpa/hibernate/DataJPAHibernateIntegrationTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024, 2025 IBM Corporation and others.
+ * Copyright (c) 2024, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -47,6 +47,6 @@ public class DataJPAHibernateIntegrationTest extends FATServletClient {
 
     @AfterClass
     public static void tearDown() throws Exception {
-        server.stopServer();
+        server.stopServer("CWWJP9991W"); // From EclipseLink schema-generation
     }
 }

--- a/dev/io.openliberty.data.internal_fat_jpa_hibernate/fat/src/test/jakarta/data/jpa/hibernate/FATSuite.java
+++ b/dev/io.openliberty.data.internal_fat_jpa_hibernate/fat/src/test/jakarta/data/jpa/hibernate/FATSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024, 2025 IBM Corporation and others.
+ * Copyright (c) 2024, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -12,6 +12,8 @@
  *******************************************************************************/
 package test.jakarta.data.jpa.hibernate;
 
+import java.util.Optional;
+
 import org.junit.ClassRule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
@@ -20,6 +22,7 @@ import org.testcontainers.containers.JdbcDatabaseContainer;
 
 import componenttest.containers.TestContainerSuite;
 import componenttest.custom.junit.runner.AlwaysPassesTest;
+import componenttest.topology.database.H2Database;
 import componenttest.topology.database.container.DatabaseContainerFactory;
 
 @RunWith(Suite.class)
@@ -30,6 +33,9 @@ import componenttest.topology.database.container.DatabaseContainerFactory;
 })
 public class FATSuite extends TestContainerSuite {
 
+    private static final H2Database h2Database = H2Database.create("dbuser1", "dbpwd1")
+                    .withDatabaseName("testdb");
+
     @ClassRule
-    public static final JdbcDatabaseContainer<?> testContainer = DatabaseContainerFactory.createLatest();
+    public static final JdbcDatabaseContainer<?> testContainer = DatabaseContainerFactory.createH2(Optional.of(h2Database));
 }

--- a/dev/io.openliberty.data.internal_fat_jpa_hibernate/publish/servers/io.openliberty.data.internal.fat.jpa.hibernate.integrate/server.xml
+++ b/dev/io.openliberty.data.internal_fat_jpa_hibernate/publish/servers/io.openliberty.data.internal.fat.jpa.hibernate.integrate/server.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2024, 2025 IBM Corporation and others.
+    Copyright (c) 2024, 2026 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -32,16 +32,16 @@
 
   <dataSource id="LibertyDataSource" jndiName="jdbc/LibertyDataSource">
     <jdbcDriver libraryRef="JDBCLibrary"/>
-    <properties.derby.embedded createDatabase="create" databaseName="memory:libertydb" user="dbuser1" password="dbpwd1"/>
+    <properties.h2 URL="jdbc:h2:mem:libertydb;DB_CLOSE_DELAY=-1" user="dbuser1" password="dbpwd1"/>
   </dataSource>
   
   <dataSource id="HibernateDataSource" jndiName="jdbc/HibernateDataSource">
     <jdbcDriver libraryRef="JDBCLibrary"/>
-    <properties.derby.embedded createDatabase="create" databaseName="memory:hibernatedb" user="dbuser1" password="dbpwd1"/>
+    <properties.h2 URL="jdbc:h2:mem:hibernatedb;DB_CLOSE_DELAY=-1" user="dbuser1" password="dbpwd1"/>
   </dataSource>
 
   <library id="JDBCLibrary">
-    <fileset dir="${shared.resource.dir}/derbyJava17Plus" includes="*.jar"/>
+    <fileset dir="${shared.resource.dir}/h2" includes="*.jar"/>
   </library>
   
   <library id="HibernateLib">

--- a/dev/io.openliberty.data.internal_fat_jpa_hibernate/publish/servers/io.openliberty.data.internal.fat.jpa.hibernate/server.xml
+++ b/dev/io.openliberty.data.internal_fat_jpa_hibernate/publish/servers/io.openliberty.data.internal.fat.jpa.hibernate/server.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2024, 2025 IBM Corporation and others.
+    Copyright (c) 2024, 2026 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at
@@ -32,7 +32,7 @@
 
   <dataSource id="DefaultDataSource" fat.modify="true">
     <jdbcDriver libraryRef="JDBCLibrary"/>
-    <properties.derby.embedded createDatabase="create" databaseName="memory:testdb" user="dbuser1" password="dbpwd1"/>
+    <properties.h2 URL="${env.DB_URL}" user="dbuser1" password="dbpwd1"/>
   </dataSource>
 
   <library id="JDBCLibrary">


### PR DESCRIPTION
Converted by Bob from Derby to H2

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
