### PR TITLE
Fixing Java2Sec in jsonp21 fat

### DIFF
--- a/dev/io.openliberty.jsonp.2.1_fat/publish/servers/jsonp2.1.customProvider.fat/server.xml
+++ b/dev/io.openliberty.jsonp.2.1_fat/publish/servers/jsonp2.1.customProvider.fat/server.xml
@@ -20,4 +20,16 @@
     <application location="ProviderFeatureApp.war" />
     <application location="BundledProviderApp.war" />
     <include location="../fatTestPorts.xml"/>
+
+    <!-- Johnzon reads org.apache.johnzon.* and unprefixed johnzon.* system properties
+         (e.g. johnzon.max-big-decimal-scale) during static initialization.
+         Grant both patterns so Java 2 Security does not block the bundled johnzon-core.jar. -->
+    <javaPermission codebase="${server.config.dir}/apps/BundledProviderApp.war"
+                    className="java.util.PropertyPermission"
+                    name="org.apache.johnzon.*"
+                    actions="read"/>
+    <javaPermission codebase="${server.config.dir}/apps/BundledProviderApp.war"
+                    className="java.util.PropertyPermission"
+                    name="johnzon.*"
+                    actions="read"/>
 </server>


### PR DESCRIPTION
Co-authored-by-AI: IBM Bob 2.0.2

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".