### PR TITLE
Context capture for scheduled methods

### DIFF
--- a/dev/com.ibm.ws.concurrent_fat_jakarta_12/test-applications/Concurrency32CDITestWeb/src/test/jakarta/concurrency32cdi/web/Concurrency32CDITestServlet.java
+++ b/dev/com.ibm.ws.concurrent_fat_jakarta_12/test-applications/Concurrency32CDITestWeb/src/test/jakarta/concurrency32cdi/web/Concurrency32CDITestServlet.java
@@ -184,7 +184,7 @@ public class Concurrency32CDITestServlet extends FATServlet {
         CountDownLatch methodStarts = schedulingBean.trackerOfNotScheduled();
 
         // wait up to 15 seconds past initialization to see if it runs
-        long elapsedNS = System.nanoTime() - initTimeNS.get();;
+        long elapsedNS = System.nanoTime() - initTimeNS.get();
         long remainingNS = TimeUnit.SECONDS.toNanos(15) - elapsedNS;
         if (remainingNS > 0)
             assertEquals(false,
@@ -207,6 +207,39 @@ public class Concurrency32CDITestServlet extends FATServlet {
                                   TimeUnit.MILLISECONDS);
         assertEquals("value3",
                      future.get(TIMEOUT_NS, TimeUnit.NANOSECONDS));
+    }
+
+    /**
+     * Confirm that a method annotated Schedule can look up resources from
+     * the java:comp namespace of the web module that provides the bean.
+     */
+    @Test
+    public void testLookupFromScheduledMethod() throws Exception {
+        LinkedBlockingQueue<Object> results = schedulingBean.trackerOfLookUp3Times();
+
+        for (int i = 1; i <= 3; i++) {
+            Object result = results.poll(TIMEOUT_NS, TimeUnit.NANOSECONDS);
+            assertNotNull("Timed out waiting for lookUp3Times execution #" + i,
+                          result);
+            if (result instanceof Throwable)
+                throw new AssertionError("lookUp3Times raised an exception" +
+                                         " on execution #" + i, //
+                                (Throwable) result);
+            assertEquals("value3", result);
+        }
+
+        // wait up to 35 seconds past initialization to see if it runs again
+        long elapsedNS = System.nanoTime() - initTimeNS.get();
+        long remainingNS = TimeUnit.SECONDS.toNanos(35) - elapsedNS;
+        Object result;
+        if (remainingNS > 0)
+            result = results.poll(remainingNS, TimeUnit.NANOSECONDS);
+        else
+            result = results.poll();
+
+        assertEquals(null,
+                     result);
+
     }
 
     /**
@@ -381,7 +414,7 @@ public class Concurrency32CDITestServlet extends FATServlet {
                      executionCount.get());
 
         // wait up to 15 seconds past initialization to see if it runs a second time
-        long elapsedNS = System.nanoTime() - initTimeNS.get();;
+        long elapsedNS = System.nanoTime() - initTimeNS.get();
         long remainingNS = TimeUnit.SECONDS.toNanos(15) - elapsedNS;
         if (remainingNS > 0)
             TimeUnit.NANOSECONDS.sleep(remainingNS);
@@ -440,7 +473,7 @@ public class Concurrency32CDITestServlet extends FATServlet {
                      executionCount.get());
 
         // wait up to 25 seconds past initialization to see if it runs a 4th time
-        long elapsedNS = System.nanoTime() - initTimeNS.get();;
+        long elapsedNS = System.nanoTime() - initTimeNS.get();
         long remainingNS = TimeUnit.SECONDS.toNanos(25) - elapsedNS;
         if (remainingNS > 0)
             TimeUnit.NANOSECONDS.sleep(remainingNS);
@@ -470,7 +503,8 @@ public class Concurrency32CDITestServlet extends FATServlet {
 
         // wait up to 20 seconds past initialization to find out if any additional
         // executions occur
-        long elapsedNS = System.nanoTime() - initTimeNS.get();;
+        long elapsedNS = System.nanoTime() - initTimeNS.get();
+
         long remainingNS = TimeUnit.SECONDS.toNanos(20) - elapsedNS;
         if (remainingNS > 0)
             TimeUnit.NANOSECONDS.sleep(remainingNS);

--- a/dev/com.ibm.ws.concurrent_fat_jakarta_12/test-applications/Concurrency32CDITestWeb/src/test/jakarta/concurrency32cdi/web/SchedulingBean.java
+++ b/dev/com.ibm.ws.concurrent_fat_jakarta_12/test-applications/Concurrency32CDITestWeb/src/test/jakarta/concurrency32cdi/web/SchedulingBean.java
@@ -20,10 +20,14 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import jakarta.enterprise.concurrent.AbortedException;
 import jakarta.enterprise.concurrent.Asynchronous;
 import jakarta.enterprise.concurrent.Lock;
 import jakarta.enterprise.concurrent.Schedule;
 import jakarta.enterprise.context.ApplicationScoped;
+
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
 
 /**
  * Bean with methods that are automatically scheduled to run per their
@@ -63,6 +67,18 @@ public class SchedulingBean {
                     new CountDownLatch(4);
 
     /**
+     * Tracks completion of 3 executions of the lookUp3Times method.
+     */
+    private final AtomicInteger lookUp3TimesCount = //
+                    new AtomicInteger(0);
+
+    /**
+     * Tracks the results of executions of the lookUp3Times method.
+     */
+    private final LinkedBlockingQueue<Object> lookUp3TimesQueue = //
+                    new LinkedBlockingQueue<>();
+
+    /**
      * Tracks the non-execution of the notScheduled method.
      */
     private final CountDownLatch notScheduledLatch = //
@@ -86,6 +102,7 @@ public class SchedulingBean {
     //       03        08        13        18        23        28        33        38        43        48        53        58
     // 00    03    06    09    12    15    18    21    24    27    30    33    36    39    42    45    48    51    54    57
     //   DD    DD    DD    DD    DD    DD    DD    DD    DD    DD    DD    DD    DD    DD    DD    DD    DD    DD    DD    DD
+    //   01              09          15            22                31              39              47              55
     // 00      04      08      12      16      20      24      28      32      36      40      44      48      52      56
 
     @Schedule(cron = "2/3 * * * * *",
@@ -137,6 +154,21 @@ public class SchedulingBean {
             throw new NoMoreExecutionsException();
     }
 
+    @Schedule(seconds = { 1, 9, 15, 22, 31, 39, 47, 55 },
+              minutes = {}, // not restricted
+              hours = {}) // not restricted
+    public void lookUp3Times() throws AbortedException, NamingException {
+        try {
+            lookUp3TimesQueue.add(InitialContext //
+                            .doLookup("java:comp/env/TestEntry"));
+            if (lookUp3TimesCount.incrementAndGet() == 3)
+                throw new AbortedException("Do not continue after 3 executions");
+        } catch (NamingException x) {
+            lookUp3TimesQueue.add(x);
+            throw x;
+        }
+    }
+
     public void notScheduled() {
         System.out.println("Running a method that is NOT SCHEDULED!");
         notScheduledLatch.countDown();
@@ -177,6 +209,15 @@ public class SchedulingBean {
      */
     public AtomicInteger trackerOfLockEvery3Seconds4Times() {
         return lockEvery3Seconds4TimesCount;
+    }
+
+    /**
+     * Returns a queue tracking the executions of the lookUp3Times method.
+     *
+     * @return a queue tracking the executions of the lookUp3Times method
+     */
+    public LinkedBlockingQueue<Object> trackerOfLookUp3Times() {
+        return lookUp3TimesQueue;
     }
 
     /**

--- a/dev/io.openliberty.concurrent.internal.cdi/src/io/openliberty/concurrent/internal/cdi/ConcurrencyExtension.java
+++ b/dev/io.openliberty.concurrent.internal.cdi/src/io/openliberty/concurrent/internal/cdi/ConcurrencyExtension.java
@@ -16,18 +16,13 @@ import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.lang.annotation.Annotation;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
 
-import org.osgi.framework.BundleContext;
-import org.osgi.framework.FrameworkUtil;
 import org.osgi.framework.InvalidSyntaxException;
-import org.osgi.framework.ServiceReference;
 
 import com.ibm.websphere.csi.J2EEName;
 import com.ibm.websphere.ras.Tr;
@@ -35,15 +30,12 @@ import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.websphere.ras.annotation.Trivial;
 import com.ibm.ws.cdi.CDIService;
 import com.ibm.ws.cdi.CDIServiceUtils;
-import com.ibm.ws.concurrent.WSManagedExecutorService;
 import com.ibm.ws.kernel.service.util.ServiceCaller;
 import com.ibm.ws.runtime.metadata.ApplicationMetaData;
 import com.ibm.ws.runtime.metadata.ComponentMetaData;
 import com.ibm.ws.runtime.metadata.MetaData;
 import com.ibm.ws.runtime.metadata.ModuleMetaData;
 import com.ibm.ws.threadContext.ComponentMetaDataAccessorImpl;
-import com.ibm.wsspi.resource.ResourceFactory;
-import com.ibm.wsspi.threadcontext.ThreadContextDescriptor;
 
 import io.openliberty.concurrent.internal.cdi.interceptor.AsyncInterceptor;
 import io.openliberty.concurrent.internal.cdi.interceptor.LockInterceptor;
@@ -64,7 +56,6 @@ import jakarta.enterprise.inject.Default;
 import jakarta.enterprise.inject.Instance;
 import jakarta.enterprise.inject.spi.AfterBeanDiscovery;
 import jakarta.enterprise.inject.spi.AfterDeploymentValidation;
-import jakarta.enterprise.inject.spi.AnnotatedMethod;
 import jakarta.enterprise.inject.spi.AnnotatedType;
 import jakarta.enterprise.inject.spi.BeanManager;
 import jakarta.enterprise.inject.spi.BeforeBeanDiscovery;
@@ -73,7 +64,6 @@ import jakarta.enterprise.inject.spi.Extension;
 import jakarta.enterprise.inject.spi.ProcessAnnotatedType;
 import jakarta.enterprise.inject.spi.WithAnnotations;
 import jakarta.enterprise.inject.spi.configurator.AnnotatedTypeConfigurator;
-import jakarta.inject.Qualifier;
 
 /**
  * CDI Extension for
@@ -82,9 +72,6 @@ import jakarta.inject.Qualifier;
  */
 public class ConcurrencyExtension implements Extension {
     private static final TraceComponent tc = Tr.register(ConcurrencyExtension.class);
-
-    private static final String DEFAULT_MSES_FILTER = //
-                    "(&(id=DefaultManagedScheduledExecutorService)(component.name=com.ibm.ws.concurrent.internal.ManagedScheduledExecutorServiceImpl))";
 
     private static final Annotation[] DEFAULT_QUALIFIER_ARRAY = //
                     new Annotation[] { Default.Literal.INSTANCE };
@@ -102,8 +89,7 @@ public class ConcurrencyExtension implements Extension {
     /**
      * Collects the bean classes that have methods directly annotated Schedule.
      */
-    private final List<AnnotatedType<?>> beanClassesWithScheduleMethods = //
-                    new ArrayList<>();
+    final List<AnnotatedType<?>> beanClassesWithScheduleMethods = new ArrayList<>();
 
     /**
      * Register interceptors before bean discovery.
@@ -165,11 +151,15 @@ public class ConcurrencyExtension implements Extension {
      * Register beans for default instances and qualified instances of concurrency
      * resources after bean discovery.
      *
+     * Arranges for methods annotated Schedule to be scheduled upon application
+     * start.
+     *
      * @param event the event
      */
     public void afterBeanDiscovery(@Observes AfterBeanDiscovery event) {
 
-        ComponentMetaData cmd = ComponentMetaDataAccessorImpl.getComponentMetaDataAccessor().getComponentMetaData();
+        ComponentMetaData cmd = ComponentMetaDataAccessorImpl //
+                        .getComponentMetaDataAccessor().getComponentMetaData();
         if (cmd == null)
             throw new IllegalStateException(); // should be unreachable
 
@@ -210,6 +200,35 @@ public class ConcurrencyExtension implements Extension {
             List<Map<List<String>, QualifiedResourceFactory>> listFromApp = extSvc.removeAll(jeeName.getApplication());
             if (listFromApp != null)
                 addBeans(event, listFromApp, extSvc);
+
+            // For bean classes with a method annotated @Schedule, group by the
+            // module that provides the bean class
+            // Group bean classes by module
+            if (!beanClassesWithScheduleMethods.isEmpty()) {
+                Map<J2EEName, List<AnnotatedType<?>>> perModule = new HashMap<>();
+                CDIService cdiSvc = extSvc.cdiServiceRef.getServiceWithException();
+                for (AnnotatedType<?> beanType : beanClassesWithScheduleMethods) {
+                    Optional<J2EEName> jeeNameOptional = cdiSvc //
+                                    .getModuleNameForClass(beanType.getJavaClass());
+                    if (jeeNameOptional.isEmpty()) {
+                        // TODO NLS error message
+                        throw new UnsupportedOperationException //
+                        (beanType.getJavaClass().getName() +
+                         " has one or more methods annotated Schedule" +
+                         " but the bean class is not associated with a" +
+                         " Jakarta EE application module.");
+                    }
+                    perModule.computeIfAbsent(jeeNameOptional.get(),
+                                              ConcurrencyExtension::newList) //
+                                    .add(beanType);
+                }
+                beanClassesWithScheduleMethods.clear();
+
+                // Arrange for methods with Schedule annotations to be scheduled when
+                // the application starts
+                if (!perModule.isEmpty())
+                    extSvc.scheduleOnAppStart(jeeName.getApplication(), perModule);
+            }
         });
 
         if (!successState) {
@@ -304,8 +323,6 @@ public class ConcurrencyExtension implements Extension {
     }
 
     /**
-     * Schedule bean methods that are annotated @Schedule.
-     *
      * Force context to be initialized for the default ManagedThreadFactory instance
      * if we were able to produce one.
      *
@@ -323,91 +340,6 @@ public class ConcurrencyExtension implements Extension {
 
             // Force instantiation of the bean in order to cause context to be captured
             mtf.toString();
-        }
-
-        // Schedule annotations on bean methods
-        if (!beanClassesWithScheduleMethods.isEmpty()) {
-            // DefaultManagedScheduledExecutor is used by all Schedule methods
-            BundleContext bc = FrameworkUtil//
-                            .getBundle(WSManagedExecutorService.class) //
-                            .getBundleContext();
-            Collection<ServiceReference<ResourceFactory>> refs = bc == null ? //
-                            List.of() : //
-                            bc.getServiceReferences(ResourceFactory.class,
-                                                    DEFAULT_MSES_FILTER);
-            WSManagedExecutorService execSvc = refs.isEmpty() ? //
-                            null : //
-                            (WSManagedExecutorService) bc //
-                                            .getService(refs.iterator().next());
-            // TODO consider if we should unget the above on applicaton stop
-            // or if it would be safe to do so at the end of this method.
-
-            // CDIService can identify which module a bean comes from
-            ServiceReference<CDIService> cdiSvcRef = bc //
-                            .getServiceReference(CDIService.class);
-            CDIService cdiSvc = cdiSvcRef == null ? null : bc.getService(cdiSvcRef);
-
-            if (execSvc == null || cdiSvc == null)
-                throw new IllegalStateException(); // TODO NLS message if shutting down?
-
-            // Group bean classes by module
-            Map<J2EEName, List<AnnotatedType<?>>> beanClassesPerModule = new HashMap<>();
-            for (AnnotatedType<?> beanType : beanClassesWithScheduleMethods) {
-                Optional<J2EEName> jeeNameOptional = cdiSvc //
-                                .getModuleNameForClass(beanType.getJavaClass());
-                if (jeeNameOptional.isEmpty()) {
-                    // TODO NLS error message
-                    throw new UnsupportedOperationException //
-                    (beanType.getJavaClass().getName() +
-                     " has one or more methods annotated Schedule" +
-                     " but the bean class is not associated with a" +
-                     " Jakarta EE application module.");
-                }
-                beanClassesPerModule //
-                                .computeIfAbsent(jeeNameOptional.get(),
-                                                 ConcurrencyExtension::newList) //
-                                .add(beanType);
-            }
-            bc.ungetService(cdiSvcRef);
-
-            for (Entry<J2EEName, List<AnnotatedType<?>>> group : //
-            /*   */ beanClassesPerModule.entrySet()) {
-                // Capture thread context for the respective module
-                ThreadContextDescriptor threadContext;
-                J2EEName moduleJeeName = group.getKey();
-                // TODO put the correct metadata onto the thread based on the module
-                try {
-                    threadContext = execSvc.captureThreadContext(null);
-                } finally {
-                    // TODO restore previous metadata
-                }
-
-                // Schedule each method that is annotated @Schedule
-                for (AnnotatedType<?> beanType : group.getValue())
-                    for (AnnotatedMethod<?> method : beanType.getMethods()) {
-                        Class<?> beanClass = beanType.getJavaClass();
-                        Schedule schedule = method.getAnnotation(Schedule.class);
-                        if (schedule != null &&
-                            !beanClass.isAnnotationPresent(Asynchronous.class) &&
-                            !method.isAnnotationPresent(Asynchronous.class)) {
-
-                            ArrayList<Annotation> beanAnnoList = new ArrayList<>();
-                            for (Annotation beanAnno : beanType.getAnnotations())
-                                if (beanAnno.annotationType() //
-                                                .isAnnotationPresent(Qualifier.class))
-                                    beanAnnoList.add(beanAnno);
-                            Annotation[] beanAnnos = beanAnnoList //
-                                            .toArray(new Annotation[beanAnnoList.size()]);
-                            new ScheduledMethod<>( //
-                                            method.getJavaMember(), //
-                                            schedule, //
-                                            threadContext, //
-                                            execSvc, //
-                                            beanClass, //
-                                            beanAnnos);
-                        } // let Asynchronous handle the invalid combination of annos
-                    }
-            }
         }
     }
 

--- a/dev/io.openliberty.concurrent.internal.cdi/src/io/openliberty/concurrent/internal/cdi/ConcurrencyExtensionMetadata.java
+++ b/dev/io.openliberty.concurrent.internal.cdi/src/io/openliberty/concurrent/internal/cdi/ConcurrencyExtensionMetadata.java
@@ -12,47 +12,96 @@
  *******************************************************************************/
 package io.openliberty.concurrent.internal.cdi;
 
+import java.lang.annotation.Annotation;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ScheduledExecutorService;
 
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.framework.InvalidSyntaxException;
 import org.osgi.framework.ServiceReference;
 import org.osgi.framework.Version;
+import org.osgi.service.component.ComponentContext;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.ConfigurationPolicy;
 import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ReferencePolicy;
 import org.osgi.service.component.annotations.ReferencePolicyOption;
 
+import com.ibm.websphere.csi.J2EEName;
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.websphere.ras.annotation.Trivial;
+import com.ibm.ws.cdi.CDIService;
 import com.ibm.ws.cdi.extension.CDIExtensionMetadataInternal;
+import com.ibm.ws.classloading.ClassLoaderIdentifierService;
+import com.ibm.ws.concurrent.WSManagedExecutorService;
+import com.ibm.ws.container.service.app.deploy.ApplicationInfo;
 import com.ibm.ws.container.service.metadata.extended.DeferredMetaDataFactory;
+import com.ibm.ws.container.service.metadata.extended.MetaDataIdentifierService;
+import com.ibm.ws.container.service.state.ApplicationStateListener;
 import com.ibm.ws.javaee.version.JavaEEVersion;
+import com.ibm.ws.runtime.metadata.ComponentMetaData;
+import com.ibm.ws.threadContext.ComponentMetaDataAccessorImpl;
+import com.ibm.wsspi.kernel.service.utils.AtomicServiceReference;
 import com.ibm.wsspi.resource.ResourceFactory;
+import com.ibm.wsspi.threadcontext.ThreadContextDescriptor;
 
 import io.openliberty.cdi.spi.CDIExtensionMetadata;
 import io.openliberty.concurrent.internal.qualified.QualifiedResourceFactories;
 import io.openliberty.concurrent.internal.qualified.QualifiedResourceFactory;
+import jakarta.enterprise.concurrent.Asynchronous;
 import jakarta.enterprise.concurrent.ContextService;
 import jakarta.enterprise.concurrent.ManagedExecutorService;
 import jakarta.enterprise.concurrent.ManagedScheduledExecutorService;
 import jakarta.enterprise.concurrent.ManagedThreadFactory;
+import jakarta.enterprise.concurrent.Schedule;
+import jakarta.enterprise.inject.spi.AnnotatedMethod;
+import jakarta.enterprise.inject.spi.AnnotatedType;
 import jakarta.enterprise.inject.spi.Extension;
+import jakarta.inject.Qualifier;
 
 @Component(configurationPolicy = ConfigurationPolicy.IGNORE,
-           service = { CDIExtensionMetadata.class, QualifiedResourceFactories.class })
-public class ConcurrencyExtensionMetadata implements CDIExtensionMetadata, CDIExtensionMetadataInternal, QualifiedResourceFactories {
-    private static final TraceComponent tc = Tr.register(ConcurrencyExtensionMetadata.class);
+           service = { ApplicationStateListener.class,
+                       CDIExtensionMetadata.class,
+                       QualifiedResourceFactories.class })
+public class ConcurrencyExtensionMetadata implements //
+                ApplicationStateListener, //
+                CDIExtensionMetadata, //
+                CDIExtensionMetadataInternal, //
+                QualifiedResourceFactories {
+    private static final TraceComponent tc = //
+                    Tr.register(ConcurrencyExtensionMetadata.class);
 
-    private static final Set<Class<?>> beanClasses = Set.of(ContextService.class,
-                                                            ManagedExecutorService.class,
-                                                            ManagedScheduledExecutorService.class,
-                                                            ManagedThreadFactory.class);
+    private static final Set<Class<?>> BEAN_CLASSES = //
+                    Set.of(ContextService.class,
+                           ManagedExecutorService.class,
+                           ManagedScheduledExecutorService.class,
+                           ManagedThreadFactory.class);
+
+    private static final String DEFAULT_MSES_FILTER = //
+                    "(&(id=DefaultManagedScheduledExecutorService)(component.name=com.ibm.ws.concurrent.internal.ManagedScheduledExecutorServiceImpl))";
+
+    /**
+     * For obtaining the JEE name of the application artifact that provides each
+     * bean with a scheduled method. AtomicServiceReference is used to avoid a
+     * circular dependency.
+     */
+    final AtomicServiceReference<CDIService> cdiServiceRef = //
+                    new AtomicServiceReference<CDIService>("CDIService");
+
+    /**
+     * For obtaining the class loader identifier of a bean with a scheduled method.
+     */
+    ClassLoaderIdentifierService classloaderIdSvc;
 
     /**
      * ResourceFactory for the default ContextService instance: java:comp/DefaultContextService.
@@ -73,7 +122,7 @@ public class ConcurrencyExtensionMetadata implements CDIExtensionMetadata, CDIEx
     /**
      * ResourceFactory for the default ManagedScheduledExecutorService instance: java:comp/DefaultManagedExecutorService.
      */
-    @Reference(target = "(&(id=DefaultManagedScheduledExecutorService)(component.name=com.ibm.ws.concurrent.internal.ManagedScheduledExecutorServiceImpl))",
+    @Reference(target = DEFAULT_MSES_FILTER,
                policy = ReferencePolicy.DYNAMIC,
                policyOption = ReferencePolicyOption.GREEDY)
     protected volatile ResourceFactory defaultManagedScheduledExecutorFactory;
@@ -90,6 +139,19 @@ public class ConcurrencyExtensionMetadata implements CDIExtensionMetadata, CDIEx
      * Jakarta EE version.
      */
     public static Version eeVersion;
+
+    /**
+     * Map of application name to a
+     * map of JEE name to bean types with methods annotated @Schedule
+     * that are waiting for the application to start.
+     */
+    private final Map<String, Map<J2EEName, List<AnnotatedType<?>>>> //
+    scheduledMethodsAwaitingAppStart = new ConcurrentHashMap<>();
+
+    /**
+     * Metadata identifier service.
+     */
+    MetaDataIdentifierService metadataIdSvc;
 
     /**
      * Creates dummy component metadata for ManagedThreadFactories based on the application metadata.
@@ -112,6 +174,16 @@ public class ConcurrencyExtensionMetadata implements CDIExtensionMetadata, CDIEx
      * Liberty Scheduled Executor.
      */
     public static ScheduledExecutorService scheduledExecutor;
+
+    /**
+     * Declarative Services method to activate this component.
+     * Best practice: this should be a protected method, not public or private
+     *
+     * @param context context for this component
+     */
+    protected void activate(ComponentContext context) {
+        cdiServiceRef.activate(context);
+    }
 
     /**
      * The resource factory builder invokes this method to add a
@@ -164,13 +236,210 @@ public class ConcurrencyExtensionMetadata implements CDIExtensionMetadata, CDIEx
     }
 
     @Override
+    @Trivial
+    public void applicationStarting(ApplicationInfo appInfo) {
+        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
+            Tr.debug(this, tc, "applicationStarting " + appInfo.getDeploymentName() +
+                               " (" + appInfo.getName() + ')');
+    }
+
+    /**
+     * Schedule bean methods that are annotated @Schedule.
+     */
+    @Override
+    @Trivial
+    public void applicationStarted(ApplicationInfo appInfo) {
+        final boolean trace = TraceComponent.isAnyTracingEnabled();
+        if (trace && tc.isEntryEnabled())
+            Tr.entry(this, tc, "applicationStarted " + appInfo.getDeploymentName() +
+                               " (" + appInfo.getName() + ')');
+
+        // Use deployment name but fall back to generated name
+        String appName = appInfo.getDeploymentName() == null //
+                        ? appInfo.getName() //
+                        : appInfo.getDeploymentName();
+
+        Map<J2EEName, List<AnnotatedType<?>>> perModule = scheduledMethodsAwaitingAppStart.remove(appName);
+        if (perModule != null && !perModule.isEmpty())
+            initScheduledMethods(perModule);
+
+        if (trace && tc.isEntryEnabled())
+            Tr.exit(this, tc, "applicationStarted");
+    }
+
+    @Override
+    @Trivial
+    public void applicationStopping(ApplicationInfo appInfo) {
+        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
+            Tr.debug(this, tc, "applicationStopping " + appInfo.getDeploymentName() +
+                               " (" + appInfo.getName() + ')');
+    }
+
+    @Override
+    @Trivial
+    public void applicationStopped(ApplicationInfo appInfo) {
+        final boolean trace = TraceComponent.isAnyTracingEnabled();
+        if (trace && tc.isEntryEnabled())
+            Tr.entry(this, tc, "applicationStopped" + appInfo.getDeploymentName() +
+                               " (" + appInfo.getName() + ')');
+
+        // TODO
+
+        if (trace && tc.isEntryEnabled())
+            Tr.exit(this, tc, "applicationStopped");
+    }
+
+    /**
+     * Declarative Services method to deactivate this component.
+     * Best practice: this should be a protected method, not public or private
+     *
+     * @param context context for this component
+     */
+    protected void deactivate(ComponentContext context) {
+        cdiServiceRef.deactivate(context);
+    }
+
+    @Override
     public Set<Class<?>> getBeanClasses() {
-        return beanClasses;
+        return BEAN_CLASSES;
     }
 
     @Override
     public Set<Class<? extends Extension>> getExtensions() {
         return Collections.singleton(ConcurrencyExtension.class);
+    }
+
+    /**
+     * Schedules bean methods that are annotated @Schedule.
+     *
+     * @param perModule map of module JEE name to AnnotatedType for beans that have
+     *                      at least one method annotated Schedule
+     */
+    void initScheduledMethods(Map<J2EEName, List<AnnotatedType<?>>> perModule) {
+        // DefaultManagedScheduledExecutor is used by all Schedule methods
+        BundleContext bc = FrameworkUtil//
+                        .getBundle(WSManagedExecutorService.class) //
+                        .getBundleContext();
+        Collection<ServiceReference<ResourceFactory>> refs;
+        try {
+            refs = bc == null ? //
+                            List.of() : //
+                            bc.getServiceReferences(ResourceFactory.class,
+                                                    DEFAULT_MSES_FILTER);
+        } catch (InvalidSyntaxException x) {
+            throw new RuntimeException(x); // should be unreachable
+        }
+        WSManagedExecutorService execSvc = refs.isEmpty() ? //
+                        null : //
+                        (WSManagedExecutorService) bc //
+                                        .getService(refs.iterator().next());
+        // TODO consider if we should unget the above on applicaton stop
+        // or if it would be safe to do so at the end of this method.
+        // Altenatively, possibly reuse defaultManagedScheduledExecutorFactory
+
+        // CDIService can identify which module a bean comes from
+        CDIService cdiSvc = cdiServiceRef.getService();
+
+        if (execSvc == null || cdiSvc == null)
+            throw new IllegalStateException(); // TODO NLS message if shutting down?
+
+        for (Entry<J2EEName, List<AnnotatedType<?>>> group : perModule.entrySet()) {
+            J2EEName moduleJeeName = group.getKey();
+            List<AnnotatedType<?>> beanTypes = group.getValue();
+
+            String appName = moduleJeeName.getApplication();
+            String modName = moduleJeeName.getModule();
+            ClassLoader beanClassLoader = beanTypes.get(0) //
+                            .getJavaClass() //
+                            .getClassLoader();
+
+            String clIdentifier = classloaderIdSvc //
+                            .getClassLoaderIdentifier(beanClassLoader);
+            if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
+                Tr.debug(this, tc, "class loader identifier: " + clIdentifier);
+
+            // metadataIdentifier examples:
+            // WEB#MyApp#MyWebModule.war
+            // EJB#MyApp#MyEJBModule.jar#MyEJB
+            String metadataIdentifier = null;
+
+            if (clIdentifier.startsWith("WebModule:")) {
+                metadataIdentifier = metadataIdSvc.getMetaDataIdentifier("WEB",
+                                                                         appName,
+                                                                         modName,
+                                                                         null);
+
+                if (!metadataIdSvc.isMetaDataAvailable(metadataIdentifier)) {
+                    if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
+                        Tr.debug(this, tc, "not available: " + metadataIdentifier);
+                    metadataIdentifier = null;
+                }
+            }
+            if (metadataIdentifier == null) {
+                metadataIdentifier = metadataIdSvc.getMetaDataIdentifier("EJB",
+                                                                         appName,
+                                                                         modName,
+                                                                         null);
+            }
+
+            ComponentMetaData metadata = (ComponentMetaData) metadataIdSvc //
+                            .getMetaData(metadataIdentifier);
+
+            // Establish context for the respective module and capture it
+            ThreadContextDescriptor threadContext;
+            ComponentMetaDataAccessorImpl accessor = //
+                            ComponentMetaDataAccessorImpl //
+                                            .getComponentMetaDataAccessor();
+            if (metadata == null)
+                accessor.beginDefaultContext();
+            else
+                accessor.beginContext(metadata);
+            try {
+                threadContext = execSvc.captureThreadContext(null);
+            } finally {
+                accessor.endContext();
+            }
+
+            // Schedule each method that is annotated @Schedule
+            for (AnnotatedType<?> beanType : beanTypes)
+                for (AnnotatedMethod<?> method : beanType.getMethods()) {
+                    Class<?> beanClass = beanType.getJavaClass();
+                    Schedule schedule = method.getAnnotation(Schedule.class);
+                    if (schedule != null &&
+                        !beanClass.isAnnotationPresent(Asynchronous.class) &&
+                        !method.isAnnotationPresent(Asynchronous.class)) {
+
+                        ArrayList<Annotation> beanAnnoList = new ArrayList<>();
+                        for (Annotation beanAnno : beanType.getAnnotations())
+                            if (beanAnno.annotationType() //
+                                            .isAnnotationPresent(Qualifier.class))
+                                beanAnnoList.add(beanAnno);
+                        Annotation[] beanAnnos = beanAnnoList //
+                                        .toArray(new Annotation[beanAnnoList.size()]);
+                        new ScheduledMethod<>( //
+                                        method.getJavaMember(), //
+                                        schedule, //
+                                        threadContext, //
+                                        execSvc, //
+                                        beanClass, //
+                                        beanAnnos);
+                    }
+                } // let Asynchronous handle the invalid combination of annos
+        }
+    }
+
+    /**
+     * Register to have methods annotated @Schedule scheduled when the given
+     * application starts.
+     *
+     * @param appName               name of the application
+     * @param annotatedWithSchedule map of module Java EE name to bean types
+     *                                  within the module that have at least
+     *                                  one method annotated Schedule
+     */
+    void scheduleOnAppStart(String appName,
+                            Map<J2EEName, List<AnnotatedType<?>>> annotatedWithSchedule) {
+        scheduledMethodsAwaitingAppStart.put(appName, annotatedWithSchedule);
     }
 
     /**
@@ -191,6 +460,21 @@ public class ConcurrencyExtensionMetadata implements CDIExtensionMetadata, CDIEx
     }
 
     /**
+     * Declarative Services method for setting the CDIService service reference.
+     *
+     * @param ref reference to the service
+     */
+    @Reference(service = CDIService.class)
+    protected void setCDIService(ServiceReference<CDIService> ref) {
+        cdiServiceRef.setReference(ref);
+    }
+
+    @Reference
+    protected void setClassLoaderIdService(ClassLoaderIdentifierService clIdSvc) {
+        this.classloaderIdSvc = clIdSvc;
+    }
+
+    /**
      * The service ranking of JavaEEVersion ensures we get the highest
      * Jakarta EE version for the configured features.
      */
@@ -200,14 +484,38 @@ public class ConcurrencyExtensionMetadata implements CDIExtensionMetadata, CDIEx
         eeVersion = Version.parseVersion(version);
     }
 
+    @Reference
+    protected void setMetaDataIdService(MetaDataIdentifierService metadataIdSvc) {
+        this.metadataIdSvc = metadataIdSvc;
+    }
+
     @Reference(target = "(deferrable=false)")
     protected void setScheduledExecutor(ScheduledExecutorService svc) {
         scheduledExecutor = svc;
     }
 
-    protected void unsetScheduledExecutor(ScheduledExecutorService svc) {
+    /**
+     * Declarative Services method for unsetting the CDIService service reference.
+     *
+     * @param ref reference to the service
+     */
+    protected void unsetCDIService(ServiceReference<CDIService> ref) {
+        cdiServiceRef.setReference(ref);
+    }
+
+    protected void unsetClassLoaderIdService(ClassLoaderIdentifierService clIdSvc) {
+        if (this.classloaderIdSvc == clIdSvc)
+            this.classloaderIdSvc = null;
     }
 
     protected void unsetEEVersion(ServiceReference<JavaEEVersion> ref) {
+    }
+
+    protected void unsetMetaDataIdService(MetaDataIdentifierService metadataIdSvc) {
+        if (this.metadataIdSvc == metadataIdSvc)
+            this.metadataIdSvc = null;
+    }
+
+    protected void unsetScheduledExecutor(ScheduledExecutorService svc) {
     }
 }

--- a/dev/io.openliberty.concurrent.internal.cdi/src/io/openliberty/concurrent/internal/cdi/ScheduledMethodAbstract.java
+++ b/dev/io.openliberty.concurrent.internal.cdi/src/io/openliberty/concurrent/internal/cdi/ScheduledMethodAbstract.java
@@ -155,6 +155,7 @@ public abstract class ScheduledMethodAbstract implements //
                 if (failure.getCause() != null)
                     failure = failure.getCause();
             }
+            // TODO application can also raise types of RuntimeException
             if (!appException)
                 FFDCFilter.processException(x, getClass().getName(), "183", this);
         } finally {


### PR DESCRIPTION
When bean methods annotated Schedule automatically run after their scheduled times, they do so with the context of the module that defines the bean, such that `java:comp` lookups for the web module's namespace will work.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
