### PR TITLE
WebSphere Application Server Liberty is affected by a server-side request forgery vulnerability when sipServlet-1.1 is enabled

### DIFF
--- a/dev/com.ibm.ws.sipcontainer/resources/OSGI-INF/l10n/metatype.properties
+++ b/dev/com.ibm.ws.sipcontainer/resources/OSGI-INF/l10n/metatype.properties
@@ -1,14 +1,11 @@
 ###############################################################################
-# Copyright (c) 2019, 2021 IBM Corporation and others.
+# Copyright (c) 2019, 2026 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-2.0/
 # 
 # SPDX-License-Identifier: EPL-2.0
-#
-# Contributors:
-#     IBM Corporation - initial API and implementation
 ###############################################################################
 # -------------------------------------------------------------------------------------------------
 #CMVCPATHNAME com.ibm.ws.build.example.project/resources/OSGI-INF/l10n/metatype.properties

--- a/dev/com.ibm.ws.sipcontainer/resources/OSGI-INF/l10n/metatype.properties
+++ b/dev/com.ibm.ws.sipcontainer/resources/OSGI-INF/l10n/metatype.properties
@@ -119,6 +119,11 @@ enableCar.desc=Applications are routed using the available custom application ro
 sipNoRouteErrorCode.name=SIP response error code when no route found
 sipNoRouteErrorCode.desc=The error response code that is sent by the SIP container when no active servlet can be mapped to an incoming initial request.
 
+sipProxyAllowList.name=SIP proxy allow list
+sipProxyAllowList.desc=A comma-separated list of permitted forwarding destinations used when the SIP container acts as a transparent proxy (routeWhenNoApp=true and no application matches the incoming request). Each entry is a host name or IP address, optionally followed by a colon and port number, for example proxy.example.com:5060 or 10.0.0.1. A host-only entry matches any port on that host. When this property is empty (the default), all transparent forwarding is blocked and the container returns the error code defined by sipNoRouteErrorCode. Configure this property to the minimum set of SIP destinations that the container is legitimately permitted to proxy to.
+
+
+
 #---------------SipStack properties------------------------------
 
 sip.stack=SIP Stack

--- a/dev/com.ibm.ws.sipcontainer/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.sipcontainer/resources/OSGI-INF/metatype/metatype.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2019, 2025 IBM Corporation and others.
+    Copyright (c) 2019, 2026 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
     which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.sipcontainer/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.sipcontainer/resources/OSGI-INF/metatype/metatype.xml
@@ -93,6 +93,11 @@
 		<AD name="internal" description="internal" id="useNettyTransport"
 			required="false" type="Boolean" default="true" />
 
+		<!-- sipProxyAllowList -->
+		<AD name="%sipProxyAllowList.name" description="%sipProxyAllowList.desc"
+			id="sipProxyAllowList" required="false" type="String"
+			default="" />
+
 	</OCD>
 
 	<Designate pid="com.ibm.ws.sip.container.internal.SipContainerComponent">

--- a/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/container/router/SipRouter.java
+++ b/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/container/router/SipRouter.java
@@ -26,9 +26,13 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.Serializable;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
 import java.util.LinkedList;
 import java.util.ListIterator;
 
+import javax.servlet.sip.Address;
+import javax.servlet.sip.ServletParseException;
 import javax.servlet.sip.SipServletRequest;
 import javax.servlet.sip.SipServletResponse;
 import javax.servlet.sip.SipSession;
@@ -1321,6 +1325,25 @@ public class SipRouter {
         	}
         	
         	if (request.isExternalRoute()) {
+				if (c_logger.isTraceDebugEnabled()) {
+					c_logger.traceDebug(this, "handleRequest", " checking sipProxyAllowList to determine if request " + request.getMethod() + " can be sent outbound");
+				}	
+        		if (!isAllowedExternalRoute(request)) {
+        			if (c_logger.isErrorEnabled()) {
+        				c_logger.error("error.mapping.to.nonexisting.siplet",
+        						Situation.SITUATION_REQUEST, new Object[]{"External route target not in sipProxyAllowList, Method=" +
+        						request.getMethod() + ", callID=" + request.getCallId(), "Unknown"});
+        			}
+        			int errorCode = PropertiesStore.getInstance().getProperties().getInt(CoreProperties.SIP_NO_ROUTE_ERROR_CODE_PROPERTY);
+        			sendErrorResponse(request, errorCode);
+        			return;
+        		}
+				if (c_logger.isTraceDebugEnabled()) {
+					c_logger.traceDebug(this, "handleRequest" , "external destination found in sipProxyAllowList (" 
+						+ PropertiesStore.getInstance().getProperties().getString(CoreProperties.SIP_PROXY_ALLOW_LIST) + 
+						"), continue processing " + request.getMethod() + " with Call-ID = " + request.getCallId());
+				}
+
         		transactionUser = m_transactionUserTable.createTransactionUserWrapper(request, true, sipApplication, (sipApplication != null));
 
         		request.setTransactionUser(transactionUser);
@@ -1399,8 +1422,8 @@ public class SipRouter {
     }
     
 	/**
-     * Send the Error response to the UAC if the incoming Request 
-	 * cannot be handled by the Container
+     * Send the Error respone to the UAC if the incommng Request cannot be
+     * handled by the Container
      * 
      * @param request
      *            Original request
@@ -1413,8 +1436,8 @@ public class SipRouter {
 	
 	
 	/**
-     * Send the Error response to the UAC if the incoming Request 
-	 * cannot be handled by the Container
+     * Send the Error respone to the UAC if the incommng Request cannot be
+     * handled by the Container
      * 
      * @param request
      *            Original request
@@ -1907,7 +1930,7 @@ public class SipRouter {
     }
 
     /**
-     * Send the resonse directly to the transport layer bypassing the transaction
+     * Send the response directly to the transport layer, bypassing the transaction
      * Will be used by 2xx retransmission from a UAS downstream through our
      * proxy to the UAC upstream. 
      * @param provider
@@ -1937,11 +1960,12 @@ public class SipRouter {
         
         if(containsOurVia){
 					
-        	// When response is a stray response which received when
-					// Application Acts as a proxy - it has an Via header which represents
-					// this container and should be removed before send. 
+        	// If response is a stray response received when
+			// Application is acting as a proxy - it has a Via header representing
+			// this container - the VIA header should be removed before 
+			// proxying the request. 
         	// If response is a response created by the 
-        	// application it has only the Via header represents UAC 
+        	// application it only has a Via header representing the UAC 
         	// that should receive this response.
 	        
         	//Remove the top via header as it should be ours
@@ -1974,6 +1998,188 @@ public class SipRouter {
             {
                 c_logger.error("error.exception", "Send Failure", null, e);
             }
+        }
+    }
+
+    /**
+     * Checks whether the Request-URI and all Route header URIs of the given external-route
+     * request are present in the {@code sipProxyAllowList} custom property.
+     * <p>
+     * The allow list is a comma-separated string of entries in the form {@code host} or
+     * {@code host:port}. A host-only entry matches any port on that host. When the property
+     * value is empty, <em>all</em> external forwarding is blocked (returns {@code false}).
+     * Any URI (Request-URI or Route) that is not a SIP URI, or whose host:port is not in
+     * the allow list, causes the method to return {@code false}.
+     *
+     * @param request the incoming request to be checked
+     * @return {@code true} if all URIs are permitted, {@code false} otherwise
+     */
+    private boolean isAllowedExternalRoute(SipServletRequestImpl request) {
+        String allowListStr = PropertiesStore.getInstance().getProperties()
+                .getString(CoreProperties.SIP_PROXY_ALLOW_LIST);
+
+        if (allowListStr == null || allowListStr.trim().isEmpty()) {
+            if (c_logger.isTraceDebugEnabled()) {
+                c_logger.traceDebug(this, "isAllowedExternalRoute",
+                        "sipProxyAllowList is empty – blocking external route for callID=" + request.getCallId());
+            }
+            return false;
+        }
+
+        String[] entries = allowListStr.split(",");
+
+        // Check Request-URI
+        javax.servlet.sip.URI requestUri = request.getRequestURI();
+        if (!isSipUriAllowed(requestUri, entries, "Request-URI")) {
+            if (c_logger.isTraceDebugEnabled()) {
+                c_logger.traceDebug(this, "isAllowedExternalRoute",
+                        "Request-URI blocked for callID=" + request.getCallId());
+            }
+            return false;
+        }
+
+        // Check all Route headers
+        try {
+            ListIterator<Address> routeHeaders = request.getAddressHeaders("Route");
+            while (routeHeaders != null && routeHeaders.hasNext()) {
+                Address routeAddr = routeHeaders.next();
+				if (c_logger.isTraceDebugEnabled()) {
+					c_logger.traceDebug(this, "isAllowedExternalRoute", " evaluating Route header content against the sipAllowProxyList");
+				}
+                if (!isSipUriAllowed(routeAddr.getURI(), entries, "Route")) {
+                    if (c_logger.isTraceDebugEnabled()) {
+                        c_logger.traceDebug(this, "isAllowedExternalRoute",
+                                "Route header blocked for callID=" + request.getCallId());
+                    }
+                    return false;
+                }
+            }
+        } catch (ServletParseException e) {
+            if (c_logger.isTraceDebugEnabled()) {
+                c_logger.traceDebug(this, "isAllowedExternalRoute",
+                        "Failed to parse Route headers – blocking external route for callID=" + request.getCallId());
+            }
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Returns {@code true} if the given URI is a {@link SipURI} whose host:port matches
+     * at least one entry in the allow list.
+     * <p>
+     * Both the allow-list entry and the URI host are resolved via {@link InetAddress} so
+     * that hostnames and IP addresses referring to the same machine compare equal
+     * (e.g. {@code localhost} matches {@code 127.0.0.1}). If DNS resolution fails for
+     * either side, the comparison falls back to a case-insensitive string match.
+     *
+     * @param uri      the URI to check
+     * @param entries  allow-list entries (already split on commas)
+     * @param label    label used in trace messages (e.g. "Request-URI" or "Route")
+     */
+    private boolean isSipUriAllowed(javax.servlet.sip.URI uri, String[] entries, String label) {
+        if (!(uri instanceof SipURI)) {
+            if (c_logger.isTraceDebugEnabled()) {
+                c_logger.traceDebug(this, "isSipUriAllowed",
+                        label + " is not a SIP URI – blocking");
+            }
+            return false;
+        }
+
+        SipURI sipUri = (SipURI) uri;
+        String targetHost = sipUri.getHost();
+        int    targetPort = sipUri.getPort(); // -1 when absent
+
+        if (targetHost == null || targetHost.isEmpty()) {
+            if (c_logger.isTraceDebugEnabled()) {
+                c_logger.traceDebug(this, "isSipUriAllowed",
+                        label + " SIP URI has no host – blocking");
+            }
+            return false;
+        }
+
+        if (c_logger.isTraceDebugEnabled()) {
+            c_logger.traceDebug(this, "isSipUriAllowed",
+                    "Evaluating " + label + " target host='" + targetHost + "' port=" + targetPort);
+        }
+
+        // Resolve the URI host once, outside the loop.
+        InetAddress targetAddr = resolveHost(targetHost);
+
+        for (String entry : entries) {
+            entry = entry.trim();
+            if (entry.isEmpty()) continue;
+
+            int colonIdx = entry.lastIndexOf(':');
+            if (colonIdx > 0) {
+                // entry is "host:port"
+                String allowHost = entry.substring(0, colonIdx).trim();
+                String portStr   = entry.substring(colonIdx + 1).trim();
+                try {
+                    int allowPort = Integer.parseInt(portStr);
+                    int effectiveTarget = (targetPort == -1) ? (sipUri.isSecure() ? 5061 : 5060) : targetPort;
+                    if (hostsMatch(allowHost, targetHost, targetAddr) && allowPort == effectiveTarget) {
+                        return true;
+                    }
+                } catch (NumberFormatException e) {
+                    if (c_logger.isTraceDebugEnabled()) {
+                        c_logger.traceDebug(this, "isSipUriAllowed",
+                                "Skipping malformed sipProxyAllowList entry: " + entry);
+                    }
+                }
+            } else {
+                // entry is "host" only – matches any port
+                if (hostsMatch(entry, targetHost, targetAddr)) {
+                    return true;
+                }
+            }
+        }
+
+        if (c_logger.isTraceDebugEnabled()) {
+            c_logger.traceDebug(this, "isSipUriAllowed",
+                    label + " target " + targetHost + ":" + targetPort +
+                    " not found in sipProxyAllowList");
+        }
+        return false;
+    }
+
+    /**
+     * Returns {@code true} if {@code allowHost} refers to the same network address as
+     * {@code targetHost}. Resolves both via DNS; falls back to case-insensitive string
+     * comparison if resolution fails for either side.
+     *
+     * @param allowHost  the host from the allow-list entry
+     * @param targetHost the host from the SIP URI
+     * @param targetAddr pre-resolved {@link InetAddress} for {@code targetHost}, or
+     *                   {@code null} if resolution previously failed
+     */
+    private boolean hostsMatch(String allowHost, String targetHost, InetAddress targetAddr) {
+        if (allowHost.equalsIgnoreCase(targetHost)) {
+            return true;
+        }
+        InetAddress allowAddr = resolveHost(allowHost);
+        if (allowAddr != null && targetAddr != null) {
+            return allowAddr.equals(targetAddr);
+        }
+        return false;
+    }
+
+    /**
+     * Resolves a hostname or IP-address literal to an {@link InetAddress}.
+     * Returns {@code null} and logs a trace message if resolution fails.
+     *
+     * @param host hostname or IP address string
+     */
+    private InetAddress resolveHost(String host) {
+        try {
+            return InetAddress.getByName(host);
+        } catch (UnknownHostException e) {
+            if (c_logger.isTraceDebugEnabled()) {
+                c_logger.traceDebug(this, "resolveHost",
+                        "Could not resolve host '" + host + "' – will use string comparison");
+            }
+            return null;
         }
     }
 
@@ -2086,7 +2292,7 @@ public class SipRouter {
 	}
 
 	/**
-	 * Notify the SipApplicationRouter about all the deployed applications and load their configuration
+	 * Notify the SipApplicationRouter about all the deployed applications and load thier configuration
 	 * This should be called only when the SipApplicationRouter is initialized and not on later applications
 	 */
 	public void notifyRouterOnDeployedApps() {

--- a/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/container/router/SipRouter.java
+++ b/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/container/router/SipRouter.java
@@ -1,14 +1,11 @@
 /*******************************************************************************
- * Copyright (c) 2003 IBM Corporation and others.
+ * Copyright (c) 2003, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
  * 
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package com.ibm.ws.sip.container.router;
 

--- a/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/properties/CoreProperties.java
+++ b/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/properties/CoreProperties.java
@@ -1,14 +1,11 @@
 /*******************************************************************************
- * Copyright (c) 2003, 2021, 2024 IBM Corporation and others.
+ * Copyright (c) 2003, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
  * 
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package com.ibm.ws.sip.properties;
 

--- a/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/properties/CoreProperties.java
+++ b/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/properties/CoreProperties.java
@@ -694,13 +694,35 @@ public class CoreProperties
 	public static final boolean MARK_INTERNAL_ERROR_RESPONSE_DEFAULT = false;
 	
 	/**
-	 * Indicates whether an incoming request needs to be sent externally to Route header if there is no next application. 
-	 * The default is true that means to route it as according to JSR 289 15.4.1. 
+	 * Indicates whether an incoming request needs to be sent externally to Route header if there is no next application.
+	 * The default is true that means to route it as according to JSR 289 15.4.1.
 	 * If this property is set to false, we send an error defined in the <code>sip.no.route.error.code</code> CP.
 	 * PI17820
 	 */
 	public static final String  WAS80_ROUTE_WHEN_NO_APPLICATION = "routeWhenNoApp";
 	public static final boolean WAS80_ROUTE_WHEN_NO_APPLICATION_DEFAULT = true;
+
+	/**
+	 * Comma-separated allow list of hosts (and optional ports) to which the SIP container
+	 * may forward requests when acting as a transparent proxy (i.e. when no SIP application
+	 * matched the incoming request and <code>routeWhenNoApp=true</code>).
+	 * <p>
+	 * Each entry is either a bare hostname / IP address (e.g. {@code proxy.example.com} or
+	 * {@code 192.168.1.10}) or a host:port pair (e.g. {@code proxy.example.com:5060}).
+	 * A host-only entry matches any port on that host.
+	 * <p>
+	 * When the property is empty (the default) all external forwarding is blocked and the
+	 * container responds with the error code defined by <code>sipNoRouteErrorCode</code>
+	 * (default 403). Set it to a non-empty value to explicitly permit forwarding to the
+	 * listed destinations. This mitigates the open-proxy / SSRF vector (CWE-918 / PH72053).
+	 * <p>
+	 * Example:
+	 * <pre>
+	 *   sipProxyAllowList=proxy.example.com:5060,10.0.0.1
+	 * </pre>
+	 */
+	public static final String  SIP_PROXY_ALLOW_LIST = "sipProxyAllowList";
+	public static final String  SIP_PROXY_ALLOW_LIST_DEFAULT = "";
 	
 	/**
 	 * This property sets a response code for session invalidated in underlying state
@@ -890,6 +912,7 @@ public class CoreProperties
 		properties.setBoolean(ENABLE_HPEL_SIP_LOG_EXTENSION, ENABLE_HPEL_SIP_LOG_EXTENSION_DEFAULT, CustPropSource.DEFAULT);
 		properties.setBoolean(SAVE_MESSAGE_ARRIVAL_TIME_ATTRIBUTE, SAVE_MESSAGE_ARRIVAL_TIME_ATTRIBUTE_DEFAULT, CustPropSource.DEFAULT);
 		properties.setBoolean(WAS80_ROUTE_WHEN_NO_APPLICATION, WAS80_ROUTE_WHEN_NO_APPLICATION_DEFAULT, CustPropSource.DEFAULT);
+		properties.setString(SIP_PROXY_ALLOW_LIST, SIP_PROXY_ALLOW_LIST_DEFAULT, CustPropSource.DEFAULT);
 		properties.setInt(WAS80_SESSION_INVALIDATE_RESPONSE, WAS80_SESSION_INVALIDATE_RESPONSE_DEFAULT, CustPropSource.DEFAULT);
 		properties.setBoolean(WAS80_TREAT_2XX_6XX_AS_BEST_RESPONSE, WAS80_TREAT_2XX_6XX_AS_BEST_RESPONSE_DEFAULT, CustPropSource.DEFAULT);
 		properties.setBoolean(ALLOW_SETTING_SYSTEM_CONTACT_DISPLAY_NAME, ALLOW_SETTING_SYSTEM_CONTACT_DISPLAY_NAME_DEFAULT, CustPropSource.DEFAULT);


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

WebSphere Application Server Liberty is affected by a server-side request forgery vulnerability when sipServlet-1.1 is enabled

Fixes: #35381


