### PR TITLE
fix race condition in scheduled task init

### DIFF
--- a/dev/io.openliberty.concurrent.internal.cdi/src/io/openliberty/concurrent/internal/cdi/ScheduledMethod.java
+++ b/dev/io.openliberty.concurrent.internal.cdi/src/io/openliberty/concurrent/internal/cdi/ScheduledMethod.java
@@ -17,6 +17,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.List;
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.TimeUnit;
 
 import com.ibm.ws.concurrent.WSManagedExecutorService;
 import com.ibm.wsspi.threadcontext.ThreadContextDescriptor;
@@ -58,6 +59,11 @@ public class ScheduledMethod<T> extends ScheduledMethodAbstract {
 
         this.beanClass = beanClass;
         this.beanQualifierAnnos = beanQualifierAnnos;
+
+        // Intentionally placed as last line of constructuor to ensure
+        // intialization is complete before the first task execution runs
+        ConcurrencyExtensionMetadata.scheduledExecutor //
+                        .schedule(this, computeDelayNanos(), TimeUnit.NANOSECONDS);
     }
 
     /**

--- a/dev/io.openliberty.concurrent.internal.cdi/src/io/openliberty/concurrent/internal/cdi/ScheduledMethodAbstract.java
+++ b/dev/io.openliberty.concurrent.internal.cdi/src/io/openliberty/concurrent/internal/cdi/ScheduledMethodAbstract.java
@@ -85,9 +85,6 @@ public abstract class ScheduledMethodAbstract implements //
         this.virtualThreadExecutor = managedExecutor //
                         .getNormalPolicyExecutor() //
                         .getVirtualThreadExecutor();
-
-        ConcurrencyExtensionMetadata.scheduledExecutor //
-                        .schedule(this, computeDelayNanos(), TimeUnit.NANOSECONDS);
     }
 
     /**
@@ -210,7 +207,7 @@ public abstract class ScheduledMethodAbstract implements //
      * @return nanoseconds until the next execution.
      */
     @Trivial
-    long computeDelayNanos() {
+    public long computeDelayNanos() {
         final boolean trace = TraceComponent.isAnyTracingEnabled();
         if (trace && tc.isEntryEnabled())
             Tr.entry(this, tc, "computeDelayNanos");

--- a/dev/io.openliberty.concurrent.internal.cdi/src/io/openliberty/concurrent/internal/cdi/interceptor/ScheduledAsyncMethod.java
+++ b/dev/io.openliberty.concurrent.internal.cdi/src/io/openliberty/concurrent/internal/cdi/interceptor/ScheduledAsyncMethod.java
@@ -16,12 +16,14 @@ import java.lang.reflect.InvocationTargetException;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.TimeUnit;
 
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.websphere.ras.annotation.Trivial;
 import com.ibm.ws.concurrent.WSManagedExecutorService;
 
+import io.openliberty.concurrent.internal.cdi.ConcurrencyExtensionMetadata;
 import io.openliberty.concurrent.internal.cdi.ScheduleCronTrigger;
 import io.openliberty.concurrent.internal.cdi.ScheduledMethodAbstract;
 import jakarta.interceptor.InvocationContext;
@@ -85,6 +87,11 @@ class ScheduledAsyncMethod extends ScheduledMethodAbstract {
 
         this.firstInvocation = firstInvocation;
         this.interceptor = interceptor;
+
+        // Intentionally placed as last line of constructuor to ensure
+        // intialization is complete before the first task execution runs
+        ConcurrencyExtensionMetadata.scheduledExecutor //
+                        .schedule(this, computeDelayNanos(), TimeUnit.NANOSECONDS);
     }
 
     /**


### PR DESCRIPTION
Fixes #35587 by eliminating a race condition in the initialization code for asynchronous scheduled methods.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
