### PR TITLE
Update Servlet 31 FAT CDIUpgradeHandlerTest to accommodate a race condition.

### DIFF
--- a/dev/com.ibm.ws.webcontainer.servlet.3.1_fat/fat/src/com/ibm/ws/webcontainer/servlet31/fat/tests/CDIUpgradeHandlerTest.java
+++ b/dev/com.ibm.ws.webcontainer.servlet.3.1_fat/fat/src/com/ibm/ws/webcontainer/servlet31/fat/tests/CDIUpgradeHandlerTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2024 IBM Corporation and others.
+ * Copyright (c) 2015, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -260,6 +260,7 @@ public class CDIUpgradeHandlerTest {
         // make sure server side is finished onWritePossible
         // wait till see this message CDITestWriteListener: onWritePossible: EXIT
         LS.waitForStringInLogUsingLastOffset("CDITestWriteListener: onWritePossible: EXIT");
+        LS.waitForStringInLogUsingLastOffset("CDITestReadListener: onDataAvailable: EXIT");
 
         LOG.info("implTestCDIUpgrade : Now check the results and compare it with [ EXPECTED_LOG2 ]");
 
@@ -268,6 +269,7 @@ public class CDIUpgradeHandlerTest {
         performUpgrade();
 
         LS.waitForStringInLogUsingLastOffset("CDITestWriteListener: onWritePossible: EXIT");
+        LS.waitForStringInLogUsingLastOffset("CDITestReadListener: onDataAvailable: EXIT");
 
         LOG.info("implTestCDIUpgrade : Now check the results and compare it with  [ EXPECTED_LOG3 ]");
 

--- a/dev/com.ibm.ws.webcontainer.servlet.3.1_fat/fat/src/com/ibm/ws/webcontainer/servlet31/fat/tests/CDIUpgradeHandlerTest.java
+++ b/dev/com.ibm.ws.webcontainer.servlet.3.1_fat/fat/src/com/ibm/ws/webcontainer/servlet31/fat/tests/CDIUpgradeHandlerTest.java
@@ -259,8 +259,18 @@ public class CDIUpgradeHandlerTest {
         performUpgrade();
         // make sure server side is finished onWritePossible
         // wait till see this message CDITestWriteListener: onWritePossible: EXIT
-        LS.waitForStringInLogUsingLastOffset("CDITestWriteListener: onWritePossible: EXIT");
-        LS.waitForStringInLogUsingLastOffset("CDITestReadListener: onDataAvailable: EXIT");
+
+        // Wait for the last server-log event in the upgrade cycle.
+        // onAllDataRead: EXIT is the final step in the async chain:
+        //   init -> setReadListener -> onDataAvailable -> setWriteListener
+        //   -> onWritePossible (closes connection) -> onAllDataRead
+        // All application log entries (including init:Exit, setReadListener:Exit,
+        // onDataAvailable:Exit, onWritePossible:Exit) are guaranteed to be written
+        // before onAllDataRead: EXIT appears in the server log.
+        LS.waitForStringInLogUsingLastOffset("CDITestReadListener: onAllDataRead: EXIT");
+
+        //LS.waitForStringInLogUsingLastOffset("CDITestWriteListener: onWritePossible: EXIT");
+        //LS.waitForStringInLogUsingLastOffset("CDITestReadListener: onDataAvailable: EXIT");
 
         LOG.info("implTestCDIUpgrade : Now check the results and compare it with [ EXPECTED_LOG2 ]");
 
@@ -268,8 +278,10 @@ public class CDIUpgradeHandlerTest {
 
         performUpgrade();
 
-        LS.waitForStringInLogUsingLastOffset("CDITestWriteListener: onWritePossible: EXIT");
-        LS.waitForStringInLogUsingLastOffset("CDITestReadListener: onDataAvailable: EXIT");
+        LS.waitForStringInLogUsingLastOffset("CDITestReadListener: onAllDataRead: EXIT");
+
+//        LS.waitForStringInLogUsingLastOffset("CDITestWriteListener: onWritePossible: EXIT");
+//        LS.waitForStringInLogUsingLastOffset("CDITestReadListener: onDataAvailable: EXIT");
 
         LOG.info("implTestCDIUpgrade : Now check the results and compare it with  [ EXPECTED_LOG3 ]");
 

--- a/dev/com.ibm.ws.webcontainer.servlet.3.1_fat/test-applications/CDI12TestV2Upgrade.war/src/com/ibm/ws/webcontainer/servlet_31_fat/cdi12testv2upgrade/war/cdi/upgrade/handlers/CDITestHttpUpgradeHandler.java
+++ b/dev/com.ibm.ws.webcontainer.servlet.3.1_fat/test-applications/CDI12TestV2Upgrade.war/src/com/ibm/ws/webcontainer/servlet_31_fat/cdi12testv2upgrade/war/cdi/upgrade/handlers/CDITestHttpUpgradeHandler.java
@@ -83,6 +83,7 @@ public class CDITestHttpUpgradeHandler implements HttpUpgradeHandler {
 
     protected void logBeanActivity(String className, String methodName, String text) {
         String activityText = ":" + className + ":" + methodName + ":" + text + ":";
+        LOG.info(className + " logBeanActivity, add to applicationLog [" + activityText + "]");
         applicationLog.addLine(activityText);
     }
 


### PR DESCRIPTION
Add a wait for server LOG to make sure both ReadListener and WriteListener (on different threads) can finish adding their activities to the applicationLog bean which is then returned in a response for asserting.