### PR TITLE
Update JNDI decode issue when plain text values are specified and decode=true 

### DIFF
--- a/dev/com.ibm.ws.jndi.open_fat/fat/src/com/ibm/ws/jndi/global/fat/JNDIEntryTests.java
+++ b/dev/com.ibm.ws.jndi.open_fat/fat/src/com/ibm/ws/jndi/global/fat/JNDIEntryTests.java
@@ -20,8 +20,8 @@ import static org.junit.Assert.assertNotNull;
 import java.util.Arrays;
 import java.util.List;
 
-import org.junit.BeforeClass;
 import org.junit.After;
+import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestRule;
@@ -30,7 +30,7 @@ import org.junit.runner.RunWith;
 import com.ibm.websphere.simplicity.ShrinkHelper;
 import com.ibm.websphere.simplicity.config.ServerConfiguration;
 
-
+import componenttest.annotation.AllowedFFDC;
 import componenttest.annotation.CheckForLeakedPasswords;
 import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
@@ -38,7 +38,6 @@ import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
 import componenttest.topology.utils.HttpUtils;
 import componenttest.vulnerability.LeakedPasswordChecker;
-import componenttest.annotation.AllowedFFDC;
 
 /**
  * Test to make sure that JNDIEntry registers the correct services
@@ -57,6 +56,7 @@ public class JNDIEntryTests extends FATServletClient {
 
     @Server("jndi_entry_dynamic_update")
     public static LibertyServer jndi_entry_dynamic_update_server;
+
     private static List<LibertyServer> testServers;
 
     @Rule
@@ -72,6 +72,7 @@ public class JNDIEntryTests extends FATServletClient {
         ShrinkHelper.exportDropinAppToServer(jndi_entry_id_update_server, FATSuite.READ_JNDI_ENTRY_WAR);
         ShrinkHelper.exportDropinAppToServer(jndi_entry_dynamic_update_server, FATSuite.READ_JNDI_ENTRY_WAR);
     }
+
     @After
     public void stopAllServers() throws Exception {
         for (LibertyServer server : testServers) {
@@ -95,36 +96,36 @@ public class JNDIEntryTests extends FATServletClient {
         // Grab the server
         jndi_entry_fat_server.startServer();
 
-            /*
-             * Wait for two debug level messages saying that the JNDI entries are registered.
-             * Use a fairly short time out as we've already waited for the app to start
-             * so this should already have appeared.
-             */
-            assertEquals("No debug message in the trace.log saying the two jndi entries defined in the server.xml were registered", 2,
-                         jndi_entry_fat_server.waitForMultipleStringsInLog(2, ".*Registering JNDIEntry", 10000, jndi_entry_fat_server.getMatchingLogFile("trace.log")));
+        /*
+         * Wait for two debug level messages saying that the JNDI entries are registered.
+         * Use a fairly short time out as we've already waited for the app to start
+         * so this should already have appeared.
+         */
+        assertEquals("No debug message in the trace.log saying the two jndi entries defined in the server.xml were registered", 2,
+                     jndi_entry_fat_server.waitForMultipleStringsInLog(2, ".*Registering JNDIEntry", 10000, jndi_entry_fat_server.getMatchingLogFile("trace.log")));
 
-            // Now make sure that the OSGi services were registered using a test servlet
-            HttpUtils.findStringInUrl(jndi_entry_fat_server, "/ReadJndiEntry/ReadJndiEntry",
-                                      "JNDI Entry found for stringJndiEntry", "Value of JNDI Entry is: String Value",
-                                      "JNDI Entry found for doubleJndiEntry", "Value of JNDI Entry is: 2.0");
+        // Now make sure that the OSGi services were registered using a test servlet
+        HttpUtils.findStringInUrl(jndi_entry_fat_server, "/ReadJndiEntry/ReadJndiEntry",
+                                  "JNDI Entry found for stringJndiEntry", "Value of JNDI Entry is: String Value",
+                                  "JNDI Entry found for doubleJndiEntry", "Value of JNDI Entry is: 2.0");
 
-            // Delete the entries and make sure they are unregistered
-            ServerConfiguration serverConfig = jndi_entry_fat_server.getServerConfiguration();
-            serverConfig.getJndiEntryElements().clear();
-            jndi_entry_fat_server.updateServerConfiguration(serverConfig);
+        // Delete the entries and make sure they are unregistered
+        ServerConfiguration serverConfig = jndi_entry_fat_server.getServerConfiguration();
+        serverConfig.getJndiEntryElements().clear();
+        jndi_entry_fat_server.updateServerConfiguration(serverConfig);
 
-            // Wait for the update
-            assertNotNull("The server configuration was not updated", jndi_entry_fat_server.waitForStringInLog("CWWKG0017I"));
+        // Wait for the update
+        assertNotNull("The server configuration was not updated", jndi_entry_fat_server.waitForStringInLog("CWWKG0017I"));
 
-            // Also wait for the debug trace messages saying that the services were unregistered
-            assertEquals("No debug message in the trace.log saying the two jndi entries deleted from the server.xml were unregistered", 2,
-                         jndi_entry_fat_server.waitForMultipleStringsInLog(2, ".*Unregistering JNDIEntry", 10000, jndi_entry_fat_server.getMatchingLogFile("trace.log")));
+        // Also wait for the debug trace messages saying that the services were unregistered
+        assertEquals("No debug message in the trace.log saying the two jndi entries deleted from the server.xml were unregistered", 2,
+                     jndi_entry_fat_server.waitForMultipleStringsInLog(2, ".*Unregistering JNDIEntry", 10000, jndi_entry_fat_server.getMatchingLogFile("trace.log")));
 
-            // Now repeat the test with the servlet, it shouldn't find any entries anymore
+        // Now repeat the test with the servlet, it shouldn't find any entries anymore
 
-            HttpUtils.findStringInUrl(jndi_entry_fat_server, "/ReadJndiEntry/ReadJndiEntry",
-                                      "javax.naming.NameNotFoundException: stringJndiEntry",
-                                      "javax.naming.NameNotFoundException: doubleJndiEntry");
+        HttpUtils.findStringInUrl(jndi_entry_fat_server, "/ReadJndiEntry/ReadJndiEntry",
+                                  "javax.naming.NameNotFoundException: stringJndiEntry",
+                                  "javax.naming.NameNotFoundException: doubleJndiEntry");
 
     }
 
@@ -134,34 +135,34 @@ public class JNDIEntryTests extends FATServletClient {
     public void testJNDIDecode() throws Exception {
         // Grab the server
         jndi_entry_decode_server.startServer();
-    
-            /*
-             * Wait for a debug level message saying that the JNDI entry is registered.
-             * Use a fairly short time out as we've already waited for the app to start
-             * so this should already have appeared.
-             */
-            assertEquals("No debug message in the trace.log saying  a jndi entry defined in the server.xml was registered", 4,
-                         jndi_entry_decode_server.waitForMultipleStringsInLog(4, ".*Registering JNDIEntry", 10000, jndi_entry_decode_server.getMatchingLogFile("trace.log")));
 
-            String decryptedStringValue = "foobar";
-            String decryptedDoubleValue = "12345.1";
-            String plainTextJndiEntry = "not_encrypted_passw0rd";
-            String invalidEncryptedValue = "{aes}invalidAES";
-            
-            // Check to make sure the decrypted JndiEntry value for "{xor}OTAwPT4t" is returned
-            HttpUtils.findStringInUrl(jndi_entry_decode_server, "/ReadJndiEntry/ReadJndiEntry",
-                                      "JNDI Entry found for stringJndiEntry", "Value of JNDI Entry is: " + decryptedStringValue);
-            HttpUtils.findStringInUrl(jndi_entry_decode_server, "/ReadJndiEntry/ReadJndiEntry",
-                                      "JNDI Entry found for doubleJndiEntry", "Value of JNDI Entry is: " + decryptedDoubleValue);
-            HttpUtils.findStringInUrl(jndi_entry_decode_server, "/ReadJndiEntry/ReadJndiEntry",
-                                      "JNDI Entry found for stringPlainTextJndiEntry", "Value of JNDI Entry is: " + plainTextJndiEntry);
-            HttpUtils.findStringInUrl(jndi_entry_decode_server, "/ReadJndiEntry/ReadJndiEntry", 
-                                      "JNDI Entry found for invalidEncryptedJndiEntry", "Value of JNDI Entry is: " + invalidEncryptedValue);                          
+        /*
+         * Wait for a debug level message saying that the JNDI entry is registered.
+         * Use a fairly short time out as we've already waited for the app to start
+         * so this should already have appeared.
+         */
+        assertEquals("No debug message in the trace.log saying  a jndi entry defined in the server.xml was registered", 4,
+                     jndi_entry_decode_server.waitForMultipleStringsInLog(4, ".*Registering JNDIEntry", 10000, jndi_entry_decode_server.getMatchingLogFile("trace.log")));
 
-            assertNotNull("Expected warning CWWKN0011W to be logged when decoding fails",
-                          jndi_entry_decode_server.waitForStringInLog("CWWKN0012W"));
-    }                           
-    
+        String decryptedStringValue = "foobar";
+        String decryptedDoubleValue = "12345.1";
+        String plainTextJndiEntry = "not_encrypted_passw0rd";
+        String invalidEncryptedValue = "{aes}invalidAES";
+
+        // Check to make sure the decrypted JndiEntry value for "{xor}OTAwPT4t" is returned
+        HttpUtils.findStringInUrl(jndi_entry_decode_server, "/ReadJndiEntry/ReadJndiEntry",
+                                  "JNDI Entry found for stringJndiEntry", "Value of JNDI Entry is: " + decryptedStringValue);
+        HttpUtils.findStringInUrl(jndi_entry_decode_server, "/ReadJndiEntry/ReadJndiEntry",
+                                  "JNDI Entry found for doubleJndiEntry", "Value of JNDI Entry is: " + decryptedDoubleValue);
+        HttpUtils.findStringInUrl(jndi_entry_decode_server, "/ReadJndiEntry/ReadJndiEntry",
+                                  "JNDI Entry found for stringPlainTextJndiEntry", "Value of JNDI Entry is: " + plainTextJndiEntry);
+        HttpUtils.findStringInUrl(jndi_entry_decode_server, "/ReadJndiEntry/ReadJndiEntry",
+                                  "JNDI Entry found for invalidEncryptedJndiEntry", "Value of JNDI Entry is: " + invalidEncryptedValue);
+
+        assertNotNull("Expected warning CWWKN0011W to be logged when decoding fails",
+                      jndi_entry_decode_server.waitForStringInLog("CWWKN0012W"));
+    }
+
 
 //    /**
 //     * This test makes sure that changing the ID of the JNDI entry does not prevent it being registered correctly.
@@ -172,34 +173,33 @@ public class JNDIEntryTests extends FATServletClient {
     public void testJNDIEntryIDUpate() throws Exception {
         // Grab the server
         jndi_entry_id_update_server.startServer();
-       
-            /*
-             * Wait for two debug level messages saying that the JNDI entries are registered.
-             * Use a fairly short time out as we've already waited for the app to start
-             * so this should already have appeared.
-             */
-            assertEquals("No debug message in the trace.log saying the two jndi entries defined in the server.xml were registered, found "
-                         + jndi_entry_id_update_server.getServerConfiguration().getJndiEntryElements(), 2,
-                         jndi_entry_id_update_server.waitForMultipleStringsInLog(2, ".*Registering JNDIEntry", 10000, jndi_entry_id_update_server.getMatchingLogFile("trace.log")));
 
-            // Now make sure that the OSGi services were registered using a test servlet
-            HttpUtils.findStringInUrl(jndi_entry_id_update_server, "/ReadJndiEntry/ReadJndiEntry",
-                                      "JNDI Entry found for stringJndiEntry", "Value of JNDI Entry is: String Value",
-                                      "JNDI Entry found for doubleJndiEntry", "Value of JNDI Entry is: 2.0");
+        /*
+         * Wait for two debug level messages saying that the JNDI entries are registered.
+         * Use a fairly short time out as we've already waited for the app to start
+         * so this should already have appeared.
+         */
+        assertEquals("No debug message in the trace.log saying the two jndi entries defined in the server.xml were registered, found "
+                     + jndi_entry_id_update_server.getServerConfiguration().getJndiEntryElements(), 2,
+                     jndi_entry_id_update_server.waitForMultipleStringsInLog(2, ".*Registering JNDIEntry", 10000, jndi_entry_id_update_server.getMatchingLogFile("trace.log")));
 
-            // Now switch the server configuration to check that we don't get a non-unique attribute value error
-            jndi_entry_id_update_server.setServerConfigurationFile("JNDIEntryUpdate/IDUpdate.xml");
-            ServerConfiguration config = jndi_entry_id_update_server.getServerConfiguration();
-            jndi_entry_id_update_server.updateServerConfiguration(config);
+        // Now make sure that the OSGi services were registered using a test servlet
+        HttpUtils.findStringInUrl(jndi_entry_id_update_server, "/ReadJndiEntry/ReadJndiEntry",
+                                  "JNDI Entry found for stringJndiEntry", "Value of JNDI Entry is: String Value",
+                                  "JNDI Entry found for doubleJndiEntry", "Value of JNDI Entry is: 2.0");
 
-            // Wait for the update
-            assertNotNull("The server configuration was not updated", jndi_entry_id_update_server.waitForStringInLog("CWWKG0017I"));
+        // Now switch the server configuration to check that we don't get a non-unique attribute value error
+        jndi_entry_id_update_server.setServerConfigurationFile("JNDIEntryUpdate/IDUpdate.xml");
+        ServerConfiguration config = jndi_entry_id_update_server.getServerConfiguration();
+        jndi_entry_id_update_server.updateServerConfiguration(config);
 
-            // Now make sure that the OSGi services are still correctly registered
-            HttpUtils.findStringInUrl(jndi_entry_id_update_server, "/ReadJndiEntry/ReadJndiEntry",
-                                      "JNDI Entry found for stringJndiEntry", "Value of JNDI Entry is: 2.0",
-                                      "JNDI Entry found for doubleJndiEntry", "Value of JNDI Entry is: String Value");
-    
+        // Wait for the update
+        assertNotNull("The server configuration was not updated", jndi_entry_id_update_server.waitForStringInLog("CWWKG0017I"));
+
+        // Now make sure that the OSGi services are still correctly registered
+        HttpUtils.findStringInUrl(jndi_entry_id_update_server, "/ReadJndiEntry/ReadJndiEntry",
+                                  "JNDI Entry found for stringJndiEntry", "Value of JNDI Entry is: 2.0",
+                                  "JNDI Entry found for doubleJndiEntry", "Value of JNDI Entry is: String Value");
     }
 
     /**
@@ -212,33 +212,32 @@ public class JNDIEntryTests extends FATServletClient {
         // Grab the server
         jndi_entry_dynamic_update_server.startServer();
 
-            /*
-             * Wait for two debug level messages saying that the JNDI entries are registered.
-             * Use a fairly short time out as we've already waited for the app to start
-             * so this should already have appeared.
-             */
-            assertEquals("No debug message in the trace.log saying the two jndi entries defined in the server.xml were registered, found "
-                         + jndi_entry_dynamic_update_server.getServerConfiguration().getJndiEntryElements(), 1,
-                         jndi_entry_dynamic_update_server.waitForMultipleStringsInLog(1, ".*Registering JNDIEntry", 10000,
-                                                                                      jndi_entry_dynamic_update_server.getMatchingLogFile("trace.log")));
+        /*
+         * Wait for two debug level messages saying that the JNDI entries are registered.
+         * Use a fairly short time out as we've already waited for the app to start
+         * so this should already have appeared.
+         */
+        assertEquals("No debug message in the trace.log saying the two jndi entries defined in the server.xml were registered, found "
+                     + jndi_entry_dynamic_update_server.getServerConfiguration().getJndiEntryElements(), 1,
+                     jndi_entry_dynamic_update_server.waitForMultipleStringsInLog(1, ".*Registering JNDIEntry", 10000,
+                                                                                  jndi_entry_dynamic_update_server.getMatchingLogFile("trace.log")));
 
-            // Now make sure that the OSGi services were registered using a test servlet
-            HttpUtils.findStringInUrl(jndi_entry_dynamic_update_server, "/ReadJndiEntry/ReadJndiEntry",
-                                      "javax.naming.NameNotFoundException: stringJndiEntry",
-                                      "JNDI Entry found for doubleJndiEntry", "Value of JNDI Entry is: 2.0");
+        // Now make sure that the OSGi services were registered using a test servlet
+        HttpUtils.findStringInUrl(jndi_entry_dynamic_update_server, "/ReadJndiEntry/ReadJndiEntry",
+                                  "javax.naming.NameNotFoundException: stringJndiEntry",
+                                  "JNDI Entry found for doubleJndiEntry", "Value of JNDI Entry is: 2.0");
 
-            // Now switch the server configuration to check that we don't get a non-unique attribute value error
-            jndi_entry_dynamic_update_server.setServerConfigurationFile("JNDIEntryUpdate/uncommentedServer.xml");
-            ServerConfiguration config = jndi_entry_dynamic_update_server.getServerConfiguration();
-            jndi_entry_dynamic_update_server.updateServerConfiguration(config);
+        // Now switch the server configuration to check that we don't get a non-unique attribute value error
+        jndi_entry_dynamic_update_server.setServerConfigurationFile("JNDIEntryUpdate/uncommentedServer.xml");
+        ServerConfiguration config = jndi_entry_dynamic_update_server.getServerConfiguration();
+        jndi_entry_dynamic_update_server.updateServerConfiguration(config);
 
-            // Wait for the update
-            assertNotNull("The server configuration was not updated", jndi_entry_dynamic_update_server.waitForStringInLog("CWWKG0017I"));
+        // Wait for the update
+        assertNotNull("The server configuration was not updated", jndi_entry_dynamic_update_server.waitForStringInLog("CWWKG0017I"));
 
-            // Now make sure that the OSGi services are still correctly registered
-            HttpUtils.findStringInUrl(jndi_entry_dynamic_update_server, "/ReadJndiEntry/ReadJndiEntry",
-                                      "JNDI Entry found for stringJndiEntry", "Value of JNDI Entry is: 2.0",
-                                      "JNDI Entry found for doubleJndiEntry", "Value of JNDI Entry is: String Value");
-                         
+        // Now make sure that the OSGi services are still correctly registered
+        HttpUtils.findStringInUrl(jndi_entry_dynamic_update_server, "/ReadJndiEntry/ReadJndiEntry",
+                                  "JNDI Entry found for stringJndiEntry", "Value of JNDI Entry is: 2.0",
+                                  "JNDI Entry found for doubleJndiEntry", "Value of JNDI Entry is: String Value");
     }
 }

--- a/dev/com.ibm.ws.jndi.open_fat/fat/src/com/ibm/ws/jndi/global/fat/JNDIEntryTests.java
+++ b/dev/com.ibm.ws.jndi.open_fat/fat/src/com/ibm/ws/jndi/global/fat/JNDIEntryTests.java
@@ -17,18 +17,28 @@ package com.ibm.ws.jndi.global.fat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
+import java.util.Arrays;
+import java.util.List;
+
 import org.junit.BeforeClass;
+import org.junit.After;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TestRule;
 import org.junit.runner.RunWith;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
 import com.ibm.websphere.simplicity.config.ServerConfiguration;
 
+
+import componenttest.annotation.CheckForLeakedPasswords;
 import componenttest.annotation.Server;
 import componenttest.custom.junit.runner.FATRunner;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
 import componenttest.topology.utils.HttpUtils;
+import componenttest.vulnerability.LeakedPasswordChecker;
+import componenttest.annotation.AllowedFFDC;
 
 /**
  * Test to make sure that JNDIEntry registers the correct services
@@ -47,13 +57,32 @@ public class JNDIEntryTests extends FATServletClient {
 
     @Server("jndi_entry_dynamic_update")
     public static LibertyServer jndi_entry_dynamic_update_server;
+    private static List<LibertyServer> testServers;
+
+    @Rule
+    public TestRule passwordChecker = new LeakedPasswordChecker(jndi_entry_decode_server);
 
     @BeforeClass
     public static void beforeClass() throws Exception {
+
+        testServers = Arrays.asList(jndi_entry_fat_server, jndi_entry_decode_server, jndi_entry_id_update_server, jndi_entry_dynamic_update_server);
+
         ShrinkHelper.exportDropinAppToServer(jndi_entry_fat_server, FATSuite.READ_JNDI_ENTRY_WAR);
         ShrinkHelper.exportDropinAppToServer(jndi_entry_decode_server, FATSuite.READ_JNDI_ENTRY_WAR);
         ShrinkHelper.exportDropinAppToServer(jndi_entry_id_update_server, FATSuite.READ_JNDI_ENTRY_WAR);
         ShrinkHelper.exportDropinAppToServer(jndi_entry_dynamic_update_server, FATSuite.READ_JNDI_ENTRY_WAR);
+    }
+    @After
+    public void stopAllServers() throws Exception {
+        for (LibertyServer server : testServers) {
+            if (server.isStarted()) {
+                if (server == jndi_entry_decode_server) {
+                    server.stopServer("CWWKN0012W", "CWWKS1859E");
+                } else {
+                    server.stopServer();
+                }
+            }
+        }
     }
 
     /**
@@ -65,7 +94,7 @@ public class JNDIEntryTests extends FATServletClient {
     public void testJNDIEntry() throws Exception {
         // Grab the server
         jndi_entry_fat_server.startServer();
-        try {
+
             /*
              * Wait for two debug level messages saying that the JNDI entries are registered.
              * Use a fairly short time out as we've already waited for the app to start
@@ -96,35 +125,43 @@ public class JNDIEntryTests extends FATServletClient {
             HttpUtils.findStringInUrl(jndi_entry_fat_server, "/ReadJndiEntry/ReadJndiEntry",
                                       "javax.naming.NameNotFoundException: stringJndiEntry",
                                       "javax.naming.NameNotFoundException: doubleJndiEntry");
-        } finally {
-            jndi_entry_fat_server.stopServer();
-        }
+
     }
 
     @Test
+    @AllowedFFDC("com.ibm.websphere.crypto.InvalidPasswordDecodingException")
+    @CheckForLeakedPasswords("not_encrypted_passw0rd")
     public void testJNDIDecode() throws Exception {
         // Grab the server
         jndi_entry_decode_server.startServer();
-        try {
+    
             /*
              * Wait for a debug level message saying that the JNDI entry is registered.
              * Use a fairly short time out as we've already waited for the app to start
              * so this should already have appeared.
              */
-            assertEquals("No debug message in the trace.log saying  a jndi entry defined in the server.xml was registered", 1,
-                         jndi_entry_decode_server.waitForMultipleStringsInLog(1, ".*Registering JNDIEntry", 10000, jndi_entry_decode_server.getMatchingLogFile("trace.log")));
+            assertEquals("No debug message in the trace.log saying  a jndi entry defined in the server.xml was registered", 4,
+                         jndi_entry_decode_server.waitForMultipleStringsInLog(4, ".*Registering JNDIEntry", 10000, jndi_entry_decode_server.getMatchingLogFile("trace.log")));
 
             String decryptedStringValue = "foobar";
-            String decryptedIntValue = "12345";
+            String decryptedDoubleValue = "12345.1";
+            String plainTextJndiEntry = "not_encrypted_passw0rd";
+            String invalidEncryptedValue = "{aes}invalidAES";
+            
             // Check to make sure the decrypted JndiEntry value for "{xor}OTAwPT4t" is returned
             HttpUtils.findStringInUrl(jndi_entry_decode_server, "/ReadJndiEntry/ReadJndiEntry",
                                       "JNDI Entry found for stringJndiEntry", "Value of JNDI Entry is: " + decryptedStringValue);
             HttpUtils.findStringInUrl(jndi_entry_decode_server, "/ReadJndiEntry/ReadJndiEntry",
-                                      "JNDI Entry found for stringJndiEntry", "Value of JNDI Entry is: " + decryptedIntValue);
-        } finally {
-            jndi_entry_decode_server.stopServer();
-        }
-    }
+                                      "JNDI Entry found for doubleJndiEntry", "Value of JNDI Entry is: " + decryptedDoubleValue);
+            HttpUtils.findStringInUrl(jndi_entry_decode_server, "/ReadJndiEntry/ReadJndiEntry",
+                                      "JNDI Entry found for stringPlainTextJndiEntry", "Value of JNDI Entry is: " + plainTextJndiEntry);
+            HttpUtils.findStringInUrl(jndi_entry_decode_server, "/ReadJndiEntry/ReadJndiEntry", 
+                                      "JNDI Entry found for invalidEncryptedJndiEntry", "Value of JNDI Entry is: " + invalidEncryptedValue);                          
+
+            assertNotNull("Expected warning CWWKN0011W to be logged when decoding fails",
+                          jndi_entry_decode_server.waitForStringInLog("CWWKN0012W"));
+    }                           
+    
 
 //    /**
 //     * This test makes sure that changing the ID of the JNDI entry does not prevent it being registered correctly.
@@ -135,7 +172,7 @@ public class JNDIEntryTests extends FATServletClient {
     public void testJNDIEntryIDUpate() throws Exception {
         // Grab the server
         jndi_entry_id_update_server.startServer();
-        try {
+       
             /*
              * Wait for two debug level messages saying that the JNDI entries are registered.
              * Use a fairly short time out as we've already waited for the app to start
@@ -162,10 +199,7 @@ public class JNDIEntryTests extends FATServletClient {
             HttpUtils.findStringInUrl(jndi_entry_id_update_server, "/ReadJndiEntry/ReadJndiEntry",
                                       "JNDI Entry found for stringJndiEntry", "Value of JNDI Entry is: 2.0",
                                       "JNDI Entry found for doubleJndiEntry", "Value of JNDI Entry is: String Value");
-
-        } finally {
-            jndi_entry_id_update_server.stopServer();
-        }
+    
     }
 
     /**
@@ -177,7 +211,7 @@ public class JNDIEntryTests extends FATServletClient {
     public void testDynamicJNDIEntryUpdate() throws Exception {
         // Grab the server
         jndi_entry_dynamic_update_server.startServer();
-        try {
+
             /*
              * Wait for two debug level messages saying that the JNDI entries are registered.
              * Use a fairly short time out as we've already waited for the app to start
@@ -205,9 +239,6 @@ public class JNDIEntryTests extends FATServletClient {
             HttpUtils.findStringInUrl(jndi_entry_dynamic_update_server, "/ReadJndiEntry/ReadJndiEntry",
                                       "JNDI Entry found for stringJndiEntry", "Value of JNDI Entry is: 2.0",
                                       "JNDI Entry found for doubleJndiEntry", "Value of JNDI Entry is: String Value");
-
-        } finally {
-            jndi_entry_dynamic_update_server.stopServer();
-        }
+                         
     }
 }

--- a/dev/com.ibm.ws.jndi.open_fat/publish/servers/jndi_entry_decode/server.xml
+++ b/dev/com.ibm.ws.jndi.open_fat/publish/servers/jndi_entry_decode/server.xml
@@ -8,7 +8,10 @@
     <include location="../fatTestPorts.xml"/>
     <!-- value="foobar" (type String)-->
     <jndiEntry jndiName="stringJndiEntry" value="{xor}OTAwPT4t" decode="true"/>
-    <!-- value="12345" (type Integer)-->
-    <jndiEntry jndiName="doubleJndiEntry" value="{xor}bm1sa2o=" decode="true"/>
+    <!-- value="12345.1" (type Double)-->
+    <jndiEntry jndiName="doubleJndiEntry" value="{xor}bm1sa2pxbg==" decode="true"/>
     <javaPermission className="java.lang.RuntimePermission" name="getClassLoader"/>
+    <jndiEntry jndiName="stringPlainTextJndiEntry" value="not_encrypted_passw0rd" decode="true"/>
+    <jndiEntry jndiName="invalidEncryptedJndiEntry" value="{aes}invalidAES" decode="true"/>
+
 </server>

--- a/dev/com.ibm.ws.jndi.open_fat/test-applications/ReadJndiEntry.war/src/com/ibm/ws/jndi/fat/web/ReadJndiEntry.java
+++ b/dev/com.ibm.ws.jndi.open_fat/test-applications/ReadJndiEntry.war/src/com/ibm/ws/jndi/fat/web/ReadJndiEntry.java
@@ -1,6 +1,6 @@
 /*
  * =============================================================================
- * Copyright (c) 2012, 2023 IBM Corporation and others.
+ * Copyright (c) 2012, 2023, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -41,6 +41,8 @@ public class ReadJndiEntry extends HttpServlet {
         // Get the OSGi bundle context so we can look up the service registrations
         findJndiEntry(String.class, "stringJndiEntry", writer);
         findJndiEntry(Double.class, "doubleJndiEntry", writer);
+        findJndiEntry(String.class, "stringPlainTextJndiEntry", writer);
+        findJndiEntry(String.class, "invalidEncryptedJndiEntry", writer);
     }
 
     private void findJndiEntry(Class jndiClass, String jndiName, PrintWriter writer) {

--- a/dev/com.ibm.ws.jndi/resources/OSGI-INF/l10n/metatype.properties
+++ b/dev/com.ibm.ws.jndi/resources/OSGI-INF/l10n/metatype.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2011 IBM Corporation and others.
+# Copyright (c) 2011, 2026 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -24,7 +24,7 @@ jndi.entry.name=JNDI entry name
 jndi.entry.name.desc=The JNDI name to use for this entry.
 jndi.entry.value=JNDI entry value
 jndi.entry.decode=JNDI decode value
-jndi.entry.decode.desc=True if value needs to be decoded on lookup.
+jndi.entry.decode.desc=Set to true to decode the JNDI entry value when it is looked up.
 jndi.entry.value.desc=The JNDI value to associate with the name.
 jndi.entry.type=JNDI entry type
 jndi.entry.type.desc=The type of data represented.

--- a/dev/com.ibm.ws.jndi/resources/com/ibm/ws/jndi/internal/resources/JNDIMessages.nlsprops
+++ b/dev/com.ibm.ws.jndi/resources/com/ibm/ws/jndi/internal/resources/JNDIMessages.nlsprops
@@ -79,3 +79,7 @@ jndi.url.create.exception.useraction=Specify a valid value for the URL string. T
 jndi.decode.failed=CWWKN0011E: An error occurred while decoding the {0} password. Verify that the password is encoded correctly. The exception was: {1}.
 jndi.decode.failed.explanation=The password is not encoded correctly.
 jndi.decode.failed.useraction=Verify that the password is encoded correctly. See the exception for details.
+
+jndi.decode.warning=CWWKN0012W: An error occurred while decoding the value for JNDI name: {0}. 
+jndi.decode.warning.explanation=The password is not encoded correctly.
+jndi.decode.warning.useraction=Verify that the password is encoded correctly. See the exception for details.

--- a/dev/com.ibm.ws.jndi/resources/com/ibm/ws/jndi/internal/resources/JNDIMessages.nlsprops
+++ b/dev/com.ibm.ws.jndi/resources/com/ibm/ws/jndi/internal/resources/JNDIMessages.nlsprops
@@ -80,6 +80,6 @@ jndi.decode.failed=CWWKN0011E: An error occurred while decoding the {0} password
 jndi.decode.failed.explanation=The password is not encoded correctly.
 jndi.decode.failed.useraction=Verify that the password is encoded correctly. See the exception for details.
 
-jndi.decode.warning=CWWKN0012W: An error occurred while decoding the value for JNDI name: {0}. 
-jndi.decode.warning.explanation=The password is not encoded correctly.
-jndi.decode.warning.useraction=Verify that the password is encoded correctly. See the exception for details.
+jndi.decode.warning=jndi.decode.warning=CWWKN0012W: The value for JNDI name {0} could not be decoded because the password is not encoded correctly.
+jndi.decode.warning.explanation=The JNDI environment lookup failed because the password value for the JNDI name is not in a supported encoding format. The server cannot decode the value and the lookup cannot complete.
+jndi.decode.warning.useraction=Encode the password for JNDI name by using the securityUtility encode command and update the JNDI configuration with the encoded value. Check the exception message for additional details.

--- a/dev/com.ibm.ws.jndi/src/com/ibm/ws/jndi/internal/JNDIEntry.java
+++ b/dev/com.ibm.ws.jndi/src/com/ibm/ws/jndi/internal/JNDIEntry.java
@@ -124,12 +124,10 @@ public class JNDIEntry {
         @Sensitive
         public Object getService(Bundle bundle, ServiceRegistration<Object> registration) {
             String serviceObject = encryptedValue;
-            if (PasswordUtil.isEncrypted(encryptedValue)) {
-                try {
-                    serviceObject = PasswordUtil.decode(encryptedValue); 
-                } catch (Exception e) {
-                    Tr.warning(tc, "jndi.decode.warning", jndiName, e);
-                }
+            try {
+                serviceObject = PasswordUtil.decode(encryptedValue);
+            } catch (Exception e) {
+                Tr.warning(tc, "jndi.decode.warning", jndiName, e);
             }
             return LiteralParser.parse(serviceObject);
         }

--- a/dev/com.ibm.ws.jndi/src/com/ibm/ws/jndi/internal/JNDIEntry.java
+++ b/dev/com.ibm.ws.jndi/src/com/ibm/ws/jndi/internal/JNDIEntry.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012 IBM Corporation and others.
+ * Copyright (c) 2012, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -29,6 +29,7 @@ import com.ibm.websphere.crypto.PasswordUtil;
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.ws.jndi.internal.literals.LiteralParser;
+import com.ibm.websphere.ras.annotation.Sensitive;
 
 /**
  * <p>
@@ -56,7 +57,7 @@ public class JNDIEntry {
      * @param context
      * @param props The properties containing values for <code>"jndiName"</code> and <code>"value"</code>
      */
-    protected synchronized void activate(BundleContext context, Map<String, Object> props) {
+    protected synchronized void activate(BundleContext context, @Sensitive Map<String, Object> props) {
 
         String jndiName = (String) props.get("jndiName");
         String originalValue = (String) props.get("value");
@@ -65,25 +66,27 @@ public class JNDIEntry {
 
         if (jndiName == null || jndiName.isEmpty() || originalValue == null || originalValue.isEmpty()) {
             if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-                Tr.debug(tc, "Unable to register JNDIEntry with jndiName " + jndiName + " and value " + originalValue + " because both must be set");
+                Tr.debug(tc, "Unable to register JNDIEntry: both jndiName and value must be set; jndiName=" + jndiName);
             }
             return;
         }
+        boolean decodeable = false;
         String value = originalValue;
-        if (decode) {
+        if (decode && PasswordUtil.isEncrypted(value)) {
             try {
-                value = PasswordUtil.decode(originalValue);
+            	value = PasswordUtil.decode(value);
+            	decodeable = true;
             } catch (Exception e) {
-                Tr.error(tc, "jndi.decode.failed", originalValue, e);
+                Tr.warning(tc, "jndi.decode.warning", jndiName, e);
             }
         }
         Object parsedValue = LiteralParser.parse(value);
         String valueClassName = parsedValue.getClass().getName();
-        final Object serviceObject = decode ? new Decode(originalValue) : parsedValue;
+        final Object serviceObject = decodeable ? new Decode(jndiName, originalValue) : parsedValue;
         Dictionary<String, Object> propertiesForJndiService = new Hashtable<>();
         propertiesForJndiService.put("osgi.jndi.service.name", jndiName);
         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-            Tr.debug(tc, "Registering JNDIEntry " + valueClassName + " with value " + parsedValue + " and JNDI name " + jndiName);
+            Tr.debug(tc, "Registering JNDIEntry with jndiName: " + jndiName);
         }
         this.serviceRegistration = context.registerService(valueClassName, serviceObject, propertiesForJndiService);
     }
@@ -103,32 +106,34 @@ public class JNDIEntry {
     }
 
     /**
-     * Extends the JNDIEntry class to allow for decryption of values. JNDIEntry elements that are to be decrypted should
-     * add the attribute 'decode="true". If decode=false; the value is simply returned'
+     * A {@link ServiceFactory} that decrypts the stored encrypted value on each {@link #getService} call.
+     * Used when {@code decode="true"} is set on the {@code <jndiEntry>} element.
      */
     private static class Decode implements ServiceFactory<Object> {
+        private final String jndiName;
+        @Sensitive private final String encryptedValue;
 
-        private final String value;
-
-        public Decode(String value) {
-            this.value = value;
+        public Decode(String jndiName, @Sensitive String encryptedValue) {
+            this.jndiName = jndiName;
+            this.encryptedValue = encryptedValue;
         }
 
         @Override
+        @Sensitive
         public Object getService(Bundle bundle, ServiceRegistration<Object> registration) {
-            try {
-                String decodedValue = PasswordUtil.decode(value);
-                Object parsedValue = LiteralParser.parse(decodedValue);
-                return parsedValue;
-            } catch (Exception e) {
-                Tr.error(tc, "jndi.decode.failed", value, e);
+            String serviceObject = encryptedValue;
+            if (PasswordUtil.isEncrypted(encryptedValue)) {
+                try {
+                    serviceObject = PasswordUtil.decode(encryptedValue); 
+                } catch (Exception e) {
+                    Tr.warning(tc, "jndi.decode.warning", jndiName, e);
+                }
             }
-            return value;
+            return LiteralParser.parse(serviceObject);
         }
 
         @Override
-        public void ungetService(Bundle bundle, ServiceRegistration<Object> registration, Object service) {}
-
+        public void ungetService(Bundle bundle, ServiceRegistration<Object> registration, @Sensitive Object service) {}
     }
 
 }

--- a/dev/com.ibm.ws.jndi/src/com/ibm/ws/jndi/internal/JNDIEntry.java
+++ b/dev/com.ibm.ws.jndi/src/com/ibm/ws/jndi/internal/JNDIEntry.java
@@ -25,11 +25,13 @@ import org.osgi.framework.ServiceRegistration;
 import org.osgi.service.component.ComponentContext;
 import org.osgi.service.component.annotations.Component;
 
+
 import com.ibm.websphere.crypto.PasswordUtil;
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
-import com.ibm.ws.jndi.internal.literals.LiteralParser;
 import com.ibm.websphere.ras.annotation.Sensitive;
+import com.ibm.ws.jndi.internal.literals.LiteralParser;
+
 
 /**
  * <p>

--- a/dev/com.ibm.ws.jndi/src/com/ibm/ws/jndi/internal/WSContext.java
+++ b/dev/com.ibm.ws.jndi/src/com/ibm/ws/jndi/internal/WSContext.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2014, 2020 IBM Corporation and others.
+ * Copyright (c) 2012, 2014, 2020, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -105,7 +105,7 @@ final class WSContext extends WSContextBase implements Context, Referenceable {
      */
     @FFDCIgnore({ NamingException.class })
     @Sensitive
-    Object resolveObject(Object o, WSName subname) throws NamingException {
+    Object resolveObject(@Sensitive Object o, WSName subname) throws NamingException {
         ServiceReference<?> ref = null;
         try {
             if (o instanceof ContextNode)
@@ -145,7 +145,7 @@ final class WSContext extends WSContextBase implements Context, Referenceable {
 
                 Object origin = ref.getProperty(JNDIServiceBinder.OSGI_JNDI_SERVICE_ORIGIN);
                 if (tc.isDebugEnabled())
-                    Tr.debug(tc, "Retrieved service from registry", o,
+                    Tr.debug(tc, "Retrieved service from registry",
                              JNDIServiceBinder.OSGI_JNDI_SERVICE_ORIGIN + "=" + origin,
                              Constants.OBJECTCLASS + "=" + Arrays.toString((String[]) ref.getProperty(Constants.OBJECTCLASS)));
                 getObjectInstance = JNDIServiceBinder.OSGI_JNDI_SERVICE_ORIGIN_VALUE.equals(origin) ||
@@ -508,6 +508,7 @@ final class WSContext extends WSContextBase implements Context, Referenceable {
     }
 
     @Override
+    @Sensitive
     public Reference getReference() throws NamingException {
         return WSContextFactory.makeReference(this);
     }
@@ -518,6 +519,7 @@ final class WSContext extends WSContextBase implements Context, Referenceable {
         return "" + myNode;
     }
 
+    @Sensitive
     private Object getReference(ServiceReference<?> ref) {
         return creatingFactory.getService(ref);
     }

--- a/dev/com.ibm.ws.jndi/src/com/ibm/ws/jndi/internal/WSContextFactory.java
+++ b/dev/com.ibm.ws.jndi/src/com/ibm/ws/jndi/internal/WSContextFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2020 IBM Corporation and others.
+ * Copyright (c) 2012, 2020, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -42,6 +42,7 @@ import org.osgi.service.component.annotations.Component;
 
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.websphere.ras.annotation.Sensitive;
 import com.ibm.ws.ffdc.annotation.FFDCIgnore;
 import com.ibm.ws.jndi.internal.JNDIServiceBinderManager.JNDIServiceBinderHolder;
 
@@ -79,6 +80,7 @@ public class WSContextFactory implements InitialContextFactory, ObjectFactory, A
         userContext.getBundle(Constants.SYSTEM_BUNDLE_LOCATION).getBundleContext().removeServiceListener(this);
     }
 
+    @Sensitive
     Object getService(final ServiceReference<?> ref) {
         return cache.computeIfAbsent(ref, (r) -> AccessController.doPrivileged((PrivilegedAction<Object>) () -> userContext.getService(r)));
     }

--- a/dev/com.ibm.ws.jndi/src/com/ibm/ws/jndi/internal/literals/LiteralParser.java
+++ b/dev/com.ibm.ws.jndi/src/com/ibm/ws/jndi/internal/literals/LiteralParser.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012 IBM Corporation and others.
+ * Copyright (c) 2012, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -23,8 +23,6 @@ public enum LiteralParser {
         for (LiteralType type : LiteralType.values())
             if (type.matches(s))
                 return type.parse(s);
-        if (tc.isDebugEnabled())
-            Tr.debug(tc, "String did not match any known types", s);
         return s;
     }
 }

--- a/dev/com.ibm.ws.jndi/src/com/ibm/ws/jndi/internal/literals/LiteralParser.java
+++ b/dev/com.ibm.ws.jndi/src/com/ibm/ws/jndi/internal/literals/LiteralParser.java
@@ -12,14 +12,12 @@
  *******************************************************************************/
 package com.ibm.ws.jndi.internal.literals;
 
-import com.ibm.websphere.ras.Tr;
-import com.ibm.websphere.ras.TraceComponent;
+import com.ibm.websphere.ras.annotation.Sensitive;
 
 public enum LiteralParser {
     ;
-    private static final TraceComponent tc = Tr.register(LiteralParser.class);
 
-    public static Object parse(String s) {
+    public static Object parse(@Sensitive String s) {
         for (LiteralType type : LiteralType.values())
             if (type.matches(s))
                 return type.parse(s);


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

When decode="true" is set on a jndiEntry, Liberty was attempting to decode the value without checking if it was actually encrypted first. 

Fixes #35447 
