### PR TITLE
Fix testUpgradeReadListenerLargeData marker 

### DIFF
--- a/dev/com.ibm.ws.webcontainer.servlet.3.1_fat.2/test-applications/LibertyReadWriteListenerTest.war/src/com/ibm/ws/webcontainer/servlet_31_fat/libertyreadwritelistenertest/war/upgradeHandler/TestUpgradeReadListener.java
+++ b/dev/com.ibm.ws.webcontainer.servlet.3.1_fat.2/test-applications/LibertyReadWriteListenerTest.war/src/com/ibm/ws/webcontainer/servlet_31_fat/libertyreadwritelistenertest/war/upgradeHandler/TestUpgradeReadListener.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2024 IBM Corporation and others.
+ * Copyright (c) 2014, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -36,6 +36,8 @@ public class TestUpgradeReadListener implements ReadListener {
     private final LinkedBlockingQueue<String> queue = new LinkedBlockingQueue<String>();
     private static final Logger LOG = Logger.getLogger(TestUpgradeReadListener.class.getName());
     long dataSize = 0;
+    private static final String COMPLETE_MESSAGE = "Sending Data Complete";
+    private int completeMessageIndex = 0;
     private final String TIMEOUT_OCCURRED = ", A Timeout has been triggered";
     private StringBuilder timeoutStringBuilder;
 
@@ -109,14 +111,21 @@ public class TestUpgradeReadListener implements ReadListener {
                     LOG.info("testUpgradeReadListenerLargeData onDataAvailable, isReady=false");
                 }
 
-                while (input.isReady() && (len = input.read(b)) != -1) {
-                    LOG.info("testUpgradeReadListenerLargeData in onDataAvailable() in TestUpgradeReadListener onDataAvailable, isReady=true , reading data from input stream and measuring its size ");
+                while (!complete && input.isReady() && (len = input.read(b)) != -1) {
                     dataSize += len;
-                    String s = new String(b);
-                    if (s.contains("Sending Data Complete")) {
-                        LOG.info("testUpgradeReadListenerLargeData in onDataAvailable() in TestUpgradeReadListener, complete message found. Test is done");
-                        dataSize -= ("Sending Data Complete").length();
-                        complete = true;
+                    for (int i = 0; i < len; i++) {
+                        if (b[i] == COMPLETE_MESSAGE.charAt(completeMessageIndex)) {
+                            completeMessageIndex++;
+                        } else {
+                            completeMessageIndex = b[i] == COMPLETE_MESSAGE.charAt(0) ? 1 : 0;
+                        }
+                        if (completeMessageIndex == COMPLETE_MESSAGE.length()) {
+                            LOG.info("testUpgradeReadListenerLargeData in onDataAvailable() in TestUpgradeReadListener, complete message found. Test is done");
+                            dataSize -= COMPLETE_MESSAGE.length();
+                            completeMessageIndex = 0;
+                            complete = true;
+                            break;
+                        }
                     }
                 }
 


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

### Background
While working on disabling Netty auto-read for HTTP upgrade paths, `UpgradeReadListenerHttpUnit#testUpgradeReadListenerLargeData` failed intermittently with read timeouts. Investigation showed the test failure was not caused by the transport changes, but by an existing bug in the test application's completion oracle.

### Problem
The test streams a 1 MB payload over an upgraded connection and ends with a "Sending Data Complete" marker. In TestUpgradeReadListener.java, the completion check converted each raw byte buffer into a string and ran s.contains("Sending Data Complete").

When network chunking or Netty buffer framing splits the marker string across two read buffers (for example, "Sending " in the first read and "Data Complete" in the next), contains() returns false on both chunks. The listener never flags completion, miscalculates the payload size, and hangs until the test runner times out.

### Fix
Replace the per-buffer string check in `TestUpgradeReadListener.java` with a byte scanner that preserves marker index state across multiple `input.read(b)` calls. Once all bytes in the sentinel match across buffer boundaries, the listener subtracts the marker length from the measured size and marks the read complete.
