### PR TITLE
Fix annotation scanner executor thread leak

### DIFF
--- a/dev/com.ibm.ws.anno/src/com/ibm/ws/annocache/targets/internal/TargetsScannerOverallImpl.java
+++ b/dev/com.ibm.ws.anno/src/com/ibm/ws/annocache/targets/internal/TargetsScannerOverallImpl.java
@@ -1337,6 +1337,8 @@ public class TargetsScannerOverallImpl extends TargetsScannerBaseImpl {
                "[ {0} ] ANNO_TARGETS_CACHE_EXCEPTION [ {1} ]",
                new Object[] { getHashText(), e });
             logger.logp(Level.WARNING, CLASS_NAME, methodName, "Cache error", e);
+        } finally {
+            readPool.shutdown();
         }
 
         if ( useHashText != null ) {
@@ -1413,6 +1415,8 @@ public class TargetsScannerOverallImpl extends TargetsScannerBaseImpl {
                "[ {0} ] ANNO_TARGETS_CACHE_EXCEPTION [ {1} ]",
                new Object[] { getHashText(), e });
             logger.logp(Level.WARNING, CLASS_NAME, methodName, "Cache error", e);
+        } finally {
+            validatorPool.shutdown();
         }
 
         int changedContainers = 0;
@@ -1524,6 +1528,8 @@ public class TargetsScannerOverallImpl extends TargetsScannerBaseImpl {
                "[ {0} ] ANNO_TARGETS_CACHE_EXCEPTION [ {1} ]",
                new Object[] { getHashText(), e });
             logger.logp(Level.WARNING, CLASS_NAME, methodName, "Cache error", e);
+        } finally {
+            completionPool.shutdown();
         }
 
         if ( useHashText != null ) {


### PR DESCRIPTION
## Problem

`TargetsScannerOverallImpl` creates temporary `UtilImpl_PoolExecutor` instances for the concurrent read, validation, and completion phases. These executors use the configured scan thread count as both the core and maximum pool size.

After each phase, the scanner waits on the executor's completion semaphore, but it does not shut the executor down. Because core thread timeout is not enabled, those worker threads remain alive after the phase has completed and can accumulate over the lifetime of the server.

Fixes #35561

## Change

Shut down each phase-scoped executor in a `finally` block after waiting for completion:

- read executor
- validation executor
- completion executor

`shutdown()` allows already-submitted tasks to complete and does not interrupt running work, so concurrent annotation scanning and startup performance are preserved. The `finally` blocks also ensure cleanup when the waiting thread is interrupted.

## Verification

- `./gradlew cnf:initialize --console=plain`
- `./gradlew com.ibm.ws.anno:build --console=plain`
- 381 tests passed, 0 failed, 0 skipped

- [x] I have considered the risk of behavior change or other zero migration impact.
- [x] If this PR fixes an Issue, the description includes "Fixes #35561".
- [ ] If this PR resolves an external Known Issue (including APARs), the description includes the relevant "Fixes #..." or "Resolves #..." reference.