### PR TITLE
Split reason header on the first occurence of the equals sign only

### DIFF
--- a/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/container/util/SipUtil.java
+++ b/dev/com.ibm.ws.sipcontainer/src/com/ibm/ws/sip/container/util/SipUtil.java
@@ -1116,7 +1116,7 @@ public class SipUtil {
 				reasonHeaderLength += reasonParam[0].length()+1; // +1 for the ';'
 				
 				for(int j=1 ; j < reasonParam.length ; j++){
-					String [] keyVal = reasonParam[j].split("=");
+					String [] keyVal = reasonParam[j].split("=", 2);
 					// parse the "cause" parameter if exists
 					if(keyVal[0].trim().equals( "cause")){
 						cause = Integer.parseInt(keyVal[1].trim());


### PR DESCRIPTION
- [ x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x ] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

The sipcontainer is throwing a parsing exception in case the text element of the Reason header contains an equal sign. As the text element is a String type, it can contain any character, including an equal sign.

