### PR TITLE
Fix #35271: HttpServletRequest.getDateHeader interprets 2-digit year with base 2000 instead of dynamic base

### DIFF
--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/internal/HttpDateFormatImpl.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/internal/HttpDateFormatImpl.java
@@ -28,6 +28,7 @@ import java.util.HashSet;
 import java.util.Locale;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
+import java.time.ZoneOffset;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.ConfigurationPolicy;
@@ -505,7 +506,7 @@ public class HttpDateFormatImpl implements HttpDateFormat {
         if (null == d) {
             throw new ParseException("Unparseable [" + input + "]", 0);
         }
-        return d;
+        return correctTwoDigitYear(d);
     }
 
     /*
@@ -520,7 +521,7 @@ public class HttpDateFormatImpl implements HttpDateFormat {
         if (null == d) {
             throw new ParseException("Unparseable [" + input + "]", 0);
         }
-        return d;
+        return correctTwoDigitYear(d);
     }
 
     /*
@@ -571,11 +572,11 @@ public class HttpDateFormatImpl implements HttpDateFormat {
 
         Date parsedDate = attemptParse(c1123Time.formatter, data);
         if (null == parsedDate) {
-            parsedDate = attemptParse(c1036Time.formatter, data);
+            parsedDate = correctTwoDigitYear(attemptParse(c1036Time.formatter, data));
             if (null == parsedDate) {
                 parsedDate = attemptParse(cAsciiTime.formatter, data);
                 if (null == parsedDate) {
-                    parsedDate = attemptParse(c2109Time.formatter, data);
+                    parsedDate = correctTwoDigitYear(attemptParse(c2109Time.formatter, data));
                     if (null == parsedDate) {
                         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
                             Tr.debug(tc, "Time does not match supported formats");
@@ -594,5 +595,22 @@ public class HttpDateFormatImpl implements HttpDateFormat {
     @Override
     public Date parseTime(byte[] inBytes) throws ParseException {
         return parseTime(GenericUtils.getEnglishString(inBytes));
+    }
+
+    private Date correctTwoDigitYear(Date parsed){
+        return correctTwoDigitYear(parsed, Instant.now());
+    }
+
+    Date correctTwoDigitYear(Date parsed, Instant now){
+        if (null == parsed){
+            return null;
+        }
+
+        Instant fiftyYearsOut = now.atZone(ZoneOffset.UTC).plusYears(50).toInstant();
+        if (parsed.toInstant().isAfter(fiftyYearsOut)) {
+            return Date.from(parsed.toInstant().atZone(ZoneOffset.UTC).minusYears(100).toInstant());
+        }
+
+        return parsed;
     }
 }

--- a/dev/com.ibm.ws.transport.http/test/com/ibm/ws/http/internal/HttpDateFormatTest.java
+++ b/dev/com.ibm.ws.transport.http/test/com/ibm/ws/http/internal/HttpDateFormatTest.java
@@ -18,10 +18,15 @@ import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Locale;
 import java.util.TimeZone;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 
 import org.junit.Test;
 
 import com.ibm.wsspi.http.HttpDateFormat;
+
+
 
 /**
  * After changing from using SimpleDateFormat to DateTimeFormatter, this test was created
@@ -254,5 +259,28 @@ public class HttpDateFormatTest {
                 Thread.sleep(50);
             }
         }
+    }
+
+    @Test
+    public void testRFC1036TwoDigitYearRollover() throws Exception{
+        Instant fixedNow = Instant.parse("2026-08-04T00:00:00Z");
+
+        Date parsed = ((HttpDateFormatImpl) formatter).parseRFC1036Time(
+                "Saturday, 28-Sep-99 16:11:14 GMT");
+
+        Date expected = Date.from(
+                ZonedDateTime.of(1999, 9, 28, 16, 11, 14, 0, ZoneOffset.UTC).toInstant());
+
+        assertEquals(expected, parsed);
+    }
+
+    @Test
+    public void testRFC2109TwoDigitYearRollover() throws Exception {
+        Date parsed = formatter.parseRFC2109Time("Sat, 28-Sep-99 16:11:14 GMT");
+
+        Date expected = Date.from(
+                ZonedDateTime.of(1999, 9, 28, 16, 11, 14, 0, ZoneOffset.UTC).toInstant());
+
+        assertEquals(expected, parsed);
     }
 }


### PR DESCRIPTION



- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [ ] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

Fixes #35271 

## Root cause

The `SimpleDateFormat` → `DateTimeFormatter` migration (23.0.0.5) changed 2-digit year resolution. `appendPattern`'s `uu` token maps to `appendValueReduced(YEAR, 2, 2, 2000)` — a fixed base of 2000, so results are always in `[2000, 2099]`, regardless of when parsing happens.

Per [RFC 7231 §7.1.1.1](https://datatracker.ietf.org/doc/html/rfc7231#section-7.1.1.1), a 2-digit year that appears more than 50 years in the future must be interpreted as the most recent past year with the same digits. `c1036Time` and `c2109Time` both use a 2-digit-year pattern and are affected; `c1123Time`, `cAsciiTime`, and `cNCSATime` use 4-digit years and are not.


fix: Added a post-parse correction implementing the RFC rule directly, applied to `parseRFC1036Time`, `parseRFC2109Time`, and the corresponding branches of `parseTime`:

```java
Date correctTwoDigitYear(Date parsed, Instant now) {
    if (null == parsed) return null;
    if (parsed.toInstant().isAfter(now.atZone(ZoneOffset.UTC).plusYears(50).toInstant())) {
        return Date.from(parsed.toInstant().atZone(ZoneOffset.UTC).minusYears(100).toInstant());
    }
    return parsed;
}
```


Considered fixing the base passed to `appendValueReduced` instead, but rejected it: it's an approximation (mismatches RFC 7231 for a real range of inputs depending on the offset chosen), and since the formatter is built once for the life of the server process, a static base would drift further from "now" the longer the server stays up.

## Testing

Added `testRFC1036TwoDigitYearRollover`, `testRFC2109TwoDigitYearRollover` to `HttpDateFormatTest`. All existing tests pass unmodified.





