### PR TITLE
Fix 311052: poll for cache write after config restore; suppress expected FFDCs in cleanup

### DIFF
--- a/dev/com.ibm.ws.session.cache_fat_config/fat/src/com/ibm/ws/session/cache/config/fat/SessionCacheErrorPathsTest.java
+++ b/dev/com.ibm.ws.session.cache_fat_config/fat/src/com/ibm/ws/session/cache/config/fat/SessionCacheErrorPathsTest.java
@@ -356,7 +356,7 @@ public class SessionCacheErrorPathsTest extends FATServletClient {
         TimeUnit.SECONDS.sleep(10);
         server.waitForConfigUpdateInLogUsingMark(APP_NAMES);
         run("testSetAttribute&attribute=testModifyFileset&value=1", session);
-        run("testCacheContains&attribute=testModifyFileset&value=1", session);
+        run("testPollCache&attribute=testModifyFileset&value=1", session);
 
         server.stopServer("CWWKL0012W.*bogus", "SRVE8059E", "CWWKE0701E.*CacheException", "SESN0307E", "SESN0309E", "SESN0306E");
     }

--- a/dev/com.ibm.ws.session.cache_fat_config/fat/src/com/ibm/ws/session/cache/config/fat/SessionCacheErrorPathsTest.java
+++ b/dev/com.ibm.ws.session.cache_fat_config/fat/src/com/ibm/ws/session/cache/config/fat/SessionCacheErrorPathsTest.java
@@ -71,7 +71,8 @@ public class SessionCacheErrorPathsTest extends FATServletClient {
     public void cleanUpPerTest() throws Exception {
         try {
             if (server.isStarted()) {
-                server.stopServer("CWWKG0033W", "SESN0307E", "SRVE8059E");
+                // CWWKL0012W and SESN0309E are expected when testModifyFileset fails before reaching its own stopServer call (e.g. cache not ready under EE11 timing).
+                server.stopServer("CWWKG0033W", "SESN0307E", "SRVE8059E", "CWWKL0012W", "SESN0309E");
             }
         } finally {
             server.updateServerConfiguration(savedConfig);


### PR DESCRIPTION
**Root cause fix (commit 2):**
testSetAttribute deliberately does not flush to JCache immediately — the write
happens at end-of-servlet-service. Under EE11 the window between the HTTP
response completing and the JCache write landing is wider than EE8, so the
immediate testCacheContains races the flush and returns null.

Swapped testCacheContains → testPollCache (already exists in the servlet for
this exact purpose). It retries every 500ms up to 2 minutes, so it tolerates
flush lag without masking a genuine dropped-write — if the write is permanently
dropped it still fails after the timeout.

Same async flush race class as defect 310428.

**Note on PR #35463:** That cleanUpPerTest allowlist commit is kept as a
defensive backstop in case other tests hit the same cleanup path. Safe to keep.