### PR TITLE
fix: typo in tck pom.xmls

### DIFF
--- a/dev/com.ibm.ws.concurrent.mp.1.2_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.concurrent.mp.1.2_fat_tck/publish/tckRunner/tck/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- 
-    Copyright (c) 2017, 2023 IBM Corporation and others. All rights reserved.
+    Copyright (c) 2017, 2026 IBM Corporation and others. All rights reserved.
     This program and the accompanying materials are made available under the 
     terms of the Eclipse Public License 2.0 which accompanies this distribution, 
     and is available at 
@@ -175,7 +175,7 @@
                     <suiteXmlFiles>
                         <suiteXmlFile>${suiteXmlFile}</suiteXmlFile>
                     </suiteXmlFiles>
-                    <testSourceDirectory>${basedir}${file.separarator}src${file.separarator}main${file.separarator}java${file.separarator}</testSourceDirectory>
+                    <testSourceDirectory>${basedir}${file.separator}src${file.separator}main${file.separator}java${file.separator}</testSourceDirectory>
                     <forkNode implementation="org.apache.maven.plugin.surefire.extensions.SurefireForkNodeFactory" /> <!-- Use TCP/IP instead of process pipes for ZOS -->
                 </configuration>
             </plugin>

--- a/dev/com.ibm.ws.concurrent.mp.1.3_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.concurrent.mp.1.3_fat_tck/publish/tckRunner/tck/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- 
-    Copyright (c) 2017, 2023 IBM Corporation and others. All rights reserved.
+    Copyright (c) 2017, 2026 IBM Corporation and others. All rights reserved.
     This program and the accompanying materials are made available under the 
     terms of the Eclipse Public License 2.0 which accompanies this distribution, 
     and is available at 
@@ -183,7 +183,7 @@
                     <suiteXmlFiles>
                         <suiteXmlFile>${suiteXmlFile}</suiteXmlFile>
                     </suiteXmlFiles>
-                    <testSourceDirectory>${basedir}${file.separarator}src${file.separarator}main${file.separarator}java${file.separarator}</testSourceDirectory>
+                    <testSourceDirectory>${basedir}${file.separator}src${file.separator}main${file.separator}java${file.separator}</testSourceDirectory>
                     <forkNode implementation="org.apache.maven.plugin.surefire.extensions.SurefireForkNodeFactory" /> <!-- Use TCP/IP instead of process pipes for ZOS -->
                 </configuration>
             </plugin>

--- a/dev/com.ibm.ws.concurrent.mp_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.concurrent.mp_fat_tck/publish/tckRunner/tck/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- 
-    Copyright (c) 2017, 2023 IBM Corporation and others. All rights reserved.
+    Copyright (c) 2017, 2026 IBM Corporation and others. All rights reserved.
     This program and the accompanying materials are made available under the 
     terms of the Eclipse Public License 2.0 which accompanies this distribution, 
     and is available at 
@@ -164,7 +164,7 @@
                     <suiteXmlFiles>
                         <suiteXmlFile>${suiteXmlFile}</suiteXmlFile>
                     </suiteXmlFiles>
-                    <testSourceDirectory>${basedir}${file.separarator}src${file.separarator}main${file.separarator}java${file.separarator}</testSourceDirectory>
+                    <testSourceDirectory>${basedir}${file.separator}src${file.separator}main${file.separator}java${file.separator}</testSourceDirectory>
                     <forkNode implementation="org.apache.maven.plugin.surefire.extensions.SurefireForkNodeFactory" /> <!-- Use TCP/IP instead of process pipes for ZOS -->
                 </configuration>
             </plugin>

--- a/dev/com.ibm.ws.jpa.container.v32_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.jpa.container.v32_fat_tck/publish/tckRunner/tck/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- 
-	~ Copyright (c) 2025 IBM Corporation and others. All rights reserved. 
+	~ Copyright (c) 2025, 2026 IBM Corporation and others. All rights reserved. 
 	~ This program and the accompanying materials are made available under the 
 	~ terms of the Eclipse Public License 2.0 which accompanies this distribution, 
 	~ and is available at 
@@ -205,7 +205,7 @@
 					<reportNameSuffix>
 						${jakarta.profile}-${jakarta.tck.database.type}</reportNameSuffix>
 					<testSourceDirectory>
-						${basedir}${file.separarator}src${file.separarator}main${file.separarator}java${file.separarator}</testSourceDirectory>
+						${basedir}${file.separator}src${file.separator}main${file.separator}java${file.separator}</testSourceDirectory>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/dev/com.ibm.ws.jpa.container.v32_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.jpa.container.v32_fat_tck/publish/tckRunner/tck/pom.xml
@@ -204,8 +204,6 @@
 					<groups>${included.groups}</groups>
 					<reportNameSuffix>
 						${jakarta.profile}-${jakarta.tck.database.type}</reportNameSuffix>
-					<testSourceDirectory>
-						${basedir}${file.separator}src${file.separator}main${file.separator}java${file.separator}</testSourceDirectory>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/dev/com.ibm.ws.microprofile.config.1.1_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.config.1.1_fat_tck/publish/tckRunner/tck/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- 
-    Copyright (c) 2017, 2023 IBM Corporation and others. All rights reserved.
+    Copyright (c) 2017, 2026 IBM Corporation and others. All rights reserved.
     This program and the accompanying materials are made available under the 
     terms of the Eclipse Public License 2.0 which accompanies this distribution, 
     and is available at 
@@ -168,7 +168,7 @@
                     <suiteXmlFiles>
                         <suiteXmlFile>${suiteXmlFile}</suiteXmlFile>
                     </suiteXmlFiles>
-                    <testSourceDirectory>${basedir}${file.separarator}src${file.separarator}main${file.separarator}java${file.separarator}</testSourceDirectory>
+                    <testSourceDirectory>${basedir}${file.separator}src${file.separator}main${file.separator}java${file.separator}</testSourceDirectory>
                 </configuration>
             </plugin>
         </plugins>

--- a/dev/com.ibm.ws.microprofile.config.1.2_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.config.1.2_fat_tck/publish/tckRunner/tck/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- 
-    Copyright (c) 2018, 2023 IBM Corporation and others. All rights reserved.
+    Copyright (c) 2018, 2026 IBM Corporation and others. All rights reserved.
     This program and the accompanying materials are made available under the 
     terms of the Eclipse Public License 2.0 which accompanies this distribution, 
     and is available at 
@@ -186,7 +186,7 @@
                     <suiteXmlFiles>
                         <suiteXmlFile>${suiteXmlFile}</suiteXmlFile>
                     </suiteXmlFiles>
-                    <testSourceDirectory>${basedir}${file.separarator}src${file.separarator}main${file.separarator}java${file.separarator}</testSourceDirectory>
+                    <testSourceDirectory>${basedir}${file.separator}src${file.separator}main${file.separator}java${file.separator}</testSourceDirectory>
                 </configuration>
             </plugin>
         </plugins>

--- a/dev/com.ibm.ws.microprofile.config.1.3_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.config.1.3_fat_tck/publish/tckRunner/tck/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- 
-    Copyright (c) 2018, 2023 IBM Corporation and others. All rights reserved.
+    Copyright (c) 2018, 2026 IBM Corporation and others. All rights reserved.
     This program and the accompanying materials are made available under the 
     terms of the Eclipse Public License 2.0 which accompanies this distribution, 
     and is available at 
@@ -175,7 +175,7 @@
                     <suiteXmlFiles>
                         <suiteXmlFile>${suiteXmlFile}</suiteXmlFile>
                     </suiteXmlFiles>
-                    <testSourceDirectory>${basedir}${file.separarator}src${file.separarator}main${file.separarator}java${file.separarator}</testSourceDirectory>
+                    <testSourceDirectory>${basedir}${file.separator}src${file.separator}main${file.separator}java${file.separator}</testSourceDirectory>
                 </configuration>
             </plugin>
         </plugins>

--- a/dev/com.ibm.ws.microprofile.config.1.4_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.config.1.4_fat_tck/publish/tckRunner/tck/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- 
-    Copyright (c) 2018, 2023 IBM Corporation and others. All rights reserved.
+    Copyright (c) 2018, 2026 IBM Corporation and others. All rights reserved.
     This program and the accompanying materials are made available under the 
     terms of the Eclipse Public License 2.0 which accompanies this distribution, 
     and is available at 
@@ -175,7 +175,7 @@
                     <suiteXmlFiles>
                         <suiteXmlFile>${suiteXmlFile}</suiteXmlFile>
                     </suiteXmlFiles>
-                    <testSourceDirectory>${basedir}${file.separarator}src${file.separarator}main${file.separarator}java${file.separarator}</testSourceDirectory>
+                    <testSourceDirectory>${basedir}${file.separator}src${file.separator}main${file.separator}java${file.separator}</testSourceDirectory>
                 </configuration>
             </plugin>
         </plugins>

--- a/dev/com.ibm.ws.microprofile.faulttolerance.1.1_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.1.1_fat_tck/publish/tckRunner/tck/pom.xml
@@ -166,7 +166,7 @@
                     <suiteXmlFiles>
                         <suiteXmlFile>${suiteXmlFile}</suiteXmlFile>
                     </suiteXmlFiles>
-                    <testSourceDirectory>${basedir}${file.separarator}src${file.separarator}main${file.separarator}java${file.separarator}</testSourceDirectory>
+                    <testSourceDirectory>${basedir}${file.separator}src${file.separator}main${file.separator}java${file.separator}</testSourceDirectory>
                 </configuration>
             </plugin>
         </plugins>

--- a/dev/com.ibm.ws.microprofile.faulttolerance.2.0_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.2.0_fat_tck/publish/tckRunner/tck/pom.xml
@@ -160,7 +160,7 @@
                     <suiteXmlFiles>
                         <suiteXmlFile>${suiteXmlFile}</suiteXmlFile>
                     </suiteXmlFiles>
-                    <testSourceDirectory>${basedir}${file.separarator}src${file.separarator}main${file.separarator}java${file.separarator}</testSourceDirectory>
+                    <testSourceDirectory>${basedir}${file.separator}src${file.separator}main${file.separator}java${file.separator}</testSourceDirectory>
                 </configuration>
             </plugin>
         </plugins>

--- a/dev/com.ibm.ws.microprofile.faulttolerance.2.1_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.faulttolerance.2.1_fat_tck/publish/tckRunner/tck/pom.xml
@@ -158,7 +158,7 @@
                     <suiteXmlFiles>
                         <suiteXmlFile>${suiteXmlFile}</suiteXmlFile>
                     </suiteXmlFiles>
-                    <testSourceDirectory>${basedir}${file.separarator}src${file.separarator}main${file.separarator}java${file.separarator}</testSourceDirectory>
+                    <testSourceDirectory>${basedir}${file.separator}src${file.separator}main${file.separator}java${file.separator}</testSourceDirectory>
                 </configuration>
             </plugin>
         </plugins>

--- a/dev/com.ibm.ws.microprofile.faulttolerance_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.faulttolerance_fat_tck/publish/tckRunner/tck/pom.xml
@@ -168,7 +168,7 @@
                     <suiteXmlFiles>
                         <suiteXmlFile>${suiteXmlFile}</suiteXmlFile>
                     </suiteXmlFiles>
-                    <testSourceDirectory>${basedir}${file.separarator}src${file.separarator}main${file.separarator}java${file.separarator}</testSourceDirectory>
+                    <testSourceDirectory>${basedir}${file.separator}src${file.separator}main${file.separator}java${file.separator}</testSourceDirectory>
                 </configuration>
             </plugin>
         </plugins>

--- a/dev/com.ibm.ws.microprofile.graphql_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.graphql_fat_tck/publish/tckRunner/tck/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- 
-    Copyright (c) 2019, 2021 IBM Corporation and others. All rights reserved.
+    Copyright (c) 2019, 2026 IBM Corporation and others. All rights reserved.
     This program and the accompanying materials are made available under the 
     terms of the Eclipse Public License 2.0 which accompanies this distribution, 
     and is available at 
@@ -222,7 +222,7 @@
                     <suiteXmlFiles>
                         <suiteXmlFile>${suiteXmlFile}</suiteXmlFile>
                     </suiteXmlFiles>
-                    <testSourceDirectory>${basedir}${file.separarator}src${file.separarator}main${file.separarator}java${file.separarator}</testSourceDirectory>
+                    <testSourceDirectory>${basedir}${file.separator}src${file.separator}main${file.separator}java${file.separator}</testSourceDirectory>
                 </configuration>
             </plugin>
         </plugins>

--- a/dev/com.ibm.ws.microprofile.health.1.0_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.health.1.0_fat_tck/publish/tckRunner/tck/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- 
-    Copyright (c) 2019, 2023 IBM Corporation and others. All rights reserved.
+    Copyright (c) 2019, 2026 IBM Corporation and others. All rights reserved.
     This program and the accompanying materials are made available under the 
     terms of the Eclipse Public License 2.0 which accompanies this distribution, 
     and is available at 
@@ -169,7 +169,7 @@
                     <suiteXmlFiles>
                         <suiteXmlFile>${suiteXmlFile}</suiteXmlFile>
                     </suiteXmlFiles>
-                    <testSourceDirectory>${basedir}${file.separarator}src${file.separarator}main${file.separarator}java${file.separarator}</testSourceDirectory>
+                    <testSourceDirectory>${basedir}${file.separator}src${file.separator}main${file.separator}java${file.separator}</testSourceDirectory>
                 </configuration>
             </plugin>
         </plugins>

--- a/dev/com.ibm.ws.microprofile.health.2.0_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.health.2.0_fat_tck/publish/tckRunner/tck/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- 
-    Copyright (c) 2019, 2023 IBM Corporation and others. All rights reserved.
+    Copyright (c) 2019, 2026 IBM Corporation and others. All rights reserved.
     This program and the accompanying materials are made available under the 
     terms of the Eclipse Public License 2.0 which accompanies this distribution, 
     and is available at 
@@ -169,7 +169,7 @@
                     <suiteXmlFiles>
                         <suiteXmlFile>${suiteXmlFile}</suiteXmlFile>
                     </suiteXmlFiles>
-                    <testSourceDirectory>${basedir}${file.separarator}src${file.separarator}main${file.separarator}java${file.separarator}</testSourceDirectory>
+                    <testSourceDirectory>${basedir}${file.separator}src${file.separator}main${file.separator}java${file.separator}</testSourceDirectory>
                 </configuration>
             </plugin>
         </plugins>

--- a/dev/com.ibm.ws.microprofile.health.2.1_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.health.2.1_fat_tck/publish/tckRunner/tck/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- 
-    Copyright (c) 2019, 2023 IBM Corporation and others. All rights reserved.
+    Copyright (c) 2019, 2026 IBM Corporation and others. All rights reserved.
     This program and the accompanying materials are made available under the 
     terms of the Eclipse Public License 2.0 which accompanies this distribution, 
     and is available at 
@@ -200,7 +200,7 @@
                     <suiteXmlFiles>
                         <suiteXmlFile>${suiteXmlFile}</suiteXmlFile>
                     </suiteXmlFiles>
-                    <testSourceDirectory>${basedir}${file.separarator}src${file.separarator}main${file.separarator}java${file.separarator}</testSourceDirectory>
+                    <testSourceDirectory>${basedir}${file.separator}src${file.separator}main${file.separator}java${file.separator}</testSourceDirectory>
                 </configuration>
             </plugin>
         </plugins>

--- a/dev/com.ibm.ws.microprofile.health.2.2_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.health.2.2_fat_tck/publish/tckRunner/tck/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- 
-    Copyright (c) 2020, 2023 IBM Corporation and others. All rights reserved.
+    Copyright (c) 2020, 2026 IBM Corporation and others. All rights reserved.
     This program and the accompanying materials are made available under the 
     terms of the Eclipse Public License 2.0 which accompanies this distribution, 
     and is available at 
@@ -192,7 +192,7 @@
                     <suiteXmlFiles>
                         <suiteXmlFile>${suiteXmlFile}</suiteXmlFile>
                     </suiteXmlFiles>
-                    <testSourceDirectory>${basedir}${file.separarator}src${file.separarator}main${file.separarator}java${file.separarator}</testSourceDirectory>
+                    <testSourceDirectory>${basedir}${file.separator}src${file.separator}main${file.separator}java${file.separator}</testSourceDirectory>
                 </configuration>
             </plugin>
         </plugins>

--- a/dev/com.ibm.ws.microprofile.mpjwt.1.0_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.mpjwt.1.0_fat_tck/publish/tckRunner/tck/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- 
-    Copyright (c) 2017. 2024 IBM Corporation and others. All rights reserved.
+    Copyright (c) 2017. 2026 IBM Corporation and others. All rights reserved.
     This program and the accompanying materials are made available under the 
     terms of the Eclipse Public License 2.0 which accompanies this distribution, 
     and is available at 
@@ -211,7 +211,7 @@
                     <suiteXmlFiles>
                         <suiteXmlFile>${suiteXmlFile}</suiteXmlFile>
                     </suiteXmlFiles>
-                    <testSourceDirectory>${basedir}${file.separarator}src${file.separarator}main${file.separarator}java${file.separarator}</testSourceDirectory>
+                    <testSourceDirectory>${basedir}${file.separator}src${file.separator}main${file.separator}java${file.separator}</testSourceDirectory>
                 </configuration>
             </plugin>
         </plugins>

--- a/dev/com.ibm.ws.microprofile.mpjwt.1.1_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.mpjwt.1.1_fat_tck/publish/tckRunner/tck/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- 
-    Copyright (c) 2018, 2023 IBM Corporation and others. All rights reserved.
+    Copyright (c) 2018, 2026 IBM Corporation and others. All rights reserved.
     This program and the accompanying materials are made available under the 
     terms of the Eclipse Public License 2.0 which accompanies this distribution, 
     and is available at 
@@ -209,7 +209,7 @@
                     <suiteXmlFiles>
                         <suiteXmlFile>${suiteXmlFile}</suiteXmlFile>
                     </suiteXmlFiles>
-                    <testSourceDirectory>${basedir}${file.separarator}src${file.separarator}main${file.separarator}java${file.separarator}</testSourceDirectory>
+                    <testSourceDirectory>${basedir}${file.separator}src${file.separator}main${file.separator}java${file.separator}</testSourceDirectory>
                 </configuration>
             </plugin>
         </plugins>

--- a/dev/com.ibm.ws.microprofile.opentracing.1.1_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.opentracing.1.1_fat_tck/publish/tckRunner/tck/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- 
-    Copyright (c) 2017, 2023 IBM Corporation and others. All rights reserved.
+    Copyright (c) 2017, 2026 IBM Corporation and others. All rights reserved.
     This program and the accompanying materials are made available under the 
     terms of the Eclipse Public License 2.0 which accompanies this distribution, 
     and is available at 
@@ -209,7 +209,7 @@
                     <suiteXmlFiles>
                         <suiteXmlFile>${suiteXmlFile}</suiteXmlFile>
                     </suiteXmlFiles>
-                    <testSourceDirectory>${basedir}${file.separarator}src${file.separarator}main${file.separarator}java${file.separarator}</testSourceDirectory>
+                    <testSourceDirectory>${basedir}${file.separator}src${file.separator}main${file.separator}java${file.separator}</testSourceDirectory>
                 </configuration>
             </plugin>
         </plugins>

--- a/dev/com.ibm.ws.microprofile.opentracing.1.2_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.opentracing.1.2_fat_tck/publish/tckRunner/tck/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- 
-    Copyright (c) 2017, 2023 IBM Corporation and others. All rights reserved.
+    Copyright (c) 2017, 2026 IBM Corporation and others. All rights reserved.
     This program and the accompanying materials are made available under the 
     terms of the Eclipse Public License 2.0 which accompanies this distribution, 
     and is available at 
@@ -215,7 +215,7 @@
                     <suiteXmlFiles>
                         <suiteXmlFile>${suiteXmlFile}</suiteXmlFile>
                     </suiteXmlFiles>
-                    <testSourceDirectory>${basedir}${file.separarator}src${file.separarator}main${file.separarator}java${file.separarator}</testSourceDirectory>
+                    <testSourceDirectory>${basedir}${file.separator}src${file.separator}main${file.separator}java${file.separator}</testSourceDirectory>
                 </configuration>
             </plugin>
         </plugins>

--- a/dev/com.ibm.ws.microprofile.opentracing.1.3_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.opentracing.1.3_fat_tck/publish/tckRunner/tck/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- 
-    Copyright (c) 2017, 2023 IBM Corporation and others. All rights reserved.
+    Copyright (c) 2017, 2026 IBM Corporation and others. All rights reserved.
     This program and the accompanying materials are made available under the 
     terms of the Eclipse Public License 2.0 which accompanies this distribution, 
     and is available at 
@@ -227,7 +227,7 @@
                     <suiteXmlFiles>
                         <suiteXmlFile>${suiteXmlFile}</suiteXmlFile>
                     </suiteXmlFiles>
-                    <testSourceDirectory>${basedir}${file.separarator}src${file.separarator}main${file.separarator}java${file.separarator}</testSourceDirectory>
+                    <testSourceDirectory>${basedir}${file.separator}src${file.separator}main${file.separator}java${file.separator}</testSourceDirectory>
                 </configuration>
             </plugin>
         </plugins>

--- a/dev/com.ibm.ws.microprofile.opentracing_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.opentracing_fat_tck/publish/tckRunner/tck/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- 
-    Copyright (c) 2017, 2023 IBM Corporation and others. All rights reserved.
+    Copyright (c) 2017, 2026 IBM Corporation and others. All rights reserved.
     This program and the accompanying materials are made available under the 
     terms of the Eclipse Public License 2.0 which accompanies this distribution, 
     and is available at 
@@ -209,7 +209,7 @@
                     <suiteXmlFiles>
                         <suiteXmlFile>${suiteXmlFile}</suiteXmlFile>
                     </suiteXmlFiles>
-                    <testSourceDirectory>${basedir}${file.separarator}src${file.separarator}main${file.separarator}java${file.separarator}</testSourceDirectory>
+                    <testSourceDirectory>${basedir}${file.separator}src${file.separator}main${file.separator}java${file.separator}</testSourceDirectory>
                 </configuration>
             </plugin>
         </plugins>

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat_tck/publish/tckRunner/tck/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- 
-    Copyright (c) 2017, 2023 IBM Corporation and others. All rights reserved.
+    Copyright (c) 2017, 2026 IBM Corporation and others. All rights reserved.
     This program and the accompanying materials are made available under the 
     terms of the Eclipse Public License 2.0 which accompanies this distribution, 
     and is available at 
@@ -144,7 +144,7 @@
                         <sun.rmi.transport.tcp.responseTimeout>${sun.rmi.transport.tcp.responseTimeout}</sun.rmi.transport.tcp.responseTimeout>
                     </systemPropertyVariables>
                     <dependenciesToScan>org.eclipse.microprofile.reactive.messaging:microprofile-reactive-messaging-tck</dependenciesToScan>
-                    <testSourceDirectory>${basedir}${file.separarator}src${file.separarator}main${file.separarator}java${file.separarator}</testSourceDirectory>
+                    <testSourceDirectory>${basedir}${file.separator}src${file.separator}main${file.separator}java${file.separator}</testSourceDirectory>
                 </configuration>
             </plugin>
         </plugins>

--- a/dev/com.ibm.ws.microprofile.reactive.streams.operators_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.reactive.streams.operators_fat_tck/publish/tckRunner/tck/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- 
-    Copyright (c) 2017, 2023 IBM Corporation and others. All rights reserved.
+    Copyright (c) 2017, 2026 IBM Corporation and others. All rights reserved.
     This program and the accompanying materials are made available under the 
     terms of the Eclipse Public License 2.0 which accompanies this distribution, 
     and is available at 
@@ -208,7 +208,7 @@
                     <suiteXmlFiles>
                         <suiteXmlFile>${suiteXmlFile}</suiteXmlFile>
                     </suiteXmlFiles>
-                    <testSourceDirectory>${basedir}${file.separarator}src${file.separarator}main${file.separarator}java${file.separarator}</testSourceDirectory>
+                    <testSourceDirectory>${basedir}${file.separator}src${file.separator}main${file.separator}java${file.separator}</testSourceDirectory>
                 </configuration>
             </plugin>
         </plugins>

--- a/dev/com.ibm.ws.microprofile.rest.client11_fat_tck/publish/tckRunner/tck/pom-manual.xml
+++ b/dev/com.ibm.ws.microprofile.rest.client11_fat_tck/publish/tckRunner/tck/pom-manual.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- 
-    Copyright (c) 2018, 2023 IBM Corporation and others. All rights reserved.
+    Copyright (c) 2018, 2026 IBM Corporation and others. All rights reserved.
     This program and the accompanying materials are made available under the 
     terms of the Eclipse Public License 2.0 which accompanies this distribution, 
     and is available at 
@@ -284,7 +284,7 @@
                         <suiteXmlFile>${suiteXmlFile}</suiteXmlFile>
                         <!-- <suiteXmlFile>tck-suite.xml</suiteXmlFile> -->
                     </suiteXmlFiles>
-                    <testSourceDirectory>${basedir}${file.separarator}src${file.separarator}main${file.separarator}java${file.separarator}</testSourceDirectory>
+                    <testSourceDirectory>${basedir}${file.separator}src${file.separator}main${file.separator}java${file.separator}</testSourceDirectory>
                 </configuration>
             </plugin>
             <plugin>

--- a/dev/com.ibm.ws.microprofile.rest.client11_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.rest.client11_fat_tck/publish/tckRunner/tck/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- 
-    Copyright (c) 2018, 2023 IBM Corporation and others. All rights reserved.
+    Copyright (c) 2018, 2026 IBM Corporation and others. All rights reserved.
     This program and the accompanying materials are made available under the 
     terms of the Eclipse Public License 2.0 which accompanies this distribution, 
     and is available at 
@@ -327,7 +327,7 @@
                         <suiteXmlFile>${suiteXmlFile}</suiteXmlFile>
                         <!-- <suiteXmlFile>tck-suite.xml</suiteXmlFile> -->
                     </suiteXmlFiles>
-                    <testSourceDirectory>${basedir}${file.separarator}src${file.separarator}main${file.separarator}java${file.separarator}</testSourceDirectory>
+                    <testSourceDirectory>${basedir}${file.separator}src${file.separator}main${file.separator}java${file.separator}</testSourceDirectory>
                 </configuration>
             </plugin>
             <plugin>

--- a/dev/com.ibm.ws.microprofile.rest.client12_fat_tck/publish/tckRunner/tck/pom-manual.xml
+++ b/dev/com.ibm.ws.microprofile.rest.client12_fat_tck/publish/tckRunner/tck/pom-manual.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- 
-    Copyright (c) 2019, 2023 IBM Corporation and others. All rights reserved.
+    Copyright (c) 2019, 2026 IBM Corporation and others. All rights reserved.
     This program and the accompanying materials are made available under the 
     terms of the Eclipse Public License 2.0 which accompanies this distribution, 
     and is available at 
@@ -264,7 +264,7 @@
                         <suiteXmlFile>${suiteXmlFile}</suiteXmlFile>
                         <!-- <suiteXmlFile>tck-suite.xml</suiteXmlFile> -->
                     </suiteXmlFiles>
-                    <testSourceDirectory>${basedir}${file.separarator}src${file.separarator}main${file.separarator}java${file.separarator}</testSourceDirectory>
+                    <testSourceDirectory>${basedir}${file.separator}src${file.separator}main${file.separator}java${file.separator}</testSourceDirectory>
                 </configuration>
             </plugin>
             <plugin>

--- a/dev/com.ibm.ws.microprofile.rest.client12_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.rest.client12_fat_tck/publish/tckRunner/tck/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- 
-    Copyright (c) 2019, 2023 IBM Corporation and others. All rights reserved.
+    Copyright (c) 2019, 2026 IBM Corporation and others. All rights reserved.
     This program and the accompanying materials are made available under the 
     terms of the Eclipse Public License 2.0 which accompanies this distribution, 
     and is available at 
@@ -323,7 +323,7 @@
                         <suiteXmlFile>${suiteXmlFile}</suiteXmlFile>
                         <!-- <suiteXmlFile>tck-suite.xml</suiteXmlFile> -->
                     </suiteXmlFiles>
-                    <testSourceDirectory>${basedir}${file.separarator}src${file.separarator}main${file.separarator}java${file.separarator}</testSourceDirectory>
+                    <testSourceDirectory>${basedir}${file.separator}src${file.separator}main${file.separator}java${file.separator}</testSourceDirectory>
                 </configuration>
             </plugin>
             <plugin>

--- a/dev/com.ibm.ws.microprofile.rest.client13_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.rest.client13_fat_tck/publish/tckRunner/tck/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- 
-    Copyright (c) 2019, 2023 IBM Corporation and others. All rights reserved.
+    Copyright (c) 2019, 2026 IBM Corporation and others. All rights reserved.
     This program and the accompanying materials are made available under the 
     terms of the Eclipse Public License 2.0 which accompanies this distribution, 
     and is available at 
@@ -372,7 +372,7 @@
                         <suiteXmlFile>${suiteXmlFile}</suiteXmlFile>
                         <!-- <suiteXmlFile>tck-suite.xml</suiteXmlFile> -->
                     </suiteXmlFiles>
-                    <testSourceDirectory>${basedir}${file.separarator}src${file.separarator}main${file.separarator}java${file.separarator}</testSourceDirectory>
+                    <testSourceDirectory>${basedir}${file.separator}src${file.separator}main${file.separator}java${file.separator}</testSourceDirectory>
                 </configuration>
             </plugin>
             <plugin>

--- a/dev/com.ibm.ws.microprofile.rest.client14_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.rest.client14_fat_tck/publish/tckRunner/tck/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- 
-    Copyright (c) 2020, 2023 IBM Corporation and others. All rights reserved.
+    Copyright (c) 2020, 2026 IBM Corporation and others. All rights reserved.
     This program and the accompanying materials are made available under the 
     terms of the Eclipse Public License 2.0 which accompanies this distribution, 
     and is available at 
@@ -375,7 +375,7 @@
                         <suiteXmlFile>${suiteXmlFile}</suiteXmlFile>
                         <!-- <suiteXmlFile>tck-suite.xml</suiteXmlFile> -->
                     </suiteXmlFiles>
-                    <testSourceDirectory>${basedir}${file.separarator}src${file.separarator}main${file.separarator}java${file.separarator}</testSourceDirectory>
+                    <testSourceDirectory>${basedir}${file.separator}src${file.separator}main${file.separator}java${file.separator}</testSourceDirectory>
                 </configuration>
             </plugin>
             <plugin>

--- a/dev/com.ibm.ws.microprofile.rest.client_fat_tck/publish/tckRunner/tck/pom-manual.xml
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat_tck/publish/tckRunner/tck/pom-manual.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- 
-    Copyright (c) 2017, 2023 IBM Corporation and others. All rights reserved.
+    Copyright (c) 2017, 2026 IBM Corporation and others. All rights reserved.
     This program and the accompanying materials are made available under the 
     terms of the Eclipse Public License 2.0 which accompanies this distribution, 
     and is available at 
@@ -248,7 +248,7 @@
                         <suiteXmlFile>${suiteXmlFile}</suiteXmlFile>
                         <!-- <suiteXmlFile>tck-suite.xml</suiteXmlFile> -->
                     </suiteXmlFiles>
-                    <testSourceDirectory>${basedir}${file.separarator}src${file.separarator}main${file.separarator}java${file.separarator}</testSourceDirectory>
+                    <testSourceDirectory>${basedir}${file.separator}src${file.separator}main${file.separator}java${file.separator}</testSourceDirectory>
                 </configuration>
             </plugin>
             <plugin>

--- a/dev/com.ibm.ws.microprofile.rest.client_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/com.ibm.ws.microprofile.rest.client_fat_tck/publish/tckRunner/tck/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- 
-    Copyright (c) 2017, 2023 IBM Corporation and others. All rights reserved.
+    Copyright (c) 2017, 2026 IBM Corporation and others. All rights reserved.
     This program and the accompanying materials are made available under the 
     terms of the Eclipse Public License 2.0 which accompanies this distribution, 
     and is available at 
@@ -297,7 +297,7 @@
                         <suiteXmlFile>${suiteXmlFile}</suiteXmlFile>
                         <!-- <suiteXmlFile>tck-suite.xml</suiteXmlFile> -->
                     </suiteXmlFiles>
-                    <testSourceDirectory>${basedir}${file.separarator}src${file.separarator}main${file.separarator}java${file.separarator}</testSourceDirectory>
+                    <testSourceDirectory>${basedir}${file.separator}src${file.separator}main${file.separator}java${file.separator}</testSourceDirectory>
                 </configuration>
             </plugin>
             <plugin>

--- a/dev/io.openliberty.jakarta.concurrency.3.0_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.jakarta.concurrency.3.0_fat_tck/publish/tckRunner/tck/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- 
-    Copyright (c) 2022, 2024 IBM Corporation and others. All rights reserved.
+    Copyright (c) 2022, 2026 IBM Corporation and others. All rights reserved.
     This program and the accompanying materials are made available under the 
     terms of the Eclipse Public License 2.0 which accompanies this distribution, 
     and is available at 
@@ -192,7 +192,7 @@
                         <suiteXmlFile>${suiteXmlFile}</suiteXmlFile> <!-- provided by MvnUtils.runTCKMvnCmd -->
                     </suiteXmlFiles>
                     <reportNameSuffix>${jakarta.tck.platform}</reportNameSuffix>
-                    <testSourceDirectory>${basedir}${file.separarator}src${file.separarator}main${file.separarator}java${file.separarator}</testSourceDirectory>
+                    <testSourceDirectory>${basedir}${file.separator}src${file.separator}main${file.separator}java${file.separator}</testSourceDirectory>
                     <forkNode implementation="org.apache.maven.plugin.surefire.extensions.SurefireForkNodeFactory" /> <!-- Use TCP/IP instead of process pipes for ZOS -->
                 </configuration>
             </plugin>

--- a/dev/io.openliberty.jakarta.concurrency.3.0_fat_tck/publish/tckRunner/tck/standalone.pom.xml
+++ b/dev/io.openliberty.jakarta.concurrency.3.0_fat_tck/publish/tckRunner/tck/standalone.pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- 
-    Copyright (c) 2022, 2024 IBM Corporation and others. All rights reserved.
+    Copyright (c) 2022, 2026 IBM Corporation and others. All rights reserved.
     This program and the accompanying materials are made available under the 
     terms of the Eclipse Public License 2.0 which accompanies this distribution, 
     and is available at 
@@ -178,7 +178,7 @@
                     <suiteXmlFiles>
                         <suiteXmlFile>${suiteXmlFile}</suiteXmlFile> <!-- provided by runtime property -->
                     </suiteXmlFiles>
-                    <testSourceDirectory>${basedir}${file.separarator}src${file.separarator}main${file.separarator}java${file.separarator}</testSourceDirectory>
+                    <testSourceDirectory>${basedir}${file.separator}src${file.separator}main${file.separator}java${file.separator}</testSourceDirectory>
                 </configuration>
             </plugin>
         </plugins>

--- a/dev/io.openliberty.jakarta.concurrency.3.1_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.jakarta.concurrency.3.1_fat_tck/publish/tckRunner/tck/pom.xml
@@ -183,7 +183,6 @@
                     </systemPropertyVariables>
                     <groups>${jakarta.tck.platform}</groups> <!-- Groups to include i.e. web/full -->
                     <reportNameSuffix>${jakarta.tck.platform}</reportNameSuffix>
-                    <testSourceDirectory>${basedir}${file.separator}src${file.separator}main${file.separator}java${file.separator}</testSourceDirectory>
                 </configuration>
             </plugin>
         </plugins>

--- a/dev/io.openliberty.jakarta.concurrency.3.1_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.jakarta.concurrency.3.1_fat_tck/publish/tckRunner/tck/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- 
-    Copyright (c) 2022, 2025 IBM Corporation and others. All rights reserved.
+    Copyright (c) 2022, 2026 IBM Corporation and others. All rights reserved.
     This program and the accompanying materials are made available under the 
     terms of the Eclipse Public License 2.0 which accompanies this distribution, 
     and is available at 
@@ -183,7 +183,7 @@
                     </systemPropertyVariables>
                     <groups>${jakarta.tck.platform}</groups> <!-- Groups to include i.e. web/full -->
                     <reportNameSuffix>${jakarta.tck.platform}</reportNameSuffix>
-                    <testSourceDirectory>${basedir}${file.separarator}src${file.separarator}main${file.separarator}java${file.separarator}</testSourceDirectory>
+                    <testSourceDirectory>${basedir}${file.separator}src${file.separator}main${file.separator}java${file.separator}</testSourceDirectory>
                 </configuration>
             </plugin>
         </plugins>

--- a/dev/io.openliberty.jakarta.concurrency.3.1_fat_tck/publish/tckRunner/tck/standalone.pom.xml
+++ b/dev/io.openliberty.jakarta.concurrency.3.1_fat_tck/publish/tckRunner/tck/standalone.pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- 
-    Copyright (c) 2024, 2025 IBM Corporation and others. All rights reserved.
+    Copyright (c) 2024, 2026 IBM Corporation and others. All rights reserved.
     This program and the accompanying materials are made available under the 
     terms of the Eclipse Public License 2.0 which accompanies this distribution, 
     and is available at 
@@ -169,7 +169,7 @@
                     </systemPropertyVariables>
                     <groups>${jakarta.tck.platform}</groups> <!-- Groups to include i.e. web/full -->
                     <reportNameSuffix>${jakarta.tck.platform}</reportNameSuffix>
-                    <testSourceDirectory>${basedir}${file.separarator}src${file.separarator}main${file.separarator}java${file.separarator}</testSourceDirectory>
+                    <testSourceDirectory>${basedir}${file.separator}src${file.separator}main${file.separator}java${file.separator}</testSourceDirectory>
                 </configuration>
             </plugin>
         </plugins>

--- a/dev/io.openliberty.jakarta.concurrency.3.2_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.jakarta.concurrency.3.2_fat_tck/publish/tckRunner/tck/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- 
-    Copyright (c) 2022, 2025 IBM Corporation and others. All rights reserved.
+    Copyright (c) 2022, 2026 IBM Corporation and others. All rights reserved.
     This program and the accompanying materials are made available under the 
     terms of the Eclipse Public License 2.0 which accompanies this distribution, 
     and is available at 
@@ -180,7 +180,7 @@
                     </systemPropertyVariables>
                     <groups>${jakarta.tck.platform}</groups> <!-- Groups to include i.e. web/full -->
                     <reportNameSuffix>${jakarta.tck.platform}</reportNameSuffix>
-                    <testSourceDirectory>${basedir}${file.separarator}src${file.separarator}main${file.separarator}java${file.separarator}</testSourceDirectory>
+                    <testSourceDirectory>${basedir}${file.separator}src${file.separator}main${file.separator}java${file.separator}</testSourceDirectory>
                 </configuration>
             </plugin>
         </plugins>

--- a/dev/io.openliberty.jakarta.concurrency.3.2_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.jakarta.concurrency.3.2_fat_tck/publish/tckRunner/tck/pom.xml
@@ -180,7 +180,6 @@
                     </systemPropertyVariables>
                     <groups>${jakarta.tck.platform}</groups> <!-- Groups to include i.e. web/full -->
                     <reportNameSuffix>${jakarta.tck.platform}</reportNameSuffix>
-                    <testSourceDirectory>${basedir}${file.separator}src${file.separator}main${file.separator}java${file.separator}</testSourceDirectory>
                 </configuration>
             </plugin>
         </plugins>

--- a/dev/io.openliberty.jakarta.concurrency.3.2_fat_tck/publish/tckRunner/tck/standalone.pom.xml
+++ b/dev/io.openliberty.jakarta.concurrency.3.2_fat_tck/publish/tckRunner/tck/standalone.pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- 
-    Copyright (c) 2024, 2025 IBM Corporation and others. All rights reserved.
+    Copyright (c) 2024, 2026 IBM Corporation and others. All rights reserved.
     This program and the accompanying materials are made available under the 
     terms of the Eclipse Public License 2.0 which accompanies this distribution, 
     and is available at 
@@ -165,7 +165,7 @@
                     </systemPropertyVariables>
                     <groups>${jakarta.tck.platform}</groups> <!-- Groups to include i.e. web/full -->
                     <reportNameSuffix>${jakarta.tck.platform}</reportNameSuffix>
-                    <testSourceDirectory>${basedir}${file.separarator}src${file.separarator}main${file.separarator}java${file.separarator}</testSourceDirectory>
+                    <testSourceDirectory>${basedir}${file.separator}src${file.separator}main${file.separator}java${file.separator}</testSourceDirectory>
                 </configuration>
             </plugin>
         </plugins>

--- a/dev/io.openliberty.jakarta.data.1.0_fat_tck/publish/tckRunner/platform/pom.xml
+++ b/dev/io.openliberty.jakarta.data.1.0_fat_tck/publish/tckRunner/platform/pom.xml
@@ -181,7 +181,6 @@
 					</excludes>
 					<groups>${included.groups}</groups>
 					<reportNameSuffix>${jakarta.profile}-${jakarta.tck.database.type}</reportNameSuffix>
-					<testSourceDirectory>${basedir}${file.separator}src${file.separator}main${file.separator}java${file.separator}</testSourceDirectory>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/dev/io.openliberty.jakarta.data.1.0_fat_tck/publish/tckRunner/platform/pom.xml
+++ b/dev/io.openliberty.jakarta.data.1.0_fat_tck/publish/tckRunner/platform/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- 
-	~ Copyright (c) 2022, 2025 IBM Corporation and others. All rights reserved. 
+	~ Copyright (c) 2022, 2026 IBM Corporation and others. All rights reserved. 
 	~ This program and the accompanying materials are made available under the 
 	~ terms of the Eclipse Public License 2.0 which accompanies this distribution, 
 	~ and is available at 
@@ -181,7 +181,7 @@
 					</excludes>
 					<groups>${included.groups}</groups>
 					<reportNameSuffix>${jakarta.profile}-${jakarta.tck.database.type}</reportNameSuffix>
-					<testSourceDirectory>${basedir}${file.separarator}src${file.separarator}main${file.separarator}java${file.separarator}</testSourceDirectory>
+					<testSourceDirectory>${basedir}${file.separator}src${file.separator}main${file.separator}java${file.separator}</testSourceDirectory>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/dev/io.openliberty.jakarta.data.1.0_fat_tck/publish/tckRunner/platform/verification.xml
+++ b/dev/io.openliberty.jakarta.data.1.0_fat_tck/publish/tckRunner/platform/verification.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- 
-	~ Copyright (c) 2022, 2024 IBM Corporation and others. All rights reserved. 
+	~ Copyright (c) 2022, 2026 IBM Corporation and others. All rights reserved. 
 	~ This program and the accompanying materials are made available under the 
 	~ terms of the Eclipse Public License 2.0 which accompanies this distribution, 
 	~ and is available at 
@@ -151,7 +151,7 @@
 					</systemPropertyVariables>
 					<groups><![CDATA[persistence & ${jakarta.tck.platform}]]></groups>
 					<reportNameSuffix>${jakarta.profile}-${jakarta.tck.database.type}</reportNameSuffix>
-					<testSourceDirectory>${basedir}${file.separarator}src${file.separarator}main${file.separarator}java${file.separarator}</testSourceDirectory>
+					<testSourceDirectory>${basedir}${file.separator}src${file.separator}main${file.separator}java${file.separator}</testSourceDirectory>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/dev/io.openliberty.jakarta.data.1.0_fat_tck/publish/tckRunner/standalone/pom.xml
+++ b/dev/io.openliberty.jakarta.data.1.0_fat_tck/publish/tckRunner/standalone/pom.xml
@@ -139,7 +139,6 @@
 					</excludes>
 					<groups>${included.groups}</groups>
 					<reportNameSuffix>${jakarta.profile}-${jakarta.tck.database.type}</reportNameSuffix>
-					<testSourceDirectory>${basedir}${file.separator}src${file.separator}main${file.separator}java${file.separator}</testSourceDirectory>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/dev/io.openliberty.jakarta.data.1.0_fat_tck/publish/tckRunner/standalone/pom.xml
+++ b/dev/io.openliberty.jakarta.data.1.0_fat_tck/publish/tckRunner/standalone/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- 
-	~ Copyright (c) 2022, 2025 IBM Corporation and others. All rights reserved. 
+	~ Copyright (c) 2022, 2026 IBM Corporation and others. All rights reserved. 
 	~ This program and the accompanying materials are made available under the 
 	~ terms of the Eclipse Public License 2.0 which accompanies this distribution, 
 	~ and is available at 
@@ -139,7 +139,7 @@
 					</excludes>
 					<groups>${included.groups}</groups>
 					<reportNameSuffix>${jakarta.profile}-${jakarta.tck.database.type}</reportNameSuffix>
-					<testSourceDirectory>${basedir}${file.separarator}src${file.separarator}main${file.separarator}java${file.separarator}</testSourceDirectory>
+					<testSourceDirectory>${basedir}${file.separator}src${file.separator}main${file.separator}java${file.separator}</testSourceDirectory>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/dev/io.openliberty.jakarta.data.1.1_fat_tck/publish/tckRunner/platform/pom.xml
+++ b/dev/io.openliberty.jakarta.data.1.1_fat_tck/publish/tckRunner/platform/pom.xml
@@ -181,7 +181,6 @@
 					</excludes>
 					<groups>${included.groups}</groups>
 					<reportNameSuffix>${jakarta.profile}-${jakarta.tck.database.type}</reportNameSuffix>
-					<testSourceDirectory>${basedir}${file.separator}src${file.separator}main${file.separator}java${file.separator}</testSourceDirectory>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/dev/io.openliberty.jakarta.data.1.1_fat_tck/publish/tckRunner/platform/pom.xml
+++ b/dev/io.openliberty.jakarta.data.1.1_fat_tck/publish/tckRunner/platform/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- 
-	~ Copyright (c) 2022, 2025 IBM Corporation and others. All rights reserved. 
+	~ Copyright (c) 2022, 2026 IBM Corporation and others. All rights reserved. 
 	~ This program and the accompanying materials are made available under the 
 	~ terms of the Eclipse Public License 2.0 which accompanies this distribution, 
 	~ and is available at 
@@ -181,7 +181,7 @@
 					</excludes>
 					<groups>${included.groups}</groups>
 					<reportNameSuffix>${jakarta.profile}-${jakarta.tck.database.type}</reportNameSuffix>
-					<testSourceDirectory>${basedir}${file.separarator}src${file.separarator}main${file.separarator}java${file.separarator}</testSourceDirectory>
+					<testSourceDirectory>${basedir}${file.separator}src${file.separator}main${file.separator}java${file.separator}</testSourceDirectory>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/dev/io.openliberty.jakarta.data.1.1_fat_tck/publish/tckRunner/platform/verification.xml
+++ b/dev/io.openliberty.jakarta.data.1.1_fat_tck/publish/tckRunner/platform/verification.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- 
-	~ Copyright (c) 2022, 2024 IBM Corporation and others. All rights reserved. 
+	~ Copyright (c) 2022, 2026 IBM Corporation and others. All rights reserved. 
 	~ This program and the accompanying materials are made available under the 
 	~ terms of the Eclipse Public License 2.0 which accompanies this distribution, 
 	~ and is available at 
@@ -151,7 +151,7 @@
 					</systemPropertyVariables>
 					<groups><![CDATA[persistence & ${jakarta.tck.platform}]]></groups>
 					<reportNameSuffix>${jakarta.profile}-${jakarta.tck.database.type}</reportNameSuffix>
-					<testSourceDirectory>${basedir}${file.separarator}src${file.separarator}main${file.separarator}java${file.separarator}</testSourceDirectory>
+					<testSourceDirectory>${basedir}${file.separator}src${file.separator}main${file.separator}java${file.separator}</testSourceDirectory>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/dev/io.openliberty.jakarta.data.1.1_fat_tck/publish/tckRunner/standalone/pom.xml
+++ b/dev/io.openliberty.jakarta.data.1.1_fat_tck/publish/tckRunner/standalone/pom.xml
@@ -140,7 +140,6 @@
 					</excludes>
 					<groups>${included.groups}</groups>
 					<reportNameSuffix>${jakarta.profile}-${jakarta.tck.database.type}</reportNameSuffix>
-					<testSourceDirectory>${basedir}${file.separator}src${file.separator}main${file.separator}java${file.separator}</testSourceDirectory>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/dev/io.openliberty.jakarta.data.1.1_fat_tck/publish/tckRunner/standalone/pom.xml
+++ b/dev/io.openliberty.jakarta.data.1.1_fat_tck/publish/tckRunner/standalone/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- 
-	~ Copyright (c) 2022, 2025 IBM Corporation and others. All rights reserved. 
+	~ Copyright (c) 2022, 2026 IBM Corporation and others. All rights reserved. 
 	~ This program and the accompanying materials are made available under the 
 	~ terms of the Eclipse Public License 2.0 which accompanies this distribution, 
 	~ and is available at 
@@ -140,7 +140,7 @@
 					</excludes>
 					<groups>${included.groups}</groups>
 					<reportNameSuffix>${jakarta.profile}-${jakarta.tck.database.type}</reportNameSuffix>
-					<testSourceDirectory>${basedir}${file.separarator}src${file.separarator}main${file.separarator}java${file.separarator}</testSourceDirectory>
+					<testSourceDirectory>${basedir}${file.separator}src${file.separator}main${file.separator}java${file.separator}</testSourceDirectory>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/dev/io.openliberty.jakarta.rest.3.1.internal_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.jakarta.rest.3.1.internal_fat_tck/publish/tckRunner/tck/pom.xml
@@ -446,7 +446,7 @@
                         <authuser>javajoe</authuser>
                         <authpassword>javajoe</authpassword>
                     </systemPropertyVariables>
-                    <testSourceDirectory>${basedir}${file.separarator}src${file.separarator}main${file.separarator}java${file.separarator}</testSourceDirectory>
+                    <testSourceDirectory>${basedir}${file.separator}src${file.separator}main${file.separator}java${file.separator}</testSourceDirectory>
                     <dependenciesToScan>
                          <dependency>io.openliberty.jakarta.ws.rs:jakarta-restful-ws-tck</dependency>   
                      </dependenciesToScan>

--- a/dev/io.openliberty.jakarta.rest.3.1.internal_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.jakarta.rest.3.1.internal_fat_tck/publish/tckRunner/tck/pom.xml
@@ -446,7 +446,6 @@
                         <authuser>javajoe</authuser>
                         <authpassword>javajoe</authpassword>
                     </systemPropertyVariables>
-                    <testSourceDirectory>${basedir}${file.separator}src${file.separator}main${file.separator}java${file.separator}</testSourceDirectory>
                     <dependenciesToScan>
                          <dependency>io.openliberty.jakarta.ws.rs:jakarta-restful-ws-tck</dependency>   
                      </dependenciesToScan>

--- a/dev/io.openliberty.jakarta.rest.4.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.jakarta.rest.4.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
@@ -420,7 +420,7 @@
                         <authuser>javajoe</authuser>
                         <authpassword>javajoe</authpassword>
                     </systemPropertyVariables>
-                    <testSourceDirectory>${basedir}${file.separarator}src${file.separarator}main${file.separarator}java${file.separarator}</testSourceDirectory>
+                    <testSourceDirectory>${basedir}${file.separator}src${file.separator}main${file.separator}java${file.separator}</testSourceDirectory>
                     <dependenciesToScan>
 						<dependency>jakarta.ws.rs:jakarta-restful-ws-tck</dependency>
  <!--                         <dependency>io.openliberty.jakarta.ws.rs:jakarta-restful-ws-tck</dependency>   -->

--- a/dev/io.openliberty.jakarta.rest.4.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.jakarta.rest.4.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
@@ -420,7 +420,6 @@
                         <authuser>javajoe</authuser>
                         <authpassword>javajoe</authpassword>
                     </systemPropertyVariables>
-                    <testSourceDirectory>${basedir}${file.separator}src${file.separator}main${file.separator}java${file.separator}</testSourceDirectory>
                     <dependenciesToScan>
 						<dependency>jakarta.ws.rs:jakarta-restful-ws-tck</dependency>
  <!--                         <dependency>io.openliberty.jakarta.ws.rs:jakarta-restful-ws-tck</dependency>   -->

--- a/dev/io.openliberty.jakarta.validation.3.1_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.jakarta.validation.3.1_fat_tck/publish/tckRunner/tck/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- 
-    Copyright (c) 2024, 2025 IBM Corporation and others. All rights reserved.
+    Copyright (c) 2024, 2026 IBM Corporation and others. All rights reserved.
     This program and the accompanying materials are made available under the 
     terms of the Eclipse Public License 2.0 which accompanies this distribution, 
     and is available at 
@@ -261,7 +261,7 @@
 					</excludes>
 					<reportNameSuffix>${jakarta.tck.platform}</reportNameSuffix>
 					<testSourceDirectory>
-						${basedir}${file.separarator}src${file.separarator}main${file.separarator}java${file.separarator}</testSourceDirectory>
+						${basedir}${file.separator}src${file.separator}main${file.separator}java${file.separator}</testSourceDirectory>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/dev/io.openliberty.microprofile.config.2.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.microprofile.config.2.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- 
-    Copyright (c) 2020, 2023 IBM Corporation and others. All rights reserved.
+    Copyright (c) 2020, 2026 IBM Corporation and others. All rights reserved.
     This program and the accompanying materials are made available under the 
     terms of the Eclipse Public License 2.0 which accompanies this distribution, 
     and is available at 
@@ -194,7 +194,7 @@
                     <suiteXmlFiles>
                         <suiteXmlFile>${suiteXmlFile}</suiteXmlFile>
                     </suiteXmlFiles>
-                    <testSourceDirectory>${basedir}${file.separarator}src${file.separarator}main${file.separarator}java${file.separarator}</testSourceDirectory>
+                    <testSourceDirectory>${basedir}${file.separator}src${file.separator}main${file.separator}java${file.separator}</testSourceDirectory>
                 </configuration>
             </plugin>
         </plugins>

--- a/dev/io.openliberty.microprofile.config.3.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.microprofile.config.3.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- 
-    Copyright (c) 2020, 2023 IBM Corporation and others. All rights reserved.
+    Copyright (c) 2020, 2026 IBM Corporation and others. All rights reserved.
     This program and the accompanying materials are made available under the 
     terms of the Eclipse Public License 2.0 which accompanies this distribution, 
     and is available at 
@@ -195,7 +195,7 @@
                     <suiteXmlFiles>
                         <suiteXmlFile>${suiteXmlFile}</suiteXmlFile>
                     </suiteXmlFiles>
-                    <testSourceDirectory>${basedir}${file.separarator}src${file.separarator}main${file.separarator}java${file.separarator}</testSourceDirectory>
+                    <testSourceDirectory>${basedir}${file.separator}src${file.separator}main${file.separator}java${file.separator}</testSourceDirectory>
                 </configuration>
             </plugin>
         </plugins>

--- a/dev/io.openliberty.microprofile.config.3.1.internal_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.microprofile.config.3.1.internal_fat_tck/publish/tckRunner/tck/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- 
-    Copyright (c) 2020, 2025 IBM Corporation and others. All rights reserved.
+    Copyright (c) 2020, 2026 IBM Corporation and others. All rights reserved.
     This program and the accompanying materials are made available under the 
     terms of the Eclipse Public License 2.0 which accompanies this distribution, 
     and is available at 
@@ -226,7 +226,7 @@
                     <suiteXmlFiles>
                         <suiteXmlFile>${suiteXmlFile}</suiteXmlFile>
                     </suiteXmlFiles>
-                    <testSourceDirectory>${basedir}${file.separarator}src${file.separarator}main${file.separarator}java${file.separarator}</testSourceDirectory>
+                    <testSourceDirectory>${basedir}${file.separator}src${file.separator}main${file.separator}java${file.separator}</testSourceDirectory>
                 </configuration>
             </plugin>
         </plugins>

--- a/dev/io.openliberty.microprofile.faulttolerance.3.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.microprofile.faulttolerance.3.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
@@ -166,7 +166,7 @@
                     <suiteXmlFiles>
                         <suiteXmlFile>${suiteXmlFile}</suiteXmlFile>
                     </suiteXmlFiles>
-                    <testSourceDirectory>${basedir}${file.separarator}src${file.separarator}main${file.separarator}java${file.separarator}</testSourceDirectory>
+                    <testSourceDirectory>${basedir}${file.separator}src${file.separator}main${file.separator}java${file.separator}</testSourceDirectory>
                 </configuration>
             </plugin>
         </plugins>

--- a/dev/io.openliberty.microprofile.faulttolerance.4.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.microprofile.faulttolerance.4.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
@@ -176,7 +176,7 @@
                     <suiteXmlFiles>
                         <suiteXmlFile>${suiteXmlFile}</suiteXmlFile>
                     </suiteXmlFiles>
-                    <testSourceDirectory>${basedir}${file.separarator}src${file.separarator}main${file.separarator}java${file.separarator}</testSourceDirectory>
+                    <testSourceDirectory>${basedir}${file.separator}src${file.separator}main${file.separator}java${file.separator}</testSourceDirectory>
                 </configuration>
             </plugin>
         </plugins>

--- a/dev/io.openliberty.microprofile.faulttolerance.4.1.internal_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.microprofile.faulttolerance.4.1.internal_fat_tck/publish/tckRunner/tck/pom.xml
@@ -176,7 +176,7 @@
                     <suiteXmlFiles>
                         <suiteXmlFile>${suiteXmlFile}</suiteXmlFile>
                     </suiteXmlFiles>
-                    <testSourceDirectory>${basedir}${file.separarator}src${file.separarator}main${file.separarator}java${file.separarator}</testSourceDirectory>
+                    <testSourceDirectory>${basedir}${file.separator}src${file.separator}main${file.separator}java${file.separator}</testSourceDirectory>
                 </configuration>
             </plugin>
         </plugins>

--- a/dev/io.openliberty.microprofile.graphql.2.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.microprofile.graphql.2.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2021, 2023 IBM Corporation and others. All rights reserved.
+    Copyright (c) 2021, 2026 IBM Corporation and others. All rights reserved.
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License 2.0 which accompanies this distribution,
     and is available at
@@ -216,7 +216,7 @@
                     <suiteXmlFiles>
                         <suiteXmlFile>${suiteXmlFile}</suiteXmlFile>
                     </suiteXmlFiles>
-                    <testSourceDirectory>${basedir}${file.separarator}src${file.separarator}main${file.separarator}java${file.separarator}</testSourceDirectory>
+                    <testSourceDirectory>${basedir}${file.separator}src${file.separator}main${file.separator}java${file.separator}</testSourceDirectory>
                 </configuration>
             </plugin>
         </plugins>

--- a/dev/io.openliberty.microprofile.health.3.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.microprofile.health.3.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- 
-    Copyright (c) 2020, 2023 IBM Corporation and others. All rights reserved.
+    Copyright (c) 2020, 2026 IBM Corporation and others. All rights reserved.
     This program and the accompanying materials are made available under the 
     terms of the Eclipse Public License 2.0 which accompanies this distribution, 
     and is available at 
@@ -203,7 +203,7 @@
                     <suiteXmlFiles>
                         <suiteXmlFile>${suiteXmlFile}</suiteXmlFile>
                     </suiteXmlFiles>
-                    <testSourceDirectory>${basedir}${file.separarator}src${file.separarator}main${file.separarator}java${file.separarator}</testSourceDirectory>
+                    <testSourceDirectory>${basedir}${file.separator}src${file.separator}main${file.separator}java${file.separator}</testSourceDirectory>
                 </configuration>
             </plugin>
         </plugins>

--- a/dev/io.openliberty.microprofile.health.3.1.internal_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.microprofile.health.3.1.internal_fat_tck/publish/tckRunner/tck/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- 
-    Copyright (c) 2020, 2023 IBM Corporation and others. All rights reserved.
+    Copyright (c) 2020, 2026 IBM Corporation and others. All rights reserved.
     This program and the accompanying materials are made available under the 
     terms of the Eclipse Public License 2.0 which accompanies this distribution, 
     and is available at 
@@ -203,7 +203,7 @@
                     <suiteXmlFiles>
                         <suiteXmlFile>${suiteXmlFile}</suiteXmlFile>
                     </suiteXmlFiles>
-                    <testSourceDirectory>${basedir}${file.separarator}src${file.separarator}main${file.separarator}java${file.separarator}</testSourceDirectory>
+                    <testSourceDirectory>${basedir}${file.separator}src${file.separator}main${file.separator}java${file.separator}</testSourceDirectory>
                 </configuration>
             </plugin>
         </plugins>

--- a/dev/io.openliberty.microprofile.health.4.0.internal.javax_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.microprofile.health.4.0.internal.javax_fat_tck/publish/tckRunner/tck/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- 
-    Copyright (c) 2025 IBM Corporation and others. All rights reserved.
+    Copyright (c) 2025, 2026 IBM Corporation and others. All rights reserved.
     This program and the accompanying materials are made available under the 
     terms of the Eclipse Public License 2.0 which accompanies this distribution, 
     and is available at 
@@ -208,7 +208,7 @@
                     <suiteXmlFiles>
                         <suiteXmlFile>${suiteXmlFile}</suiteXmlFile>
                     </suiteXmlFiles>
-                    <testSourceDirectory>${basedir}${file.separarator}src${file.separarator}main${file.separarator}java${file.separarator}</testSourceDirectory>
+                    <testSourceDirectory>${basedir}${file.separator}src${file.separator}main${file.separator}java${file.separator}</testSourceDirectory>
                 </configuration>
             </plugin>
         </plugins>

--- a/dev/io.openliberty.microprofile.health.4.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.microprofile.health.4.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- 
-    Copyright (c) 2021, 2023 IBM Corporation and others. All rights reserved.
+    Copyright (c) 2021, 2026 IBM Corporation and others. All rights reserved.
     This program and the accompanying materials are made available under the 
     terms of the Eclipse Public License 2.0 which accompanies this distribution, 
     and is available at 
@@ -203,7 +203,7 @@
                     <suiteXmlFiles>
                         <suiteXmlFile>${suiteXmlFile}</suiteXmlFile>
                     </suiteXmlFiles>
-                    <testSourceDirectory>${basedir}${file.separarator}src${file.separarator}main${file.separarator}java${file.separarator}</testSourceDirectory>
+                    <testSourceDirectory>${basedir}${file.separator}src${file.separator}main${file.separator}java${file.separator}</testSourceDirectory>
                 </configuration>
             </plugin>
         </plugins>

--- a/dev/io.openliberty.microprofile.jwt.1.2.internal_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.microprofile.jwt.1.2.internal_fat_tck/publish/tckRunner/tck/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- 
-    Copyright (c) 2020, 2023 IBM Corporation and others. All rights reserved.
+    Copyright (c) 2020, 2026 IBM Corporation and others. All rights reserved.
     This program and the accompanying materials are made available under the 
     terms of the Eclipse Public License 2.0 which accompanies this distribution, 
     and is available at 
@@ -208,7 +208,7 @@
                     <suiteXmlFiles>
                         <suiteXmlFile>${suiteXmlFile}</suiteXmlFile>
                     </suiteXmlFiles>
-                    <testSourceDirectory>${basedir}${file.separarator}src${file.separarator}main${file.separarator}java${file.separarator}</testSourceDirectory>
+                    <testSourceDirectory>${basedir}${file.separator}src${file.separator}main${file.separator}java${file.separator}</testSourceDirectory>
                 </configuration>
             </plugin>
         </plugins>

--- a/dev/io.openliberty.microprofile.jwt.2.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.microprofile.jwt.2.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- 
-    Copyright (c) 2021, 2023 IBM Corporation and others. All rights reserved.
+    Copyright (c) 2021, 2026 IBM Corporation and others. All rights reserved.
     This program and the accompanying materials are made available under the 
     terms of the Eclipse Public License 2.0 which accompanies this distribution, 
     and is available at 
@@ -279,7 +279,7 @@
                     <suiteXmlFiles>
                         <suiteXmlFile>${suiteXmlFile}</suiteXmlFile>
                     </suiteXmlFiles>
-                    <testSourceDirectory>${basedir}${file.separarator}src${file.separarator}main${file.separarator}java${file.separarator}</testSourceDirectory>
+                    <testSourceDirectory>${basedir}${file.separator}src${file.separator}main${file.separator}java${file.separator}</testSourceDirectory>
                 </configuration>
             </plugin>
         </plugins>

--- a/dev/io.openliberty.microprofile.jwt.2.1.internal_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.microprofile.jwt.2.1.internal_fat_tck/publish/tckRunner/tck/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- 
-    Copyright (c) 2022, 2023 IBM Corporation and others. All rights reserved.
+    Copyright (c) 2022, 2026 IBM Corporation and others. All rights reserved.
     This program and the accompanying materials are made available under the 
     terms of the Eclipse Public License 2.0 which accompanies this distribution, 
     and is available at 
@@ -281,7 +281,7 @@
                     <suiteXmlFiles>
                         <suiteXmlFile>${suiteXmlFile}</suiteXmlFile>
                     </suiteXmlFiles>
-                    <testSourceDirectory>${basedir}${file.separarator}src${file.separarator}main${file.separarator}java${file.separarator}</testSourceDirectory>
+                    <testSourceDirectory>${basedir}${file.separator}src${file.separator}main${file.separator}java${file.separator}</testSourceDirectory>
                 </configuration>
             </plugin>
         </plugins>

--- a/dev/io.openliberty.microprofile.opentracing.2.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.microprofile.opentracing.2.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Copyright (c) 2020, 2023 IBM Corporation and others. All rights reserved. 
+<!-- Copyright (c) 2020, 2026 IBM Corporation and others. All rights reserved. 
     This program and the accompanying materials are made available under the 
     terms of the Eclipse Public License 2.0 which accompanies this distribution, 
     and is available at http://www.eclipse.org/legal/epl-2.0/ Contributors: 
@@ -224,7 +224,7 @@
                     <suiteXmlFiles>
                         <suiteXmlFile>${suiteXmlFile}</suiteXmlFile>
                     </suiteXmlFiles>
-                    <testSourceDirectory>${basedir}${file.separarator}src${file.separarator}main${file.separarator}java${file.separarator}</testSourceDirectory>
+                    <testSourceDirectory>${basedir}${file.separator}src${file.separator}main${file.separator}java${file.separator}</testSourceDirectory>
                 </configuration>
             </plugin>
         </plugins>

--- a/dev/io.openliberty.microprofile.opentracing.3.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.microprofile.opentracing.3.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Copyright (c) 2020, 2023 IBM Corporation and others. All rights reserved. 
+<!-- Copyright (c) 2020, 2026 IBM Corporation and others. All rights reserved. 
     This program and the accompanying materials are made available under the 
     terms of the Eclipse Public License 2.0 which accompanies this distribution, 
     and is available at http://www.eclipse.org/legal/epl-2.0/ Contributors: 
@@ -286,7 +286,7 @@
                     <suiteXmlFiles>
                         <suiteXmlFile>${suiteXmlFile}</suiteXmlFile>
                     </suiteXmlFiles>
-                    <testSourceDirectory>${basedir}${file.separarator}src${file.separarator}main${file.separarator}java${file.separarator}</testSourceDirectory>
+                    <testSourceDirectory>${basedir}${file.separator}src${file.separator}main${file.separator}java${file.separator}</testSourceDirectory>
                 </configuration>
             </plugin>
         </plugins>

--- a/dev/io.openliberty.microprofile.reactive.messaging30.internal_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.microprofile.reactive.messaging30.internal_fat_tck/publish/tckRunner/tck/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2023, 2024 IBM Corporation and others.
+  ~ Copyright (c) 2023, 2026 IBM Corporation and others.
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License 2.0
   ~ which accompanies this distribution, and is available at
@@ -231,7 +231,7 @@
                         <tck_port>${tck_port}</tck_port>
                         <sun.rmi.transport.tcp.responseTimeout>${sun.rmi.transport.tcp.responseTimeout}</sun.rmi.transport.tcp.responseTimeout>
                     </systemPropertyVariables>
-                    <testSourceDirectory>${basedir}${file.separarator}src${file.separarator}main${file.separarator}java${file.separarator}</testSourceDirectory>
+                    <testSourceDirectory>${basedir}${file.separator}src${file.separator}main${file.separator}java${file.separator}</testSourceDirectory>
                     <dependenciesToScan>org.eclipse.microprofile.reactive.messaging:microprofile-reactive-messaging-tck</dependenciesToScan>
                 </configuration>
             </plugin>

--- a/dev/io.openliberty.microprofile.reactive.streams.operators30.internal_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.microprofile.reactive.streams.operators30.internal_fat_tck/publish/tckRunner/tck/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- 
-    Copyright (c) 2017, 2023 IBM Corporation and others. All rights reserved.
+    Copyright (c) 2017, 2026 IBM Corporation and others. All rights reserved.
     This program and the accompanying materials are made available under the 
     terms of the Eclipse Public License 2.0 which accompanies this distribution, 
     and is available at 
@@ -209,7 +209,7 @@
                     <suiteXmlFiles>
                         <suiteXmlFile>${suiteXmlFile}</suiteXmlFile>
                     </suiteXmlFiles>
-                    <testSourceDirectory>${basedir}${file.separarator}src${file.separarator}main${file.separarator}java${file.separarator}</testSourceDirectory>
+                    <testSourceDirectory>${basedir}${file.separator}src${file.separator}main${file.separator}java${file.separator}</testSourceDirectory>
                 </configuration>
             </plugin>
         </plugins>

--- a/dev/io.openliberty.microprofile.rest.client.2.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.microprofile.rest.client.2.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- 
-    Copyright (c) 2020, 2023 IBM Corporation and others. All rights reserved.
+    Copyright (c) 2020, 2026 IBM Corporation and others. All rights reserved.
     This program and the accompanying materials are made available under the 
     terms of the Eclipse Public License 2.0 which accompanies this distribution, 
     and is available at 
@@ -405,7 +405,7 @@
                         <suiteXmlFile>${suiteXmlFile}</suiteXmlFile>
                         <!-- <suiteXmlFile>tck-suite.xml</suiteXmlFile> -->
                     </suiteXmlFiles>
-                    <testSourceDirectory>${basedir}${file.separarator}src${file.separarator}main${file.separarator}java${file.separarator}</testSourceDirectory>
+                    <testSourceDirectory>${basedir}${file.separator}src${file.separator}main${file.separator}java${file.separator}</testSourceDirectory>
                 </configuration>
             </plugin>
             <plugin>

--- a/dev/io.openliberty.microprofile.rest.client.3.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.microprofile.rest.client.3.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- 
-    Copyright (c) 2021, 2023 IBM Corporation and others. All rights reserved.
+    Copyright (c) 2021, 2026 IBM Corporation and others. All rights reserved.
     This program and the accompanying materials are made available under the 
     terms of the Eclipse Public License 2.0 which accompanies this distribution, 
     and is available at 
@@ -393,7 +393,7 @@
                         <suiteXmlFile>${suiteXmlFile}</suiteXmlFile>
                         <!-- <suiteXmlFile>tck-suite.xml</suiteXmlFile> -->
                     </suiteXmlFiles>
-                    <testSourceDirectory>${basedir}${file.separarator}src${file.separarator}main${file.separarator}java${file.separarator}</testSourceDirectory>
+                    <testSourceDirectory>${basedir}${file.separator}src${file.separator}main${file.separator}java${file.separator}</testSourceDirectory>
                 </configuration>
             </plugin>
             <plugin>

--- a/dev/io.openliberty.microprofile.rest.client.4.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.microprofile.rest.client.4.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- 
-    Copyright (c) 2024,2026 IBM Corporation and others. All rights reserved.
+    Copyright (c) 2024, 2026 IBM Corporation and others. All rights reserved.
     This program and the accompanying materials are made available under the 
     terms of the Eclipse Public License 2.0 which accompanies this distribution, 
     and is available at 
@@ -415,7 +415,7 @@
                         <suiteXmlFile>${suiteXmlFile}</suiteXmlFile>
                         <!-- <suiteXmlFile>tck-suite.xml</suiteXmlFile> -->
                     </suiteXmlFiles>
-                    <testSourceDirectory>${basedir}${file.separarator}src${file.separarator}main${file.separarator}java${file.separarator}</testSourceDirectory>
+                    <testSourceDirectory>${basedir}${file.separator}src${file.separator}main${file.separator}java${file.separator}</testSourceDirectory>
                 </configuration>
             </plugin>
             <plugin>

--- a/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.microprofile.telemetry.1.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- 
-    Copyright (c) 2021, 2025 IBM Corporation and others. All rights reserved.
+    Copyright (c) 2021, 2026 IBM Corporation and others. All rights reserved.
     This program and the accompanying materials are made available under the 
     terms of the Eclipse Public License 2.0 which accompanies this distribution, 
     and is available at 
@@ -235,7 +235,7 @@
                     <suiteXmlFiles>
                         <suiteXmlFile>tck-suite.xml</suiteXmlFile>
                     </suiteXmlFiles>
-                    <testSourceDirectory>${basedir}${file.separarator}src${file.separarator}main${file.separarator}java${file.separarator}</testSourceDirectory>
+                    <testSourceDirectory>${basedir}${file.separator}src${file.separator}main${file.separator}java${file.separator}</testSourceDirectory>
                 </configuration>
             </plugin>
         </plugins>

--- a/dev/io.openliberty.microprofile.telemetry.1.1.internal_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.microprofile.telemetry.1.1.internal_fat_tck/publish/tckRunner/tck/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- 
-    Copyright (c) 2023, 2025 IBM Corporation and others. All rights reserved.
+    Copyright (c) 2023, 2026 IBM Corporation and others. All rights reserved.
     This program and the accompanying materials are made available under the 
     terms of the Eclipse Public License 2.0 which accompanies this distribution, 
     and is available at 
@@ -235,7 +235,7 @@
                     <suiteXmlFiles>
                         <suiteXmlFile>tck-suite.xml</suiteXmlFile>
                     </suiteXmlFiles>
-                    <testSourceDirectory>${basedir}${file.separarator}src${file.separarator}main${file.separarator}java${file.separarator}</testSourceDirectory>
+                    <testSourceDirectory>${basedir}${file.separator}src${file.separator}main${file.separator}java${file.separator}</testSourceDirectory>
                 </configuration>
             </plugin>
         </plugins>

--- a/dev/io.openliberty.microprofile.telemetry.2.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.microprofile.telemetry.2.0.internal_fat_tck/publish/tckRunner/tck/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- 
-    Copyright (c) 2023, 2025 IBM Corporation and others. All rights reserved.
+    Copyright (c) 2023, 2026 IBM Corporation and others. All rights reserved.
     This program and the accompanying materials are made available under the 
     terms of the Eclipse Public License 2.0 which accompanies this distribution, 
     and is available at 
@@ -245,7 +245,7 @@
                     <suiteXmlFiles>
                         <suiteXmlFile>${suiteXmlFile}</suiteXmlFile>
                     </suiteXmlFiles>
-                    <testSourceDirectory>${basedir}${file.separarator}src${file.separarator}main${file.separarator}java${file.separarator}</testSourceDirectory>
+                    <testSourceDirectory>${basedir}${file.separator}src${file.separator}main${file.separator}java${file.separator}</testSourceDirectory>
                 </configuration>
             </plugin>
         </plugins>

--- a/dev/io.openliberty.microprofile.telemetry.2.1.internal_fat_tck/publish/tckRunner/tck/pom.xml
+++ b/dev/io.openliberty.microprofile.telemetry.2.1.internal_fat_tck/publish/tckRunner/tck/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- 
-    Copyright (c) 2023, 2025 IBM Corporation and others. All rights reserved.
+    Copyright (c) 2023, 2026 IBM Corporation and others. All rights reserved.
     This program and the accompanying materials are made available under the 
     terms of the Eclipse Public License 2.0 which accompanies this distribution, 
     and is available at 
@@ -245,7 +245,7 @@
                     <suiteXmlFiles>
                         <suiteXmlFile>${suiteXmlFile}</suiteXmlFile>
                     </suiteXmlFiles>
-                    <testSourceDirectory>${basedir}${file.separarator}src${file.separarator}main${file.separarator}java${file.separarator}</testSourceDirectory>
+                    <testSourceDirectory>${basedir}${file.separator}src${file.separator}main${file.separator}java${file.separator}</testSourceDirectory>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

- fix typo in tck runner pom.xmls
- remove typo in tck runner pom.xmls that are using junit instead of testng. 