### PR TITLE
﻿Fix #29751: audit feature creates unexpected JSESSIONID cookie on REST endpoints 

### DIFF
--- a/dev/com.ibm.websphere.security/src/com/ibm/wsspi/security/audit/AuditService.java
+++ b/dev/com.ibm.websphere.security/src/com/ibm/wsspi/security/audit/AuditService.java
@@ -50,6 +50,16 @@ public interface AuditService {
     String getServerID();
 
     /**
+     * Returns whether the audit service is configured to generate a new HTTP session
+     * when retrieving a session ID for audit events.
+     * When false, getSession(false) is used so no new session is created.
+     * Default is true to preserve existing behavior.
+     *
+     * @return true if a new session should be created when none exists, false otherwise
+     */
+    boolean isGenerateNewSession();
+
+    /**
      * @param configuredEvents
      * @return
      */

--- a/dev/com.ibm.ws.request.probe.audit.servlet/src/com/ibm/ws/request/probe/audit/servlet/AuditPE.java
+++ b/dev/com.ibm.ws.request.probe.audit.servlet/src/com/ibm/ws/request/probe/audit/servlet/AuditPE.java
@@ -335,18 +335,20 @@ public class AuditPE implements ProbeExtension {
 						auditManager.setLocalAddr(req.getLocalAddr());
 						auditManager.setLocalPort(String.valueOf(req.getLocalPort()));
 						String sessionID = null;
-						final HttpServletRequest f_req = req;
-						sessionID = AccessController.doPrivileged(new PrivilegedAction<String>() {
-							@Override
-							public String run() {
-								HttpSession session = f_req.getSession();
-								if (session != null) {
-									return session.getId();
-								} else {
-									return null;
+							final HttpServletRequest f_req = req;
+							final boolean createNew = auditServiceRef.getService() == null
+									|| auditServiceRef.getService().isGenerateNewSession();
+							sessionID = AccessController.doPrivileged(new PrivilegedAction<String>() {
+								@Override
+								public String run() {
+									HttpSession session = createNew ? f_req.getSession() : f_req.getSession(false);
+									if (session != null) {
+										return session.getId();
+									} else {
+										return null;
+									}
 								}
-							}
-						});
+							});
 						if (sessionID != null) {
 							auditManager.setSessionId(sessionID);
 						}

--- a/dev/com.ibm.ws.security.audit.source/resources/OSGI-INF/l10n/metatype.properties
+++ b/dev/com.ibm.ws.security.audit.source/resources/OSGI-INF/l10n/metatype.properties
@@ -14,6 +14,12 @@
 #NLS_ENCODING=UNICODE
 #NLS_MESSAGEFORMAT_NONE
 
+auditSource.name=Audit Source
+auditSource.desc=Configures global audit source behavior.
+
+generateNewSession.name=Generate new session
+generateNewSession.desc=Controls whether the audit service creates a new HTTP session when one does not already exist. Set to false to prevent the audit service from creating a new session, which avoids unexpected JSESSIONID cookies in REST endpoint responses. The default value is true to preserve existing behavior.
+
 auditEvent.name=Audit Event
 auditEvent.desc=An audit event
 

--- a/dev/com.ibm.ws.security.audit.source/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.security.audit.source/resources/OSGI-INF/metatype/metatype.xml
@@ -16,6 +16,15 @@
                    localization="OSGI-INF/l10n/metatype">
 
 
+<!-- Global audit source configuration -->
+<OCD id="com.ibm.ws.security.audit.source.metatype" name="%auditSource.name" description="%auditSource.desc" ibm:alias="auditSource">
+   <AD id="generateNewSession" name="%generateNewSession.name" description="%generateNewSession.desc" required="false" type="Boolean" default="true"/>
+</OCD>
+
+<Designate pid="com.ibm.ws.security.audit.source">
+   <Object ocdref="com.ibm.ws.security.audit.source.metatype"/>
+</Designate>
+
 <OCD id="com.ibm.ws.security.audit.event.metatype" name="%auditEvent.name" description="%auditEvent.desc" ibm:alias="auditEvent">
    <AD id="eventName" name="%eventName.name" description="%eventName.desc" required="false" type="String">
             <Option label="%securityAuditMgmt.desc" value="SECURITY_AUDIT_MGMT"/>  

--- a/dev/com.ibm.ws.security.audit.source/src/com/ibm/ws/security/audit/source/AuditServiceImpl.java
+++ b/dev/com.ibm.ws.security.audit.source/src/com/ibm/ws/security/audit/source/AuditServiceImpl.java
@@ -59,7 +59,9 @@ import com.ibm.wsspi.security.audit.AuditService;
  * This class is the security audit service. It handles audit config and is also
  * a collector manager Source for audit events.
  */
-@Component(service = { AuditService.class, Source.class }, configurationPid = "com.ibm.ws.security.audit.event", configurationPolicy = ConfigurationPolicy.OPTIONAL,
+@Component(service = { AuditService.class, Source.class },
+           configurationPid = { "com.ibm.ws.security.audit.source", "com.ibm.ws.security.audit.event" },
+           configurationPolicy = ConfigurationPolicy.OPTIONAL,
            property = "service.vendor=IBM", immediate = true)
 
 public class AuditServiceImpl implements AuditService, Source {
@@ -132,7 +134,9 @@ public class AuditServiceImpl implements AuditService, Source {
     private boolean auditServiceStarted = false;
     private boolean emitted1 = false;
     private final boolean emitted2 = false;
-    private boolean emitMsgOnce = true; 
+    private boolean emitMsgOnce = true;
+    private static final String KEY_GENERATE_NEW_SESSION = "generateNewSession";
+    private volatile boolean generateNewSession = true;
 
     @Activate
     protected void activate(ComponentContext cc, Map<String, Object> configuration) {
@@ -151,6 +155,10 @@ public class AuditServiceImpl implements AuditService, Source {
                     setAuditData(value);
                 } else if (key.equals(AuditConstants.OUTCOME)) {
                     setOutcome(value);
+                } else if (key.equals(KEY_GENERATE_NEW_SESSION)) {
+                    if (value instanceof Boolean) {
+                        generateNewSession = (Boolean) value;
+                    }
                 }
             }
         }
@@ -203,7 +211,20 @@ public class AuditServiceImpl implements AuditService, Source {
     }
 
     @Modified
-    protected void modified(Map<String, Object> configuration) {}
+    protected void modified(Map<String, Object> configuration) {
+        if (configuration != null) {
+            Object value = configuration.get(KEY_GENERATE_NEW_SESSION);
+            if (value instanceof Boolean) {
+                generateNewSession = (Boolean) value;
+            }
+        }
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public boolean isGenerateNewSession() {
+        return generateNewSession;
+    }
 
     /*
      * (non-Javadoc)

--- a/dev/com.ibm.ws.security.audit.source/src/com/ibm/ws/security/audit/source/utils/AuditUtils.java
+++ b/dev/com.ibm.ws.security.audit.source/src/com/ibm/ws/security/audit/source/utils/AuditUtils.java
@@ -38,7 +38,6 @@ import com.ibm.wsspi.kernel.service.utils.AtomicServiceReference;
 import com.ibm.wsspi.security.audit.AuditService;
 import com.ibm.wsspi.security.registry.RegistryHelper;
 
-
 /**
  * Various and sundry utility methods for auditing.
  */
@@ -72,11 +71,18 @@ public class AuditUtils {
     /**
      * Return the session id if the request has an HttpSession,
      * otherwise return null.
+     * <p>
+     * When {@code generateNewSession} is configured to {@code false} on the
+     * {@code auditSource} element, this method will not create a new HTTP
+     * session if one does not already exist (uses {@code getSession(false)}).
+     * The default behavior (true) creates a new session if none exists.
      *
      * @param req
      * @return session id or null
      */
     public static String getSessionID(HttpServletRequest req) {
+        AuditService svc = auditServiceRef.getService();
+        final boolean createNew = (svc == null) || svc.isGenerateNewSession();
         String sessionID = null;
         final HttpServletRequest f_req = req;
 
@@ -84,7 +90,7 @@ public class AuditUtils {
             sessionID = AccessController.doPrivileged(new PrivilegedExceptionAction<String>() {
                 @Override
                 public String run() throws Exception {
-                    HttpSession session = f_req.getSession();
+                    HttpSession session = createNew ? f_req.getSession() : f_req.getSession(false);
                     if (session != null) {
                         return session.getId();
                     } else {
@@ -98,7 +104,8 @@ public class AuditUtils {
                     sessionID = AccessController.doPrivileged(new PrivilegedAction<String>() {
                         @Override
                         public String run() {
-                            return f_req.getSession().getId();
+                            HttpSession session = createNew ? f_req.getSession() : f_req.getSession(false);
+                            return session != null ? session.getId() : null;
                         }
                     });
                 } else {
@@ -117,7 +124,8 @@ public class AuditUtils {
                     sessionID = AccessController.doPrivileged(new PrivilegedAction<String>() {
                         @Override
                         public String run() {
-                            return f_req.getSession().getId();
+                            HttpSession session = createNew ? f_req.getSession() : f_req.getSession(false);
+                            return session != null ? session.getId() : null;
                         }
                     });
                 } else {

--- a/dev/io.openliberty.security.audit.internal_fat/bnd.bnd
+++ b/dev/io.openliberty.security.audit.internal_fat/bnd.bnd
@@ -1,0 +1,36 @@
+#*******************************************************************************
+# Copyright (c) 2025 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+#*******************************************************************************
+-include= ~../cnf/resources/bnd/bundle.props
+bVersion=1.0
+
+src: \
+    fat/src,\
+    test-applications/AuditSessionApp/src
+
+fat.project: true
+
+tested.features: \
+    audit-1.0,\
+    audit-2.0,\
+    servlet-6.0,\
+    restfulws-3.1
+
+-buildpath: \
+    com.ibm.websphere.javaee.servlet.3.1;version=latest,\
+    com.ibm.websphere.javaee.jaxrs.2.1;version=latest,\
+    com.ibm.websphere.javaee.annotation.1.3;version=latest,\
+    com.ibm.ws.componenttest.2.0,\
+    io.openliberty.jakarta.restfulWS.3.1;version=latest,\
+    io.openliberty.jakarta.servlet.6.0;version=latest
+
+-sub: *.bnd

--- a/dev/io.openliberty.security.audit.internal_fat/build.gradle
+++ b/dev/io.openliberty.security.audit.internal_fat/build.gradle
@@ -1,0 +1,14 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+addRequiredLibraries.dependsOn addJakartaTransformer

--- a/dev/io.openliberty.security.audit.internal_fat/fat/src/io/openliberty/security/audit/internal/fat/AuditGenerateNewSessionTest.java
+++ b/dev/io.openliberty.security.audit.internal_fat/fat/src/io/openliberty/security/audit/internal/fat/AuditGenerateNewSessionTest.java
@@ -1,0 +1,182 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.security.audit.internal.fat;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertEquals;
+
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions;
+import com.ibm.websphere.simplicity.log.Log;
+
+import componenttest.annotation.Server;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.utils.HttpUtils;
+
+/**
+ * Tests for GH issue #29751: audit-1.0 must not create an unexpected JSESSIONID
+ * cookie when auditing REST endpoints that do not use HttpSession.
+ *
+ * <p>Two scenarios:
+ * <ol>
+ *   <li>{@code generateNewSession=true} (default) — verifies the legacy behaviour:
+ *       the audit code is permitted to create a new session (JSESSIONID may appear).</li>
+ *   <li>{@code generateNewSession=false} — verifies the fix: no JSESSIONID cookie
+ *       is returned for a session-free REST call.</li>
+ * </ol>
+ */
+@RunWith(FATRunner.class)
+public class AuditGenerateNewSessionTest {
+
+    private static final Class<?> c = AuditGenerateNewSessionTest.class;
+
+    public static final String APP_NAME = "AuditSessionApp";
+    public static final String SERVER_NAME = "AuditSessionServer";
+
+    /** Config snippet that sets generateNewSession=false */
+    private static final String SERVER_XML_NO_NEW_SESSION = "generateNewSession_false.xml";
+
+    private static final int CONN_TIMEOUT = 10;
+
+    @Server(SERVER_NAME)
+    public static LibertyServer server;
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        ShrinkHelper.defaultApp(server, APP_NAME, new DeployOptions[] { DeployOptions.SERVER_ONLY },
+                "io.openliberty.security.audit.internal.fat.app");
+        server.saveServerConfiguration();
+        server.startServer();
+        // Wait for audit service ready
+        assertNotNull("Audit service did not report ready",
+                server.waitForStringInLog("CWWKS5851I"));
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        if (server != null && server.isStarted()) {
+            server.stopServer();
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------------
+
+    private String restEndpointUrl() {
+        return "http://" + server.getHostname() + ":" + server.getHttpDefaultPort()
+                + "/" + APP_NAME + "/hello";
+    }
+
+    /**
+     * Sends a GET to the REST endpoint and returns the value of the
+     * {@code Set-Cookie} response header, or {@code null} if not present.
+     */
+    private String getSetCookieHeader() throws Exception {
+        URL url = new URL(restEndpointUrl());
+        HttpURLConnection con = HttpUtils.getHttpConnection(url, HttpURLConnection.HTTP_OK, CONN_TIMEOUT);
+        try {
+            assertEquals("Expected HTTP 200 from REST endpoint", HttpURLConnection.HTTP_OK,
+                    con.getResponseCode());
+            Map<String, List<String>> headers = con.getHeaderFields();
+            // Header names in HttpURLConnection are case-insensitive when iterated
+            for (Map.Entry<String, List<String>> entry : headers.entrySet()) {
+                if ("Set-Cookie".equalsIgnoreCase(entry.getKey())) {
+                    for (String cookieValue : entry.getValue()) {
+                        if (cookieValue != null && cookieValue.toUpperCase().startsWith("JSESSIONID")) {
+                            return cookieValue;
+                        }
+                    }
+                }
+            }
+            return null;
+        } finally {
+            con.disconnect();
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Tests
+    // -----------------------------------------------------------------------
+
+    /**
+     * Default behaviour: {@code generateNewSession=true}.
+     * The audit subsystem is allowed to create a new session, so a JSESSIONID
+     * Set-Cookie header MAY appear. We simply verify the endpoint is reachable
+     * and the server is stable — we do not assert on cookie presence because
+     * the legacy behaviour is preserved deliberately.
+     */
+    @Test
+    public void testDefaultGenerateNewSession_endpointReachable() throws Exception {
+        Log.info(c, "testDefaultGenerateNewSession_endpointReachable",
+                "Calling REST endpoint with generateNewSession=true (default)");
+
+        URL url = new URL(restEndpointUrl());
+        HttpURLConnection con = HttpUtils.getHttpConnection(url, HttpURLConnection.HTTP_OK, CONN_TIMEOUT);
+        try {
+            assertEquals("REST endpoint should return HTTP 200", HttpURLConnection.HTTP_OK,
+                    con.getResponseCode());
+        } finally {
+            con.disconnect();
+        }
+        Log.info(c, "testDefaultGenerateNewSession_endpointReachable", "PASSED");
+    }
+
+    /**
+     * Fix verification: {@code generateNewSession=false}.
+     * The audit subsystem must NOT create a new HTTP session. No JSESSIONID
+     * Set-Cookie header should appear in the response from a session-free REST
+     * endpoint.
+     */
+    @Test
+    public void testGenerateNewSessionFalse_noJSessionIdCookie() throws Exception {
+        Log.info(c, "testGenerateNewSessionFalse_noJSessionIdCookie",
+                "Switching server config to generateNewSession=false");
+
+        server.setMarkToEndOfLog();
+        server.setServerConfigurationFile(SERVER_XML_NO_NEW_SESSION);
+        // Wait for config update to take effect
+        server.waitForConfigUpdateInLogUsingMark(null);
+
+        try {
+            Log.info(c, "testGenerateNewSessionFalse_noJSessionIdCookie",
+                    "Calling REST endpoint — expecting no JSESSIONID Set-Cookie header");
+
+            String jsessionCookie = getSetCookieHeader();
+
+            assertNull("With generateNewSession=false the audit service must not create a new HTTP session. "
+                    + "Unexpected JSESSIONID Set-Cookie header found: " + jsessionCookie,
+                    jsessionCookie);
+
+            Log.info(c, "testGenerateNewSessionFalse_noJSessionIdCookie",
+                    "PASSED — no JSESSIONID cookie returned");
+        } finally {
+            // Restore the original server configuration for subsequent tests
+            server.setMarkToEndOfLog();
+            server.restoreServerConfiguration();
+            server.waitForConfigUpdateInLogUsingMark(null);
+        }
+    }
+}

--- a/dev/io.openliberty.security.audit.internal_fat/fat/src/io/openliberty/security/audit/internal/fat/FATSuite.java
+++ b/dev/io.openliberty.security.audit.internal_fat/fat/src/io/openliberty/security/audit/internal/fat/FATSuite.java
@@ -1,0 +1,32 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.security.audit.internal.fat;
+
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+import org.junit.runners.Suite.SuiteClasses;
+
+/**
+ * FAT suite for audit generateNewSession tests.
+ *
+ * Covers GH issue #29751: audit-1.0 unexpectedly creates an HTTP session
+ * (and returns a JSESSIONID cookie) when auditing REST endpoints that do
+ * not use sessions. Setting {@code <auditSource generateNewSession="false"/>}
+ * in server.xml disables this behaviour.
+ */
+@RunWith(Suite.class)
+@SuiteClasses({
+    AuditGenerateNewSessionTest.class
+})
+public class FATSuite {
+}

--- a/dev/io.openliberty.security.audit.internal_fat/publish/servers/AuditSessionServer/generateNewSession_false.xml
+++ b/dev/io.openliberty.security.audit.internal_fat/publish/servers/AuditSessionServer/generateNewSession_false.xml
@@ -1,0 +1,17 @@
+<!--
+    Copyright (c) 2025 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License 2.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-2.0/
+
+    SPDX-License-Identifier: EPL-2.0
+
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+
+<!-- Override: generateNewSession=false prevents audit from creating a new JSESSIONID -->
+<server>
+    <auditSource generateNewSession="false"/>
+</server>

--- a/dev/io.openliberty.security.audit.internal_fat/publish/servers/AuditSessionServer/server.xml
+++ b/dev/io.openliberty.security.audit.internal_fat/publish/servers/AuditSessionServer/server.xml
@@ -1,0 +1,34 @@
+<!--
+    Copyright (c) 2025 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License 2.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-2.0/
+
+    SPDX-License-Identifier: EPL-2.0
+
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<server description="Audit Session FAT Server">
+
+    <featureManager>
+        <feature>audit-1.0</feature>
+        <feature>restfulWS-3.1</feature>
+        <feature>componentTest-2.0</feature>
+    </featureManager>
+
+    <include location="../fatTestPorts.xml"/>
+
+    <!-- Default: generateNewSession=true means audit may create a new JSESSIONID -->
+    <auditSource generateNewSession="true"/>
+
+    <auditFileHandler>
+        <events eventName="SECURITY_AUTHN" outcome="SUCCESS"/>
+        <events eventName="SECURITY_AUTHN" outcome="FAILURE"/>
+        <events eventName="SECURITY_AUTHZ"/>
+    </auditFileHandler>
+
+    <application location="AuditSessionApp.war" contextRoot="/AuditSessionApp"/>
+
+</server>

--- a/dev/io.openliberty.security.audit.internal_fat/test-applications/AuditSessionApp/src/io/openliberty/security/audit/internal/fat/app/AuditSessionApp.java
+++ b/dev/io.openliberty.security.audit.internal_fat/test-applications/AuditSessionApp/src/io/openliberty/security/audit/internal/fat/app/AuditSessionApp.java
@@ -1,0 +1,20 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.security.audit.internal.fat.app;
+
+import jakarta.ws.rs.ApplicationPath;
+import jakarta.ws.rs.core.Application;
+
+@ApplicationPath("/")
+public class AuditSessionApp extends Application {
+}

--- a/dev/io.openliberty.security.audit.internal_fat/test-applications/AuditSessionApp/src/io/openliberty/security/audit/internal/fat/app/HelloResource.java
+++ b/dev/io.openliberty.security.audit.internal_fat/test-applications/AuditSessionApp/src/io/openliberty/security/audit/internal/fat/app/HelloResource.java
@@ -1,0 +1,35 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.security.audit.internal.fat.app;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+/**
+ * Simple stateless REST endpoint. It deliberately does not use HttpSession.
+ * When the audit feature is enabled with generateNewSession=true (default),
+ * the audit code creates a new session and the response will contain a
+ * Set-Cookie: JSESSIONID header. With generateNewSession=false no new session
+ * is created and no JSESSIONID cookie is returned.
+ */
+@Path("/hello")
+public class HelloResource {
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public String hello() {
+        return "SUCCESS";
+    }
+}


### PR DESCRIPTION
- [X] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [X] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [X] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
- 
﻿Fixes #29751

Add generateNewSession attribute to auditSource element in server.xml. When set to false, audit code uses getSession(false) instead of getSession() so no new HTTP session is created if one does not already exist.

Default is true to preserve existing behavior (zero migration impact).

Files changed:
- AuditService.java: add isGenerateNewSession() to interface
- AuditServiceImpl.java: read generateNewSession from new PID com.ibm.ws.security.audit.source; implement isGenerateNewSession()
- AuditUtils.java: use getSession(false) when generateNewSession=false
- AuditPE.java: same fix for inline session lookup in auditEventAuthn01()
- metatype.xml: new auditSource OCD with generateNewSession AD
- metatype.properties: NLS keys for new attribute
- io.openliberty.security.audit.internal_fat: new FAT bucket with two tests covering default and generateNewSession=false behaviour