### PR TITLE
Fix metrics /metrics endpoint 500 on invalidated session

### DIFF
--- a/dev/com.ibm.ws.microprofile.metrics.2.0/src/com/ibm/ws/microprofile/metrics/BaseMetricsRESTProxyServlet.java
+++ b/dev/com.ibm.ws.microprofile.metrics.2.0/src/com/ibm/ws/microprofile/metrics/BaseMetricsRESTProxyServlet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2023 IBM Corporation and others.
+ * Copyright (c) 2017, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -86,8 +86,14 @@ public abstract class BaseMetricsRESTProxyServlet extends HttpServlet {
                 throw new ServletException("OSGi service RESTHandlerContainer is not available.");
             } else {
                 REST_HANDLER_CONTAINER = ctxt.getService(ref);
-                // generate initial session metrics
-                request.getSession();
+                // generate initial session metrics - guard against an already-invalidated
+                // session on the triggering request (the container has been successfully
+                // initialised above so we must not let this throw)
+                try {
+                    request.getSession();
+                } catch (IllegalStateException e) {
+                    // session was invalidated before we could use it; safe to ignore
+                }
             }
         }
     }

--- a/dev/com.ibm.ws.microprofile.metrics/src/com/ibm/ws/microprofile/metrics/BaseMetricsRESTProxyServlet.java
+++ b/dev/com.ibm.ws.microprofile.metrics/src/com/ibm/ws/microprofile/metrics/BaseMetricsRESTProxyServlet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2023 IBM Corporation and others.
+ * Copyright (c) 2017, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -86,8 +86,14 @@ public abstract class BaseMetricsRESTProxyServlet extends HttpServlet {
                 throw new ServletException("OSGi service RESTHandlerContainer is not available.");
             } else {
                 REST_HANDLER_CONTAINER = ctxt.getService(ref);
-                // generate initial session metrics
-                request.getSession();
+                // generate initial session metrics - guard against an already-invalidated
+                // session on the triggering request (the container has been successfully
+                // initialised above so we must not let this throw)
+                try {
+                    request.getSession();
+                } catch (IllegalStateException e) {
+                    // session was invalidated before we could use it; safe to ignore
+                }
             }
         }
     }

--- a/dev/io.openliberty.microprofile.metrics.5.0.internal/src/io/openliberty/microprofile/metrics50/rest/BaseMetricsRESTProxyServlet.java
+++ b/dev/io.openliberty.microprofile.metrics.5.0.internal/src/io/openliberty/microprofile/metrics50/rest/BaseMetricsRESTProxyServlet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2023 IBM Corporation and others.
+ * Copyright (c) 2017, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -87,8 +87,14 @@ public abstract class BaseMetricsRESTProxyServlet extends HttpServlet {
                 throw new ServletException("OSGi service RESTHandlerContainer is not available.");
             } else {
                 REST_HANDLER_CONTAINER = ctxt.getService(ref);
-                // generate initial session metrics
-                request.getSession();
+                // generate initial session metrics - guard against an already-invalidated
+                // session on the triggering request (the container has been successfully
+                // initialised above so we must not let this throw)
+                try {
+                    request.getSession();
+                } catch (IllegalStateException e) {
+                    // session was invalidated before we could use it; safe to ignore
+                }
             }
         }
     }


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

---

## Summary

`BaseMetricsRESTProxyServlet.getAndSetRESTHandlerContainer()` calls `request.getSession()` on the first request to generate initial session metrics. If the triggering request's HTTP session has already been invalidated (e.g. by a concurrent GraphQL request), this throws `IllegalStateException` which propagates as an unhandled `ServletException`, causing the `/metrics` endpoint to return HTTP 500.

The `RESTHandlerContainer` is successfully retrieved immediately before the `getSession()` call, so the initialisation itself is complete. The fix wraps `request.getSession()` in a `try/catch IllegalStateException` so that an invalidated session on the triggering request does not abort the already-successful container initialisation.

Fixes #35488

## Changes

- `dev/io.openliberty.microprofile.metrics.5.0.internal/src/io/openliberty/microprofile/metrics50/rest/BaseMetricsRESTProxyServlet.java` — primary fix (mpMetrics-5.x)
- `dev/com.ibm.ws.microprofile.metrics.2.0/src/com/ibm/ws/microprofile/metrics/BaseMetricsRESTProxyServlet.java` — same fix for mpMetrics-2.x
- `dev/com.ibm.ws.microprofile.metrics/src/com/ibm/ws/microprofile/metrics/BaseMetricsRESTProxyServlet.java` — same fix for mpMetrics-1.x/3.x/4.x