### PR TITLE
Update JNDI decode issue when plain text values are specfied and decode=true

### DIFF
--- a/dev/com.ibm.ws.jndi/src/com/ibm/ws/jndi/internal/JNDIEntry.java
+++ b/dev/com.ibm.ws.jndi/src/com/ibm/ws/jndi/internal/JNDIEntry.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012 IBM Corporation and others.
+ * Copyright (c) 2012, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -69,15 +69,7 @@ public class JNDIEntry {
             }
             return;
         }
-        String value = originalValue;
-        if (decode) {
-            try {
-                value = PasswordUtil.decode(originalValue);
-            } catch (Exception e) {
-                Tr.error(tc, "jndi.decode.failed", originalValue, e);
-            }
-        }
-        Object parsedValue = LiteralParser.parse(value);
+        Object parsedValue = parseLiteral(originalValue, decode);
         String valueClassName = parsedValue.getClass().getName();
         final Object serviceObject = decode ? new Decode(originalValue) : parsedValue;
         Dictionary<String, Object> propertiesForJndiService = new Hashtable<>();
@@ -86,6 +78,23 @@ public class JNDIEntry {
             Tr.debug(tc, "Registering JNDIEntry " + valueClassName + " with value " + parsedValue + " and JNDI name " + jndiName);
         }
         this.serviceRegistration = context.registerService(valueClassName, serviceObject, propertiesForJndiService);
+    }
+
+    /**
+     * @param val the value to parse
+     * @param decode if true, val is decoded if it's encrypted, otherwise val is parsed directly.
+     * @return the parsed literal value
+     */
+    static Object parseLiteral(String val, boolean decode) {
+        String decodedVal = val;
+        if (decode && PasswordUtil.isEncrypted(val)) {
+            try {
+                decodedVal = PasswordUtil.decode(val);
+            } catch (Exception e) {
+                Tr.error(tc, "jndi.decode.failed", val, e);
+            }
+        }
+        return LiteralParser.parse(decodedVal);
     }
 
     /**
@@ -116,14 +125,7 @@ public class JNDIEntry {
 
         @Override
         public Object getService(Bundle bundle, ServiceRegistration<Object> registration) {
-            try {
-                String decodedValue = PasswordUtil.decode(value);
-                Object parsedValue = LiteralParser.parse(decodedValue);
-                return parsedValue;
-            } catch (Exception e) {
-                Tr.error(tc, "jndi.decode.failed", value, e);
-            }
-            return value;
+            return parseLiteral(value, true);
         }
 
         @Override

--- a/dev/com.ibm.ws.jndi/src/com/ibm/ws/jndi/internal/JNDIEntry.java
+++ b/dev/com.ibm.ws.jndi/src/com/ibm/ws/jndi/internal/JNDIEntry.java
@@ -70,7 +70,7 @@ public class JNDIEntry {
             return;
         }
         String value = originalValue;
-        if (decode) {
+        if (decode && PasswordUtil.isEncrypted(originalValue)) {
             try {
                 value = PasswordUtil.decode(originalValue);
             } catch (Exception e) {
@@ -116,12 +116,14 @@ public class JNDIEntry {
 
         @Override
         public Object getService(Bundle bundle, ServiceRegistration<Object> registration) {
-            try {
-                String decodedValue = PasswordUtil.decode(value);
-                Object parsedValue = LiteralParser.parse(decodedValue);
-                return parsedValue;
-            } catch (Exception e) {
-                Tr.error(tc, "jndi.decode.failed", value, e);
+            if (PasswordUtil.isEncrypted(value)) {
+                try {
+                    String decodedValue = PasswordUtil.decode(value);
+                    Object parsedValue = LiteralParser.parse(decodedValue);
+                    return parsedValue;
+                } catch (Exception e) {
+                    Tr.error(tc, "jndi.decode.failed", value, e);
+                }
             }
             return value;
         }

--- a/dev/com.ibm.ws.jndi/src/com/ibm/ws/jndi/internal/JNDIEntry.java
+++ b/dev/com.ibm.ws.jndi/src/com/ibm/ws/jndi/internal/JNDIEntry.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012 IBM Corporation and others.
+* Copyright (c) 2012, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -69,15 +69,7 @@ public class JNDIEntry {
             }
             return;
         }
-        String value = originalValue;
-        if (decode && PasswordUtil.isEncrypted(originalValue)) {
-            try {
-                value = PasswordUtil.decode(originalValue);
-            } catch (Exception e) {
-                Tr.error(tc, "jndi.decode.failed", originalValue, e);
-            }
-        }
-        Object parsedValue = LiteralParser.parse(value);
+        Object parsedValue = parseLiteral(originalValue, decode);
         String valueClassName = parsedValue.getClass().getName();
         final Object serviceObject = decode ? new Decode(originalValue) : parsedValue;
         Dictionary<String, Object> propertiesForJndiService = new Hashtable<>();
@@ -87,6 +79,23 @@ public class JNDIEntry {
         }
         this.serviceRegistration = context.registerService(valueClassName, serviceObject, propertiesForJndiService);
     }
+
+	/**
+	 * @param val the value to parse
+	 * @param decode if true, val is decoded if it's encrypted, otherwise val is parsed directly.
+	 * @return
+	 */
+	private static Object parseLiteral(String val, boolean decode) {
+		String decodedVal = val;
+        if (decode && PasswordUtil.isEncrypted(val)) {
+            try {
+                decodedVal = PasswordUtil.decode(val);
+            } catch (Exception e) {
+                Tr.error(tc, "jndi.decode.failed", val, e);
+            }
+        }
+        return LiteralParser.parse(decodedVal);
+	}
 
     /**
      * Unregisters a service if one was registered
@@ -116,16 +125,7 @@ public class JNDIEntry {
 
         @Override
         public Object getService(Bundle bundle, ServiceRegistration<Object> registration) {
-            if (PasswordUtil.isEncrypted(value)) {
-                try {
-                    String decodedValue = PasswordUtil.decode(value);
-                    Object parsedValue = LiteralParser.parse(decodedValue);
-                    return parsedValue;
-                } catch (Exception e) {
-                    Tr.error(tc, "jndi.decode.failed", value, e);
-                }
-            }
-            return value;
+        		return parseLiteral(value, true);
         }
 
         @Override

--- a/dev/com.ibm.ws.jndi/test/com/ibm/ws/jndi/internal/JNDIEntryTest.java
+++ b/dev/com.ibm.ws.jndi/test/com/ibm/ws/jndi/internal/JNDIEntryTest.java
@@ -1,0 +1,104 @@
+package com.ibm.ws.jndi.internal;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+import com.ibm.websphere.crypto.PasswordUtil;
+
+import test.common.SharedOutputManager;
+
+public class JNDIEntryTest {
+
+    private static final String DOUBLE_LITERAL = "1.1D";
+
+    @Rule
+    public SharedOutputManager outputMgr = SharedOutputManager.getInstance().trace("*=all");
+
+    /**
+     * Test 1: value is encrypted, decode=true
+     * Expected: value is decrypted and returned as a Double; CWWKN0011E is NOT logged.
+     */
+    @Test
+    public void testEncryptedValue_DecodeTrue() throws Exception {
+        double expected = Double.parseDouble(DOUBLE_LITERAL);
+        String encrypted = PasswordUtil.encode(DOUBLE_LITERAL, "xor");
+
+        Object result = JNDIEntry.parseLiteral(encrypted, true);
+
+        assertEquals("Expected Double type", Double.class, result.getClass());
+        assertEquals(expected, (Double) result, 0.0);
+        assertFalse("CWWKN0011E should not be logged because decryption succeeded",
+                outputMgr.checkForStandardErr("CWWKN0011E"));
+    }
+
+    /**
+     * Test 2: value is NOT encrypted, decode=true
+     * Expected: decryption step is skipped (value is not encrypted), parsed Double is returned;
+     * CWWKN0011E is NOT logged.
+     */
+    @Test
+    public void testUnencryptedValue_DecodeTrue() throws Exception {
+        double expected = Double.parseDouble(DOUBLE_LITERAL);
+
+        Object result = JNDIEntry.parseLiteral(DOUBLE_LITERAL, true);
+
+        assertEquals("Expected Double type", Double.class, result.getClass());
+        assertEquals(expected, (Double) result, 0.0);
+        assertFalse("CWWKN0011E should not be logged when value is not encrypted",
+                outputMgr.checkForStandardErr("CWWKN0011E"));
+    }
+
+    /**
+     * Test 3: value is encrypted, decode=false
+     * Expected: value is NOT decoded; the raw encrypted String is returned as-is;
+     * CWWKN0011E is NOT logged.
+     */
+    @Test
+    public void testEncryptedValue_DecodeFalse() throws Exception {
+        String encrypted = PasswordUtil.encode(DOUBLE_LITERAL, "xor");
+
+        Object result = JNDIEntry.parseLiteral(encrypted, false);
+
+        assertEquals("Expected String type", String.class, result.getClass());
+        assertEquals(encrypted, result);
+        assertFalse("CWWKN0011E should not be logged when decode=false",
+                outputMgr.checkForStandardErr("CWWKN0011E"));
+    }
+
+    /**
+     * Test 4: value is NOT encrypted, decode=false
+     * Expected: value is parsed normally and returned as a Double; CWWKN0011E is NOT logged.
+     */
+    @Test
+    public void testUnencryptedValue_DecodeFalse() throws Exception {
+        double expected = Double.parseDouble(DOUBLE_LITERAL);
+
+        Object result = JNDIEntry.parseLiteral(DOUBLE_LITERAL, false);
+
+        assertEquals("Expected Double type", Double.class, result.getClass());
+        assertEquals(expected, (Double) result, 0.0);
+        assertFalse("CWWKN0011E should not be logged when value is not encrypted",
+                outputMgr.checkForStandardErr("CWWKN0011E"));
+    }
+
+    /**
+     * Test 5: value appears encrypted but the payload is corrupt, decode=true
+     * Expected: the raw (undecoded) String is returned as a fallback;
+     * CWWKN0011E IS logged to signal the decryption failure.
+     */
+    @Test
+    public void testEncryptedValue_DecodeTrue_DecodeFails() throws Exception {
+        String corrupt = "{aes}notAesEncoded";
+
+        Object result = JNDIEntry.parseLiteral(corrupt, true);
+
+        assertEquals("Expected String type", String.class, result.getClass());
+        assertEquals(corrupt, result);
+        assertTrue("CWWKN0011E should be logged because decryption failed",
+                outputMgr.checkForStandardErr("CWWKN0011E"));
+    }
+}


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

################################################################################################

When decode="true" is set on a jndiEntry, Liberty was attempting to decode the value without checking if it was actually encrypted first. 
################################################################################################
