### PR TITLE
Concurrency 3.2/CDI 5.0 tests should not run on Java SE 8

### DIFF
--- a/dev/com.ibm.ws.concurrent_fat_cdi/fat/src/com/ibm/ws/concurrent/cdi/fat/ConcurrentCDI5Test.java
+++ b/dev/com.ibm.ws.concurrent_fat_cdi/fat/src/com/ibm/ws/concurrent/cdi/fat/ConcurrentCDI5Test.java
@@ -35,7 +35,7 @@ import componenttest.topology.utils.FATServletClient;
 import concurrent.cdi4_1.web.ConcurrentCDI4_1Servlet;
 
 @RunWith(FATRunner.class)
-@MinimumJavaLevel(javaLevel = 17)
+@MinimumJavaLevel(javaLevel = 21)
 public class ConcurrentCDI5Test extends FATServletClient {
 
     public static final String APP_NAME = "concurrentCDI4_1App";
@@ -46,7 +46,7 @@ public class ConcurrentCDI5Test extends FATServletClient {
     @TestServlets({
                     @TestServlet(servlet = ConcurrentCDI4_1Servlet.class,
                                  contextRoot = APP_NAME,
-                                 minJavaLevel = 17)
+                                 minJavaLevel = 21)
     })
     public static LibertyServer server;
 

--- a/dev/com.ibm.ws.concurrent_fat_cdi/fat/src/com/ibm/ws/concurrent/cdi/fat/ConcurrentCDI5Test.java
+++ b/dev/com.ibm.ws.concurrent_fat_cdi/fat/src/com/ibm/ws/concurrent/cdi/fat/ConcurrentCDI5Test.java
@@ -45,7 +45,8 @@ public class ConcurrentCDI5Test extends FATServletClient {
     @Server("concurrent_fat_cdi5")
     @TestServlets({
                     @TestServlet(servlet = ConcurrentCDI4_1Servlet.class,
-                                 contextRoot = APP_NAME)
+                                 contextRoot = APP_NAME,
+                                 minJavaLevel = 17)
     })
     public static LibertyServer server;
 

--- a/dev/com.ibm.ws.concurrent_fat_cdi/fat/src/com/ibm/ws/concurrent/cdi/fat/FATSuite.java
+++ b/dev/com.ibm.ws.concurrent_fat_cdi/fat/src/com/ibm/ws/concurrent/cdi/fat/FATSuite.java
@@ -22,7 +22,7 @@ import org.junit.runners.Suite.SuiteClasses;
                 ConcurrentCDI3Test.class, // Jakarta EE 9
                 ConcurrentCDI4Test.class, // Jakarta EE 10
                 ConcurrentCDI4_1Test.class, // Jakarta EE 11
-                ConcurrentCDI5Test.class
+                ConcurrentCDI5Test.class // Jakarta EE 12
 })
 public class FATSuite {
 }


### PR DESCRIPTION
fixes #35399

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
