### PR TITLE
Add java2 security permissions needed for kafka

### DIFF
--- a/dev/io.openliberty.microprofile.reactive.messaging.internal_fat/fat/src/io/openliberty/microprofile/reactive/messaging/fat/startup/TestMessageOnStartupTest.java
+++ b/dev/io.openliberty.microprofile.reactive.messaging.internal_fat/fat/src/io/openliberty/microprofile/reactive/messaging/fat/startup/TestMessageOnStartupTest.java
@@ -13,6 +13,7 @@ package io.openliberty.microprofile.reactive.messaging.fat.startup;
 import static com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions.SERVER_ONLY;
 import static com.ibm.ws.microprofile.reactive.messaging.fat.kafka.common.ConnectorProperties.simpleIncomingChannel;
 import static com.ibm.ws.microprofile.reactive.messaging.fat.kafka.common.KafkaUtils.kafkaClientLibs;
+import static com.ibm.ws.microprofile.reactive.messaging.fat.kafka.common.KafkaUtils.kafkaPermissions;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -105,6 +106,7 @@ public class TestMessageOnStartupTest extends FATServletClient {
         EnterpriseArchive ear = ShrinkWrap.create(EnterpriseArchive.class, APP_NAME + ".ear")
                         .addAsModule(war)
                         .addAsLibrary(jar)
+                        .addAsManifestResource(kafkaPermissions(), "permissions.xml")
                         .addAsResource(new org.jboss.shrinkwrap.api.asset.StringAsset(applicationXml), "META-INF/application.xml");
 
         ShrinkHelper.exportAppToServer(server, ear, SERVER_ONLY, DeployOptions.DISABLE_VALIDATION);//we're testing tolerance for custom names so this needs to be manual.


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

Resolves work item: https://wasrtc.hursley.ibm.com:9443/jazz/web/projects/WS-CD#action=com.ibm.team.workitem.viewWorkItem&id=311395 by adding the needed test permissions. 