### PR TITLE
Add FAT tests for UriInfo and HttpHeaders API differences between CXF and RESTEasy

### DIFF
--- a/dev/com.ibm.ws.jaxrs.2.1_fat/test-applications/jaxrs21uriInfo/src/com/ibm/ws/jaxrs21/fat/uriInfo/ClientTestServlet.java
+++ b/dev/com.ibm.ws.jaxrs.2.1_fat/test-applications/jaxrs21uriInfo/src/com/ibm/ws/jaxrs21/fat/uriInfo/ClientTestServlet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -46,6 +46,35 @@ public class ClientTestServlet extends FATServlet {
     @After
     private void teardown() {
         client.close();
+    }
+
+    /**
+     * strips the leading '/' from UriInfo.getPath().
+     */
+    @Test
+    public void testGetPathNoLeadingSlashOnCXF() throws Exception {
+        Response response = client.target(URI_CONTEXT_ROOT)
+                                  .path("resources/test/getpath")
+                                  .request()
+                                  .get();
+        assertEquals(200, response.getStatus());
+        // strips the leading '/' from UriInfo.getPath()
+        assertEquals("test/getpath", response.readEntity(String.class));
+    }
+
+    /**
+     * returns null from HttpHeaders.getRequestHeader() when
+     * the requested header is not present in the request.
+     */
+    @Test
+    public void testMissingHeaderIsNullOnCXF() throws Exception {
+        Response response = client.target(URI_CONTEXT_ROOT)
+                                  .path("resources/test/missingheader")
+                                  .request()
+                                  .get();
+        assertEquals(200, response.getStatus());
+        // returns null for absent headers; resource echoes "null"
+        assertEquals("null", response.readEntity(String.class));
     }
 
     @Test

--- a/dev/com.ibm.ws.jaxrs.2.1_fat/test-applications/jaxrs21uriInfo/src/com/ibm/ws/jaxrs21/fat/uriInfo/TestResource.java
+++ b/dev/com.ibm.ws.jaxrs.2.1_fat/test-applications/jaxrs21uriInfo/src/com/ibm/ws/jaxrs21/fat/uriInfo/TestResource.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -12,12 +12,15 @@
  *******************************************************************************/
 package com.ibm.ws.jaxrs21.fat.uriInfo;
 
+import java.util.List;
+
 import javax.inject.Inject;
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.Context;
+import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.UriInfo;
 
@@ -29,6 +32,9 @@ public class TestResource {
 
     @Context
     UriInfo uriInfo;
+
+    @Context
+    HttpHeaders httpHeaders;
 
     @Inject
     TestClient testClient;
@@ -56,5 +62,28 @@ public class TestResource {
     @Path("client")
     public String clientRequest() {
         return "";
+    }
+
+    /**
+     * returns the raw value of UriInfo.getPath() for the request path.
+     * strips the leading '/' — returns e.g. "test/getpath"
+     */
+    @GET
+    @Path("getpath")
+    @Produces(MediaType.TEXT_PLAIN)
+    public String getPath() {
+        return uriInfo.getPath();
+    }
+
+    /**
+     * returns "null" if HttpHeaders.getRequestHeader() returns null for an absent header,
+     * or "empty" if it returns an empty (non-null) list.
+     */
+    @GET
+    @Path("missingheader")
+    @Produces(MediaType.TEXT_PLAIN)
+    public String getMissingHeader() {
+        List<String> values = httpHeaders.getRequestHeader("X-Absent-Header");
+        return (values == null) ? "null" : "empty";
     }
 }

--- a/dev/io.openliberty.restfulWS.3.1_fat/fat/src/io/openliberty/restfulWS31/fat/FATSuite.java
+++ b/dev/io.openliberty.restfulWS.3.1_fat/fat/src/io/openliberty/restfulWS31/fat/FATSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022, 2024 IBM Corporation and others.
+ * Copyright (c) 2022, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -23,7 +23,8 @@ import componenttest.rules.repeater.RepeatTests;
 @RunWith(Suite.class)
 @SuiteClasses({
     JavaSeBootstrapContainerTest.class,
-    MultipartTest.class
+    MultipartTest.class,
+    UriInfoTest.class
 })
 public class FATSuite {
     @ClassRule

--- a/dev/io.openliberty.restfulWS.3.1_fat/fat/src/io/openliberty/restfulWS31/fat/UriInfoTest.java
+++ b/dev/io.openliberty.restfulWS.3.1_fat/fat/src/io/openliberty/restfulWS31/fat/UriInfoTest.java
@@ -1,0 +1,51 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.restfulWS31.fat;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.runner.RunWith;
+
+import com.ibm.websphere.simplicity.ShrinkHelper;
+import io.openliberty.restfulWS31.fat.uriInfo.UriInfoServlet;
+
+import componenttest.annotation.Server;
+import componenttest.annotation.TestServlet;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.utils.FATServletClient;
+
+
+@RunWith(FATRunner.class)
+public class UriInfoTest extends FATServletClient {
+
+    private static final String app = "uriInfo";
+
+    @Server("uriInfo")
+    @TestServlet(servlet = UriInfoServlet.class, contextRoot = app)
+    public static LibertyServer server;
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        ShrinkHelper.defaultDropinApp(server, app,
+                                      "io.openliberty.restfulWS31.fat.uriInfo");
+        server.startServer();
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        if (server != null && server.isStarted()) {
+            server.stopServer();
+        }
+    }
+}

--- a/dev/io.openliberty.restfulWS.3.1_fat/fat/src/io/openliberty/restfulWS31/fat/uriInfo/UriInfoApplication.java
+++ b/dev/io.openliberty.restfulWS.3.1_fat/fat/src/io/openliberty/restfulWS31/fat/uriInfo/UriInfoApplication.java
@@ -1,0 +1,20 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.restfulWS31.fat.uriInfo;
+
+import jakarta.ws.rs.ApplicationPath;
+import jakarta.ws.rs.core.Application;
+
+@ApplicationPath("resources")
+public class UriInfoApplication extends Application {
+}

--- a/dev/io.openliberty.restfulWS.3.1_fat/fat/src/io/openliberty/restfulWS31/fat/uriInfo/UriInfoResource.java
+++ b/dev/io.openliberty.restfulWS.3.1_fat/fat/src/io/openliberty/restfulWS31/fat/uriInfo/UriInfoResource.java
@@ -1,0 +1,59 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.restfulWS31.fat.uriInfo;
+
+import java.util.List;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.UriInfo;
+
+@Path("test")
+public class UriInfoResource {
+
+    @Context
+    UriInfo uriInfo;
+
+    @Context
+    HttpHeaders httpHeaders;
+
+    /**
+     * Returns the raw value of UriInfo.getPath().
+     * RESTEasy (restfulWS-3.1+): includes leading '/' e.g. "/test/getpath"
+     * CXF (jaxrs-2.1): strips leading '/' e.g. "test/getpath"
+     */
+    @GET
+    @Path("getpath")
+    @Produces(MediaType.TEXT_PLAIN)
+    public String getPath() {
+        return uriInfo.getPath();
+    }
+
+    /**
+     * Returns "null" or "empty" based on what HttpHeaders.getRequestHeader()
+     * returns for a header not present in the request.
+     * RESTEasy (restfulWS-3.1+): returns empty List (never null)
+     * CXF (jaxrs-2.1): returns null
+     */
+    @GET
+    @Path("missingheader")
+    @Produces(MediaType.TEXT_PLAIN)
+    public String getMissingHeader() {
+        List<String> values = httpHeaders.getRequestHeader("X-Absent-Header");
+        return (values == null) ? "null" : "empty";
+    }
+}

--- a/dev/io.openliberty.restfulWS.3.1_fat/fat/src/io/openliberty/restfulWS31/fat/uriInfo/UriInfoServlet.java
+++ b/dev/io.openliberty.restfulWS.3.1_fat/fat/src/io/openliberty/restfulWS31/fat/uriInfo/UriInfoServlet.java
@@ -1,0 +1,76 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.restfulWS31.fat.uriInfo;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.ws.rs.client.Client;
+import jakarta.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.core.Response;
+
+import org.junit.After;
+import org.junit.Test;
+
+import componenttest.app.FATServlet;
+
+
+@WebServlet(urlPatterns = "/UriInfoServlet")
+public class UriInfoServlet extends FATServlet {
+
+    private static final long serialVersionUID = 1L;
+
+    static final String URI_CONTEXT_ROOT = "http://localhost:"
+            + Integer.getInteger("bvt.prop.HTTP_default") + "/uriInfo/";
+
+    private Client client;
+
+    @Override
+    public void init() throws jakarta.servlet.ServletException {
+        client = ClientBuilder.newClient();
+    }
+
+    @After
+    private void teardown() {
+        client.close();
+    }
+
+    /**
+     * returns UriInfo.getPath() WITH a leading '/'.
+     */
+    @Test
+    public void testGetPathHasLeadingSlash() throws Exception {
+        Response response = client.target(URI_CONTEXT_ROOT)
+                                  .path("resources/test/getpath")
+                                  .request()
+                                  .get();
+        assertEquals(200, response.getStatus());
+        String path = response.readEntity(String.class);
+        assertTrue("Expected path to start with '/' but was: " + path, path.startsWith("/"));
+        assertEquals("/test/getpath", path);
+    }
+
+    /**
+     * returns an empty (non-null) List for an absent request header.
+     */
+    @Test
+    public void testMissingHeaderReturnsEmpty() throws Exception {
+        Response response = client.target(URI_CONTEXT_ROOT)
+                                  .path("resources/test/missingheader")
+                                  .request()
+                                  .get();
+        assertEquals(200, response.getStatus());
+        assertEquals("empty", response.readEntity(String.class));
+    }
+}

--- a/dev/io.openliberty.restfulWS.3.1_fat/publish/servers/uriInfo/bootstrap.properties
+++ b/dev/io.openliberty.restfulWS.3.1_fat/publish/servers/uriInfo/bootstrap.properties
@@ -1,0 +1,4 @@
+com.ibm.ws.logging.trace.specification=*=info
+com.ibm.ws.logging.max.file.size=0
+
+bootstrap.include=../testports.properties

--- a/dev/io.openliberty.restfulWS.3.1_fat/publish/servers/uriInfo/server.xml
+++ b/dev/io.openliberty.restfulWS.3.1_fat/publish/servers/uriInfo/server.xml
@@ -1,0 +1,13 @@
+<server>
+    <featureManager>
+        <feature>componenttest-2.0</feature>
+        <feature>restfulWS-3.1</feature>
+        <feature>servlet-6.0</feature>
+    </featureManager>
+
+    <include location="../fatTestPorts.xml"/>
+    <javaPermission className="java.util.PropertyPermission" name="bvt.prop.HTTP_default" actions="read"/>
+
+    <javaPermission className="java.util.PropertyPermission" name="*" actions="read"/>
+    <javaPermission className="java.io.FilePermission" name="&lt;&lt;ALL FILES&gt;&gt;" actions="read"/>
+</server>


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [ ] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

---

## Summary

Adds FAT tests that lock in two confirmed behaviour differences between `jaxrs-2.1` (Apache CXF, EE8) and `restfulWS-3.1`/`restfulWS-4.0` (RESTEasy, EE10/EE11).

These differences were surfaced by a customer migrating from EE8 to EE10 and are not explicitly called out in the existing migration documentation.

## Behaviour differences covered

**1. `UriInfo.getPath()` — leading slash**
- CXF : strips the leading `/` → returns `"test/getpath"`
- RESTEasy : preserves the leading `/` → returns `"/test/getpath"`

**2. `HttpHeaders.getRequestHeader()` for an absent header**
- CXF : returns `null`
- RESTEasy : returns an empty `List` (never null)
