### PR TITLE
Fix hard break for reactive messaging fat

### DIFF
--- a/dev/com.ibm.ws.microprofile.reactive.messaging.kafka/src/com/ibm/ws/microprofile/reactive/messaging/kafka/AppAwareKafkaInput.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging.kafka/src/com/ibm/ws/microprofile/reactive/messaging/kafka/AppAwareKafkaInput.java
@@ -1,0 +1,118 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package com.ibm.ws.microprofile.reactive.messaging.kafka;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+
+import org.eclipse.microprofile.reactive.messaging.Message;
+import org.eclipse.microprofile.reactive.streams.operators.PublisherBuilder;
+
+import com.ibm.ws.cdi.CDIService;
+import com.ibm.ws.kernel.service.util.ServiceCaller;
+import com.ibm.ws.microprofile.reactive.messaging.kafka.adapter.KafkaAdapterFactory;
+import com.ibm.ws.microprofile.reactive.messaging.kafka.adapter.KafkaConsumer;
+import com.ibm.ws.runtime.metadata.ComponentMetaData;
+import com.ibm.ws.threadContext.ComponentMetaDataAccessorImpl;
+import com.ibm.wsspi.kernel.service.utils.FrameworkState;
+
+import io.openliberty.microprofile.reactive.messaging.internal.interfaces.RMAsyncProvider;
+
+public class AppAwareKafkaInput<K, V> extends KafkaInput<K, V> {
+
+    /**
+     * The name of the application that created this KafkaInput, captured at construction time.
+     * May be {@code null} if the application name could not be determined.
+     */
+    private final String applicationName;
+
+    /**
+     * Cached flag set to {@code true} once the application-started latch has been observed to have
+     * counted down. Once {@code true}, subsequent calls to {@link #executePollActions} skip the
+     * latch await entirely for performance.
+     */
+    private volatile boolean applicationStarted = false;
+
+    /**
+     * Latch obtained from {@link KafkaApplicationStateListener} for the owning application.
+     * Counted down to zero once the application has fully started.
+     * {@link #executePollActions} awaits this latch before entering its poll loop so
+     * that messages are never dispatched to application code before the application
+     * is fully started.
+     */
+    private final CountDownLatch applicationStartedLatch;
+
+    private final static ServiceCaller<KafkaApplicationStateListener> APP_STATE_LISTENER_CALLER = new ServiceCaller<>(KafkaInput.class,
+                                                                                                                      KafkaApplicationStateListener.class);
+
+    public AppAwareKafkaInput(KafkaAdapterFactory kafkaAdapterFactory, PartitionTrackerFactory partitionTrackerFactory, KafkaConsumer<K, V> kafkaConsumer,
+                              RMAsyncProvider asyncProvider, String topic, int unackedLimit, boolean fastAck) {
+        super(kafkaAdapterFactory, partitionTrackerFactory, kafkaConsumer, asyncProvider, topic, unackedLimit, fastAck);
+
+        this.applicationName = resolveApplicationName();
+
+        if (applicationName == null) {
+            throw new IllegalStateException("Could not determine the application name for this KafkaInput");
+        }
+
+        this.applicationStartedLatch = APP_STATE_LISTENER_CALLER.run(kasl -> kasl.getLatch(applicationName))
+                                                                .orElseThrow(() -> new IllegalStateException("Could not acquire the latch KafkaInput with applicationName "
+                                                                                                             + applicationName));
+
+    }
+
+    /**
+     * Capture the application name at construction time.
+     * <p>
+     * Mirrors OSGiConfigUtils.getApplicationName (in io.openliberty.microprofile.config.internal.serverxml):
+     * reads the thread-local {@link ComponentMetaData} first then falls back to asking the {@link CDIService}
+     * for the current application context ID.
+     *
+     * @return the application name, or {@code null} if it cannot be determined
+     */
+    private static String resolveApplicationName() {
+        if (!FrameworkState.isValid()) {
+            return null;
+        }
+        ComponentMetaData cmd = ComponentMetaDataAccessorImpl.getComponentMetaDataAccessor().getComponentMetaData();
+        if (cmd != null) {
+            return cmd.getJ2EEName().getApplication();
+        }
+
+        //Fallback to try getting the name from CDI. This will work if CDI's startup routine is on the current thread stack.
+        return ServiceCaller.runOnce(KafkaInput.class, CDIService.class,
+                                     CDIService::getCurrentApplicationContextID)
+                            .orElse(null);
+    }
+
+    @Override
+    protected void countDownAppStartedLatch() {
+        applicationStartedLatch.countDown();
+    }
+
+    @Override
+    protected boolean isAppStarted() {
+        return applicationStarted;
+    }
+
+    @Override
+    protected boolean waitForAppStart(CompletableFuture<PublisherBuilder<Message<V>>> result) {
+        if (!applicationStarted) {
+            try {
+                applicationStartedLatch.await();
+                applicationStarted = true;
+            } catch (InterruptedException e) {
+                result.completeExceptionally(e);
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/dev/com.ibm.ws.microprofile.reactive.messaging.kafka/src/com/ibm/ws/microprofile/reactive/messaging/kafka/AppAwareKafkaInput.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging.kafka/src/com/ibm/ws/microprofile/reactive/messaging/kafka/AppAwareKafkaInput.java
@@ -16,6 +16,7 @@ import org.eclipse.microprofile.reactive.messaging.Message;
 import org.eclipse.microprofile.reactive.streams.operators.PublisherBuilder;
 
 import com.ibm.ws.cdi.CDIService;
+import com.ibm.ws.ffdc.annotation.FFDCIgnore;
 import com.ibm.ws.kernel.service.util.ServiceCaller;
 import com.ibm.ws.microprofile.reactive.messaging.kafka.adapter.KafkaAdapterFactory;
 import com.ibm.ws.microprofile.reactive.messaging.kafka.adapter.KafkaConsumer;
@@ -103,6 +104,7 @@ public class AppAwareKafkaInput<K, V> extends KafkaInput<K, V> {
     }
 
     @Override
+    @FFDCIgnore(InterruptedException.class)
     protected boolean waitForAppStart(CompletableFuture<PublisherBuilder<Message<V>>> result) {
         if (!applicationStarted) {
             try {

--- a/dev/com.ibm.ws.microprofile.reactive.messaging.kafka/src/com/ibm/ws/microprofile/reactive/messaging/kafka/KafkaIncomingConnector.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging.kafka/src/com/ibm/ws/microprofile/reactive/messaging/kafka/KafkaIncomingConnector.java
@@ -1,14 +1,11 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2023 IBM Corporation and others.
+ * Copyright (c) 2019, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package com.ibm.ws.microprofile.reactive.messaging.kafka;
 
@@ -161,8 +158,8 @@ public class KafkaIncomingConnector implements IncomingConnectorFactory, Quiesce
             }
 
             // Create our connector around the kafkaConsumer
-            KafkaInput<String, Object> kafkaInput = new KafkaInput<>(this.kafkaAdapterFactory, partitionTrackerFactory, kafkaConsumer, asyncProvider,
-                                                                     topic, unackedLimit, fastAck);
+            KafkaInput<String, Object> kafkaInput = new AppAwareKafkaInput<>(this.kafkaAdapterFactory, partitionTrackerFactory, kafkaConsumer, asyncProvider,
+                                                                             topic, unackedLimit, fastAck);
             kafkaInputs.add(kafkaInput);
 
             return kafkaInput.getPublisher();

--- a/dev/com.ibm.ws.microprofile.reactive.messaging.kafka/src/com/ibm/ws/microprofile/reactive/messaging/kafka/KafkaInput.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging.kafka/src/com/ibm/ws/microprofile/reactive/messaging/kafka/KafkaInput.java
@@ -24,7 +24,6 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ConcurrentLinkedQueue;
-import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Function;
@@ -35,10 +34,8 @@ import org.eclipse.microprofile.reactive.streams.operators.ReactiveStreams;
 
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
-import com.ibm.ws.cdi.CDIService;
 import com.ibm.ws.ffdc.FFDCFilter;
 import com.ibm.ws.ffdc.annotation.FFDCIgnore;
-import com.ibm.ws.kernel.service.util.ServiceCaller;
 import com.ibm.ws.microprofile.reactive.messaging.kafka.adapter.ConsumerRebalanceListener;
 import com.ibm.ws.microprofile.reactive.messaging.kafka.adapter.ConsumerRecord;
 import com.ibm.ws.microprofile.reactive.messaging.kafka.adapter.ConsumerRecords;
@@ -47,9 +44,6 @@ import com.ibm.ws.microprofile.reactive.messaging.kafka.adapter.KafkaConsumer;
 import com.ibm.ws.microprofile.reactive.messaging.kafka.adapter.OffsetAndMetadata;
 import com.ibm.ws.microprofile.reactive.messaging.kafka.adapter.TopicPartition;
 import com.ibm.ws.microprofile.reactive.messaging.kafka.adapter.WakeupException;
-import com.ibm.ws.runtime.metadata.ComponentMetaData;
-import com.ibm.ws.threadContext.ComponentMetaDataAccessorImpl;
-import com.ibm.wsspi.kernel.service.utils.FrameworkState;
 
 import io.openliberty.microprofile.reactive.messaging.internal.interfaces.RMAsyncProvider;
 import io.openliberty.microprofile.reactive.messaging.internal.interfaces.RMContext;
@@ -62,7 +56,7 @@ import io.openliberty.microprofile.reactive.messaging.internal.interfaces.RMCont
  * @param V
  *            the value type
  */
-public class KafkaInput<K, V> implements ConsumerRebalanceListener {
+public abstract class KafkaInput<K, V> implements ConsumerRebalanceListener {
 
     private static final TraceComponent tc = Tr.register(KafkaInput.class);
     private static final Duration FOREVER = Duration.ofMillis(Long.MAX_VALUE);
@@ -70,28 +64,6 @@ public class KafkaInput<K, V> implements ConsumerRebalanceListener {
     private final KafkaConsumer<K, V> kafkaConsumer;
     private final RMAsyncProvider asyncProvider;
     private final Collection<String> topics;
-
-    /**
-     * The name of the application that created this KafkaInput, captured at construction time.
-     * May be {@code null} if the application name could not be determined.
-     */
-    private final String applicationName;
-
-    /**
-     * Cached flag set to {@code true} once the application-started latch has been observed to have
-     * counted down. Once {@code true}, subsequent calls to {@link #executePollActions} skip the
-     * latch await entirely for performance.
-     */
-    private volatile boolean applicationStarted = false;
-
-    /**
-     * Latch obtained from {@link KafkaApplicationStateListener} for the owning application.
-     * Counted down to zero once the application has fully started.
-     * {@link #executePollActions} awaits this latch before entering its poll loop so
-     * that messages are never dispatched to application code before the application
-     * is fully started.
-     */
-    private final CountDownLatch applicationStartedLatch;
 
     private PublisherBuilder<Message<V>> publisher;
     private boolean subscribed = false;
@@ -128,9 +100,6 @@ public class KafkaInput<K, V> implements ConsumerRebalanceListener {
      */
     private final ReentrantLock lock = new ReentrantLock();
 
-    private final static ServiceCaller<KafkaApplicationStateListener> APP_STATE_LISTENER_CALLER = new ServiceCaller<>(KafkaInput.class,
-                                                                                                                      KafkaApplicationStateListener.class);
-
     public KafkaInput(KafkaAdapterFactory kafkaAdapterFactory, PartitionTrackerFactory partitionTrackerFactory,
                       KafkaConsumer<K, V> kafkaConsumer, RMAsyncProvider asyncProvider,
                       String topic, int unackedLimit, boolean fastAck) {
@@ -147,40 +116,6 @@ public class KafkaInput<K, V> implements ConsumerRebalanceListener {
             this.unackedMessageCounter = ThresholdCounter.UNLIMITED;
         }
         this.fastAck = fastAck;
-        this.applicationName = resolveApplicationName();
-
-        if (applicationName == null) {
-            throw new IllegalStateException("Could not determine the application name for this KafkaInput");
-        }
-
-        this.applicationStartedLatch = APP_STATE_LISTENER_CALLER.run(kasl -> kasl.getLatch(applicationName))
-                                                                .orElseThrow(() -> new IllegalStateException("Could not acquire the latch KafkaInput with applicationName "
-                                                                                                             + applicationName));
-
-    }
-
-    /**
-     * Capture the application name at construction time.
-     * <p>
-     * Mirrors OSGiConfigUtils.getApplicationName (in io.openliberty.microprofile.config.internal.serverxml):
-     * reads the thread-local {@link ComponentMetaData} first then falls back to asking the {@link CDIService}
-     * for the current application context ID.
-     *
-     * @return the application name, or {@code null} if it cannot be determined
-     */
-    private static String resolveApplicationName() {
-        if (!FrameworkState.isValid()) {
-            return null;
-        }
-        ComponentMetaData cmd = ComponentMetaDataAccessorImpl.getComponentMetaDataAccessor().getComponentMetaData();
-        if (cmd != null) {
-            return cmd.getJ2EEName().getApplication();
-        }
-
-        //Fallback to try getting the name from CDI. This will work if CDI's startup routine is on the current thread stack.
-        return ServiceCaller.runOnce(KafkaInput.class, CDIService.class,
-                                     CDIService::getCurrentApplicationContextID)
-                            .orElse(null);
     }
 
     public PublisherBuilder<Message<V>> getPublisher() {
@@ -257,6 +192,8 @@ public class KafkaInput<K, V> implements ConsumerRebalanceListener {
         return null;
     }
 
+    protected abstract void countDownAppStartedLatch();
+
     public void shutdown() {
         if (TraceComponent.isAnyTracingEnabled() && tc.isEventEnabled()) {
             Tr.event(tc, "Shutting down Kafka connection");
@@ -265,7 +202,7 @@ public class KafkaInput<K, V> implements ConsumerRebalanceListener {
         this.running = false;
         // Unlock the application-started latch so threads
         // can observe running == false and exit cleanly.
-        applicationStartedLatch.countDown();
+        countDownAppStartedLatch();
 
         this.kafkaConsumer.wakeup();
         this.lock.lock();
@@ -279,6 +216,8 @@ public class KafkaInput<K, V> implements ConsumerRebalanceListener {
             tracker.close();
         }
     }
+
+    protected abstract boolean isAppStarted();
 
     @FFDCIgnore({ WakeupException.class, RejectedExecutionException.class })
     private CompletionStage<PublisherBuilder<Message<V>>> pollKafkaAsync() {
@@ -305,7 +244,7 @@ public class KafkaInput<K, V> implements ConsumerRebalanceListener {
 
         ConsumerRecords<K, V> records = null;
 
-        while (applicationStarted && this.lock.tryLock()) {
+        while (isAppStarted() && this.lock.tryLock()) {
             try {
                 records = this.kafkaConsumer.poll(ZERO);
                 break;
@@ -339,6 +278,8 @@ public class KafkaInput<K, V> implements ConsumerRebalanceListener {
         return result;
     }
 
+    protected abstract boolean waitForAppStart(CompletableFuture<PublisherBuilder<Message<V>>> result);
+
     /**
      * Run any pending actions and then poll Kafka for messages.
      * <p>
@@ -348,14 +289,8 @@ public class KafkaInput<K, V> implements ConsumerRebalanceListener {
      */
     @FFDCIgnore({ WakeupException.class, InterruptedException.class })
     private void executePollActions(CompletableFuture<PublisherBuilder<Message<V>>> result) {
-        if (!applicationStarted) {
-            try {
-                applicationStartedLatch.await();
-                applicationStarted = true;
-            } catch (InterruptedException e) {
-                result.completeExceptionally(e);
-                return;
-            }
+        if (!waitForAppStart(result)) {
+            return;
         }
         this.lock.lock();
         try {

--- a/dev/com.ibm.ws.microprofile.reactive.messaging.kafka/src/com/ibm/ws/microprofile/reactive/messaging/kafka/KafkaInput.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging.kafka/src/com/ibm/ws/microprofile/reactive/messaging/kafka/KafkaInput.java
@@ -287,7 +287,7 @@ public abstract class KafkaInput<K, V> implements ConsumerRebalanceListener {
      * so that messages are never dispatched to application code during application startup.
      * The wait is skipped on subsequent calls once {@link #applicationStarted} is {@code true}.
      */
-    @FFDCIgnore({ WakeupException.class, InterruptedException.class })
+    @FFDCIgnore({ WakeupException.class })
     private void executePollActions(CompletableFuture<PublisherBuilder<Message<V>>> result) {
         if (!waitForAppStart(result)) {
             return;

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/tck/KafkaPublisherVerification.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/tck/KafkaPublisherVerification.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2025 IBM Corporation and others.
+ * Copyright (c) 2019, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -112,7 +112,7 @@ public class KafkaPublisherVerification extends PublisherVerification<Message<St
         PartitionTrackerFactory trackerFactory = new PartitionTrackerFactory();
         trackerFactory.setAsyncProvider(asyncProvider);
         trackerFactory.setAutoCommitEnabled(false);
-        KafkaInput<String, String> kafkaInput = new KafkaInput<>(kafkaAdapterFactory, trackerFactory, kafkaConsumer, asyncProvider, topicName, 100, false);
+        KafkaInput<String, String> kafkaInput = new TestKafkaInput<>(kafkaAdapterFactory, trackerFactory, kafkaConsumer, asyncProvider, topicName, 100, false);
         kafkaInputs.add(kafkaInput);
         return kafkaInput.getPublisher().buildRs();
     }
@@ -148,7 +148,7 @@ public class KafkaPublisherVerification extends PublisherVerification<Message<St
         PartitionTrackerFactory trackerFactory = new PartitionTrackerFactory();
         trackerFactory.setAsyncProvider(asyncProvider);
         trackerFactory.setAutoCommitEnabled(false);
-        KafkaInput<String, String> kafkaInput = new KafkaInput<>(kafkaAdapterFactory, trackerFactory, kafkaConsumer, asyncProvider, topicName, 100, false);
+        KafkaInput<String, String> kafkaInput = new TestKafkaInput<>(kafkaAdapterFactory, trackerFactory, kafkaConsumer, asyncProvider, topicName, 100, false);
         kafkaInputs.add(kafkaInput);
         return kafkaInput.getPublisher().buildRs();
     }

--- a/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/tck/TestKafkaInput.java
+++ b/dev/com.ibm.ws.microprofile.reactive.messaging_fat/fat/src/com/ibm/ws/microprofile/reactive/messaging/fat/kafka/tck/TestKafkaInput.java
@@ -1,0 +1,46 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package com.ibm.ws.microprofile.reactive.messaging.fat.kafka.tck;
+
+import java.util.concurrent.CompletableFuture;
+
+import org.eclipse.microprofile.reactive.messaging.Message;
+import org.eclipse.microprofile.reactive.streams.operators.PublisherBuilder;
+
+import com.ibm.ws.microprofile.reactive.messaging.kafka.KafkaInput;
+import com.ibm.ws.microprofile.reactive.messaging.kafka.PartitionTrackerFactory;
+import com.ibm.ws.microprofile.reactive.messaging.kafka.adapter.KafkaAdapterFactory;
+import com.ibm.ws.microprofile.reactive.messaging.kafka.adapter.KafkaConsumer;
+
+import io.openliberty.microprofile.reactive.messaging.internal.interfaces.RMAsyncProvider;
+
+public class TestKafkaInput<K, V> extends KafkaInput<K, V> {
+
+    public TestKafkaInput(KafkaAdapterFactory kafkaAdapterFactory, PartitionTrackerFactory partitionTrackerFactory, KafkaConsumer<K, V> kafkaConsumer,
+                          RMAsyncProvider asyncProvider, String topic, int unackedLimit, boolean fastAck) {
+        super(kafkaAdapterFactory, partitionTrackerFactory, kafkaConsumer, asyncProvider, topic, unackedLimit, fastAck);
+    }
+
+    @Override
+    protected void countDownAppStartedLatch() {
+        // Nothing to do
+    }
+
+    @Override
+    protected boolean isAppStarted() {
+        return true;
+    }
+
+    @Override
+    protected boolean waitForAppStart(CompletableFuture<PublisherBuilder<Message<V>>> result) {
+        return true;
+    }
+
+}


### PR DESCRIPTION
- #35349 added reference to ServiceCaller in the code, but test also uses the class which will not work.  Update to use a different implementation for test than for runtime.

- [ ] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [ ] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
