### PR TITLE
Fix BroadcasterTest SRVE8055E/SRVE8056E log scan failure (SSE FAT)

### DIFF
--- a/dev/com.ibm.ws.jaxrs.2.1.sse_fat/fat/src/com/ibm/ws/jaxrs21/sse/fat/BroadcasterTest.java
+++ b/dev/com.ibm.ws.jaxrs.2.1.sse_fat/fat/src/com/ibm/ws/jaxrs21/sse/fat/BroadcasterTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 IBM Corporation and others.
+ * Copyright (c) 2017, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -45,7 +45,11 @@ public class BroadcasterTest extends FATServletClient {
 
     @AfterClass
     public static void afterClass() throws Exception {
-        server.stopServer();
+        // SRVE8055E/SRVE8056E: Expected when the Liberty server shuts down while SSE
+        // client connections are still open. The webcontainer logs these when it tries
+        // to flush/close response streams that the client has already disconnected from
+        // (Connection reset by peer). This is normal SSE teardown behaviour.
+        server.stopServer("SRVE8055E", "SRVE8056E");
     }
 
 }


### PR DESCRIPTION
**Fixes:** `com.ibm.ws.jaxrs21.sse.fat.BroadcasterTest` failing on EE10 repeat with `SRVE8055E`/`SRVE8056E` log scan error.

---

## Summary

`BroadcasterTest.afterClass()` called `server.stopServer()` with no error allowlist. When Liberty shuts down it tries to flush and close the active SSE response streams that were open during the test. If the client-side `SseEventSource` connections are already closed/reset (which is the normal test teardown path — all `ClientListener`s are closed in the `finally` block before `afterClass` runs), the webcontainer logs:

```
SRVE8055E: An unexpected exception occurred flushng out the rest of the response data.
SRVE8056E: An unexpected exception occurred closing the output stream.
```

Both are caused by `java.io.IOException: Connection reset by peer` — the client socket was closed before the server finished writing. This is **expected behaviour** for SSE streams during server shutdown, not a product defect.

Identical messages are already allowlisted in `com.ibm.ws.grpc_fat` (`StoreProducerServletClientTests`, `ClientConfigTests`) for the same reason — HTTP/2 streaming connections behave identically.

## Change

[`BroadcasterTest.java`](dev/com.ibm.ws.jaxrs.2.1.sse_fat/fat/src/com/ibm/ws/jaxrs21/sse/fat/BroadcasterTest.java) — add `"SRVE8055E"` and `"SRVE8056E"` to the `stopServer()` allowlist in `afterClass()`.
