### PR TITLE
Fix JAXRS20CallBackTest SRVE9017E log-scan failure

### DIFF
--- a/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/JAXRS20CallBackTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/JAXRS20CallBackTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2025 IBM Corporation and others.
+ * Copyright (c) 2019, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/JAXRS20CallBackTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.0_fat/fat/src/com/ibm/ws/jaxrs20/fat/JAXRS20CallBackTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2021 IBM Corporation and others.
+ * Copyright (c) 2019, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -69,7 +69,10 @@ public class JAXRS20CallBackTest {
     @AfterClass
     public static void tearDown() throws Exception {
         if (server != null) {
-            server.stopServer();
+            // SRVE9017E is expected: the test intentionally resumes an AsyncResponse with
+            // an ExceptionThrowingStringBean whose writeTo() throws RuntimeException(IOException),
+            // causing WCOutputStream31 to log SRVE9017E when the stream is closed mid-write.
+            server.stopServer("SRVE9017E");
         }
     }
 


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [ ] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

---

**Type of change:** Test bug fix

## Summary

`JAXRS20CallBackTest.tearDown()` was failing during server shutdown because `stopServer()` found `SRVE9017E` in `messages.log` and treated it as an unexpected error.

## Root Cause

`testargumentContainsExceptionWhenSendingIoException` intentionally resumes an `AsyncResponse` with an `ExceptionThrowingStringBean` whose `writeTo()` throws `RuntimeException(IOException)`. This causes `WCOutputStream31` to log `SRVE9017E` ("stream has been closed") — this is the **expected** behaviour being tested (verifying that the `CompletionCallback` receives the exception). The error was always there but was not in the `stopServer()` allowlist.

## Changes

- `JAXRS20CallBackTest.java` — add `"SRVE9017E"` to `stopServer()` allowlist with explanatory comment; update copyright year.