### PR TITLE
Lock thread interrupted

### DIFF
--- a/dev/com.ibm.ws.concurrent_fat_jakarta_12/test-applications/Concurrency32CDITestWeb/src/test/jakarta/concurrency32cdi/web/Concurrency32CDITestServlet.java
+++ b/dev/com.ibm.ws.concurrent_fat_jakarta_12/test-applications/Concurrency32CDITestWeb/src/test/jakarta/concurrency32cdi/web/Concurrency32CDITestServlet.java
@@ -108,6 +108,61 @@ public class Concurrency32CDITestServlet extends FATServlet {
     }
 
     /**
+     * Tests the current thread being interrupted while waiting for a lock
+     */
+    @Test
+    public void testInterruptedDuringBeanMethod() throws Exception {
+        try {
+            writeLockBean.interruptSelf();
+            fail("Bean method should raise InterruptedException.");
+        } catch (InterruptedException x) {
+            // expected
+        }
+    }
+
+    /**
+     * Tests the current thread being interrupted while waiting for a lock
+     */
+    @Test
+    public void testInterruptedWhileAttemptingLock() throws Exception {
+        Thread currentThread = Thread.currentThread();
+
+        // thread2 acquires the WRITE lock and repeatedly interrupts the current thread
+        CountDownLatch running = new CountDownLatch(1);
+        CountDownLatch doneInterrupting = new CountDownLatch(1);
+        Future<?> thread2Future = testThreads.submit(() -> writeLockBean //
+                        .interruptRepeatedly(currentThread,
+                                             running,
+                                             doneInterrupting));
+        cancelAfterTest.add(thread2Future);
+        running.await(TIMEOUT_NS, TimeUnit.NANOSECONDS);
+
+        // current thread attempts to acquire the WRITE lock while thread2 holds it;
+        // the repeated interrupts must cause this to raise InterruptedException
+        try {
+            writeLockBean.blockingWriteNumber(22);
+            fail("Expected InterruptedException while waiting for the WRITE lock.");
+        } catch (IllegalStateException x) {
+            if (x.getCause() instanceof InterruptedException)
+                ; // expected
+            else
+                throw x;
+        }
+
+        // cancel and wait for thread 2 to stop interrupting
+        thread2Future.cancel(true);
+        for (boolean thread2Done = false; !thread2Done;)
+            try {
+                assertEquals(true,
+                             thread2Done = doneInterrupting //
+                                             .await(TIMEOUT_NS,
+                                                    TimeUnit.NANOSECONDS));
+            } catch (InterruptedException x) {
+                thread2Done = false;
+            }
+    }
+
+    /**
      * Confirm that a java:comp lookup can be successfully performed from a
      * scheduled task.
      */

--- a/dev/com.ibm.ws.concurrent_fat_jakarta_12/test-applications/Concurrency32CDITestWeb/src/test/jakarta/concurrency32cdi/web/ReadLockBean.java
+++ b/dev/com.ibm.ws.concurrent_fat_jakarta_12/test-applications/Concurrency32CDITestWeb/src/test/jakarta/concurrency32cdi/web/ReadLockBean.java
@@ -47,10 +47,10 @@ public class ReadLockBean {
         value = newValue;
     }
 
-    public String delayedReadValue(CountDownLatch methodisRunning,
+    public String delayedReadValue(CountDownLatch methodIsRunning,
                                    CountDownLatch delayer) //
                     throws InterruptedException, TimeoutException {
-        methodisRunning.countDown();
+        methodIsRunning.countDown();
         if (delayer.await(MAX_DELAY_MS, TimeUnit.MILLISECONDS))
             return value;
         else
@@ -59,11 +59,11 @@ public class ReadLockBean {
 
     @Lock(type = Lock.Type.WRITE,
           accessTimeout = Lock.IMMEDIATE)
-    public void delayedWriteValue(CountDownLatch methodisRunning,
+    public void delayedWriteValue(CountDownLatch methodIsRunning,
                                   CountDownLatch delayer,
                                   String newValue) //
                     throws InterruptedException, TimeoutException {
-        methodisRunning.countDown();
+        methodIsRunning.countDown();
         if (delayer.await(MAX_DELAY_MS, TimeUnit.MILLISECONDS))
             value = newValue;
         else

--- a/dev/com.ibm.ws.concurrent_fat_jakarta_12/test-applications/Concurrency32CDITestWeb/src/test/jakarta/concurrency32cdi/web/WriteLockBean.java
+++ b/dev/com.ibm.ws.concurrent_fat_jakarta_12/test-applications/Concurrency32CDITestWeb/src/test/jakarta/concurrency32cdi/web/WriteLockBean.java
@@ -47,10 +47,10 @@ public class WriteLockBean {
 
     @Lock(type = Lock.Type.READ,
           accessTimeout = Lock.IMMEDIATE)
-    public int delayedReadNumber(CountDownLatch methodisRunning,
+    public int delayedReadNumber(CountDownLatch methodIsRunning,
                                  CountDownLatch delayer) //
                     throws InterruptedException, TimeoutException {
-        methodisRunning.countDown();
+        methodIsRunning.countDown();
         if (delayer.await(MAX_DELAY_MS, TimeUnit.MILLISECONDS))
             return number;
         else
@@ -59,11 +59,11 @@ public class WriteLockBean {
 
     @Lock(type = Lock.Type.WRITE,
           accessTimeout = Lock.IMMEDIATE)
-    public boolean delayedWriteNumber(CountDownLatch methodisRunning,
+    public boolean delayedWriteNumber(CountDownLatch methodIsRunning,
                                       CountDownLatch delayer,
                                       int newNumber) //
                     throws InterruptedException, TimeoutException {
-        methodisRunning.countDown();
+        methodIsRunning.countDown();
         if (delayer.await(MAX_DELAY_MS, TimeUnit.MILLISECONDS)) {
             number = newNumber;
             return true;
@@ -74,9 +74,9 @@ public class WriteLockBean {
 
     // type defaults to WRITE
     public void interruptRepeatedly(Thread threadToInterrupt,
-                                    CountDownLatch methodisRunning,
+                                    CountDownLatch methodIsRunning,
                                     CountDownLatch doneInterrupting) {
-        methodisRunning.countDown();
+        methodIsRunning.countDown();
         while (!Thread.interrupted()) {
             try {
                 TimeUnit.MILLISECONDS.sleep(200);

--- a/dev/com.ibm.ws.concurrent_fat_jakarta_12/test-applications/Concurrency32CDITestWeb/src/test/jakarta/concurrency32cdi/web/WriteLockBean.java
+++ b/dev/com.ibm.ws.concurrent_fat_jakarta_12/test-applications/Concurrency32CDITestWeb/src/test/jakarta/concurrency32cdi/web/WriteLockBean.java
@@ -72,6 +72,30 @@ public class WriteLockBean {
         }
     }
 
+    // type defaults to WRITE
+    public void interruptRepeatedly(Thread threadToInterrupt,
+                                    CountDownLatch methodisRunning,
+                                    CountDownLatch doneInterrupting) {
+        methodisRunning.countDown();
+        while (!Thread.interrupted()) {
+            try {
+                TimeUnit.MILLISECONDS.sleep(200);
+            } catch (InterruptedException x) {
+                break;
+            }
+            threadToInterrupt.interrupt();
+        }
+        doneInterrupting.countDown();
+    }
+
+    @Lock(type = Lock.Type.WRITE,
+          accessTimeout = 7L,
+          unit = TimeUnit.DAYS)
+    public void interruptSelf() throws InterruptedException {
+        Thread.currentThread().interrupt();
+        Thread.sleep(1000); // cause InterruptedException to be raised
+    }
+
     @Lock(type = Lock.Type.READ,
           accessTimeout = 100L,
           unit = TimeUnit.MILLISECONDS)

--- a/dev/io.openliberty.concurrent.internal.cdi/src/io/openliberty/concurrent/internal/cdi/interceptor/LockInterceptor.java
+++ b/dev/io.openliberty.concurrent.internal.cdi/src/io/openliberty/concurrent/internal/cdi/interceptor/LockInterceptor.java
@@ -110,7 +110,10 @@ public class LockInterceptor implements Serializable {
     locks = new ConcurrentHashMap<>();
 
     @AroundInvoke
-    @FFDCIgnore({ Error.class, Exception.class }) // raised by user's @Lock method
+    @FFDCIgnore({
+                  Error.class, Exception.class, // raised by user's @Lock method
+                  InterruptedException.class, // interrupted while awaiting Lock
+    })
     @Trivial
     public Object intercept(InvocationContext invocation) throws Exception {
         Method method = invocation.getMethod();
@@ -170,6 +173,17 @@ public class LockInterceptor implements Serializable {
             if (trace && tc.isEntryEnabled())
                 Tr.exit(this, tc, "invoke " + method.getName(), result);
             return result;
+        } catch (InterruptedException x) {
+            if (trace && tc.isEntryEnabled())
+                Tr.exit(this, tc, "invoke " + method.getName(), x);
+            Thread.currentThread().interrupt(); // restore interrupted status
+            for (Class<?> c : invocation.getMethod().getExceptionTypes())
+                if (c.isInstance(x))
+                    throw x;
+            String message = acquired //
+                            ? x.toString() //
+                            : "Interrupted while waiting for lock"; // TODO NLS
+            throw new IllegalStateException(message, x);
         } catch (Exception x) {
             if (trace && tc.isEntryEnabled())
                 Tr.exit(this, tc, "invoke " + method.getName(), x);


### PR DESCRIPTION
A Lock method can be interrupted while waiting to obtain a lock, or it can be interrupted while the method is running. If the bean method that is annotated Lock also declares that it raises InterruptedException then an interrupted exception can be surfaced directly to the invoker.  Otherwise, raise an IllegalStateException with InterruptedException as its cause.  This PR covers both of these scenarios and adds automated test.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
