### PR TITLE
MCP: Make tests wait for LTPA+TLS to be ready

### DIFF
--- a/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/oidc/tests/AuthorizationFlowTests.java
+++ b/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/oidc/tests/AuthorizationFlowTests.java
@@ -112,6 +112,9 @@ public class AuthorizationFlowTests extends FATServletClient {
 
         server.startServer();
         assertNotNull(server.waitForStringInLog("MCP server endpoint: .*/mcp$"));
+        // Wait for LTPA configuration to be ready
+        server.waitForLTPAConfigReady();
+        server.waitForDefaultHTTPEndpointSSLStart();
 
         // Build the combined HTTPS client now that key.p12 exists
         // This client trusts both Liberty's auto-generated cert and the Keycloak self-signed cert

--- a/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/oidc/tests/OidcTests.java
+++ b/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/oidc/tests/OidcTests.java
@@ -71,7 +71,11 @@ public class OidcTests extends FATServletClient {
         keycloakContainer.setupRealm();
         server.startServer();
         keycloakContainer.updateServerConfig(server);
+
         assertNotNull(server.waitForStringInLog("MCP server endpoint: .*/mcp$"));
+        // Wait for LTPA configuration to be ready
+        server.waitForLTPAConfigReady();
+        server.waitForDefaultHTTPEndpointSSLStart();
     }
 
     @AfterClass

--- a/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/tool/AsyncToolCancellationTest.java
+++ b/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/tool/AsyncToolCancellationTest.java
@@ -64,6 +64,8 @@ public class AsyncToolCancellationTest extends FATServletClient {
         server.startServer();
         executor = Executors.newSingleThreadExecutor();
         assertNotNull(server.waitForStringInLog("MCP server endpoint: .*/mcp$"));
+        // Wait for LTPA configuration to be ready
+        server.waitForLTPAConfigReady();
     }
 
     @AfterClass

--- a/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/tool/AuthCancellationTest.java
+++ b/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/tool/AuthCancellationTest.java
@@ -10,6 +10,7 @@
 package io.openliberty.mcp.internal.fat.tool;
 
 import static com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions.SERVER_ONLY;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import java.util.concurrent.Callable;
@@ -62,6 +63,9 @@ public class AuthCancellationTest extends FATServletClient {
         ShrinkHelper.exportDropinAppToServer(server, war, SERVER_ONLY);
 
         server.startServer();
+        assertNotNull(server.waitForStringInLog("MCP server endpoint: .*/mcp$"));
+        // Wait for LTPA configuration to be ready
+        server.waitForLTPAConfigReady();
 
         executor = Executors.newSingleThreadExecutor();
     }


### PR DESCRIPTION
Tests that use the appSecurity feature need to wait for LTPA to be ready before starting to run the test, otherwise we get failures on slow build systems with low entropy.

Some also need the HTTPS port to be ready, so wait for that too.

Fixes RTC 308772

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".