### PR TITLE
Branch and fork owner are required for Detect Secrets to run

### DIFF
--- a/.ci-orchestrator/checks.yml
+++ b/.ci-orchestrator/checks.yml
@@ -13,10 +13,10 @@ triggers:
       isRequired: true
       description: "PR number to perform delivery requirement verification against e.g. 30188"
     - name: githubPRBranch
-      isRequired: false
+      isRequired: true
       description: "Head branch of specified PR"
     - name: githubPRBranchOwner
-      isRequired: false
+      isRequired: true
       description: "PR head branch owner"
 
 steps:


### PR DESCRIPTION
The "(optional)" descriptor text by githubPRBranch and githubPRBranchOwner fields in the manual trigger is misleading. Since a green DS scan status check is needed for PRs to be mergeable, don't make these fields optional anymore. If they're left blank, the Detect Secrets Scan build will fail.