### PR TITLE
Java 27 FAT - Revision

### DIFF
--- a/dev/cnf/oss_ibm.maven
+++ b/dev/cnf/oss_ibm.maven
@@ -98,7 +98,7 @@ io.openliberty:java-apps:23.1.0
 io.openliberty:java-apps:24.1.0
 io.openliberty:java-apps:25.1.0
 io.openliberty:java-apps:26.1.0
-io.openliberty:java-apps:27.1.0
+io.openliberty:java-apps:27.2.0
 net.sf.jtidy:jtidy:9.3.8
 org.apache.aries.blueprint:org.apache.aries.blueprint:1.3.0-ibm-s20170710-0926
 org.apache.geronimo.specs:geronimo-ejb_3.1_spec-alt:1.0.0

--- a/dev/cnf/oss_ibm.maven
+++ b/dev/cnf/oss_ibm.maven
@@ -98,7 +98,7 @@ io.openliberty:java-apps:23.1.0
 io.openliberty:java-apps:24.1.0
 io.openliberty:java-apps:25.1.0
 io.openliberty:java-apps:26.1.0
-io.openliberty:java-apps:27.0.0
+io.openliberty:java-apps:27.1.0
 net.sf.jtidy:jtidy:9.3.8
 org.apache.aries.blueprint:org.apache.aries.blueprint:1.3.0-ibm-s20170710-0926
 org.apache.geronimo.specs:geronimo-ejb_3.1_spec-alt:1.0.0

--- a/dev/io.openliberty.java.internal_fat/build.gradle
+++ b/dev/io.openliberty.java.internal_fat/build.gradle
@@ -39,7 +39,7 @@ configurations {
     app24 'io.openliberty:java-apps:24.1.0'
     app25 'io.openliberty:java-apps:25.1.0'
     app26 'io.openliberty:java-apps:26.1.0'
-    app27 'io.openliberty:java-apps:27.1.0'
+    app27 'io.openliberty:java-apps:27.2.0'
     requiredLibs project(':com.ibm.ws.kernel.service')
  }
 

--- a/dev/io.openliberty.java.internal_fat/build.gradle
+++ b/dev/io.openliberty.java.internal_fat/build.gradle
@@ -39,7 +39,7 @@ configurations {
     app24 'io.openliberty:java-apps:24.1.0'
     app25 'io.openliberty:java-apps:25.1.0'
     app26 'io.openliberty:java-apps:26.1.0'
-    app27 'io.openliberty:java-apps:27.0.0'
+    app27 'io.openliberty:java-apps:27.1.0'
     requiredLibs project(':com.ibm.ws.kernel.service')
  }
 

--- a/dev/io.openliberty.java.internal_fat/fat/src/io/openliberty/java/internal/fat/Java27Test.java
+++ b/dev/io.openliberty.java.internal_fat/fat/src/io/openliberty/java/internal/fat/Java27Test.java
@@ -52,17 +52,17 @@ public class Java27Test extends FATServletClient {
 
     /**
      * Test JEP 527 — Post-Quantum Hybrid Key Exchange for TLS 1.3.
-     * Verifies that the three ML-KEM/ECDHE hybrid named groups introduced in Java 27
-     * (X25519MLKEM768, SecP256r1MLKEM768, SecP384r1MLKEM1024) are present in the
-     * default SSLParameters.
+     * X25519MLKEM768 is the primary hybrid group mandated by JEP 527 and is hard-asserted.
+     * SecP256r1MLKEM768 and SecP384r1MLKEM1024 are optional — present on some JDK builds
+     * but not all (e.g. absent on Oracle JDK 27 EA). The WAR logs them as
+     * "Hybrid group optional (not present on this JDK build)" when absent.
+     * Supported by Oracle JDK 27 and IBM Semeru SR8 FP55+ (APAR IJ55706).
      */
     @Test
     public void testPostQuantumTLS() throws Exception {
         String appResponse = HttpUtils.getHttpResponseAsString(server, APP_NAME + '/');
         assertContains(appResponse, "Beginning JEP 527 testing: Post-Quantum Hybrid Key Exchange for TLS 1.3");
         assertContains(appResponse, "Hybrid group present: X25519MLKEM768");
-        assertContains(appResponse, "Hybrid group present: SecP256r1MLKEM768");
-        assertContains(appResponse, "Hybrid group present: SecP384r1MLKEM1024");
         assertContains(appResponse, "Leaving JEP 527 testing");
     }
 
@@ -86,6 +86,7 @@ public class Java27Test extends FATServletClient {
      * Test JEP 536 — JFR In-Process Data Redaction.
      * Verifies that a system property whose key matches the default *password* filter
      * is recorded as [REDACTED] in a JFR recording rather than in plain text.
+     * On JVMs where JEP 536 is not yet active the servlet logs a NOTE instead of failing.
      * The property -Djep536.test.password=test-fixture-value is set in jvm.options.
      */
     @Test
@@ -96,6 +97,7 @@ public class Java27Test extends FATServletClient {
                    appResponse.contains("SUCCESS: JEP 536 redacted")
                    || appResponse.contains("NOTE:"));
         assertContains(appResponse, "Leaving JEP 536 testing");
+        assertContains(appResponse, "<<< EXIT SUCCESSFUL");
     }
 
     /**

--- a/dev/io.openliberty.java.internal_fat/src-reference/java27/io/openliberty/java/internal/TestService.java
+++ b/dev/io.openliberty.java.internal_fat/src-reference/java27/io/openliberty/java/internal/TestService.java
@@ -55,6 +55,9 @@ public class TestService {
 
     // JEP 527: Post-Quantum Hybrid Key Exchange for TLS 1.3
     // https://openjdk.org/jeps/527
+    // X25519MLKEM768 is the primary hybrid group mandated by JEP 527 and must always
+    // be present. SecP256r1MLKEM768 and SecP384r1MLKEM1024 are optional; their
+    // availability is JDK-vendor/build-dependent (e.g. absent on Oracle JDK 27 EA).
 
     private void testPostQuantumTLS() throws Exception {
         log("Beginning JEP 527 testing: Post-Quantum Hybrid Key Exchange for TLS 1.3");
@@ -69,13 +72,17 @@ public class TestService {
         }
         log("Default TLS named groups (" + namedGroups.length + "): " + java.util.Arrays.toString(namedGroups));
 
-        // All three hybrid groups must be present; ordering is vendor-dependent
         java.util.Set<String> groups = new java.util.HashSet<>(java.util.Arrays.asList(namedGroups));
-        for (String hybrid : new String[]{"X25519MLKEM768", "SecP256r1MLKEM768", "SecP384r1MLKEM1024"}) {
-            if (!groups.contains(hybrid)) {
-                throw new Exception("JEP 527 FAILED: hybrid group missing from supported set: " + hybrid);
+        if (!groups.contains("X25519MLKEM768")) {
+            throw new Exception("JEP 527 FAILED: X25519MLKEM768 missing from default SSLParameters named groups");
+        }
+        log("Hybrid group present: X25519MLKEM768");
+        for (String hybrid : new String[]{"SecP256r1MLKEM768", "SecP384r1MLKEM1024"}) {
+            if (groups.contains(hybrid)) {
+                log("Hybrid group present: " + hybrid);
+            } else {
+                log("Hybrid group optional (not present on this JDK build): " + hybrid);
             }
-            log("Hybrid group present: " + hybrid);
         }
 
         log("Leaving JEP 527 testing");


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [ ] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".


JEP 527 — Post-Quantum Hybrid Key Exchange for TLS 1.3: verifies that X25519MLKEM768 (the mandatory ML-KEM hybrid group) is present in the default SSLParameters. SecP256r1MLKEM768 and SecP384r1MLKEM1024 are treated as optional since their inclusion is JDK-build-dependent (e.g. absent on Oracle JDK 27 EA). Uploaded the correct jar version in DHE and Artifactory 