### PR TITLE
Skip iSeries that does not yet have right Java version

### DIFF
--- a/dev/com.ibm.ws.security.wim.adapter.ldap_fat.krb5.2/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/krb5/TicketCacheBadPrincipalJava8.java
+++ b/dev/com.ibm.ws.security.wim.adapter.ldap_fat.krb5.2/fat/src/com/ibm/ws/security/wim/adapter/ldap/fat/krb5/TicketCacheBadPrincipalJava8.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2021, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -13,9 +13,12 @@
 package com.ibm.ws.security.wim.adapter.ldap.fat.krb5;
 
 import static componenttest.topology.utils.LDAPFatUtils.updateConfigDynamically;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeThat;
 
+import componenttest.topology.impl.JavaInfo;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -30,6 +33,8 @@ import componenttest.custom.junit.runner.FATRunner;
 import componenttest.custom.junit.runner.Mode;
 import componenttest.custom.junit.runner.Mode.TestMode;
 
+import java.io.IOException;
+
 /**
  * Java 8 test where we hit an NPE if the krb5Principal name was not found in the ticketCache
  *
@@ -42,7 +47,11 @@ public class TicketCacheBadPrincipalJava8 extends CommonBindTest {
     private static final Class<?> c = TicketCacheBadPrincipalJava8.class;
 
     @BeforeClass
-    public static void setStopMessages() {
+    public static void setStopMessages() throws IOException {
+        if(System.getProperty("os.name").equalsIgnoreCase("OS/400")){
+            JavaInfo ji = JavaInfo.forServer(server);
+            assumeThat(ji.serviceRelease()>8 || ji.fixpack() >= 65, is(true));
+        }
         stopStrings = new String[] { "CWIML4507E", "CWWKS4347E", "CWIML4512E", "CWIML4520E" };
     }
 


### PR DESCRIPTION
Currently iSeries is the only platform that does not have a version of Java that fixes the underlying issue.

Introduce a check for iSeries that should not need removing once iSeries has been updated.

As test runs only on Java 8, only the Service release and fixpack are important. the fix was including in 8.0.8.65, so we either want the service release > 8 or the fixpack to be greater or equal to 65.

Fixes [#305751](https://wasrtc.hursley.ibm.com:9443/jazz/web/projects/WS-CD#action=com.ibm.team.workitem.viewWorkItem&id=305751)

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
