### PR TITLE
CDI events for life cycle operations

### DIFF
--- a/dev/io.openliberty.data.internal/bnd.bnd
+++ b/dev/io.openliberty.data.internal/bnd.bnd
@@ -56,7 +56,7 @@ Import-Package: \
   !jakarta.data.*, \
   !jakarta.validation, \
   !jakarta.validation.*, \
-  jakarta.annotation;version="[2.1,4)", \
+  jakarta.annotation.*;version="[2.1,4)", \
   jakarta.persistence;version="[3.2,5)", \
   jakarta.persistence.*;version="[3.2,5)", \
   *
@@ -101,7 +101,7 @@ instrument.classesExcludes: io/openliberty/data/internal/resources/*.class
 	com.ibm.ws.tx.embeddable.jakarta;version=latest,\
 	io.openliberty.data,\
 	io.openliberty.jakarta.annotation.2.1,\
-	io.openliberty.jakarta.cdi.4.0,\
+	io.openliberty.jakarta.cdi.4.1,\
 	io.openliberty.jakarta.data.1.1,\
 	io.openliberty.jakarta.interceptor.2.1,\
 	io.openliberty.jakarta.persistence.3.2;version=latest,\

--- a/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/EntityInfo.java
+++ b/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/EntityInfo.java
@@ -29,7 +29,16 @@ import java.util.concurrent.CompletableFuture;
 
 import com.ibm.websphere.ras.annotation.Trivial;
 
+import jakarta.data.event.PostDeleteEvent;
+import jakarta.data.event.PostInsertEvent;
+import jakarta.data.event.PostUpdateEvent;
+import jakarta.data.event.PostUpsertEvent;
+import jakarta.data.event.PreDeleteEvent;
+import jakarta.data.event.PreInsertEvent;
+import jakarta.data.event.PreUpdateEvent;
+import jakarta.data.event.PreUpsertEvent;
 import jakarta.data.exceptions.MappingException;
+import jakarta.enterprise.util.TypeLiteral;
 import jakarta.persistence.Inheritance;
 
 /**
@@ -76,8 +85,25 @@ public class EntityInfo {
     final SortedMap<String, Member> idClassAttributeAccessors; // null if no IdClass
     final boolean inheritance;
     public final boolean isHibernate;
-    final String name; // entity name to use in query language. If a record, the name will be [RecordName]Entity.
+
+    /**
+     * Entity name to use in query language.
+     * If a record, the name will be [RecordName]Entity.
+     */
+    final String name;
+
+    // for life cycle events in Data 1.1+. Otherwise null.
+    final TypeLiteral<PostDeleteEvent<Object>> postDeleteLiteral;
+    final TypeLiteral<PostInsertEvent<Object>> postInsertLiteral;
+    final TypeLiteral<PostUpdateEvent<Object>> postUpdateLiteral;
+    final TypeLiteral<PostUpsertEvent<Object>> postUpsertLiteral;
+    final TypeLiteral<PreDeleteEvent<Object>> preDeleteLiteral;
+    final TypeLiteral<PreInsertEvent<Object>> preInsertLiteral;
+    final TypeLiteral<PreUpdateEvent<Object>> preUpdateLiteral;
+    final TypeLiteral<PreUpsertEvent<Object>> preUpsertLiteral;
+
     final Class<?> recordClass; // null if not a record
+
     final String versionAttributeName; // null if unversioned
 
     // embeddable class -> fully qualified attribute names of embeddable, or
@@ -115,6 +141,28 @@ public class EntityInfo {
         this.versionAttributeName = versionAttributeName;
 
         inheritance = entityClass.getAnnotation(Inheritance.class) != null;
+
+        @SuppressWarnings("unchecked")
+        Class<Object> entityType = (Class<Object>) getType();
+        if (entityHandlerFactory.provider.compat.atLeast(1, 1)) {
+            postDeleteLiteral = new EventTypeLiteral<>(PostDeleteEvent.class, entityType);
+            postInsertLiteral = new EventTypeLiteral<>(PostInsertEvent.class, entityType);
+            postUpdateLiteral = new EventTypeLiteral<>(PostUpdateEvent.class, entityType);
+            postUpsertLiteral = new EventTypeLiteral<>(PostUpsertEvent.class, entityType);
+            preDeleteLiteral = new EventTypeLiteral<>(PreDeleteEvent.class, entityType);
+            preInsertLiteral = new EventTypeLiteral<>(PreInsertEvent.class, entityType);
+            preUpdateLiteral = new EventTypeLiteral<>(PreUpdateEvent.class, entityType);
+            preUpsertLiteral = new EventTypeLiteral<>(PreUpsertEvent.class, entityType);
+        } else {
+            postDeleteLiteral = null;
+            postInsertLiteral = null;
+            postUpdateLiteral = null;
+            postUpsertLiteral = null;
+            preDeleteLiteral = null;
+            preInsertLiteral = null;
+            preUpdateLiteral = null;
+            preUpsertLiteral = null;
+        }
 
         validate();
     }

--- a/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/EventTypeLiteral.java
+++ b/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/EventTypeLiteral.java
@@ -1,0 +1,122 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.data.internal;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.Arrays;
+
+import com.ibm.websphere.ras.annotation.Trivial;
+
+import jakarta.data.event.LifecycleEvent;
+import jakarta.enterprise.util.TypeLiteral;
+
+/**
+ * A TypeLiteral that can be created at run time for the CDI events that
+ * Jakarta Data must send for Delete, Insert, Save, and Update life cycle
+ * operations.
+ *
+ * @param <L> type of LifecycleEvent, such as PreDeleteEvent
+ * @param <E> entity class to use as the type parameter of the LifecycleEvent
+ */
+@Trivial
+final class EventTypeLiteral<L extends LifecycleEvent<E>, E> //
+                extends TypeLiteral<L> {
+    private static final long serialVersionUID = 1;
+
+    /**
+     * Construct a TypeLiteral at run time for a CDI event for a life cycle
+     * operation.
+     *
+     * @param lifeCycleEventClass one of the life cycle event classes, such as
+     *                                PreDeleteEvent or PostDeleteEvent
+     * @param entityClass         the entity class for which the event is fired
+     */
+    public EventTypeLiteral(Class<?> lifeCycleEventClass,
+                            Class<E> entityClass) {
+        // According to Bob, WELD uses this same workaround for the
+        // TypeLiteral.getType() method being final and non-overridable.
+        // Reflection is used to assign the field value before it lazily
+        // initializes.
+        try {
+            // actualType = PreDeleteEvent<MyEntity>
+            Field f = TypeLiteral.class.getDeclaredField("actualType");
+            f.setAccessible(true);
+            f.set(this, //
+                  new ParameterizedLifeCycleEventType( //
+                                  lifeCycleEventClass, //
+                                  entityClass));
+        } catch (Exception x) {
+            throw new RuntimeException(x);
+        }
+    }
+
+    /**
+     * Represents a LifeCycle event type with type parameters.
+     * For example, PreDeleteEvent<MyEntity>
+     */
+    private static class ParameterizedLifeCycleEventType //
+                    implements ParameterizedType {
+        private final Class<?> eventClass;
+        private final Type[] eventTypeParamType;
+
+        private ParameterizedLifeCycleEventType(Class<?> eventClass, //
+                                                Class<?> entityClass) {
+            this.eventClass = eventClass;
+            this.eventTypeParamType = new Type[] { entityClass };
+        }
+
+        /**
+         * equals and hashCode are needed because CDI containers use type equality
+         * when matching observers, so they must be consistent with how
+         * sun.reflect.generics implements them.
+         *
+         * @param other instance against which to compare
+         * @return true if equal; otherwise false
+         */
+        @Override
+        public boolean equals(Object other) {
+            return other instanceof ParameterizedType p
+                   && eventClass.equals(p.getRawType())
+                   && Arrays.equals(eventTypeParamType, p.getActualTypeArguments());
+        }
+
+        @Override
+        public Type[] getActualTypeArguments() {
+            return eventTypeParamType;
+        }
+
+        @Override
+        public Type getOwnerType() {
+            return null;
+        }
+
+        @Override
+        public Type getRawType() {
+            return eventClass;
+        }
+
+        /**
+         * hashCode and equals are needed because CDI containers use type equality
+         * when matching observers, so they must be consistent with how
+         * sun.reflect.generics implements them (XOR of raw type hash and args hash).
+         *
+         * @return the computed hash code
+         */
+        @Override
+        public int hashCode() {
+            return Arrays.hashCode(eventTypeParamType) ^ eventClass.hashCode();
+        }
+    }
+}

--- a/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/Fail.java
+++ b/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/Fail.java
@@ -940,16 +940,20 @@ public class Fail {
      * Raises ClassCastException for a repository method return type that does
      * not match the number of entities returned.
      *
-     * @param info                   query information for the repository method.
-     * @param lifeCycleMethodAnno    type of life cycle method. For example, @Insert.
-     * @param hasSingularEntityParam indicates if the method's entity parameter is
-     *                                   singular (one entity) vs multiple.
+     * @param info                query information for the repository method.
+     * @param lifeCycleMethodAnno type of life cycle method. For example, @Insert.
+     * @param numResults          number of results returned by the query
      * @throws the ClassCastException.
      */
     static ClassCastException resultSizeMismatch(QueryInfo info,
                                                  String lifeCycleMethodAnno,
-                                                 int numResults,
-                                                 boolean hasSingularEntityParam) {
+                                                 int numResults) {
+        boolean hasSingularEntityParam //
+                        = info.entityParamType != null &&
+                          !info.entityParamType.isArray() &&
+                          !Iterable.class.isAssignableFrom(info.entityParamType) &&
+                          !Stream.class.isAssignableFrom(info.entityParamType);
+
         throw exc(ClassCastException.class,
                   "CWWKD1094.return.mismatch",
                   info.method.getName(),
@@ -984,25 +988,29 @@ public class Fail {
      * Raises UnsupportedOperationException for a return type that is not valid
      * for the repository method.
      *
-     * @param info                   query information for the repository method.
-     * @param lifeCycleMethodType    type of life cycle method. For example, Insert.
-     * @param hasSingularEntityParam indicates if the method's entity parameter is
-     *                                   singular (one entity) vs multiple.
-     * @param validReturnTypes       valid return types, if always the same.
-     *                                   Otherwise null.
-     * @param resultClass            resultClass from which to infer valid return
-     *                                   types. Otherwise null.
+     * @param info                query information for the repository method.
+     * @param lifeCycleMethodType type of life cycle method. For example, Insert.
+     * @param validReturnTypes    valid return types, if always the same.
+     *                                Otherwise null.
+     * @param resultClass         resultClass from which to infer valid return
+     *                                types. Otherwise null.
      * @throws the UnsupportedOperationException.
      */
     static UnsupportedOperationException returnTypeInvalid(QueryInfo info,
                                                            String lifeCycleMethodType,
-                                                           boolean hasSingularEntityParam,
                                                            String validReturnTypes,
                                                            Class<?> resultClass) {
-        if (validReturnTypes == null)
+        if (validReturnTypes == null) {
+            boolean hasSingularEntityParam //
+                            = info.entityParamType != null &&
+                              !info.entityParamType.isArray() &&
+                              !Iterable.class.isAssignableFrom(info.entityParamType) &&
+                              !Stream.class.isAssignableFrom(info.entityParamType);
+
             validReturnTypes = Util.lifeCycleReturnTypes(resultClass.getSimpleName(),
                                                          hasSingularEntityParam,
                                                          false).toString();
+        }
 
         throw exc(UnsupportedOperationException.class,
                   "CWWKD1003.rtrn.err",

--- a/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/QueryInfo.java
+++ b/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/QueryInfo.java
@@ -76,6 +76,8 @@ import io.openliberty.data.internal.cdi.RepositoryProducer;
 import jakarta.data.Limit;
 import jakarta.data.Order;
 import jakarta.data.Sort;
+import jakarta.data.event.PostDeleteEvent;
+import jakarta.data.event.PreDeleteEvent;
 import jakarta.data.exceptions.DataException;
 import jakarta.data.exceptions.EmptyResultException;
 import jakarta.data.exceptions.MappingException;
@@ -1341,6 +1343,11 @@ public abstract class QueryInfo {
         if (!entityInfo.getType().isInstance(e))
             throw Fail.entityMismatch(this, e);
 
+        if (producer.lifeCycleEvents != null)
+            producer.lifeCycleEvents //
+                            .select(entityInfo.preDeleteLiteral) //
+                            .fire(new PreDeleteEvent<>(e));
+
         String jpql = ql;
 
         int versionParamIndex = (entityInfo.idClassAttributeAccessors == null //
@@ -1401,6 +1408,11 @@ public abstract class QueryInfo {
             // ought to be unreachable
             throw new DataException("Found " + numDeleted + " matching entities.");
         }
+
+        if (producer.lifeCycleEvents != null)
+            producer.lifeCycleEvents //
+                            .select(entityInfo.postDeleteLiteral) //
+                            .fire(new PostDeleteEvent<>(e));
 
         if (trace && tc.isEntryEnabled())
             Tr.exit(this, tc, "deleteOne", numDeleted);

--- a/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/QueryInfo.java
+++ b/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/QueryInfo.java
@@ -1314,7 +1314,7 @@ public abstract class QueryInfo {
             args = list;
             entityCount = list.size();
         } else {
-            args = List.of(arg);
+            args = Collections.singletonList(arg);
             entityCount = 1;
         }
 
@@ -1876,7 +1876,6 @@ public abstract class QueryInfo {
     Object findAndUpdate(Object arg, AutoCloseable entityHandler) throws Exception {
         Iterable<?> args;
         int entityCount = 0;
-        boolean hasSingularEntityParam = false;
 
         if (entityParamType.isArray()) {
             entityCount = Array.getLength(arg);
@@ -1896,9 +1895,8 @@ public abstract class QueryInfo {
             args = list;
             entityCount = list.size();
         } else {
-            args = List.of(arg);
+            args = Collections.singletonList(arg);
             entityCount = 1;
-            hasSingularEntityParam = true;
         }
 
         final boolean trace = TraceComponent.isAnyTracingEnabled();
@@ -1967,7 +1965,7 @@ public abstract class QueryInfo {
                 else if (Iterator.class.equals(multiType))
                     returnValue = results.iterator();
                 else
-                    throw Fail.returnTypeInvalid(this, "Update", hasSingularEntityParam,
+                    throw Fail.returnTypeInvalid(this, "Update",
                                                  null, results.get(0).getClass());
             }
         }
@@ -1983,7 +1981,7 @@ public abstract class QueryInfo {
         } else if (returnValue != null &&
                    !Util.wrapperClassIfPrimitive(returnType) //
                                    .isAssignableFrom(returnValue.getClass())) {
-            throw Fail.returnTypeInvalid(this, "Update", hasSingularEntityParam,
+            throw Fail.returnTypeInvalid(this, "Update",
                                          null, results.get(0).getClass());
         }
 
@@ -4268,7 +4266,6 @@ public abstract class QueryInfo {
     Object insert(Object arg, AutoCloseable entityHandler) throws Exception {
         Iterable<?> args;
         int entityCount = 0;
-        boolean hasSingularEntityParam = false;
 
         if (entityParamType.isArray()) {
             entityCount = Array.getLength(arg);
@@ -4288,9 +4285,8 @@ public abstract class QueryInfo {
             args = list;
             entityCount = list.size();
         } else {
-            args = List.of(arg);
+            args = Collections.singletonList(arg);
             entityCount = 1;
-            hasSingularEntityParam = true;
         }
 
         final boolean trace = TraceComponent.isAnyTracingEnabled();
@@ -4351,8 +4347,7 @@ public abstract class QueryInfo {
                 else if (results.isEmpty())
                     returnValue = null;
                 else
-                    throw Fail.resultSizeMismatch(this, "@Insert", results.size(),
-                                                  hasSingularEntityParam);
+                    throw Fail.resultSizeMismatch(this, "@Insert", results.size());
             else if (multiType.isInstance(results))
                 returnValue = results;
             else if (Stream.class.equals(multiType))
@@ -4362,7 +4357,7 @@ public abstract class QueryInfo {
             else if (Iterator.class.equals(multiType))
                 returnValue = results.iterator();
             else
-                throw Fail.returnTypeInvalid(this, "Insert", hasSingularEntityParam,
+                throw Fail.returnTypeInvalid(this, "Insert",
                                              null, results.get(0).getClass());
         }
 
@@ -4371,7 +4366,7 @@ public abstract class QueryInfo {
             // useful for @Asynchronous
             returnValue = CompletableFuture.completedFuture(returnValue);
         } else if (!resultVoid && !returnType.isInstance(returnValue)) {
-            throw Fail.returnTypeInvalid(this, "Insert", hasSingularEntityParam,
+            throw Fail.returnTypeInvalid(this, "Insert",
                                          null, results.get(0).getClass());
         }
 
@@ -4667,7 +4662,6 @@ public abstract class QueryInfo {
                              Void.class.equals(singleType);
         ArrayList<Object> results;
 
-        boolean hasSingularEntityParam = false;
         int count = 0;
         if (entityParamType.isArray()) {
             int length = Array.getLength(arg);
@@ -4687,7 +4681,6 @@ public abstract class QueryInfo {
             }
         } else {
             count = 1;
-            hasSingularEntityParam = true;
             results = resultVoid ? null : new ArrayList<>(1);
             Object merged = em.merge(entityNotNull(arg));
             if (results != null)
@@ -4713,8 +4706,7 @@ public abstract class QueryInfo {
                     else if (results.isEmpty())
                         returnValue = null;
                     else
-                        throw Fail.resultSizeMismatch(this, "@Merge", results.size(),
-                                                      hasSingularEntityParam);
+                        throw Fail.resultSizeMismatch(this, "@Merge", results.size());
                 else if (multiType.isInstance(results))
                     returnValue = results;
                 else if (Stream.class.equals(multiType))
@@ -4724,7 +4716,7 @@ public abstract class QueryInfo {
                 else if (Iterator.class.equals(multiType))
                     returnValue = results.iterator();
                 else
-                    throw Fail.returnTypeInvalid(this, "Merge", hasSingularEntityParam,
+                    throw Fail.returnTypeInvalid(this, "Merge",
                                                  null, results.get(0).getClass());
             }
         }
@@ -4734,7 +4726,7 @@ public abstract class QueryInfo {
             // useful for @Asynchronous
             returnValue = CompletableFuture.completedFuture(returnValue);
         } else if (!resultVoid && !returnType.isInstance(returnValue)) {
-            throw Fail.returnTypeInvalid(this, "Merge", hasSingularEntityParam,
+            throw Fail.returnTypeInvalid(this, "Merge",
                                          null, results.get(0).getClass());
         }
 
@@ -5722,7 +5714,6 @@ public abstract class QueryInfo {
     Object save(Object arg, AutoCloseable entityHandler) throws Exception {
         Iterable<?> args;
         int entityCount = 0;
-        boolean hasSingularEntityParam = false;
 
         if (entityParamType.isArray()) {
             entityCount = Array.getLength(arg);
@@ -5742,9 +5733,8 @@ public abstract class QueryInfo {
             args = list;
             entityCount = list.size();
         } else {
-            args = List.of(arg);
+            args = Collections.singletonList(arg);
             entityCount = 1;
-            hasSingularEntityParam = true;
         }
 
         final boolean trace = TraceComponent.isAnyTracingEnabled();
@@ -5804,8 +5794,7 @@ public abstract class QueryInfo {
                 else if (results.isEmpty())
                     returnValue = null;
                 else
-                    throw Fail.resultSizeMismatch(this, "@Save", results.size(),
-                                                  hasSingularEntityParam);
+                    throw Fail.resultSizeMismatch(this, "@Save", results.size());
             else if (multiType.isInstance(results))
                 returnValue = results;
             else if (Stream.class.equals(multiType))
@@ -5815,7 +5804,7 @@ public abstract class QueryInfo {
             else if (Iterator.class.equals(multiType))
                 returnValue = results.iterator();
             else
-                throw Fail.returnTypeInvalid(this, "Save", hasSingularEntityParam,
+                throw Fail.returnTypeInvalid(this, "Save",
                                              null, results.get(0).getClass());
         }
 
@@ -5824,7 +5813,7 @@ public abstract class QueryInfo {
             // useful for @Asynchronous
             returnValue = CompletableFuture.completedFuture(returnValue);
         } else if (!resultVoid && !returnType.isInstance(returnValue)) {
-            throw Fail.returnTypeInvalid(this, "Save", hasSingularEntityParam,
+            throw Fail.returnTypeInvalid(this, "Save",
                                          null, results.get(0).getClass());
         }
 
@@ -6411,7 +6400,7 @@ public abstract class QueryInfo {
             args = list;
             entityCount = list.size();
         } else {
-            args = List.of(arg);
+            args = Collections.singletonList(arg);
             entityCount = 1;
         }
 
@@ -6586,7 +6575,7 @@ public abstract class QueryInfo {
              !CompletableFuture.class.equals(multiType) &&
              !CompletionStage.class.equals(multiType)))
 
-            throw Fail.returnTypeInvalid(this, "exists", false, "boolean, Boolean", null);
+            throw Fail.returnTypeInvalid(this, "exists", "boolean, Boolean", null);
     }
 
     /**

--- a/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/QueryInfo.java
+++ b/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/QueryInfo.java
@@ -77,7 +77,11 @@ import jakarta.data.Limit;
 import jakarta.data.Order;
 import jakarta.data.Sort;
 import jakarta.data.event.PostDeleteEvent;
+import jakarta.data.event.PostInsertEvent;
+import jakarta.data.event.PostUpsertEvent;
 import jakarta.data.event.PreDeleteEvent;
+import jakarta.data.event.PreInsertEvent;
+import jakarta.data.event.PreUpsertEvent;
 import jakarta.data.exceptions.DataException;
 import jakarta.data.exceptions.EmptyResultException;
 import jakarta.data.exceptions.MappingException;
@@ -93,6 +97,7 @@ import jakarta.data.repository.OrderBy;
 import jakarta.data.repository.Param;
 import jakarta.data.repository.Query;
 import jakarta.data.repository.Update;
+import jakarta.enterprise.event.Event;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.LockModeType;
 import jakarta.persistence.TypedQuery;
@@ -4206,50 +4211,62 @@ public abstract class QueryInfo {
      */
     @Trivial
     Object insert(Object arg, AutoCloseable entityHandler) throws Exception {
-        arg = arg instanceof Stream //
-                        ? ((Stream<?>) arg).sequential().toList() //
-                        : arg;
+        Iterable<?> args;
+        int entityCount = 0;
+        boolean hasSingularEntityParam = false;
+
+        if (entityParamType.isArray()) {
+            entityCount = Array.getLength(arg);
+            List<Object> list = new ArrayList<>(entityCount);
+            for (int i = 0; i < entityCount; i++)
+                list.add(Array.get(arg, i));
+            args = list;
+        } else if (arg instanceof Collection<?> c) {
+            args = c;
+            entityCount = c.size();
+        } else if (arg instanceof Iterable<?> it) {
+            args = it;
+            for (Object e : it)
+                entityCount++;
+        } else if (arg instanceof Stream<?> s) {
+            List<?> list = s.sequential().toList();
+            args = list;
+            entityCount = list.size();
+        } else {
+            args = List.of(arg);
+            entityCount = 1;
+            hasSingularEntityParam = true;
+        }
 
         final boolean trace = TraceComponent.isAnyTracingEnabled();
         if (trace && tc.isEntryEnabled())
-            Tr.entry(this, tc, "insert", loggable(arg));
-
-        boolean resultVoid = void.class.equals(singleType) ||
-                             Void.class.equals(singleType);
-        ArrayList<Object> results;
-
-        boolean hasSingularEntityParam = false;
-        int entityCount = 0;
-        if (entityParamType.isArray()) {
-            int length = Array.getLength(arg);
-            results = resultVoid ? null : new ArrayList<>(length);
-            for (; entityCount < length; entityCount++) {
-                Object entity = toEntity(Array.get(arg, entityCount));
-                ehInsert(entityHandler, entity); // TODO entityAgent.insertMultiple?
-                if (results != null)
-                    results.add(entity);
-            }
-        } else if (arg instanceof Iterable) {
-            results = resultVoid ? null : new ArrayList<>();
-            for (Object e : ((Iterable<?>) arg)) {
-                entityCount++;
-                Object entity = toEntity(e);
-                ehInsert(entityHandler, entity);
-                if (results != null)
-                    results.add(entity);
-            }
-        } else {
-            entityCount = 1;
-            hasSingularEntityParam = true;
-            results = resultVoid ? null : new ArrayList<>(1);
-            Object entity = toEntity(arg);
-            ehInsert(entityHandler, entity);
-            if (results != null)
-                results.add(entity);
-        }
+            Tr.entry(this, tc, "insert", loggable(args));
 
         if (entityCount == 0)
             throw Fail.emptyLifeCycleParam(this);
+
+        // PreInsertEvent
+        if (producer.lifeCycleEvents != null) {
+            Event<PreInsertEvent<Object>> event = producer.lifeCycleEvents //
+                            .select(entityInfo.preInsertLiteral);
+            for (Object e : args)
+                event.fire(new PreInsertEvent<>(e));
+        }
+
+        boolean resultVoid = void.class.equals(singleType) ||
+                             Void.class.equals(singleType);
+
+        List<Object> results = resultVoid && producer.lifeCycleEvents == null //
+                        ? null //
+                        : new ArrayList<>(entityCount);
+
+        // insert the entities
+        for (Object e : args) {
+            Object entity = toEntity(e);
+            ehInsert(entityHandler, entity); // TODO entityAgent.insertMultiple?
+            if (results != null)
+                results.add(entity);
+        }
 
         if (entityHandler instanceof EntityManager em) {
             if (trace && tc.isDebugEnabled())
@@ -4257,40 +4274,41 @@ public abstract class QueryInfo {
             em.flush();
         }
 
+        if (results != null && entityInfo.recordClass != null)
+            // Converting from Java record to entity and back to Java record
+            // is important so that any mutations JPA makes to the entity
+            // are included.
+            for (int i = 0; i < results.size(); i++)
+                results.set(i, entityInfo.toRecord(results.get(i)));
+
         Class<?> returnType = method.getReturnType();
         Object returnValue;
         if (resultVoid) {
             returnValue = null;
+        } else if (returnArrayType != null) {
+            Object[] newArray = (Object[]) Array.newInstance(returnArrayType,
+                                                             results.size());
+            returnValue = results.toArray(newArray);
         } else {
-            if (entityInfo.recordClass != null)
-                for (int i = 0; i < results.size(); i++)
-                    results.set(i, entityInfo.toRecord(results.get(i)));
-
-            if (returnArrayType != null) {
-                Object[] newArray = (Object[]) Array.newInstance(returnArrayType,
-                                                                 results.size());
-                returnValue = results.toArray(newArray);
-            } else {
-                if (multiType == null)
-                    if (results.size() == 1)
-                        returnValue = results.get(0);
-                    else if (results.isEmpty())
-                        returnValue = null;
-                    else
-                        throw Fail.resultSizeMismatch(this, "@Insert", results.size(),
-                                                      hasSingularEntityParam);
-                else if (multiType.isInstance(results))
-                    returnValue = results;
-                else if (Stream.class.equals(multiType))
-                    returnValue = results.stream();
-                else if (Iterable.class.isAssignableFrom(multiType))
-                    returnValue = convertToIterable(results, multiType, null, null);
-                else if (Iterator.class.equals(multiType))
-                    returnValue = results.iterator();
+            if (multiType == null)
+                if (results.size() == 1)
+                    returnValue = results.get(0);
+                else if (results.isEmpty())
+                    returnValue = null;
                 else
-                    throw Fail.returnTypeInvalid(this, "Insert", hasSingularEntityParam,
-                                                 null, results.get(0).getClass());
-            }
+                    throw Fail.resultSizeMismatch(this, "@Insert", results.size(),
+                                                  hasSingularEntityParam);
+            else if (multiType.isInstance(results))
+                returnValue = results;
+            else if (Stream.class.equals(multiType))
+                returnValue = results.stream();
+            else if (Iterable.class.isAssignableFrom(multiType))
+                returnValue = convertToIterable(results, multiType, null, null);
+            else if (Iterator.class.equals(multiType))
+                returnValue = results.iterator();
+            else
+                throw Fail.returnTypeInvalid(this, "Insert", hasSingularEntityParam,
+                                             null, results.get(0).getClass());
         }
 
         if (CompletableFuture.class.equals(returnType) ||
@@ -4300,6 +4318,14 @@ public abstract class QueryInfo {
         } else if (!resultVoid && !returnType.isInstance(returnValue)) {
             throw Fail.returnTypeInvalid(this, "Insert", hasSingularEntityParam,
                                          null, results.get(0).getClass());
+        }
+
+        // PostInsertEvent
+        if (producer.lifeCycleEvents != null) {
+            Event<PostInsertEvent<Object>> event = producer.lifeCycleEvents //
+                            .select(entityInfo.postInsertLiteral);
+            for (Object e : results)
+                event.fire(new PostInsertEvent<>(e));
         }
 
         if (trace && tc.isEntryEnabled())
@@ -5639,47 +5665,61 @@ public abstract class QueryInfo {
      */
     @Trivial // avoid logging customer data
     Object save(Object arg, AutoCloseable entityHandler) throws Exception {
-        arg = arg instanceof Stream //
-                        ? ((Stream<?>) arg).sequential().toList() //
-                        : arg;
+        Iterable<?> args;
+        int entityCount = 0;
+        boolean hasSingularEntityParam = false;
+
+        if (entityParamType.isArray()) {
+            entityCount = Array.getLength(arg);
+            List<Object> list = new ArrayList<>(entityCount);
+            for (int i = 0; i < entityCount; i++)
+                list.add(Array.get(arg, i));
+            args = list;
+        } else if (arg instanceof Collection<?> c) {
+            args = c;
+            entityCount = c.size();
+        } else if (arg instanceof Iterable<?> it) {
+            args = it;
+            for (Object e : it)
+                entityCount++;
+        } else if (arg instanceof Stream<?> s) {
+            List<?> list = s.sequential().toList();
+            args = list;
+            entityCount = list.size();
+        } else {
+            args = List.of(arg);
+            entityCount = 1;
+            hasSingularEntityParam = true;
+        }
 
         final boolean trace = TraceComponent.isAnyTracingEnabled();
         if (trace && tc.isEntryEnabled())
-            Tr.entry(this, tc, "save", loggable(arg));
-
-        boolean resultVoid = void.class.equals(singleType) ||
-                             Void.class.equals(singleType);
-        List<Object> results;
-
-        boolean hasSingularEntityParam = false;
-        int entityCount = 0;
-        if (entityParamType.isArray()) {
-            results = new ArrayList<>();
-            int length = Array.getLength(arg);
-            for (; entityCount < length; entityCount++)
-                // workaround is not possible when multiple entities
-                results.add(ehUpsert(entityHandler,
-                                     toEntity(Array.get(arg, entityCount))));
-        } else if (Iterable.class.isAssignableFrom(entityParamType)) {
-            results = new ArrayList<>();
-            for (Object e : ((Iterable<?>) arg)) {
-                entityCount++;
-                // workaround is not possible when multiple entities
-                results.add(ehUpsert(entityHandler,
-                                     toEntity(e)));
-            }
-        } else {
-            entityCount = 1;
-            hasSingularEntityParam = true;
-            results = resultVoid ? null : new ArrayList<>(1);
-            Object entity = ehUpsert(entityHandler,
-                                     toEntity(arg));
-            if (results != null)
-                results.add(entity);
-        }
+            Tr.entry(this, tc, "save", loggable(args));
 
         if (entityCount == 0)
             throw Fail.emptyLifeCycleParam(this);
+
+        // PreUpsertEvent
+        if (producer.lifeCycleEvents != null) {
+            Event<PreUpsertEvent<Object>> event = producer.lifeCycleEvents //
+                            .select(entityInfo.preUpsertLiteral);
+            for (Object e : args)
+                event.fire(new PreUpsertEvent<>(e));
+        }
+
+        boolean resultVoid = void.class.equals(singleType) ||
+                             Void.class.equals(singleType);
+        List<Object> results = resultVoid && producer.lifeCycleEvents == null //
+                        ? null //
+                        : new ArrayList<>(entityCount);
+
+        // update or insert the entities
+        for (Object e : args) {
+            Object entity = toEntity(e);
+            entity = ehUpsert(entityHandler, entity); // TODO entityAgent.upsertMultiple?
+            if (results != null)
+                results.add(entity);
+        }
 
         if (entityHandler instanceof EntityManager em) {
             if (trace && tc.isDebugEnabled())
@@ -5687,39 +5727,41 @@ public abstract class QueryInfo {
             em.flush();
         }
 
+        if (results != null && entityInfo.recordClass != null)
+            // Converting from Java record to entity and back to Java record
+            // is important so that any mutations JPA makes to the entity
+            // are included.
+            for (int i = 0; i < results.size(); i++)
+                results.set(i, entityInfo.toRecord(results.get(i)));
+
         Class<?> returnType = method.getReturnType();
         Object returnValue;
         if (resultVoid) {
             returnValue = null;
+        } else if (returnArrayType != null) {
+            Object[] newArray = (Object[]) Array.newInstance(returnArrayType,
+                                                             results.size());
+            returnValue = results.toArray(newArray);
         } else {
-            if (entityInfo.recordClass != null)
-                for (int i = 0; i < results.size(); i++)
-                    results.set(i, entityInfo.toRecord(results.get(i)));
-
-            if (returnArrayType != null) {
-                Object[] newArray = (Object[]) Array.newInstance(returnArrayType, results.size());
-                returnValue = results.toArray(newArray);
-            } else {
-                if (multiType == null)
-                    if (results.size() == 1)
-                        returnValue = results.get(0);
-                    else if (results.isEmpty())
-                        returnValue = null;
-                    else
-                        throw Fail.resultSizeMismatch(this, "@Save", results.size(),
-                                                      hasSingularEntityParam);
-                else if (multiType.isInstance(results))
-                    returnValue = results;
-                else if (Stream.class.equals(multiType))
-                    returnValue = results.stream();
-                else if (Iterable.class.isAssignableFrom(multiType))
-                    returnValue = convertToIterable(results, multiType, null, null);
-                else if (Iterator.class.equals(multiType))
-                    returnValue = results.iterator();
+            if (multiType == null)
+                if (results.size() == 1)
+                    returnValue = results.get(0);
+                else if (results.isEmpty())
+                    returnValue = null;
                 else
-                    throw Fail.returnTypeInvalid(this, "Save", hasSingularEntityParam,
-                                                 null, results.get(0).getClass());
-            }
+                    throw Fail.resultSizeMismatch(this, "@Save", results.size(),
+                                                  hasSingularEntityParam);
+            else if (multiType.isInstance(results))
+                returnValue = results;
+            else if (Stream.class.equals(multiType))
+                returnValue = results.stream();
+            else if (Iterable.class.isAssignableFrom(multiType))
+                returnValue = convertToIterable(results, multiType, null, null);
+            else if (Iterator.class.equals(multiType))
+                returnValue = results.iterator();
+            else
+                throw Fail.returnTypeInvalid(this, "Save", hasSingularEntityParam,
+                                             null, results.get(0).getClass());
         }
 
         if (CompletableFuture.class.equals(returnType) ||
@@ -5729,6 +5771,14 @@ public abstract class QueryInfo {
         } else if (!resultVoid && !returnType.isInstance(returnValue)) {
             throw Fail.returnTypeInvalid(this, "Save", hasSingularEntityParam,
                                          null, results.get(0).getClass());
+        }
+
+        // PostUpsertEvent
+        if (producer.lifeCycleEvents != null) {
+            Event<PostUpsertEvent<Object>> event = producer.lifeCycleEvents //
+                            .select(entityInfo.postUpsertLiteral);
+            for (Object e : results)
+                event.fire(new PostUpsertEvent<>(e));
         }
 
         if (trace && tc.isEntryEnabled())

--- a/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/QueryInfo.java
+++ b/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/QueryInfo.java
@@ -78,9 +78,11 @@ import jakarta.data.Order;
 import jakarta.data.Sort;
 import jakarta.data.event.PostDeleteEvent;
 import jakarta.data.event.PostInsertEvent;
+import jakarta.data.event.PostUpdateEvent;
 import jakarta.data.event.PostUpsertEvent;
 import jakarta.data.event.PreDeleteEvent;
 import jakarta.data.event.PreInsertEvent;
+import jakarta.data.event.PreUpdateEvent;
 import jakarta.data.event.PreUpsertEvent;
 import jakarta.data.exceptions.DataException;
 import jakarta.data.exceptions.EmptyResultException;
@@ -245,7 +247,7 @@ public abstract class QueryInfo {
     /**
      * Producer for the repository bean.
      */
-    final RepositoryProducer<?> producer;
+    public final RepositoryProducer<?> producer;
 
     /**
      * The query, typically in the JPQL query language.
@@ -1291,38 +1293,63 @@ public abstract class QueryInfo {
      */
     @Trivial
     Object delete(Object arg, AutoCloseable entityHandler) throws Exception {
-        arg = arg instanceof Stream //
-                        ? ((Stream<?>) arg).sequential().toList() //
-                        : arg;
+        Iterable<?> args;
+        int entityCount = 0;
+
+        if (entityParamType.isArray()) {
+            entityCount = Array.getLength(arg);
+            List<Object> list = new ArrayList<>(entityCount);
+            for (int i = 0; i < entityCount; i++)
+                list.add(Array.get(arg, i));
+            args = list;
+        } else if (arg instanceof Collection<?> c) {
+            args = c;
+            entityCount = c.size();
+        } else if (arg instanceof Iterable<?> iterable) {
+            args = iterable;
+            for (Iterator<?> it = iterable.iterator(); it.hasNext(); it.next())
+                entityCount++;
+        } else if (arg instanceof Stream<?> s) {
+            List<?> list = s.sequential().toList();
+            args = list;
+            entityCount = list.size();
+        } else {
+            args = List.of(arg);
+            entityCount = 1;
+        }
 
         final boolean trace = TraceComponent.isAnyTracingEnabled();
         if (trace && tc.isEntryEnabled())
-            Tr.entry(this, tc, "delete", loggable(arg));
+            Tr.entry(this, tc, "delete", loggable(args));
 
-        int updateCount = 0;
-        int numExpected = 0;
-
-        if (arg instanceof Iterable) {
-            for (Object e : ((Iterable<?>) arg)) {
-                numExpected++;
-                updateCount += deleteOne(e, entityHandler);
-            }
-        } else if (entityParamType.isArray()) {
-            numExpected = Array.getLength(arg);
-            for (int i = 0; i < numExpected; i++)
-                updateCount += deleteOne(Array.get(arg, i), entityHandler);
-        } else {
-            numExpected = 1;
-            updateCount = deleteOne(arg, entityHandler);
-        }
-
-        if (numExpected == 0)
+        if (entityCount == 0)
             throw Fail.emptyLifeCycleParam(this);
 
-        if (updateCount < numExpected)
-            throw Fail.optimisticLockConflict(this, updateCount, numExpected);
+        // PreDeleteEvent
+        if (producer.lifeCycleEvents != null) {
+            Event<PreDeleteEvent<Object>> event = producer.lifeCycleEvents //
+                            .select(entityInfo.preDeleteLiteral);
+            for (Object e : args)
+                event.fire(new PreDeleteEvent<>(e));
+        }
+
+        // delete the entities
+        int updateCount = 0;
+        for (Object e : args)
+            updateCount += deleteOne(e, entityHandler);
+
+        if (updateCount < entityCount)
+            throw Fail.optimisticLockConflict(this, updateCount, entityCount);
 
         Object returnValue = toReturnValue(updateCount, method.getReturnType());
+
+        // PostDeleteEvent
+        if (producer.lifeCycleEvents != null) {
+            Event<PostDeleteEvent<Object>> event = producer.lifeCycleEvents //
+                            .select(entityInfo.postDeleteLiteral);
+            for (Object e : args)
+                event.fire(new PostDeleteEvent<>(e));
+        }
 
         if (trace && tc.isEntryEnabled())
             Tr.exit(this, tc, "delete", loggable(returnValue));
@@ -1347,11 +1374,6 @@ public abstract class QueryInfo {
 
         if (!entityInfo.getType().isInstance(e))
             throw Fail.entityMismatch(this, e);
-
-        if (producer.lifeCycleEvents != null)
-            producer.lifeCycleEvents //
-                            .select(entityInfo.preDeleteLiteral) //
-                            .fire(new PreDeleteEvent<>(e));
 
         String jpql = ql;
 
@@ -1413,11 +1435,6 @@ public abstract class QueryInfo {
             // ought to be unreachable
             throw new DataException("Found " + numDeleted + " matching entities.");
         }
-
-        if (producer.lifeCycleEvents != null)
-            producer.lifeCycleEvents //
-                            .select(entityInfo.postDeleteLiteral) //
-                            .fire(new PostDeleteEvent<>(e));
 
         if (trace && tc.isEntryEnabled())
             Tr.exit(this, tc, "deleteOne", numDeleted);
@@ -1857,32 +1874,53 @@ public abstract class QueryInfo {
      * @throws Exception                         if an error occurs.
      */
     Object findAndUpdate(Object arg, AutoCloseable entityHandler) throws Exception {
+        Iterable<?> args;
+        int entityCount = 0;
+        boolean hasSingularEntityParam = false;
+
+        if (entityParamType.isArray()) {
+            entityCount = Array.getLength(arg);
+            List<Object> list = new ArrayList<>(entityCount);
+            for (int i = 0; i < entityCount; i++)
+                list.add(Array.get(arg, i));
+            args = list;
+        } else if (arg instanceof Collection<?> c) {
+            args = c;
+            entityCount = c.size();
+        } else if (arg instanceof Iterable<?> iterable) {
+            args = iterable;
+            for (Iterator<?> it = iterable.iterator(); it.hasNext(); it.next())
+                entityCount++;
+        } else if (arg instanceof Stream<?> s) {
+            List<?> list = s.sequential().toList();
+            args = list;
+            entityCount = list.size();
+        } else {
+            args = List.of(arg);
+            entityCount = 1;
+            hasSingularEntityParam = true;
+        }
+
         final boolean trace = TraceComponent.isAnyTracingEnabled();
         if (trace && tc.isEntryEnabled())
             Tr.entry(this, tc, "findAndUpdate", loggable(arg));
 
-        List<Object> results;
+        if (entityCount == 0)
+            throw Fail.emptyLifeCycleParam(this);
 
-        boolean hasSingularEntityParam = false;
-        if (entityParamType.isArray()) {
-            int length = Array.getLength(arg);
-            results = new ArrayList<>(length);
-            for (int i = 0; i < length; i++)
-                results.add(findAndUpdateOne(Array.get(arg, i), entityHandler));
-        } else {
-            arg = arg instanceof Stream //
-                            ? ((Stream<?>) arg).sequential().toList() //
-                            : arg;
+        // PreUpdateEvent
+        if (producer.lifeCycleEvents != null) {
+            Event<PreUpdateEvent<Object>> event = producer.lifeCycleEvents //
+                            .select(entityInfo.preUpdateLiteral);
+            for (Object e : args)
+                event.fire(new PreUpdateEvent<>(e));
+        }
 
-            results = new ArrayList<>();
-            if (arg instanceof Iterable) {
-                for (Object e : ((Iterable<?>) arg))
-                    results.add(findAndUpdateOne(e, entityHandler));
-            } else {
-                hasSingularEntityParam = true;
-                results = new ArrayList<>(1);
-                results.add(findAndUpdateOne(arg, entityHandler));
-            }
+        List<Object> results = new ArrayList<>(entityCount);
+
+        // find and update the entities
+        for (Object e : args) {
+            results.add(findAndUpdateOne(e, entityHandler));
         }
 
         if (!results.isEmpty() && entityHandler instanceof EntityManager em) {
@@ -1898,17 +1936,19 @@ public abstract class QueryInfo {
         } else if (Util.PRIMITIVE_NUMERIC_TYPES.contains(singleType) ||
                    Number.class.isAssignableFrom(singleType)) {
             returnValue = convert(results.size(), singleType, true);
-        } else if (results.isEmpty()) {
-            throw Fail.emptyLifeCycleParam(this);
         } else if (void.class.equals(returnType) || Void.class.equals(returnType)) {
             returnValue = null;
         } else {
             if (entityInfo.recordClass != null)
+                // Converting from Java record to entity and back to Java record
+                // is important so that any mutations JPA makes to the entity
+                // are included.
                 for (int i = 0; i < results.size(); i++)
                     results.set(i, entityInfo.toRecord(results.get(i)));
 
             if (returnArrayType != null) {
-                Object[] newArray = (Object[]) Array.newInstance(returnArrayType, results.size());
+                Object[] newArray = (Object[]) Array.newInstance(returnArrayType,
+                                                                 results.size());
                 returnValue = results.toArray(newArray);
             } else {
                 if (multiType == null)
@@ -1945,6 +1985,21 @@ public abstract class QueryInfo {
                                    .isAssignableFrom(returnValue.getClass())) {
             throw Fail.returnTypeInvalid(this, "Update", hasSingularEntityParam,
                                          null, results.get(0).getClass());
+        }
+
+        // PostUpdateEvent
+        if (producer.lifeCycleEvents != null) {
+            if (entityInfo.recordClass != null &&
+                (returnValue == null ||
+                 returnValue instanceof Boolean ||
+                 returnValue instanceof Number))
+                for (int i = 0; i < results.size(); i++)
+                    results.set(i, entityInfo.toRecord(results.get(i)));
+
+            Event<PostUpdateEvent<Object>> event = producer.lifeCycleEvents //
+                            .select(entityInfo.postUpdateLiteral);
+            for (Object e : results)
+                event.fire(new PostUpdateEvent<>(e));
         }
 
         if (trace && tc.isEntryEnabled())
@@ -4224,9 +4279,9 @@ public abstract class QueryInfo {
         } else if (arg instanceof Collection<?> c) {
             args = c;
             entityCount = c.size();
-        } else if (arg instanceof Iterable<?> it) {
-            args = it;
-            for (Object e : it)
+        } else if (arg instanceof Iterable<?> iterable) {
+            args = iterable;
+            for (Iterator<?> it = iterable.iterator(); it.hasNext(); it.next())
                 entityCount++;
         } else if (arg instanceof Stream<?> s) {
             List<?> list = s.sequential().toList();
@@ -5678,9 +5733,9 @@ public abstract class QueryInfo {
         } else if (arg instanceof Collection<?> c) {
             args = c;
             entityCount = c.size();
-        } else if (arg instanceof Iterable<?> it) {
-            args = it;
-            for (Object e : it)
+        } else if (arg instanceof Iterable<?> iterable) {
+            args = iterable;
+            for (Iterator<?> it = iterable.iterator(); it.hasNext(); it.next())
                 entityCount++;
         } else if (arg instanceof Stream<?> s) {
             List<?> list = s.sequential().toList();
@@ -6335,30 +6390,50 @@ public abstract class QueryInfo {
      */
     @Trivial
     Object update(Object arg, AutoCloseable entityHandler) throws Exception {
-        arg = arg instanceof Stream //
-                        ? ((Stream<?>) arg).sequential().toList() //
-                        : arg;
+        Iterable<?> args;
+        int entityCount = 0;
+
+        if (entityParamType.isArray()) {
+            entityCount = Array.getLength(arg);
+            List<Object> list = new ArrayList<>(entityCount);
+            for (int i = 0; i < entityCount; i++)
+                list.add(Array.get(arg, i));
+            args = list;
+        } else if (arg instanceof Collection<?> c) {
+            args = c;
+            entityCount = c.size();
+        } else if (arg instanceof Iterable<?> iterable) {
+            args = iterable;
+            for (Iterator<?> it = iterable.iterator(); it.hasNext(); it.next())
+                entityCount++;
+        } else if (arg instanceof Stream<?> s) {
+            List<?> list = s.sequential().toList();
+            args = list;
+            entityCount = list.size();
+        } else {
+            args = List.of(arg);
+            entityCount = 1;
+        }
 
         final boolean trace = TraceComponent.isAnyTracingEnabled();
         if (trace && tc.isEntryEnabled())
-            Tr.entry(this, tc, "update", loggable(arg));
+            Tr.entry(this, tc, "update", loggable(args));
 
-        int updateCount = 0;
-        int numExpected = 0;
+        if (entityCount == 0)
+            throw Fail.emptyLifeCycleParam(this);
 
-        if (arg instanceof Iterable) {
-            for (Object e : ((Iterable<?>) arg)) {
-                numExpected++;
-                updateCount += updateOne(e, entityHandler);
-            }
-        } else if (entityParamType.isArray()) {
-            numExpected = Array.getLength(arg);
-            for (int i = 0; i < numExpected; i++)
-                updateCount += updateOne(Array.get(arg, i), entityHandler);
-        } else {
-            numExpected = 1;
-            updateCount = updateOne(arg, entityHandler);
+        // PreUpdateEvent
+        if (producer.lifeCycleEvents != null) {
+            Event<PreUpdateEvent<Object>> event = producer.lifeCycleEvents //
+                            .select(entityInfo.preUpdateLiteral);
+            for (Object e : args)
+                event.fire(new PreUpdateEvent<>(e));
         }
+
+        // update the entities
+        int updateCount = 0;
+        for (Object e : args)
+            updateCount += updateOne(e, entityHandler);
 
         if (entityHandler instanceof EntityManager em) {
             if (trace && tc.isDebugEnabled())
@@ -6366,13 +6441,18 @@ public abstract class QueryInfo {
             em.flush();
         }
 
-        if (numExpected == 0)
-            throw Fail.emptyLifeCycleParam(this);
-
-        if (updateCount < numExpected)
-            throw Fail.optimisticLockConflict(this, updateCount, numExpected);
+        if (updateCount < entityCount)
+            throw Fail.optimisticLockConflict(this, updateCount, entityCount);
 
         Object returnValue = toReturnValue(updateCount, method.getReturnType());
+
+        // PostUpdateEvent
+        if (producer.lifeCycleEvents != null) {
+            Event<PostUpdateEvent<Object>> event = producer.lifeCycleEvents //
+                            .select(entityInfo.postUpdateLiteral);
+            for (Object e : args)
+                event.fire(new PostUpdateEvent<>(e));
+        }
 
         if (trace && tc.isEntryEnabled())
             Tr.exit(this, tc, "update", loggable(returnValue));

--- a/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/cdi/RepositoryProducer.java
+++ b/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/cdi/RepositoryProducer.java
@@ -50,6 +50,7 @@ import jakarta.data.exceptions.DataException;
 import jakarta.data.repository.Repository;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.context.spi.CreationalContext;
+import jakarta.enterprise.event.Event;
 import jakarta.enterprise.inject.Any;
 import jakarta.enterprise.inject.Default;
 import jakarta.enterprise.inject.spi.Bean;
@@ -110,6 +111,13 @@ public class RepositoryProducer<R> implements Producer<R>, ProducerFactory<R>, B
     private final Map<R, R> intercepted = new ConcurrentHashMap<>();
 
     /**
+     * CDI Event proxy for firing types of LifecycleEvent, such as PreDeleteEvent,
+     * in response to beginning or end of the respective life cycle operation.
+     * Null in Data 1.0.
+     */
+    public final Event<Object> lifeCycleEvents;
+
+    /**
      * Primary entity class, if any, for the repository.
      */
     private Class<?> primaryEntityClass;
@@ -161,6 +169,8 @@ public class RepositoryProducer<R> implements Producer<R>, ProducerFactory<R>, B
         this.beanMgr = beanMgr;
         this.beanTypes = Set.of(repositoryInterface);
         this.extension = extension;
+        this.lifeCycleEvents = provider.compat.atLeast(1, 1) //
+                        ? beanMgr.getEvent() : null;
         this.provider = provider;
         this.queriesPerEntityClass = queriesPerEntityClass;
         this.repositoryInterface = repositoryInterface;

--- a/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/DataErrPathsTestServlet.java
+++ b/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPathsTestApp/src/test/jakarta/data/errpaths/web/DataErrPathsTestServlet.java
@@ -1220,10 +1220,8 @@ public class DataErrPathsTestServlet extends FATServlet {
             voters.addPollingLocation(null);
             fail("Should not be able to insert a null entity.");
         } catch (NullPointerException x) {
-            if (x.getMessage() == null ||
-                !x.getMessage().startsWith("CWWKD1015E") ||
-                !x.getMessage().contains("addPollingLocation"))
-                throw x;
+            // might be CWWKD1015E, or
+            // might be raised by Jakarta Data's new PreInsertEvent(null)
         }
     }
 

--- a/dev/io.openliberty.jakarta.data.1.1/src/jakarta/data/event/LifecycleEvent.java
+++ b/dev/io.openliberty.jakarta.data.1.1/src/jakarta/data/event/LifecycleEvent.java
@@ -13,6 +13,7 @@
 package jakarta.data.event;
 
 import jakarta.annotation.Nonnull;
+import jakarta.data.messages.Messages;
 
 public abstract class LifecycleEvent<E> {
 
@@ -20,6 +21,7 @@ public abstract class LifecycleEvent<E> {
     private final E entityInstance;
 
     public LifecycleEvent(@Nonnull E entity) {
+        Messages.requireNonNull(entity, "entity");
         entityInstance = entity;
     }
 


### PR DESCRIPTION
Send CDI events for life cycle operations: Delete, Insert, Update, and Save (upsert).
This covers two paths for update, depending on whether updated entities are retrieved.
With this PR, I found one bug in the Jakarta Data TCK tests for life cycle events, and other TCK tests for life cycle events are now passing.  This PR includes caching of generated TypeLiterals per entity, which are reused on the common path where events are published around the stateless life cycle operations.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
