### PR TITLE
Prevent infinite recursion in JSONConverter

### DIFF
--- a/dev/com.ibm.ws.jmx.connector.client.rest/src/com/ibm/ws/jmx/connector/converter/JSONConverter.java
+++ b/dev/com.ibm.ws.jmx.connector.client.rest/src/com/ibm/ws/jmx/connector/converter/JSONConverter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2021 IBM Corporation and others.
+ * Copyright (c) 2012, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -3347,9 +3347,10 @@ public class JSONConverter {
         JSONArray json = (JSONArray) in;
         int size = json.size();
         OpenType<?>[] openTypes = new OpenType[size];
+        Set<Integer> inProgress = new HashSet<Integer>();
         try {
             for (int i = 0; i < size; i++) {
-                readOpenType(json, i, openTypes);
+                readOpenType(json, i, openTypes, inProgress);
             }
         } catch (OpenDataException e) {
             throwConversionException(e, in);
@@ -3358,9 +3359,12 @@ public class JSONConverter {
     }
 
     @SuppressWarnings({ "unchecked", "rawtypes" })
-    private OpenType<?> readOpenType(JSONArray json, int i, OpenType<?>[] openTypes) throws ConversionException, ClassNotFoundException, OpenDataException {
+    private OpenType<?> readOpenType(JSONArray json, int i, OpenType<?>[] openTypes, Set<Integer> inProgress) throws ConversionException, ClassNotFoundException, OpenDataException {
         if (openTypes[i] != null) {
             return openTypes[i];
+        }
+        if (!inProgress.add(i)) {
+            throwConversionException("readOpenType() detected a cyclic reference in the openTypes array at index " + i + ".", json.get(i));
         }
         Object o = json.get(i);
         if (o instanceof String) {
@@ -3368,6 +3372,7 @@ public class JSONConverter {
             if (openTypes[i] == null) {
                 throwConversionException("readOpenType() received an unknown simple type name.", o);
             }
+            inProgress.remove(i);
             return openTypes[i];
         }
 
@@ -3382,6 +3387,7 @@ public class JSONConverter {
             if (!(ret instanceof OpenType<?>)) {
                 throwConversionException("readOpenType() expects an OpenType.", serialized);
             }
+            inProgress.remove(i);
             return openTypes[i] = (OpenType<?>) ret;
         }
 
@@ -3392,10 +3398,12 @@ public class JSONConverter {
             if (elementType < 0 || elementType >= openTypes.length) {
                 throwConversionException("readOpenType() receives an out-of-range open type index.", type.get(N_ELEMENTTYPE));
             }
-            OpenType<?> etype = readOpenType(json, elementType, openTypes);
+            OpenType<?> etype = readOpenType(json, elementType, openTypes, inProgress);
             if (etype instanceof SimpleType<?>) {
+                inProgress.remove(i);
                 return openTypes[i] = new ArrayType((SimpleType<?>) etype, PrimitiveArrayTypes.contains(etype.getClassName()));
             } else {
+                inProgress.remove(i);
                 return openTypes[i] = new ArrayType(dimension, etype);
             }
         }
@@ -3427,8 +3435,9 @@ public class JSONConverter {
                 if (itemType < 0 || itemType >= openTypes.length) {
                     throwConversionException("readOpenType() receives an out-of-range open type index.", item.get(N_TYPE));
                 }
-                itemTypes[p] = readOpenType(json, itemType, openTypes);
+                itemTypes[p] = readOpenType(json, itemType, openTypes, inProgress);
             }
+            inProgress.remove(i);
             return openTypes[i] = new CompositeType(typeName, description, itemNames, itemDescriptions, itemTypes);
         }
 
@@ -3440,7 +3449,7 @@ public class JSONConverter {
                 throwConversionException("readOpenType() receives an out-of-range open type index.", type.get(N_ROWTYPE));
             }
 
-            OpenType<?> rtype = readOpenType(json, rowType, openTypes);
+            OpenType<?> rtype = readOpenType(json, rowType, openTypes, inProgress);
             if (!(rtype instanceof CompositeType)) {
                 throwConversionException("readOpenType() expects a CompositeType.", rtype);
             }
@@ -3458,6 +3467,7 @@ public class JSONConverter {
                 // Original code: indexNames[i] = readStringInternal(names.get(p));
                 indexNames[p] = readStringInternal(names.get(p));
             }
+            inProgress.remove(i);
             return openTypes[i] = new TabularType(typeName, description, (CompositeType) rtype, indexNames);
         }
 

--- a/dev/com.ibm.ws.jmx.connector.client.rest/test/com/ibm/ws/jmx/connector/converter/JSONConverterTest.java
+++ b/dev/com.ibm.ws.jmx.connector.client.rest/test/com/ibm/ws/jmx/connector/converter/JSONConverterTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2021 IBM Corporation and others.
+ * Copyright (c) 2012, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -61,6 +61,7 @@ import com.ibm.json.java.JSONArray;
 import com.ibm.json.java.JSONArtifact;
 import com.ibm.json.java.JSONObject;
 import com.ibm.ws.jmx.connector.client.rest.ClientProvider;
+import com.ibm.ws.jmx.connector.datatypes.ConversionException;
 import com.ibm.ws.jmx.connector.datatypes.CreateMBean;
 import com.ibm.ws.jmx.connector.datatypes.Invocation;
 import com.ibm.ws.jmx.connector.datatypes.JMXServerInfo;
@@ -3460,4 +3461,100 @@ public class JSONConverterTest {
         }
         return false;
     }
+
+    /**
+     * Test method for {@link JSONConverter#readAttributeList} when the POJO
+     * value of an attribute contains an openTypes array with invalid index
+     * references. The converter must reject the malformed input with a
+     * ConversionException.
+     */
+    @Test
+    public void testReadAttributeList_invalidOpenTypeRef_throwsConversionException() throws Exception {
+        String json = "["
+            + "{"
+            + "  \"name\": \"CollectionUsage\","
+            + "  \"value\": {"
+            + "    \"value\": { \"committed\": \"2686976\" },"
+            + "    \"type\": {"
+            + "      \"className\": \"javax.management.openmbean.CompositeDataSupport\","
+            + "      \"openType\": \"0\""
+            + "    },"
+            + "    \"openTypes\": ["
+            + "      {"
+            + "        \"openTypeClass\": \"javax.management.openmbean.CompositeType\","
+            + "        \"className\":     \"javax.management.openmbean.CompositeData\","
+            + "        \"typeName\":      \"java.lang.management.MemoryUsage\","
+            + "        \"description\":   \"java.lang.management.MemoryUsage\","
+            + "        \"items\": [ { \"key\": \"committed\", \"description\": \"committed\","
+            + "                       \"type\": \"1\" } ]"
+            + "      },"
+            + "      {"
+            + "        \"openTypeClass\": \"javax.management.openmbean.CompositeType\","
+            + "        \"className\":     \"javax.management.openmbean.CompositeData\","
+            + "        \"typeName\":      \"java.lang.management.MemoryUsage\","
+            + "        \"description\":   \"java.lang.management.MemoryUsage\","
+            + "        \"items\": [ { \"key\": \"committed\", \"description\": \"committed\","
+            + "                       \"type\": \"0\" } ]"
+            + "      }"
+            + "    ]"
+            + "  }"
+            + "}"
+            + "]";
+
+        InputStream in = new ByteArrayInputStream(json.getBytes("UTF-8"));
+
+        try {
+            converter.readAttributeList(in);
+            fail("Expected ConversionException for malformed openTypes");
+        } catch (ConversionException e) {
+            // expected — malformed openTypes rejected cleanly
+        }
+    }
+
+    /**
+     * Test method for {@link JSONConverter#readAttributeList} when the POJO
+     * value of an attribute contains an openTypes array where two composite
+     * type items reference the same index. The converter must successfully
+     * parse the attribute list without error.
+     */
+    @Test
+    public void testReadAttributeList_sharedOpenTypeRef_succeeds() throws Exception {
+        // openTypes[0] is a SimpleType (java.lang.Long).
+        // openTypes[1] is a CompositeType with two items both pointing at index 0.
+        // This is a valid shared-reference (diamond) pattern and must parse cleanly.
+        String json = "["
+            + "{"
+            + "  \"name\": \"HeapMemoryUsage\","
+            + "  \"value\": {"
+            + "    \"value\": { \"committed\": \"536870912\", \"used\": \"268435456\" },"
+            + "    \"type\": {"
+            + "      \"className\": \"javax.management.openmbean.CompositeDataSupport\","
+            + "      \"openType\": \"1\""
+            + "    },"
+            + "    \"openTypes\": ["
+            + "      \"java.lang.Long\","
+            + "      {"
+            + "        \"openTypeClass\": \"javax.management.openmbean.CompositeType\","
+            + "        \"className\":     \"javax.management.openmbean.CompositeData\","
+            + "        \"typeName\":      \"java.lang.management.MemoryUsage\","
+            + "        \"description\":   \"java.lang.management.MemoryUsage\","
+            + "        \"items\": ["
+            + "          { \"key\": \"committed\", \"description\": \"committed\", \"type\": \"0\" },"
+            + "          { \"key\": \"used\",      \"description\": \"used\",      \"type\": \"0\" }"
+            + "        ]"
+            + "      }"
+            + "    ]"
+            + "  }"
+            + "}"
+            + "]";
+
+        InputStream in = new ByteArrayInputStream(json.getBytes("UTF-8"));
+        try {
+            AttributeList result = converter.readAttributeList(in);
+            assertTrue("Expected non-empty AttributeList", result != null && !result.isEmpty());
+        } catch (Exception e) {
+            fail("Unexpected exception for valid shared openType reference: " + e);
+        }
+    }
+
 }


### PR DESCRIPTION
A badly formed mbean query request could contain cyclic references in the open types array, leading to an infinite loop while trying to parse it.
Add a guard against this to prevent stack overflow errors.


- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

fixes #35469
fixes #DT496294 

