### PR TITLE
Fix MCP tests failing in CI

### DIFF
--- a/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/serverinfo/CustomServerInfoTest.java
+++ b/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/serverinfo/CustomServerInfoTest.java
@@ -51,6 +51,9 @@ public class CustomServerInfoTest {
     @Rule
     public McpClient customClient = new McpClient(server, "/fullyCustomServerInfoTest");
 
+    @Rule
+    public McpClient dynamicClient = new McpClient(server, "/dynamicServerInfoUpdateTest");
+
     @Server("mcp-server-custom-info")
     public static LibertyServer server;
 
@@ -64,13 +67,19 @@ public class CustomServerInfoTest {
         WebArchive customWar = ShrinkWrap.create(WebArchive.class, "fullyCustomServerInfoTest.war")
                                          .addPackage(BasicTools.class.getPackage());
 
+        // Deploy second app with serverInfo to be dynamically updated
+        WebArchive dynamicWar = ShrinkWrap.create(WebArchive.class, "dynamicServerInfoUpdateTest.war")
+                                          .addPackage(BasicTools.class.getPackage());
+
         ShrinkHelper.exportAppToServer(server, partialWar, SERVER_ONLY);
         ShrinkHelper.exportAppToServer(server, customWar, SERVER_ONLY);
+        ShrinkHelper.exportAppToServer(server, dynamicWar, SERVER_ONLY);
 
         server.startServer();
-        // Wait for both applications to be fully deployed and MCP endpoints to be available
+        // Wait for all applications to be fully deployed and MCP endpoints to be available
         assertNotNull(server.waitForStringInLog("MCP server endpoint: .*/partialServerInfoTest/mcp$"));
         assertNotNull(server.waitForStringInLog("MCP server endpoint: .*/fullyCustomServerInfoTest/mcp$"));
+        assertNotNull(server.waitForStringInLog("MCP server endpoint: .*/dynamicServerInfoUpdateTest/mcp$"));
     }
 
     @AfterClass
@@ -202,7 +211,7 @@ public class CustomServerInfoTest {
                         }
                         """;
 
-        String initialResponse = customClient.callMCP(request);
+        String initialResponse = dynamicClient.callMCP(request);
 
         String expectedInitialResponse = """
                         {
@@ -216,10 +225,10 @@ public class CustomServerInfoTest {
                               }
                             },
                             "serverInfo": {
-                              "name": "my-custom-server",
-                              "title": "My Custom MCP Server",
+                              "name": "my-unchanged-server",
+                              "title": "My Unupdated MCP Server",
                               "version": "2.5.0",
-                              "description": "My custom description"
+                              "description": "My unupdated description"
                             }
                           }
                         }
@@ -231,15 +240,15 @@ public class CustomServerInfoTest {
 
         // Mark the session as deleted since config changes will invalidate it
         // This prevents the cleanup code from trying to delete an already-invalid session
-        customClient.markSessionDeleted();
+        dynamicClient.markSessionDeleted();
 
         // Dynamically update the serverInfo configuration by replacing the server.xml
         server.setServerConfigurationFile("server_updated_info.xml");
-        server.waitForConfigUpdateInLogUsingMark(Collections.singleton("fullyCustomServerInfoTest"));
+        server.waitForConfigUpdateInLogUsingMark(Collections.singleton("dynamicServerInfoUpdateTest"));
 
         // Re-initialize the session after config update since the old session was invalidated
         // Create a new client which will automatically establish a new session
-        McpClient newClient = new McpClient(server, "/fullyCustomServerInfoTest");
+        McpClient newClient = new McpClient(server, "/dynamicServerInfoUpdateTest");
         newClient.initializeSession();
 
         try {

--- a/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/timeout/ConfigurableAsyncTimeoutTest.java
+++ b/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/timeout/ConfigurableAsyncTimeoutTest.java
@@ -14,6 +14,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import java.time.Duration;
 import java.util.Collections;
 
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -89,7 +90,7 @@ public class ConfigurableAsyncTimeoutTest {
      */
     @Test
     public void testShortAsyncTimeout() throws Exception {
-        long startTime = System.currentTimeMillis();
+        long startTime = System.nanoTime();
 
         String request = """
                         {
@@ -109,11 +110,12 @@ public class ConfigurableAsyncTimeoutTest {
             shortTimeoutClient.callMCP(request);
             fail("Expected timeout exception was not thrown");
         } catch (Exception e) {
-            long elapsedTime = System.currentTimeMillis() - startTime;
-            assertTrue("Timeout should occur within 5 seconds, but took " + elapsedTime + "ms",
-                       elapsedTime < 5000);
-            assertTrue("Timeout should take at least 2 seconds, but took " + elapsedTime + "ms",
-                       elapsedTime >= 2000);
+            long elapsedMs = Duration.ofNanos(System.nanoTime() - startTime).toMillis();
+            // Allow much longer than should be necessary to accommodate slow build systems
+            assertTrue("Timeout should occur within 25 seconds, but took " + elapsedMs + "ms",
+                       elapsedMs < 25000);
+            assertTrue("Timeout should take at least 2 seconds, but took " + elapsedMs + "ms",
+                       elapsedMs >= 2000);
         }
     }
 
@@ -176,15 +178,11 @@ public class ConfigurableAsyncTimeoutTest {
      *
      * Initial configuration: asyncTimeout="2s"
      * Updated configuration: asyncTimeout="5s"
-     *
-     * This test verifies that after updating the configuration, a tool that takes
-     * 3 seconds to complete will timeout with the initial 2s timeout but succeed
-     * with the updated 5s timeout.
      */
     @Test
     @Mode(TestMode.FULL)
     public void testDynamicAsyncTimeoutUpdate() throws Exception {
-        // First, verify the initial timeout (2 seconds) causes a timeout for a 3-second operation
+        // First, verify the initial timeout (2 seconds) causes a timeout
         String timeoutRequest = """
                         {
                           "jsonrpc": "2.0",
@@ -199,16 +197,15 @@ public class ConfigurableAsyncTimeoutTest {
                         }
                         """;
 
-        long startTime = System.currentTimeMillis();
+        long startTime = System.nanoTime();
         try {
             shortTimeoutClient.callMCP(timeoutRequest);
             fail("Expected timeout exception was not thrown with initial 2s timeout");
         } catch (Exception e) {
-            long elapsedTime = System.currentTimeMillis() - startTime;
-            assertTrue("Initial timeout should occur within 5 seconds, but took " + elapsedTime + "ms",
-                       elapsedTime < 5000);
-            assertTrue("Initial timeout should take at least 2 seconds, but took " + elapsedTime + "ms",
-                       elapsedTime >= 2000);
+            long elapsedMs = Duration.ofNanos(System.nanoTime() - startTime).toMillis();
+            // Don't test that elpasedTime < 5s because this test is unreliable on slow build systems
+            assertTrue("Initial timeout should take at least 2 seconds, but took " + elapsedMs + "ms",
+                       elapsedMs >= 2000);
         }
 
         server.setMarkToEndOfLog();
@@ -230,16 +227,14 @@ public class ConfigurableAsyncTimeoutTest {
         try {
             // Verify that with the updated timeout (5 seconds), the same operation still times out
             // but takes longer (since asyncToolThatNeverCompletes never completes)
-            startTime = System.currentTimeMillis();
+            startTime = System.nanoTime();
             try {
                 newShortTimeoutClient.callMCP(timeoutRequest);
                 fail("Expected timeout exception was not thrown with updated 5s timeout");
             } catch (Exception e) {
-                long elapsedTime = System.currentTimeMillis() - startTime;
-                assertTrue("Updated timeout should occur within 8 seconds, but took " + elapsedTime + "ms",
-                           elapsedTime < 8000);
-                assertTrue("Updated timeout should take at least 5 seconds, but took " + elapsedTime + "ms",
-                           elapsedTime >= 5000);
+                long elapsedMs = Duration.ofNanos(System.nanoTime() - startTime).toMillis();
+                assertTrue("Updated timeout should take at least 5 seconds, but took " + elapsedMs + "ms",
+                           elapsedMs >= 5000);
             }
 
             // Verify that a quick operation still works with the updated timeout

--- a/dev/io.openliberty.mcp.internal_fat/publish/files/server_updated_info.xml
+++ b/dev/io.openliberty.mcp.internal_fat/publish/files/server_updated_info.xml
@@ -16,13 +16,24 @@
 
 	<application location="fullyCustomServerInfoTest.war">
 	    <mcp>
-	        <!-- Updated values to test dynamic configuration -->
-	        <info name="updated-server-name"
-	              title="Updated Server Title"
-	              version="3.0.0"
-	              description="Updated server description" />
+	        <!-- Provide all custom fields to test full configuration -->
+	        <info name="my-custom-server"
+	              title="My Custom MCP Server"
+	              version="2.5.0"
+	              description="My custom description" />
 	    </mcp>
 	</application>
+
+    <application location="dynamicServerInfoUpdateTest.war">
+        <mcp>
+            <!-- Updated values to test dynamic configuration -->
+            <info name="updated-server-name"
+                  title="Updated Server Title"
+                  version="3.0.0"
+                  description="Updated server description" />
+        </mcp>
+    </application>
+
 
   <include location="../fatTestPorts.xml" />
   

--- a/dev/io.openliberty.mcp.internal_fat/publish/servers/mcp-server-custom-info/server.xml
+++ b/dev/io.openliberty.mcp.internal_fat/publish/servers/mcp-server-custom-info/server.xml
@@ -23,6 +23,17 @@
 	              description="My custom description" />
 	    </mcp>
 	</application>
+	
+    <application location="dynamicServerInfoUpdateTest.war">
+        <mcp>
+            <!-- Set all fields to test dynamic updates -->
+            <info name="my-unchanged-server"
+                  title="My Unupdated MCP Server"
+                  version="2.5.0"
+                  description="My unupdated description" />
+        </mcp>
+    </application>
+
 
   <include location="../fatTestPorts.xml" />
   


### PR DESCRIPTION
Fixes RTC 311528 and 311527

- Make `CustomerServerInfoTest` order independent because test execution order varies between Java implementations
- Allow longer timeouts in `ConfigurableAsyncTimeoutTest` because CI systems can be slow, especially processing the first request, and the timeout windows on this test were not wide enough.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
