### PR TITLE
MCP: Add DNS rebinding protection

### DIFF
--- a/dev/io.openliberty.mcp.internal/resources/io/openliberty/mcp/internal/resources/CWMCM.nlsprops
+++ b/dev/io.openliberty.mcp.internal/resources/io/openliberty/mcp/internal/resources/CWMCM.nlsprops
@@ -341,3 +341,9 @@ CWMCM0042E.metadata.value.conversion.error.useraction=Review the error message, 
 CWMCM0043W.unsupported.annotation=CWMCM0043W: The {0} method uses the {1} annotation which is not supported. This method is ignored.
 CWMCM0043W.unsupported.annotation.explanation=The Model Context Protocol (MCP) Java API includes annotations for features that are not supported by this implementation. Methods annotated with unsupported annotations are ignored.
 CWMCM0043W.unsupported.annotation.useraction=Remove the unsupported annotation from the method, or use only supported Model Context Protocol (MCP) annotations.
+
+# Used for server logging
+# Do not translate "MCP", "localhost", or "Origin"
+CWMCM0044I.localhost.header.rejected=CWMCM0044I: A local MCP request was rejected due to an invalid Origin header.
+CWMCM0044I.localhost.header.rejected.explanation=Unsecured HTTP requests from localhost must not have an Origin header containing anything other than localhost or a loopback address to protect against DNS rebinding attacks.
+CWMCM0044I.localhost.header.rejected.useraction=Ensure that requests from localhost do not have an Origin header that indicates anything other than localhost.

--- a/dev/io.openliberty.mcp.internal/src/io/openliberty/mcp/internal/LocalhostHeaderChecks.java
+++ b/dev/io.openliberty.mcp.internal/src/io/openliberty/mcp/internal/LocalhostHeaderChecks.java
@@ -1,0 +1,89 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.mcp.internal;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.regex.Pattern;
+
+import com.ibm.ws.ffdc.annotation.FFDCIgnore;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+/**
+ * Utilities to protect against DNS rebinding attacks
+ */
+public class LocalhostHeaderChecks {
+
+    private static final Pattern LOCAL_ADDR = Pattern.compile("localhost|127\\.\\d+\\.\\d+\\.\\d+|\\[::1\\]|::1");
+    private static final boolean DISABLE_REBINDING_PROTECTION = Boolean.getBoolean("mcp.disable.rebinding.protection");
+
+    /**
+     * Validate the host and origin headers if the request comes from a loopback address to protect against DNS rebinding.
+     *
+     * @param req the request
+     * @return {@code true} if the origin and host headers are acceptable for the request
+     */
+    public static boolean validateLocalhostHeaders(HttpServletRequest req) {
+        if (req.isSecure()) {
+            // Do not need this check for secure connections since TLS verifies the hostname
+            return true;
+        }
+
+        if (DISABLE_REBINDING_PROTECTION) {
+            // Provide an escape hatch in case this check causes unforeseen problems
+            return true;
+        }
+
+        if (!isLocalAddr(req.getRemoteAddr())) {
+            // Only do this check for requests from localhost where we know what the requested hostname _should_ be
+            return true;
+        }
+
+        return isOriginValidForLocalhost(req.getHeader("Origin"));
+    }
+
+    /**
+     * Checks whether the Origin header is valid for a request from the local host
+     *
+     * @param originHeader the Origin header, or {@code null} if there was no Origin header set
+     * @return {@code true} if {@code originHeader} is valid
+     */
+    @FFDCIgnore(URISyntaxException.class)
+    public static boolean isOriginValidForLocalhost(String originHeader) {
+        if (originHeader == null) {
+            return true;
+        }
+        try {
+            URI originUri = new URI(originHeader);
+            String originHost = originUri.getHost();
+            if (originHost == null) {
+                // No host in origin header
+                return false;
+            }
+
+            return isLocalAddr(originHost);
+        } catch (URISyntaxException e) {
+            // origin header not a valid URI
+            return false;
+        }
+    }
+
+    /**
+     * Checks whether an IP address or hostname represents localhost
+     *
+     * @param address the address or hostname
+     * @return {@code true} if {@code address} is "localhost" or a loopback IP address
+     */
+    public static boolean isLocalAddr(String address) {
+        return LOCAL_ADDR.matcher(address).matches();
+    }
+
+}

--- a/dev/io.openliberty.mcp.internal/src/io/openliberty/mcp/internal/McpServlet.java
+++ b/dev/io.openliberty.mcp.internal/src/io/openliberty/mcp/internal/McpServlet.java
@@ -126,6 +126,11 @@ public class McpServlet extends HttpServlet {
     @Override
     @FFDCIgnore({ JSONRPCException.class, HttpResponseException.class })
     protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException, JSONRPCException {
+        if (!LocalhostHeaderChecks.validateLocalhostHeaders(req)) {
+            resp.setStatus(HttpServletResponse.SC_FORBIDDEN);
+            Tr.info(tc, "CWMCM0044I.localhost.header.rejected");
+            return;
+        }
         McpTransport transport = new McpTransport(req, resp, jsonb, mcpConfig.asyncTimeoutMs());
         McpOperationMetrics metrics = new McpOperationMetrics();
 

--- a/dev/io.openliberty.mcp.internal/test/io/openliberty/mcp/internal/test/LocalhostHeaderChecksTest.java
+++ b/dev/io.openliberty.mcp.internal/test/io/openliberty/mcp/internal/test/LocalhostHeaderChecksTest.java
@@ -1,0 +1,46 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package io.openliberty.mcp.internal.test;
+
+import static io.openliberty.mcp.internal.LocalhostHeaderChecks.isLocalAddr;
+import static io.openliberty.mcp.internal.LocalhostHeaderChecks.isOriginValidForLocalhost;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class LocalhostHeaderChecksTest {
+
+    @Test
+    public void testIsLocalAddr() {
+        assertTrue(isLocalAddr("127.0.0.1"));
+        assertTrue(isLocalAddr("localhost"));
+        assertTrue(isLocalAddr("::1"));
+        assertTrue(isLocalAddr("[::1]"));
+        assertFalse(isLocalAddr("192.168.1.1"));
+        assertFalse(isLocalAddr("10.0.0.1"));
+        assertFalse(isLocalAddr("example.com"));
+    }
+
+    @Test
+    public void testIsOriginValidForLocalhost() {
+        assertTrue(isOriginValidForLocalhost(null));
+        assertTrue(isOriginValidForLocalhost("http://localhost"));
+        assertTrue(isOriginValidForLocalhost("http://127.0.0.1"));
+        assertTrue(isOriginValidForLocalhost("http://localhost:9080"));
+        assertTrue(isOriginValidForLocalhost("http://[::1]"));
+        assertTrue(isOriginValidForLocalhost("http://[::1]:9080"));
+
+        assertFalse(isOriginValidForLocalhost("http://example.com"));
+        assertFalse(isOriginValidForLocalhost("http://192.168.1.1"));
+        assertFalse(isOriginValidForLocalhost("not a valid uri ://"));
+        assertFalse(isOriginValidForLocalhost("file:///no-host"));
+    }
+}

--- a/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/protocol/HttpTest.java
+++ b/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/protocol/HttpTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2025 IBM Corporation and others.
+ * Copyright (c) 2025, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -16,11 +16,15 @@ import static io.openliberty.mcp.internal.fat.utils.TestConstants.VALUE_ACCEPT_D
 import static io.openliberty.mcp.internal.fat.utils.TestConstants.VALUE_APPLICATION_JSON;
 import static io.openliberty.mcp.internal.fat.utils.TestConstants.VALUE_MCP_PROTOCOL_VERSION;
 import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeThat;
+
+import java.util.function.Function;
 
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
@@ -172,26 +176,7 @@ public class HttpTest {
 
     @Test
     public void testPingWithoutSessionId() throws Exception {
-        String request = """
-                        {
-                          "jsonrpc": "2.0",
-                          "id": 1,
-                          "method": "ping"
-                        }
-                        """;
-
-        HttpRequest httpRequest = new HttpRequest(server, ENDPOINT)
-                                                                   .requestProp(ACCEPT, VALUE_ACCEPT_DEFAULT)
-                                                                   .requestProp(MCP_PROTOCOL_VERSION, VALUE_MCP_PROTOCOL_VERSION)
-                                                                   .jsonBody(request)
-                                                                   .method("POST")
-                                                                   .expectCode(200);
-        String response = httpRequest.run(String.class);
-
-        assertTrue("Expected 'result' field in ping response", response.contains("\"result\""));
-
-        String contentType = httpRequest.getResponseHeader("Content-Type");
-        assertThat(contentType, containsString(VALUE_APPLICATION_JSON));
+        callPing(200, req -> req);
     }
 
     @Test
@@ -207,5 +192,49 @@ public class HttpTest {
                         """;
 
         client.callMCPNotification(notification);
+    }
+
+    @Test
+    public void testInvalidLocalhostOriginHeaderReturns403() throws Exception {
+        assumeThat(server.getHostname(), equalTo("localhost")); // Test is not valid if the server is not local
+        server.setMarkToEndOfLog();
+        callPing(403, req -> req.requestProp("Origin", "http://evil.example.com"));
+        callPing(403, req -> req.requestProp("Origin", "something odd"));
+        assertNotNull(server.waitForStringInLogUsingMark("CWMCM0044I: A local MCP request was rejected due to an invalid Origin header."));
+    }
+
+    @Test
+    public void testValidLocalhostOriginHeaderReturns200() throws Exception {
+        assumeThat(server.getHostname(), equalTo("localhost")); // Test is not valid if the server is not local
+        callPing(200, req -> req); // No extra headers
+        callPing(200, req -> req.requestProp("Origin", "http://localhost"));
+        callPing(200, req -> req.requestProp("Origin", "http://127.0.0.1"));
+        callPing(200, req -> req.requestProp("Origin", "http://[::1]"));
+    }
+
+    void callPing(int expectedResponseCode, Function<HttpRequest, HttpRequest> requestCustomizer) throws Exception {
+        String request = """
+                        {
+                          "jsonrpc": "2.0",
+                          "id": 1,
+                          "method": "ping"
+                        }
+                        """;
+
+        HttpRequest httpRequest = new HttpRequest(server, ENDPOINT).requestProp(ACCEPT, VALUE_ACCEPT_DEFAULT)
+                                                                   .requestProp(MCP_PROTOCOL_VERSION, VALUE_MCP_PROTOCOL_VERSION)
+                                                                   .jsonBody(request)
+                                                                   .method("POST")
+                                                                   .expectCode(expectedResponseCode);
+        httpRequest = requestCustomizer.apply(httpRequest);
+        String response = httpRequest.run(String.class);
+
+        if (expectedResponseCode == 200) {
+            // Also validate ping response
+            assertTrue("Expected 'result' field in ping response", response.contains("\"result\""));
+
+            String contentType = httpRequest.getResponseHeader("Content-Type");
+            assertThat(contentType, containsString(VALUE_APPLICATION_JSON));
+        }
     }
 }


### PR DESCRIPTION
Protect against DNS rebinding attacks if the server is running locally.

Fixes #35516

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
