### PR TITLE
Fix failure to commit wok on kafka shutdown.

### DIFF
--- a/dev/com.ibm.ws.microprofile.reactive.messaging.kafka.adapter.impl/src/com/ibm/ws/microprofile/reactive/messaging/kafka/adapter/impl/KafkaConsumerImpl.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging.kafka.adapter.impl/src/com/ibm/ws/microprofile/reactive/messaging/kafka/adapter/impl/KafkaConsumerImpl.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2020 IBM Corporation and others.
+ * Copyright (c) 2019, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -96,6 +96,18 @@ public class KafkaConsumerImpl<K, V> extends AbstractKafkaAdapter<org.apache.kaf
         }
         ConsumerRecords<K, V> records = new ConsumerRecordsImpl<>(delegateRecords);
         return records;
+    }
+
+    /**
+     * @param offsets
+     */
+    @Override
+    public void commitSync(Map<TopicPartition, OffsetAndMetadata> offsets) {
+        if (LOGGER.isLoggable(Level.FINEST)) {
+            LOGGER.logp(Level.FINEST, CLAZZ, "commitSync", "Offsets: {0}", offsets);
+        }
+        Map<org.apache.kafka.common.TopicPartition, org.apache.kafka.clients.consumer.OffsetAndMetadata> delegateOffsets = unwrap(offsets);
+        this.getDelegate().commitSync(delegateOffsets);
     }
 
     /**

--- a/dev/com.ibm.ws.microprofile.reactive.messaging.kafka.adapter/src/com/ibm/ws/microprofile/reactive/messaging/kafka/adapter/KafkaConsumer.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging.kafka.adapter/src/com/ibm/ws/microprofile/reactive/messaging/kafka/adapter/KafkaConsumer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2020 IBM Corporation and others.
+ * Copyright (c) 2019, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -53,6 +53,13 @@ public interface KafkaConsumer<K, V> extends KafkaAdapter {
      * @param object
      */
     void commitAsync(Map<TopicPartition, OffsetAndMetadata> offsets, OffsetCommitCallback callback);
+
+    /**
+     * Synchronously commit the specified offsets. Blocks until the broker acknowledges the commit or throws.
+     *
+     * @param offsets the offsets to commit
+     */
+    void commitSync(Map<TopicPartition, OffsetAndMetadata> offsets);
 
     long position(TopicPartition partition);
 

--- a/dev/com.ibm.ws.microprofile.reactive.messaging.kafka/src/com/ibm/ws/microprofile/reactive/messaging/kafka/CommittingPartitionTracker.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging.kafka/src/com/ibm/ws/microprofile/reactive/messaging/kafka/CommittingPartitionTracker.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2020, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -158,7 +158,7 @@ public class CommittingPartitionTracker extends PartitionTracker {
                 pendingCommitTask.cancel(true);
             }
             // commit now
-            commitCompletedWork();
+            commitCompletedWork(false);
         } else {
             if ((pendingCommitTask == null) && !maxCommitBatchInterval.isZero()) {
                 // commit later
@@ -166,7 +166,7 @@ public class CommittingPartitionTracker extends PartitionTracker {
                     Tr.debug(this, tc, "Scheduling deferred commit task", this);
                 }
                 pendingCommitTask = asyncProvider.getScheduledExecutorService()
-                                                 .schedule(this::commitCompletedWork, maxCommitBatchInterval.toNanos(), TimeUnit.NANOSECONDS);
+                                                 .schedule(() -> commitCompletedWork(false), maxCommitBatchInterval.toNanos(), TimeUnit.NANOSECONDS);
             }
         }
     }
@@ -177,7 +177,7 @@ public class CommittingPartitionTracker extends PartitionTracker {
      * We can only commit the offset for a record if all prior records are complete. This method looks through the committed work to see which messages can be committed without
      * leaving a gap and then commits them.
      */
-    private void commitCompletedWork() {
+    private void commitCompletedWork(boolean waitForCommit) {
         synchronized (completedWork) {
             if (Thread.interrupted()) {
                 // Don't do anything if we were cancelled
@@ -209,14 +209,20 @@ public class CommittingPartitionTracker extends PartitionTracker {
             }
 
             if (newestWork != null) {
-                // commit
                 long originalCommitOffset = committedOffset;
                 long finalCommitOffset = newCommitOffset;
 
                 if (TraceComponent.isAnyTracingEnabled() && tc.isEventEnabled()) {
                     Tr.event(this, tc, "Committing from " + originalCommitOffset + " to " + finalCommitOffset, this);
                 }
-                commitUpTo(newestWork).whenCompleteAsync((r, t) -> processCommittedWork(originalCommitOffset, finalCommitOffset, t), asyncProvider.getExecutorService());
+                if (waitForCommit) {
+                    Throwable commitException = commitUpToSync(newestWork);
+                    processCommittedWork(originalCommitOffset, finalCommitOffset, commitException);
+                } else {
+                    commitUpTo(newestWork).whenCompleteAsync((r, t) -> processCommittedWork(originalCommitOffset, finalCommitOffset, t), asyncProvider.getExecutorService());
+                }
+            } else if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                Tr.debug(this, tc, "There was no new work to commit");
             }
 
             outstandingUncommittedWork -= newCommitOffset - committedOffset;
@@ -226,7 +232,7 @@ public class CommittingPartitionTracker extends PartitionTracker {
     }
 
     /**
-     * Commit the offset up to the offset of the given work
+     * Commit the offset up to the offset of the given work asynchronously
      *
      * @param work
      * @return completion stage which completes with the result of the commit, or completes exceptionally if the commit failed
@@ -238,6 +244,24 @@ public class CommittingPartitionTracker extends PartitionTracker {
         // Therefore, the offset which we are about to commit must be the offset _after_ the last message we have processed.
         OffsetAndMetadata offsetAndMetadata = factory.newOffsetAndMetadata(work.offset + 1, work.leaderEpoch, null);
         return kafkaInput.commitOffsets(this, offsetAndMetadata);
+    }
+
+    /**
+     * Commit the offset up to the offset of the given work synchronously.
+     * <p>
+     * Blocks until the broker acknowledges the commit. Intended for use during shutdown only.
+     *
+     * @param work the work whose offset (+ 1) should be committed
+     * @return {@code null} on success, or the exception if the commit failed
+     */
+    private Throwable commitUpToSync(CompletedWork work) {
+        OffsetAndMetadata offsetAndMetadata = factory.newOffsetAndMetadata(work.offset + 1, work.leaderEpoch, null);
+        try {
+            kafkaInput.commitOffsetsSync(this, offsetAndMetadata);
+            return null;
+        } catch (RuntimeException e) {
+            return e;
+        }
     }
 
     /**
@@ -342,13 +366,12 @@ public class CommittingPartitionTracker extends PartitionTracker {
     public void close() {
         synchronized (completedWork) {
             try {
-                // A request to commit may have been queued but not run yet.
-                // Allow queued tasks to run while we hold the completedWork lock
-                kafkaInput.runPendingActions();
-
                 if (!completedWork.isEmpty()) {
-                    // Attempt a final commit before we relinquish the partition
-                    commitCompletedWork();
+                    // Attempt a final synchronous commit before we relinquish the partition.
+                    // We use waitForCommit=true so that commitUpToSync is called, which calls
+                    // kafkaInput.commitOffsetsSync() directly — bypassing both the running guard
+                    // and the need for a future poll() to deliver the async callback.
+                    commitCompletedWork(true);
                 }
             } finally {
                 super.close();

--- a/dev/com.ibm.ws.microprofile.reactive.messaging.kafka/src/com/ibm/ws/microprofile/reactive/messaging/kafka/KafkaInput.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging.kafka/src/com/ibm/ws/microprofile/reactive/messaging/kafka/KafkaInput.java
@@ -250,6 +250,36 @@ public class KafkaInput<K, V> implements ConsumerRebalanceListener {
         }
     }
 
+    /**
+     * Synchronously commit the offset for the given partition tracker directly on the Kafka consumer.
+     * <p>
+     * Unlike {@link #commitOffsets}, this method does not go via the task queue and does not require
+     * {@link #running} to be {@code true}. It is intended for use during shutdown, after the consumer
+     * has been woken but before it has been closed.
+     * <p>
+     * If the commit fails, the exception is logged as a warning and then rethrown so that the caller
+     * can propagate the failure to any waiting completion stages.
+     *
+     * @param partitionTracker the tracker whose partition offset should be committed
+     * @param offset           the offset to commit
+     * @throws RuntimeException if the underlying Kafka commitSync throws
+     */
+    public void commitOffsetsSync(PartitionTracker partitionTracker, OffsetAndMetadata offset) {
+        Map<TopicPartition, OffsetAndMetadata> offsets = Collections.singletonMap(partitionTracker.getTopicPartition(), offset);
+        this.lock.lock();
+        try {
+            if (isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                Tr.debug(this, tc, "Committing offsets synchronously during shutdown", offsets);
+            }
+            this.kafkaConsumer.commitSync(offsets);
+        } catch (RuntimeException t) {
+            Tr.warning(tc, "kafka.read.offsets.commit.warning.CWMRX1001W", t);
+            throw t;
+        } finally {
+            this.lock.unlock();
+        }
+    }
+
     private static <T> Void logPollFailure(T result, Throwable t) {
         if (t != null) {
             Tr.error(tc, "kafka.poll.error.CWMRX1002E", t);

--- a/dev/io.openliberty.microprofile.reactive.messaging.internal_fat/fat/src/io/openliberty/microprofile/reactive/messaging/fat/apps/shutdown/AckOnShutdownKafkaConsumer.java
+++ b/dev/io.openliberty.microprofile.reactive.messaging.internal_fat/fat/src/io/openliberty/microprofile/reactive/messaging/fat/apps/shutdown/AckOnShutdownKafkaConsumer.java
@@ -1,0 +1,31 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ *******************************************************************************/
+package io.openliberty.microprofile.reactive.messaging.fat.apps.shutdown;
+
+import java.util.concurrent.CompletionStage;
+
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+import org.eclipse.microprofile.reactive.messaging.Message;
+
+import com.ibm.ws.microprofile.reactive.messaging.fat.kafka.framework.AbstractReceptionBean;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class AckOnShutdownKafkaConsumer extends AbstractReceptionBean<String> {
+
+    @Incoming("TestAckOnShutdown")
+    @Override
+    public CompletionStage<Void> receiveMessage(Message<String> message) {
+        return super.receiveMessage(message);
+    }
+
+}

--- a/dev/io.openliberty.microprofile.reactive.messaging.internal_fat/fat/src/io/openliberty/microprofile/reactive/messaging/fat/apps/shutdown/AckOnShutdownKafkaConsumer.java
+++ b/dev/io.openliberty.microprofile.reactive.messaging.internal_fat/fat/src/io/openliberty/microprofile/reactive/messaging/fat/apps/shutdown/AckOnShutdownKafkaConsumer.java
@@ -12,6 +12,7 @@ package io.openliberty.microprofile.reactive.messaging.fat.apps.shutdown;
 
 import java.util.concurrent.CompletionStage;
 
+import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.eclipse.microprofile.reactive.messaging.Incoming;
 import org.eclipse.microprofile.reactive.messaging.Message;
 
@@ -25,7 +26,15 @@ public class AckOnShutdownKafkaConsumer extends AbstractReceptionBean<String> {
     @Incoming("TestAckOnShutdown")
     @Override
     public CompletionStage<Void> receiveMessage(Message<String> message) {
-        return super.receiveMessage(message);
+        @SuppressWarnings("unchecked")
+        ConsumerRecord<?, String> record = message.unwrap(ConsumerRecord.class);
+        System.out.println("AckOnShutdown processing message:"
+                           + " partition=" + record.partition()
+                           + " offset=" + record.offset()
+                           + " leaderEpoch=" + record.leaderEpoch().orElse(-1)
+                           + " timestamp=" + record.timestamp()
+                           + " payload=" + record.value());
+        return message.ack();
     }
 
 }

--- a/dev/io.openliberty.microprofile.reactive.messaging.internal_fat/fat/src/io/openliberty/microprofile/reactive/messaging/fat/apps/shutdown/AckOnShutdownKafkaConsumer.java
+++ b/dev/io.openliberty.microprofile.reactive.messaging.internal_fat/fat/src/io/openliberty/microprofile/reactive/messaging/fat/apps/shutdown/AckOnShutdownKafkaConsumer.java
@@ -23,6 +23,8 @@ import jakarta.enterprise.context.ApplicationScoped;
 @ApplicationScoped
 public class AckOnShutdownKafkaConsumer extends AbstractReceptionBean<String> {
 
+    int messagesProcessed = 1;
+
     @Incoming("TestAckOnShutdown")
     @Override
     public CompletionStage<Void> receiveMessage(Message<String> message) {
@@ -33,7 +35,10 @@ public class AckOnShutdownKafkaConsumer extends AbstractReceptionBean<String> {
                            + " offset=" + record.offset()
                            + " leaderEpoch=" + record.leaderEpoch().orElse(-1)
                            + " timestamp=" + record.timestamp()
-                           + " payload=" + record.value());
+                           + " payload=" + record.value()
+                           + " messages processed= " + messagesProcessed);
+
+        messagesProcessed++;
         return message.ack();
     }
 

--- a/dev/io.openliberty.microprofile.reactive.messaging.internal_fat/fat/src/io/openliberty/microprofile/reactive/messaging/fat/apps/shutdown/TestAckOnShutdownServlet.java
+++ b/dev/io.openliberty.microprofile.reactive.messaging.internal_fat/fat/src/io/openliberty/microprofile/reactive/messaging/fat/apps/shutdown/TestAckOnShutdownServlet.java
@@ -1,0 +1,31 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ *******************************************************************************/
+package io.openliberty.microprofile.reactive.messaging.fat.apps.shutdown;
+
+import org.junit.Test;
+
+import componenttest.app.FATServlet;
+import jakarta.inject.Inject;
+import jakarta.servlet.annotation.WebServlet;
+
+@SuppressWarnings("serial")
+@WebServlet("/TestAckOnShutdown")
+public class TestAckOnShutdownServlet extends FATServlet {
+
+    @Inject
+    private AckOnShutdownKafkaConsumer consumer;
+
+    @Test
+    public void testAckOnShutdown() throws Exception {
+        // TODO: implement test
+    }
+
+}

--- a/dev/io.openliberty.microprofile.reactive.messaging.internal_fat/fat/src/io/openliberty/microprofile/reactive/messaging/fat/shutdown/TestAckOnShutdownTest.java
+++ b/dev/io.openliberty.microprofile.reactive.messaging.internal_fat/fat/src/io/openliberty/microprofile/reactive/messaging/fat/shutdown/TestAckOnShutdownTest.java
@@ -1,0 +1,80 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ *******************************************************************************/
+package io.openliberty.microprofile.reactive.messaging.fat.shutdown;
+
+import static com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions.SERVER_ONLY;
+import static com.ibm.ws.microprofile.reactive.messaging.fat.kafka.common.ConnectorProperties.simpleIncomingChannel;
+import static com.ibm.ws.microprofile.reactive.messaging.fat.kafka.common.KafkaUtils.kafkaClientLibs;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.runner.RunWith;
+
+import com.ibm.websphere.simplicity.PropertiesAsset;
+import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.ws.microprofile.reactive.messaging.fat.kafka.common.ConnectorProperties;
+import com.ibm.ws.microprofile.reactive.messaging.fat.kafka.framework.AbstractReceptionBean;
+import com.ibm.ws.microprofile.reactive.messaging.fat.repeats.ReactiveMessagingActions;
+
+import componenttest.annotation.Server;
+import componenttest.annotation.TestServlet;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.custom.junit.runner.Mode;
+import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.rules.repeater.RepeatTests;
+import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.utils.FATServletClient;
+import io.openliberty.microprofile.reactive.messaging.fat.apps.shutdown.TestAckOnShutdownServlet;
+import io.openliberty.microprofile.reactive.messaging.fat.suite.KafkaTests;
+
+@RunWith(FATRunner.class)
+@Mode(TestMode.FULL)
+public class TestAckOnShutdownTest extends FATServletClient {
+
+    public static final String APP_NAME = "TestAckOnShutdown";
+    public static final String SERVER_NAME = "TestAckOnShutdownServer";
+    public static final String TOPIC_NAME = APP_NAME;
+
+    @Server(SERVER_NAME)
+    @TestServlet(contextRoot = APP_NAME, servlet = TestAckOnShutdownServlet.class)
+    public static LibertyServer server;
+
+    @ClassRule
+    public static final RepeatTests r = ReactiveMessagingActions.reactive30Repeats(SERVER_NAME);
+
+    @BeforeClass
+    public static void setup() throws Exception {
+        ConnectorProperties inputConfig = simpleIncomingChannel(KafkaTests.connectionProperties(),
+                                                                APP_NAME,
+                                                                APP_NAME);
+
+        PropertiesAsset appConfig = new PropertiesAsset()
+                        .include(inputConfig);
+
+        WebArchive war = ShrinkWrap.create(WebArchive.class, APP_NAME + ".war")
+                        .addAsLibraries(kafkaClientLibs())
+                        .addPackage(TestAckOnShutdownServlet.class.getPackage())
+                        .addPackage(AbstractReceptionBean.class.getPackage())
+                        .addAsResource(appConfig, "META-INF/microprofile-config.properties");
+
+        ShrinkHelper.exportAppToServer(server, war, SERVER_ONLY);
+        server.startServer();
+    }
+
+    @AfterClass
+    public static void teardown() throws Exception {
+        server.stopServer();
+    }
+
+}

--- a/dev/io.openliberty.microprofile.reactive.messaging.internal_fat/fat/src/io/openliberty/microprofile/reactive/messaging/fat/shutdown/TestAckOnShutdownTest.java
+++ b/dev/io.openliberty.microprofile.reactive.messaging.internal_fat/fat/src/io/openliberty/microprofile/reactive/messaging/fat/shutdown/TestAckOnShutdownTest.java
@@ -14,24 +14,31 @@ import static com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions.SERVER_ONL
 import static com.ibm.ws.microprofile.reactive.messaging.fat.kafka.common.ConnectorProperties.simpleIncomingChannel;
 import static com.ibm.ws.microprofile.reactive.messaging.fat.kafka.common.KafkaUtils.kafkaClientLibs;
 
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.apache.kafka.clients.producer.RecordMetadata;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
+import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import com.ibm.websphere.simplicity.PropertiesAsset;
 import com.ibm.websphere.simplicity.ShrinkHelper;
 import com.ibm.ws.microprofile.reactive.messaging.fat.kafka.common.ConnectorProperties;
+import com.ibm.ws.microprofile.reactive.messaging.fat.kafka.common.KafkaTestConstants;
 import com.ibm.ws.microprofile.reactive.messaging.fat.kafka.framework.AbstractReceptionBean;
+import com.ibm.ws.microprofile.reactive.messaging.fat.kafka.framework.KafkaTestClient;
+import com.ibm.ws.microprofile.reactive.messaging.fat.kafka.framework.KafkaWriter;
 import com.ibm.ws.microprofile.reactive.messaging.fat.repeats.ReactiveMessagingActions;
 
 import componenttest.annotation.Server;
-import componenttest.annotation.TestServlet;
 import componenttest.custom.junit.runner.FATRunner;
-import componenttest.custom.junit.runner.Mode;
-import componenttest.custom.junit.runner.Mode.TestMode;
 import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
@@ -39,15 +46,13 @@ import io.openliberty.microprofile.reactive.messaging.fat.apps.shutdown.TestAckO
 import io.openliberty.microprofile.reactive.messaging.fat.suite.KafkaTests;
 
 @RunWith(FATRunner.class)
-@Mode(TestMode.FULL)
+//@Mode(TestMode.FULL)
 public class TestAckOnShutdownTest extends FATServletClient {
 
     public static final String APP_NAME = "TestAckOnShutdown";
     public static final String SERVER_NAME = "TestAckOnShutdownServer";
-    public static final String TOPIC_NAME = APP_NAME;
 
     @Server(SERVER_NAME)
-    @TestServlet(contextRoot = APP_NAME, servlet = TestAckOnShutdownServlet.class)
     public static LibertyServer server;
 
     @ClassRule
@@ -72,9 +77,66 @@ public class TestAckOnShutdownTest extends FATServletClient {
         server.startServer();
     }
 
+    @Test
+    public void testAckOnShutdown() throws Exception {
+        AtomicBoolean stopSending = new AtomicBoolean(false);
+        AtomicReference<Exception> senderException = new AtomicReference<>(null);
+        // Tracks the Kafka offset of the last message successfully sent to the broker
+        AtomicLong lastSentOffset = new AtomicLong(-1);
+
+        KafkaTestClient kafkaTestClient = new KafkaTestClient(KafkaTests.kafkaContainer.getBootstrapServers());
+
+        Thread sender = new Thread(() -> {
+            try (KafkaWriter<String, String> writer = kafkaTestClient.writerFor(APP_NAME)) {
+                int count = 0;
+                while (!stopSending.get()) {
+                    RecordMetadata meta = writer.sendMessage("test message " + ++count);
+                    lastSentOffset.set(meta.offset());
+                    Thread.sleep(10); // 1/100th of a second
+                }
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            } catch (Exception e) {
+                senderException.set(e);
+                stopSending.set(true);
+            }
+        });
+
+        sender.setDaemon(true);
+        sender.start();
+
+        // Let messages flow for 3 seconds while the app is running
+        TimeUnit.SECONDS.sleep(3);
+
+        // Shut down the server while messages are still being sent
+        server.stopServer();
+
+        // Signal the sender thread to stop and wait for it to finish
+        stopSending.set(true);
+        sender.join(TimeUnit.SECONDS.toMillis(10));
+
+        // Propagate any exception thrown on the sender thread to fail the test
+        Exception e = senderException.get();
+        if (e != null) {
+            throw e;
+        }
+
+        // The committed offset must be lastSentOffset + 1 (Kafka's committed offset
+        // points to the next message to fetch, so acking offset N commits N+1).
+        // This verifies that every message delivered to the broker before shutdown
+        // was acknowledged by the application.
+        long expectedCommittedOffset = lastSentOffset.get() + 1;
+        kafkaTestClient.assertTopicOffsetAdvancesTo(expectedCommittedOffset,
+                                                    KafkaTestConstants.DEFAULT_KAFKA_TIMEOUT,
+                                                    APP_NAME,
+                                                    APP_NAME);
+    }
+
     @AfterClass
     public static void teardown() throws Exception {
-        server.stopServer();
+        if (server.isStarted()) {
+            server.stopServer();
+        }
     }
 
 }

--- a/dev/io.openliberty.microprofile.reactive.messaging.internal_fat/fat/src/io/openliberty/microprofile/reactive/messaging/fat/shutdown/TestAckOnShutdownTest.java
+++ b/dev/io.openliberty.microprofile.reactive.messaging.internal_fat/fat/src/io/openliberty/microprofile/reactive/messaging/fat/shutdown/TestAckOnShutdownTest.java
@@ -13,13 +13,13 @@ package io.openliberty.microprofile.reactive.messaging.fat.shutdown;
 import static com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions.SERVER_ONLY;
 import static com.ibm.ws.microprofile.reactive.messaging.fat.kafka.common.ConnectorProperties.simpleIncomingChannel;
 import static com.ibm.ws.microprofile.reactive.messaging.fat.kafka.common.KafkaUtils.kafkaClientLibs;
+import static org.junit.Assert.assertFalse;
 
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
-import org.apache.kafka.clients.producer.RecordMetadata;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.AfterClass;
@@ -39,6 +39,8 @@ import com.ibm.ws.microprofile.reactive.messaging.fat.repeats.ReactiveMessagingA
 
 import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
+import componenttest.custom.junit.runner.Mode;
+import componenttest.custom.junit.runner.Mode.TestMode;
 import componenttest.rules.repeater.RepeatTests;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
@@ -46,7 +48,7 @@ import io.openliberty.microprofile.reactive.messaging.fat.apps.shutdown.TestAckO
 import io.openliberty.microprofile.reactive.messaging.fat.suite.KafkaTests;
 
 @RunWith(FATRunner.class)
-//@Mode(TestMode.FULL)
+@Mode(TestMode.FULL)
 public class TestAckOnShutdownTest extends FATServletClient {
 
     public static final String APP_NAME = "TestAckOnShutdown";
@@ -81,8 +83,6 @@ public class TestAckOnShutdownTest extends FATServletClient {
     public void testAckOnShutdown() throws Exception {
         AtomicBoolean stopSending = new AtomicBoolean(false);
         AtomicReference<Exception> senderException = new AtomicReference<>(null);
-        // Tracks the Kafka offset of the last message successfully sent to the broker
-        AtomicLong lastSentOffset = new AtomicLong(-1);
 
         KafkaTestClient kafkaTestClient = new KafkaTestClient(KafkaTests.kafkaContainer.getBootstrapServers());
 
@@ -90,8 +90,7 @@ public class TestAckOnShutdownTest extends FATServletClient {
             try (KafkaWriter<String, String> writer = kafkaTestClient.writerFor(APP_NAME)) {
                 int count = 0;
                 while (!stopSending.get()) {
-                    RecordMetadata meta = writer.sendMessage("test message " + ++count);
-                    lastSentOffset.set(meta.offset());
+                    writer.sendMessage("test message " + ++count);
                     Thread.sleep(10); // 1/100th of a second
                 }
             } catch (InterruptedException e) {
@@ -108,28 +107,40 @@ public class TestAckOnShutdownTest extends FATServletClient {
         // Let messages flow for 3 seconds while the app is running
         TimeUnit.SECONDS.sleep(3);
 
-        // Shut down the server while messages are still being sent
-        server.stopServer();
+        // Shut down the server while messages are still being sent.
+        // Pass false to skip post-stop archiving so that messages.log remains
+        // readable at its original path; we archive manually in the finally block.
+        server.stopServer(false);
+        try {
 
-        // Signal the sender thread to stop and wait for it to finish
-        stopSending.set(true);
-        sender.join(TimeUnit.SECONDS.toMillis(10));
+            // Signal the sender thread to stop and wait for it to finish
+            stopSending.set(true);
+            sender.join(TimeUnit.SECONDS.toMillis(10));
 
-        // Propagate any exception thrown on the sender thread to fail the test
-        Exception e = senderException.get();
-        if (e != null) {
-            throw e;
+            // Propagate any exception thrown on the sender thread to fail the test
+            Exception e = senderException.get();
+            if (e != null) {
+                throw e;
+            }
+
+            // Find the last "AckOnShutdown processing message:" line in messages.log and
+            // extract the message number from the payload (e.g. "payload=test message 234"
+            // -> 234). The Kafka committed offset equals offset+1, and since offset is
+            // zero-based the committed offset equals the 1-based payload message number.
+            List<String> processingLines = server.findStringsInLogs("AckOnShutdown processing message:.*payload=test message \\d+");
+            assertFalse("No 'AckOnShutdown processing message' lines found in server log", processingLines.isEmpty());
+            String lastLine = processingLines.get(processingLines.size() - 1);
+            String payloadPrefix = "payload=test message ";
+            int payloadIdx = lastLine.lastIndexOf(payloadPrefix);
+            long expectedCommittedOffset = Long.parseLong(lastLine.substring(payloadIdx + payloadPrefix.length()).trim());
+
+            kafkaTestClient.assertTopicOffsetAdvancesTo(expectedCommittedOffset,
+                                                        KafkaTestConstants.DEFAULT_KAFKA_TIMEOUT,
+                                                        APP_NAME,
+                                                        APP_NAME);
+        } finally {
+            server.postStopServerArchive();
         }
-
-        // The committed offset must be lastSentOffset + 1 (Kafka's committed offset
-        // points to the next message to fetch, so acking offset N commits N+1).
-        // This verifies that every message delivered to the broker before shutdown
-        // was acknowledged by the application.
-        long expectedCommittedOffset = lastSentOffset.get() + 1;
-        kafkaTestClient.assertTopicOffsetAdvancesTo(expectedCommittedOffset,
-                                                    KafkaTestConstants.DEFAULT_KAFKA_TIMEOUT,
-                                                    APP_NAME,
-                                                    APP_NAME);
     }
 
     @AfterClass

--- a/dev/io.openliberty.microprofile.reactive.messaging.internal_fat/fat/src/io/openliberty/microprofile/reactive/messaging/fat/shutdown/TestAckOnShutdownTest.java
+++ b/dev/io.openliberty.microprofile.reactive.messaging.internal_fat/fat/src/io/openliberty/microprofile/reactive/messaging/fat/shutdown/TestAckOnShutdownTest.java
@@ -88,6 +88,10 @@ public class TestAckOnShutdownTest extends FATServletClient {
 
         KafkaTestClient kafkaTestClient = new KafkaTestClient(KafkaTests.kafkaContainer.getBootstrapServers());
 
+        // Capture the committed offset before any messages are sent so that the
+        // assertion is relative to this run, not affected by previous test repeats.
+        long baselineOffset = kafkaTestClient.getTopicOffset(APP_NAME, APP_NAME);
+
         Thread sender = new Thread(() -> {
             try (KafkaWriter<String, String> writer = kafkaTestClient.writerFor(APP_NAME)) {
                 int count = 0;
@@ -126,15 +130,16 @@ public class TestAckOnShutdownTest extends FATServletClient {
             }
 
             // Find the last "AckOnShutdown processing message:" line in messages.log and
-            // extract the message number from the payload (e.g. "payload=test message 234"
+            // extract the message number from the messages processed number (e.g. "messages processed=11"
             // -> 234). The Kafka committed offset equals offset+1, and since offset is
-            // zero-based the committed offset equals the 1-based payload message number.
-            List<String> processingLines = server.findStringsInLogs("AckOnShutdown processing message:.*payload=test message \\d+");
+            // zero-based the committed offset equals the 1-based message processed number.
+            List<String> processingLines = server.findStringsInLogs("AckOnShutdown processing message:.*messages processed= \\d+");
             assertFalse("No 'AckOnShutdown processing message' lines found in server log", processingLines.isEmpty());
             String lastLine = processingLines.get(processingLines.size() - 1);
-            String payloadPrefix = "payload=test message ";
-            int payloadIdx = lastLine.lastIndexOf(payloadPrefix);
-            long expectedCommittedOffset = Long.parseLong(lastLine.substring(payloadIdx + payloadPrefix.length()).trim());
+            String prefix = "messages processed= ";
+            int index = lastLine.lastIndexOf(prefix);
+            long messagesProcessed = Long.parseLong(lastLine.substring(index + prefix.length()).trim());
+            long expectedCommittedOffset = baselineOffset + messagesProcessed;
 
             kafkaTestClient.assertTopicOffsetAdvancesTo(expectedCommittedOffset,
                                                         KafkaTestConstants.DEFAULT_KAFKA_TIMEOUT,
@@ -142,6 +147,7 @@ public class TestAckOnShutdownTest extends FATServletClient {
                                                         APP_NAME);
         } finally {
             server.postStopServerArchive();
+            kafkaTestClient.cleanUp();
         }
     }
 

--- a/dev/io.openliberty.microprofile.reactive.messaging.internal_fat/fat/src/io/openliberty/microprofile/reactive/messaging/fat/shutdown/TestAckOnShutdownTest.java
+++ b/dev/io.openliberty.microprofile.reactive.messaging.internal_fat/fat/src/io/openliberty/microprofile/reactive/messaging/fat/shutdown/TestAckOnShutdownTest.java
@@ -13,6 +13,7 @@ package io.openliberty.microprofile.reactive.messaging.fat.shutdown;
 import static com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions.SERVER_ONLY;
 import static com.ibm.ws.microprofile.reactive.messaging.fat.kafka.common.ConnectorProperties.simpleIncomingChannel;
 import static com.ibm.ws.microprofile.reactive.messaging.fat.kafka.common.KafkaUtils.kafkaClientLibs;
+import static com.ibm.ws.microprofile.reactive.messaging.fat.kafka.common.KafkaUtils.kafkaPermissions;
 import static org.junit.Assert.assertFalse;
 
 import java.util.List;
@@ -73,6 +74,7 @@ public class TestAckOnShutdownTest extends FATServletClient {
                         .addAsLibraries(kafkaClientLibs())
                         .addPackage(TestAckOnShutdownServlet.class.getPackage())
                         .addPackage(AbstractReceptionBean.class.getPackage())
+                        .addAsManifestResource(kafkaPermissions(), "permissions.xml")
                         .addAsResource(appConfig, "META-INF/microprofile-config.properties");
 
         ShrinkHelper.exportAppToServer(server, war, SERVER_ONLY);

--- a/dev/io.openliberty.microprofile.reactive.messaging.internal_fat/fat/src/io/openliberty/microprofile/reactive/messaging/fat/suite/KafkaTests.java
+++ b/dev/io.openliberty.microprofile.reactive.messaging.internal_fat/fat/src/io/openliberty/microprofile/reactive/messaging/fat/suite/KafkaTests.java
@@ -30,6 +30,7 @@ import io.openliberty.microprofile.reactive.messaging.fat.kafka.metrics.MetricsT
 import io.openliberty.microprofile.reactive.messaging.fat.kafka.metrics.MultiAppMetricsTest;
 import io.openliberty.microprofile.reactive.messaging.fat.kafka.nack.KafkaNackTest;
 import io.openliberty.microprofile.reactive.messaging.fat.kafka.validation.KafkaValidationTests;
+import io.openliberty.microprofile.reactive.messaging.fat.shutdown.TestAckOnShutdownTest;
 import io.openliberty.microprofile.reactive.messaging.fat.startup.TestMessageOnStartupTest;
 import io.openliberty.microprofile.reactive.messaging.fat.telemetry.ReactiveMessagingTelemetryTest;
 import io.openliberty.microprofile.reactive.messaging.fat.telemetry.ReactiveMessagingTelemetryTestWithJAXRS;
@@ -45,7 +46,8 @@ import io.openliberty.microprofile.reactive.messaging.fat.telemetry.ReactiveMess
                 KafkaEmitterTest.class,
                 KafkaEmitterRestfulTest.class,
                 KafkaEmitterNackRestfulTest.class,
-                TestMessageOnStartupTest.class
+                TestMessageOnStartupTest.class,
+                TestAckOnShutdownTest.class
 })
 public class KafkaTests {
 

--- a/dev/io.openliberty.microprofile.reactive.messaging.internal_fat/publish/servers/TestAckOnShutdownServer/bootstrap.properties
+++ b/dev/io.openliberty.microprofile.reactive.messaging.internal_fat/publish/servers/TestAckOnShutdownServer/bootstrap.properties
@@ -1,0 +1,14 @@
+###############################################################################
+# Copyright (c) 2026 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+###############################################################################
+bootstrap.include=../testports.properties
+com.ibm.ws.logging.trace.specification = *=info:logservice=detail:REACTIVEMESSAGE=all

--- a/dev/io.openliberty.microprofile.reactive.messaging.internal_fat/publish/servers/TestAckOnShutdownServer/server.xml
+++ b/dev/io.openliberty.microprofile.reactive.messaging.internal_fat/publish/servers/TestAckOnShutdownServer/server.xml
@@ -1,0 +1,26 @@
+<!--
+    Copyright (c) 2026 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License 2.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-2.0/
+
+    SPDX-License-Identifier: EPL-2.0
+ -->
+<server>
+
+    <include location="../fatTestPorts.xml" />
+
+    <featureManager>
+        <feature>componenttest-2.0</feature>
+        <feature>localConnector-1.0</feature>
+        <feature>mpReactiveMessaging-3.0</feature>
+        <feature>cdi-4.0</feature>
+        <feature>concurrent-3.0</feature>
+        <feature>servlet-5.0</feature>
+        <feature>mpConfig-3.1</feature>
+    </featureManager>
+
+    <application location="TestAckOnShutdown.war" />
+
+</server>


### PR DESCRIPTION
- [ ] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [ ] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

This fixes the close routine for kafka, we already attempt to do one final commit of completed work. This does so on the same thread as the shutdown command to avoid a race condition where the shutdown routine has already set flags that stop an aysc commit from completing. 