### PR TITLE
Write lock, loopback, and tests

### DIFF
--- a/dev/com.ibm.ws.concurrent_fat_jakarta_12/test-applications/Concurrency32CDITestWeb/src/test/jakarta/concurrency32cdi/web/Concurrency32CDITestServlet.java
+++ b/dev/com.ibm.ws.concurrent_fat_jakarta_12/test-applications/Concurrency32CDITestWeb/src/test/jakarta/concurrency32cdi/web/Concurrency32CDITestServlet.java
@@ -13,17 +13,22 @@
 package test.jakarta.concurrency32cdi.web;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 import jakarta.annotation.Resource;
 import jakarta.enterprise.concurrent.ManagedScheduledExecutorDefinition;
@@ -67,6 +72,9 @@ public class Concurrency32CDITestServlet extends FATServlet {
     ReadLockBean readLockBean;
 
     ExecutorService testThreads = Executors.newVirtualThreadPerTaskExecutor();
+
+    @Inject
+    WriteLockBean writeLockBean;
 
     /**
      * Cancel futures that are still incomplete when tests methods end,
@@ -150,5 +158,136 @@ public class Concurrency32CDITestServlet extends FATServlet {
                      readLockBean.readValue());
 
         thread2Future.cancel(true);
+    }
+
+    /**
+     * When the current thread holds a READ lock, another thread must not be able
+     * to acquire a WRITE lock.
+     */
+    @Test
+    public void testReadLockPreventsWriteLockFromOtherThread() throws Exception {
+        readLockBean.writeValue("testReadLockPreventsWriteLockFromOtherThread");
+
+        CountDownLatch blocker = new CountDownLatch(1);
+        CountDownLatch running = new CountDownLatch(1);
+        CompletableFuture<?> thread2Future = CompletableFuture.runAsync(() -> {
+            // wait for main thread to acquire READ lock
+            try {
+                assertEquals(true,
+                             running.await(TIMEOUT_NS, TimeUnit.NANOSECONDS));
+            } catch (InterruptedException x) {
+                throw new AssertionError(x);
+            }
+
+            try {
+                readLockBean.writeValue("thread2's value");
+            } finally {
+                // allow main thread to complete
+                blocker.countDown();
+            }
+        });
+
+        // obtain READ lock and block until thread2 allows us to continue
+        assertEquals("testReadLockPreventsWriteLockFromOtherThread",
+                     readLockBean.delayedReadValue(running, blocker));
+
+        try {
+            thread2Future.get(TIMEOUT_NS, TimeUnit.NANOSECONDS);
+        } catch (ExecutionException x) {
+            if (x.getCause() instanceof TimeoutException) // TODO different exception
+                ; // expected
+            else
+                throw x;
+        }
+
+        try {
+            thread2Future.join();
+        } catch (CompletionException x) {
+            if (x.getCause() instanceof TimeoutException) // TODO different exception
+                ; // expected
+            else
+                throw x;
+        }
+
+        readLockBean.blockingWriteValue(null);
+    }
+
+    /**
+     * Bean methods that require a WRITE Lock must not run at the same time on
+     * different threads.
+     * An ApplicationScoped CDI bean is annotated with a Lock of type WRITE, which
+     * becomes the default for all bean methods unless explicitly overridden by
+     * annotating the method.
+     */
+    @Test
+    public void testWriteLockNotAcquiredByMultipleThreads() throws Exception {
+
+        // write by single thread
+        writeLockBean.writeNumber(41);
+
+        // have thread2 acquire WRITE lock on bean
+        CountDownLatch blocker = new CountDownLatch(1);
+        CountDownLatch running = new CountDownLatch(1);
+        Future<Boolean> thread2Future = testThreads.submit(() -> writeLockBean //
+                        .delayedWriteNumber(running, blocker, 51));
+        cancelAfterTest.add(thread2Future);
+        running.await(TIMEOUT_NS, TimeUnit.NANOSECONDS);
+
+        // have thread3 attempt WRITE lock and end up blocked
+        Future<?> thread3Future = testThreads.submit(() -> writeLockBean //
+                        .blockingWriteNumber(61));
+        cancelAfterTest.add(thread3Future);
+
+        // current thread must not be able to acquire WRITE lock on bean
+        try {
+            writeLockBean.writeNumber(71);
+            fail("Should not be able to acquire the WRITE lock while the second" +
+                 " thread still holds the WRITE lock.");
+        } catch (CompletionException x) {
+            if (x.getCause() instanceof TimeoutException) // TODO different exception
+                ; // expected
+            else
+                throw x;
+        }
+
+        // current thread must not be able to acquire READ lock on bean
+        try {
+            int num = writeLockBean.readNumber();
+            fail("Should not be able to acquire a READ lock while the second" +
+                 " thread still holds the WRITE lock. Result: " + num);
+        } catch (CompletionException x) {
+            if (x.getCause() instanceof TimeoutException) // TODO different exception
+                ; // expected
+            else
+                throw x;
+        }
+
+        try {
+            thread3Future.get(1, TimeUnit.SECONDS);
+            fail("A third thread should not be able to acquire the WRITE lock" +
+                 " while the second thread still holds the WRITE lock.");
+        } catch (TimeoutException x) {
+            // expected
+        }
+
+        // interrupt thread3 while it is waiting for the WRITE lock
+        assertEquals(true,
+                     thread3Future.cancel(true));
+
+        // allow thread2 to complete
+        blocker.countDown();
+
+        // current thread can acquire READ lock now
+        assertEquals(51,
+                     writeLockBean.blockingReadNumber());
+
+        // current thread can acquire WRITE lock now
+        writeLockBean.writeNumber(81);
+
+        assertEquals(81,
+                     writeLockBean.readNumber());
+
+        assertEquals(true,
+                     thread2Future.get(TIMEOUT_NS, TimeUnit.NANOSECONDS));
     }
 }

--- a/dev/com.ibm.ws.concurrent_fat_jakarta_12/test-applications/Concurrency32CDITestWeb/src/test/jakarta/concurrency32cdi/web/Concurrency32CDITestServlet.java
+++ b/dev/com.ibm.ws.concurrent_fat_jakarta_12/test-applications/Concurrency32CDITestWeb/src/test/jakarta/concurrency32cdi/web/Concurrency32CDITestServlet.java
@@ -69,6 +69,9 @@ public class Concurrency32CDITestServlet extends FATServlet {
     ManagedScheduledExecutorService async3Scheduler;
 
     @Inject
+    LoopbackBean loopbackBean;
+
+    @Inject
     ReadLockBean readLockBean;
 
     ExecutorService testThreads = Executors.newVirtualThreadPerTaskExecutor();
@@ -161,6 +164,47 @@ public class Concurrency32CDITestServlet extends FATServlet {
     }
 
     /**
+     * Invoke a bean method annotated Lock(READ) which invokes another
+     * method of the same bean instance annotated Lock(READ).
+     * The LoopbackBean.power method is annotated Lock(READ) and recursively
+     * invokes itself through the CDI proxy, also annotated Lock(READ).
+     * Because READ locks are shared and reentrant, this must succeed.
+     */
+    @Test
+    public void testReadLockLoopbackToReadLock() throws Exception {
+        loopbackBean.setNumber(3);
+
+        // power(4, bean) returns number^4 = 81; exercises deep READ->READ recursion
+        assertEquals(81L, loopbackBean.power(4, loopbackBean));
+    }
+
+    /**
+     * Invoke a bean method annotated Lock(READ) which invokes another
+     * method of the same bean instance annotated Lock(WRITE) and confirm
+     * that this raises IllegalStateException as required by the Lock
+     * annotation.
+     * The LoopbackBean.square method is annotated Lock(READ) and calls
+     * setNumber which is annotated Lock(WRITE, accessTimeout=IMMEDIATE).
+     * Upgrading from READ to WRITE on the same thread is prohibited, so
+     * IllegalStateException must be raised.
+     */
+    @Test
+    public void testReadLockLoopbackToWriteLock() throws Exception {
+        loopbackBean.setNumber(5);
+
+        try {
+            loopbackBean.square(loopbackBean);
+            fail("Expected IllegalStateException when a READ-locked method " +
+                 "attempts to invoke a WRITE-locked method via loopback.");
+        } catch (IllegalStateException x) {
+            // expected: READ -> WRITE loopback is not permitted
+        }
+
+        // The value must be unchanged because the write was blocked
+        assertEquals(5L, loopbackBean.getNumber());
+    }
+
+    /**
      * When the current thread holds a READ lock, another thread must not be able
      * to acquire a WRITE lock.
      */
@@ -210,6 +254,41 @@ public class Concurrency32CDITestServlet extends FATServlet {
         }
 
         readLockBean.blockingWriteValue(null);
+    }
+
+    /**
+     * Invoke a bean method annotated Lock(WRITE) which invokes another
+     * method of the same bean instance annotated Lock(READ).
+     * The LoopbackBean.increment method is annotated Lock(WRITE) and calls
+     * getNumber which is annotated Lock(READ, accessTimeout=UNLIMITED).
+     * A thread holding the WRITE lock may also acquire a READ lock, so
+     * this must succeed and leave the number incremented by one.
+     */
+    @Test
+    public void testWriteLockLoopbackToReadLock() throws Exception {
+        loopbackBean.setNumber(2);
+
+        loopbackBean.increment(loopbackBean);
+
+        assertEquals(3L, loopbackBean.getNumber());
+    }
+
+    /**
+     * Invoke a bean method annotated Lock(WRITE) which invokes another
+     * method of the same bean instance annotated Lock(WRITE).
+     * The LoopbackBean.clear method is annotated Lock(WRITE) and calls
+     * setNumber which is annotated Lock(WRITE, accessTimeout=IMMEDIATE).
+     * Because WRITE locks are reentrant on the same thread, this must
+     * succeed and leave the number set to zero.
+     */
+    @Test
+    public void testWriteLockLoopbackToWriteLock() throws Exception {
+        loopbackBean.setNumber(99);
+        assertEquals(99L, loopbackBean.getNumber());
+
+        loopbackBean.clear(loopbackBean);
+
+        assertEquals(0L, loopbackBean.getNumber());
     }
 
     /**

--- a/dev/com.ibm.ws.concurrent_fat_jakarta_12/test-applications/Concurrency32CDITestWeb/src/test/jakarta/concurrency32cdi/web/LoopbackBean.java
+++ b/dev/com.ibm.ws.concurrent_fat_jakarta_12/test-applications/Concurrency32CDITestWeb/src/test/jakarta/concurrency32cdi/web/LoopbackBean.java
@@ -1,0 +1,98 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package test.jakarta.concurrency32cdi.web;
+
+import java.util.concurrent.TimeUnit;
+
+import jakarta.enterprise.concurrent.Lock;
+import jakarta.enterprise.context.RequestScoped;
+
+/**
+ * A bean with some methods that are annotated Lock, some of which invoke
+ * other methods of the bean that are annotated Lock.
+ */
+@RequestScoped
+public class LoopbackBean {
+    /**
+     * Maximum amount of time for an operation to remain delayed.
+     */
+    static final long MAX_DELAY_MS = TimeUnit.MINUTES.toMillis(5);
+
+    private long number;
+
+    // For WRITE to WRITE
+    @Lock(type = Lock.Type.WRITE,
+          accessTimeout = 100) // seconds
+    public void clear(LoopbackBean bean) {
+        bean.setNumber(0);
+    }
+
+    // for WRITE to unannotated (implicit WRITE)
+    @Lock(type = Lock.Type.WRITE)
+    public long decreaseBy(long amount, LoopbackBean bean) {
+        long decremented = Long.MIN_VALUE; // uninitialized
+        for (long l = 0; l < amount; l++)
+            decremented = bean.decrementAndGet(bean);
+        return decremented;
+    }
+
+    // defaults to @Lock, which defaults to WRITE 60 SECONDS
+    public long decrementAndGet(LoopbackBean bean) {
+        return --number;
+    }
+
+    // for READ to unannotated (implicit WRITE): error
+    @Lock(type = Lock.Type.READ)
+    public void doubleDecrement(LoopbackBean bean) {
+        bean.decrementAndGet(bean);
+        bean.decrementAndGet(bean);
+    }
+
+    @Lock(type = Lock.Type.READ,
+          accessTimeout = Lock.UNLIMITED)
+    public long getNumber() {
+        return number;
+    }
+
+    // For WRITE to READ
+    @Lock(type = Lock.Type.WRITE,
+          accessTimeout = Lock.IMMEDIATE)
+    public void increment(LoopbackBean bean) {
+        number = bean.getNumber() + 1;
+    }
+
+    // For READ to READ to READ to ...
+    @Lock(type = Lock.Type.READ,
+          accessTimeout = Lock.IMMEDIATE)
+    public long power(long exponent, LoopbackBean bean) {
+        if (exponent < 1)
+            return 1;
+        else
+            return number * bean.power(exponent - 1, bean);
+    }
+
+    @Lock(type = Lock.Type.WRITE,
+          accessTimeout = Lock.IMMEDIATE)
+    public long setNumber(long number) {
+        long previous = number;
+        this.number = number;
+        return previous;
+    }
+
+    // For READ to WRITE: error
+    @Lock(type = Lock.Type.READ,
+          accessTimeout = Lock.IMMEDIATE)
+    public void square(LoopbackBean bean) {
+        bean.setNumber(number * number);
+    }
+}

--- a/dev/com.ibm.ws.concurrent_fat_jakarta_12/test-applications/Concurrency32CDITestWeb/src/test/jakarta/concurrency32cdi/web/LoopbackBean.java
+++ b/dev/com.ibm.ws.concurrent_fat_jakarta_12/test-applications/Concurrency32CDITestWeb/src/test/jakarta/concurrency32cdi/web/LoopbackBean.java
@@ -84,7 +84,7 @@ public class LoopbackBean {
     @Lock(type = Lock.Type.WRITE,
           accessTimeout = Lock.IMMEDIATE)
     public long setNumber(long number) {
-        long previous = number;
+        long previous = this.number;
         this.number = number;
         return previous;
     }

--- a/dev/com.ibm.ws.concurrent_fat_jakarta_12/test-applications/Concurrency32CDITestWeb/src/test/jakarta/concurrency32cdi/web/WriteLockBean.java
+++ b/dev/com.ibm.ws.concurrent_fat_jakarta_12/test-applications/Concurrency32CDITestWeb/src/test/jakarta/concurrency32cdi/web/WriteLockBean.java
@@ -20,64 +20,69 @@ import jakarta.enterprise.concurrent.Lock;
 import jakarta.enterprise.context.ApplicationScoped;
 
 /**
- * A bean that is annotated at the class level to require a Lock of type READ.
+ * A bean that is annotated at the class level to require a Lock of type WRITE.
  * Unannotated methods should follow the class level annotation.
  * Annotated methods override the class level annotation.
  */
+@Lock(type = Lock.Type.WRITE,
+      accessTimeout = Lock.UNLIMITED)
 @ApplicationScoped
-@Lock(type = Lock.Type.READ,
-      accessTimeout = Lock.IMMEDIATE)
-public class ReadLockBean {
+public class WriteLockBean {
     /**
      * Maximum amount of time for an operation to remain delayed.
      */
     static final long MAX_DELAY_MS = TimeUnit.MINUTES.toMillis(5);
 
-    private String value;
+    private int number;
 
     @Lock(type = Lock.Type.READ,
           accessTimeout = Lock.UNLIMITED)
-    public String blockingReadValue() {
-        return value;
+    public int blockingReadNumber() {
+        return number;
     }
 
-    @Lock(// type defaults to WRITE
-          accessTimeout = Lock.UNLIMITED)
-    public void blockingWriteValue(String newValue) {
-        value = newValue;
+    public void blockingWriteNumber(int newNumber) {
+        number = newNumber;
     }
 
-    public String delayedReadValue(CountDownLatch methodisRunning,
-                                   CountDownLatch delayer) //
+    @Lock(type = Lock.Type.READ,
+          accessTimeout = Lock.IMMEDIATE)
+    public int delayedReadNumber(CountDownLatch methodisRunning,
+                                 CountDownLatch delayer) //
                     throws InterruptedException, TimeoutException {
         methodisRunning.countDown();
         if (delayer.await(MAX_DELAY_MS, TimeUnit.MILLISECONDS))
-            return value;
+            return number;
         else
             throw new TimeoutException("timed out");
     }
 
     @Lock(type = Lock.Type.WRITE,
           accessTimeout = Lock.IMMEDIATE)
-    public void delayedWriteValue(CountDownLatch methodisRunning,
-                                  CountDownLatch delayer,
-                                  String newValue) //
+    public boolean delayedWriteNumber(CountDownLatch methodisRunning,
+                                      CountDownLatch delayer,
+                                      int newNumber) //
                     throws InterruptedException, TimeoutException {
         methodisRunning.countDown();
-        if (delayer.await(MAX_DELAY_MS, TimeUnit.MILLISECONDS))
-            value = newValue;
-        else
-            throw new TimeoutException("timed out");
+        if (delayer.await(MAX_DELAY_MS, TimeUnit.MILLISECONDS)) {
+            number = newNumber;
+            return true;
+        } else {
+            return false;
+        }
     }
 
-    public String readValue() {
-        return value;
+    @Lock(type = Lock.Type.READ,
+          accessTimeout = 100L,
+          unit = TimeUnit.MILLISECONDS)
+    public int readNumber() {
+        return number;
     }
 
     @Lock(// type defaults to WRITE
-          accessTimeout = 222333L,
-          unit = TimeUnit.MICROSECONDS)
-    public void writeValue(String newValue) {
-        value = newValue;
+          accessTimeout = 111222333L,
+          unit = TimeUnit.NANOSECONDS)
+    public void writeNumber(int newNumber) {
+        number = newNumber;
     }
 }

--- a/dev/io.openliberty.concurrent.internal.cdi/src/io/openliberty/concurrent/internal/cdi/interceptor/LockInterceptor.java
+++ b/dev/io.openliberty.concurrent.internal.cdi/src/io/openliberty/concurrent/internal/cdi/interceptor/LockInterceptor.java
@@ -189,7 +189,9 @@ public class LockInterceptor implements Serializable {
                 if (trace && tc.isDebugEnabled())
                     Tr.debug(this, tc,
                              (read ? "READ" : "WRITE") + " completed, with " +
-                                       lockCount + " Lock methods still accessing");
+                                       lockCount + " Lock methods still accessing, " +
+                                       reentrantLock.getQueueLength() +
+                                       " Lock methods waiting");
             }
         }
     }

--- a/dev/io.openliberty.concurrent.internal.cdi/src/io/openliberty/concurrent/internal/cdi/interceptor/LockInterceptor.java
+++ b/dev/io.openliberty.concurrent.internal.cdi/src/io/openliberty/concurrent/internal/cdi/interceptor/LockInterceptor.java
@@ -146,7 +146,7 @@ public class LockInterceptor implements Serializable {
             } else if (timeout == 0) { // IMMEDIATE
                 acquired = lock.tryLock();
             } else if (timeout == -1) { // UNLIMITED
-                lock.lock();
+                lock.lockInterruptibly();
                 acquired = true;
             } else { // negative accessTimeout value
                 throw new CompletionException(new UnsupportedOperationException//
@@ -175,11 +175,16 @@ public class LockInterceptor implements Serializable {
             throw x;
         } finally {
             if (acquired) {
+                int lockCount = 0;
+                if (trace && tc.isDebugEnabled())
+                    lockCount = reentrantLock.getReadLockCount() +
+                                reentrantLock.getWriteHoldCount() -
+                                1; // -1 for subsequent unlock
                 lock.unlock();
                 if (trace && tc.isDebugEnabled())
                     Tr.debug(this, tc,
-                             (read ? "READ" : "WRITE") + " completed for " +
-                                       beanInstance);
+                             (read ? "READ" : "WRITE") + " completed, with " +
+                                       lockCount + " Lock methods still accessing");
             }
         }
     }

--- a/dev/io.openliberty.concurrent.internal.cdi/src/io/openliberty/concurrent/internal/cdi/interceptor/LockInterceptor.java
+++ b/dev/io.openliberty.concurrent.internal.cdi/src/io/openliberty/concurrent/internal/cdi/interceptor/LockInterceptor.java
@@ -141,6 +141,11 @@ public class LockInterceptor implements Serializable {
 
         boolean acquired = false;
         try {
+            // reject unsupported escalation from READ to WRITE
+            // (which would otherwise time out or deadlock self)
+            if (!read && reentrantLock.getReadHoldCount() > 0)
+                throw new IllegalStateException("Cannot upgrade from READ to WRITE lock"); // TODO NLS
+
             if (timeout > 0) {
                 acquired = lock.tryLock(timeout, unit);
             } else if (timeout == 0) { // IMMEDIATE


### PR DESCRIPTION
Covers Lock(type=WRITE), loopback of Lock methods (which means that a bean method annotated `@Lock` calls a method also annotated `@Lock` of the same bean, with the respective Lock requirements of each bean method applying.  This could involve recursion as well as scenarios from WRITE to WRITE (allowed), WRITE to READ (allowed), READ to READ (allowed) and READ to WRITE (not allowed).  In the latter case, we take special action to force an immediate failure rather the application eventually getting a time out or being self deadlocked.  This PR includes automated tests.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
