### PR TITLE
Remove references to empty MCP src directories

### DIFF
--- a/dev/io.openliberty.mcp.internal.mpmetrics/.classpath
+++ b/dev/io.openliberty.mcp.internal.mpmetrics/.classpath
@@ -7,10 +7,5 @@
 	</classpathentry>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="src" output="bin" path="src"/>
-	<classpathentry kind="src" output="bin_test" path="test">
-		<attributes>
-			<attribute name="test" value="true"/>
-		</attributes>
-	</classpathentry>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/dev/io.openliberty.mcp.internal.mptelemetry/.classpath
+++ b/dev/io.openliberty.mcp.internal.mptelemetry/.classpath
@@ -7,10 +7,5 @@
 	</classpathentry>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="src" output="bin" path="src"/>
-	<classpathentry kind="src" output="bin_test" path="test">
-		<attributes>
-			<attribute name="test" value="true"/>
-		</attributes>
-	</classpathentry>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/dev/io.openliberty.org.mcpjava.mcp-server-api.fragment/.classpath
+++ b/dev/io.openliberty.org.mcpjava.mcp-server-api.fragment/.classpath
@@ -6,6 +6,5 @@
 		</attributes>
 	</classpathentry>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
-	<classpathentry kind="src" output="bin" path="src"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/dev/io.openliberty.org.mcpjava.mcp-server-api/.classpath
+++ b/dev/io.openliberty.org.mcpjava.mcp-server-api/.classpath
@@ -6,6 +6,5 @@
 		</attributes>
 	</classpathentry>
 	<classpathentry exported="true" kind="con" path="aQute.bnd.classpath.container"/>
-	<classpathentry kind="src" output="bin" path="src"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>


### PR DESCRIPTION
Cleanup the MCP .classpath files to remove empty source directories.


- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".