### PR TITLE
Fix annotation scanner executor thread leak

### DIFF
--- a/dev/com.ibm.ws.anno/src/com/ibm/ws/annocache/targets/internal/TargetsScannerOverallImpl.java
+++ b/dev/com.ibm.ws.anno/src/com/ibm/ws/annocache/targets/internal/TargetsScannerOverallImpl.java
@@ -1337,6 +1337,8 @@ public class TargetsScannerOverallImpl extends TargetsScannerBaseImpl {
                "[ {0} ] ANNO_TARGETS_CACHE_EXCEPTION [ {1} ]",
                new Object[] { getHashText(), e });
             logger.logp(Level.WARNING, CLASS_NAME, methodName, "Cache error", e);
+        } finally {
+            readPool.shutdown();
         }
 
         if ( useHashText != null ) {
@@ -1413,6 +1415,8 @@ public class TargetsScannerOverallImpl extends TargetsScannerBaseImpl {
                "[ {0} ] ANNO_TARGETS_CACHE_EXCEPTION [ {1} ]",
                new Object[] { getHashText(), e });
             logger.logp(Level.WARNING, CLASS_NAME, methodName, "Cache error", e);
+        } finally {
+            validatorPool.shutdown();
         }
 
         int changedContainers = 0;
@@ -1524,6 +1528,8 @@ public class TargetsScannerOverallImpl extends TargetsScannerBaseImpl {
                "[ {0} ] ANNO_TARGETS_CACHE_EXCEPTION [ {1} ]",
                new Object[] { getHashText(), e });
             logger.logp(Level.WARNING, CLASS_NAME, methodName, "Cache error", e);
+        } finally {
+            completionPool.shutdown();
         }
 
         if ( useHashText != null ) {


### PR DESCRIPTION
Test PR for #35561 

Shut down the temporary read, validation, and completion executors after their work completes. This preserves concurrent annotation scanning while allowing idle core worker threads to terminate instead of remaining alive for the lifetime of the server.

Co-authored-by-AI: OpenAI Codex (GPT-5)

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [ ] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

################################################################################################
