### PR TITLE
Adding Json-p 2.2 src and tests

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.jsonpImpl-2.2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.jsonpImpl-2.2.0.feature
@@ -9,7 +9,7 @@ visibility=private
   com.ibm.websphere.appserver.eeCompatible-12.0, \
   io.openliberty.noShip-1.0
 -bundles=\
- io.openliberty.jakarta.jsonp.2.1; location:="dev/api/spec/,lib/"; mavenCoordinates="jakarta.json:jakarta.json-api:2.1.3"
+ io.openliberty.jakarta.jsonp.2.2; location:="dev/api/spec/,lib/"; mavenCoordinates="jakarta.json:jakarta.json-api:2.2.0-SNAPSHOT"
 kind=noship
 edition=full
 WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.jsonpImpl-2.2.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.jsonpImpl-2.2.0.feature
@@ -9,7 +9,7 @@ visibility=private
   com.ibm.websphere.appserver.eeCompatible-12.0, \
   io.openliberty.noShip-1.0
 -bundles=\
- io.openliberty.jakarta.jsonp.2.2; location:="dev/api/spec/,lib/"; mavenCoordinates="jakarta.json:jakarta.json-api:2.2.0-SNAPSHOT"
+ io.openliberty.jakarta.jsonp.2.2; location:="dev/api/spec/,lib/"
 kind=noship
 edition=full
 WLP-Activation-Type: parallel

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.jsonpImpl-2.2.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.jsonpImpl-2.2.1.feature
@@ -7,7 +7,7 @@ visibility=private
   com.ibm.websphere.appserver.eeCompatible-12.0, \
   io.openliberty.noShip-1.0
 -bundles=\
-  io.openliberty.jakarta.jsonp.2.2; location:="dev/api/spec/,lib/"; mavenCoordinates="jakarta.json:jakarta.json-api:2.2.0-SNAPSHOT", \
+  io.openliberty.jakarta.jsonp.2.2; location:="dev/api/spec/,lib/", \
   io.openliberty.org.eclipse.parsson.1.1
 kind=noship
 edition=full

--- a/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.jsonpImpl-2.2.1.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/private/io.openliberty.jsonpImpl-2.2.1.feature
@@ -7,7 +7,7 @@ visibility=private
   com.ibm.websphere.appserver.eeCompatible-12.0, \
   io.openliberty.noShip-1.0
 -bundles=\
-  io.openliberty.jakarta.jsonp.2.1; location:="dev/api/spec/,lib/"; mavenCoordinates="jakarta.json:jakarta.json-api:2.1.3", \
+  io.openliberty.jakarta.jsonp.2.2; location:="dev/api/spec/,lib/"; mavenCoordinates="jakarta.json:jakarta.json-api:2.2.0-SNAPSHOT", \
   io.openliberty.org.eclipse.parsson.1.1
 kind=noship
 edition=full

--- a/dev/io.openliberty.jakarta.jsonp.2.2/.classpath
+++ b/dev/io.openliberty.jakarta.jsonp.2.2/.classpath
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
+	<classpathentry kind="output" path="bin"/>
+</classpath>

--- a/dev/io.openliberty.jakarta.jsonp.2.2/.project
+++ b/dev/io.openliberty.jakarta.jsonp.2.2/.project
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>io.openliberty.jakarta.jsonp.2.2</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>bndtools.core.bndbuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>bndtools.core.bndnature</nature>
+	</natures>
+</projectDescription>

--- a/dev/io.openliberty.jakarta.jsonp.2.2/bnd.bnd
+++ b/dev/io.openliberty.jakarta.jsonp.2.2/bnd.bnd
@@ -1,0 +1,40 @@
+#*******************************************************************************
+# Copyright (c) 2026 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+#*******************************************************************************
+# Local-source overlay: builds the Jakarta JSON-P API from src/ (provider-cache
+# branch of jsonp-api) 
+#
+# TODO update to Maven dependency after Milestone release
+
+-include= ~../cnf/resources/bnd/bundle.props
+bVersion=1.0
+
+javac.source: 17
+javac.target: 17
+
+Require-Capability: osgi.ee; filter:="(&(osgi.ee=JavaSE)(version=17))"
+
+Bundle-SymbolicName: io.openliberty.jakarta.jsonp.2.2
+
+# Optionally import eclipse Parsson impl because spec jar does Class.forName() of it as a fallback option
+Import-Package: \
+   org.eclipse.parsson;resolution:=optional, \
+   *
+
+Export-Package: \
+   jakarta.json;thread-context=true;version=2.2, \
+   jakarta.json.spi;version=2.2, \
+   jakarta.json.stream;version=2.2
+
+instrument.disabled: true
+
+publish.wlp.jar.suffix: dev/api/spec

--- a/dev/io.openliberty.jakarta.jsonp.2.2/src/jakarta/json/EmptyArray.java
+++ b/dev/io.openliberty.jakarta.jsonp.2.2/src/jakarta/json/EmptyArray.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.json;
+
+import java.io.Serializable;
+import java.util.AbstractList;
+import java.util.Collections;
+import java.util.List;
+import java.util.RandomAccess;
+
+/**
+ * Private implementation of immutable {@link JsonArray}.
+ *
+ * @author Lukas Jungmann
+ */
+final class EmptyArray extends AbstractList<JsonValue> implements JsonArray, Serializable, RandomAccess {
+
+    /** for serialization */
+    private static final long serialVersionUID = 7295439472061642859L;
+
+    /** Default constructor. */
+    EmptyArray() {}
+
+    @Override
+    public JsonValue get(int index) {
+        throw new IndexOutOfBoundsException("Index: " + index);
+    }
+
+    @Override
+    public int size() {
+        return 0;
+    }
+
+    @Override
+    public JsonObject getJsonObject(int index) {
+        return (JsonObject) get(index);
+    }
+
+    @Override
+    public JsonArray getJsonArray(int index) {
+        return (JsonArray) get(index);
+    }
+
+    @Override
+    public JsonNumber getJsonNumber(int index) {
+        return (JsonNumber) get(index);
+    }
+
+    @Override
+    public JsonString getJsonString(int index) {
+        return (JsonString) get(index);
+    }
+
+    @Override
+    public <T extends JsonValue> List<T> getValuesAs(Class<T> clazz) {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public String getString(int index) {
+        return getJsonString(index).getString();
+    }
+
+    @Override
+    public String getString(int index, String defaultValue) {
+        return defaultValue;
+    }
+
+    @Override
+    public int getInt(int index) {
+        return getJsonNumber(index).intValue();
+    }
+
+    @Override
+    public int getInt(int index, int defaultValue) {
+        return defaultValue;
+    }
+
+    @Override
+    public boolean getBoolean(int index) {
+        return get(index) == JsonValue.TRUE;
+    }
+
+    @Override
+    public boolean getBoolean(int index, boolean defaultValue) {
+        return defaultValue;
+    }
+
+    @Override
+    public boolean isNull(int index) {
+        return get(index) == JsonValue.NULL;
+    }
+
+    @Override
+    public ValueType getValueType() {
+        return ValueType.ARRAY;
+    }
+
+    /**
+     * Preserves singleton property
+     * @return {@link JsonValue#EMPTY_JSON_ARRAY}
+     */
+    private Object readResolve() {
+        return JsonValue.EMPTY_JSON_ARRAY;
+    }
+}

--- a/dev/io.openliberty.jakarta.jsonp.2.2/src/jakarta/json/EmptyObject.java
+++ b/dev/io.openliberty.jakarta.jsonp.2.2/src/jakarta/json/EmptyObject.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2017, 2022 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.json;
+
+import java.io.Serializable;
+import java.util.AbstractMap;
+import java.util.Collections;
+import java.util.Set;
+
+/**
+ * Private implementation of immutable {@link JsonObject}.
+ *
+ * @author Lukas Jungmann
+ */
+final class EmptyObject extends AbstractMap<String, JsonValue> implements JsonObject, Serializable {
+
+    /** for serialization */
+    private static final long serialVersionUID = -1461653546889072583L;
+
+    /** Default constructor. */
+    EmptyObject() {}
+
+    @Override
+    public Set<Entry<String, JsonValue>> entrySet() {
+        return Collections.<Entry<String, JsonValue>>emptySet();
+    }
+
+    @Override
+    public JsonArray getJsonArray(String name) {
+        return (JsonArray) get(name);
+    }
+
+    @Override
+    public JsonObject getJsonObject(String name) {
+        return (JsonObject) get(name);
+    }
+
+    @Override
+    public JsonNumber getJsonNumber(String name) {
+        return (JsonNumber) get(name);
+    }
+
+    @Override
+    public JsonString getJsonString(String name) {
+        return (JsonString) get(name);
+    }
+
+    @Override
+    public String getString(String name) {
+        return getJsonString(name).getString();
+    }
+
+    @Override
+    public String getString(String name, String defaultValue) {
+        return defaultValue;
+    }
+
+    @Override
+    public int getInt(String name) {
+        return getJsonNumber(name).intValue();
+    }
+
+    @Override
+    public int getInt(String name, int defaultValue) {
+        return defaultValue;
+    }
+
+    @Override
+    public boolean getBoolean(String name) {
+        throw new NullPointerException();
+    }
+
+    @Override
+    public boolean getBoolean(String name, boolean defaultValue) {
+        return defaultValue;
+    }
+
+    @Override
+    public boolean isNull(String name) {
+        throw new NullPointerException();
+    }
+
+    @Override
+    public ValueType getValueType() {
+        return ValueType.OBJECT;
+    }
+
+    /**
+     * Preserves singleton property
+     * @return {@link JsonValue#EMPTY_JSON_OBJECT}
+     */
+    private Object readResolve() {
+        return JsonValue.EMPTY_JSON_OBJECT;
+    }
+}

--- a/dev/io.openliberty.jakarta.jsonp.2.2/src/jakarta/json/Json.java
+++ b/dev/io.openliberty.jakarta.jsonp.2.2/src/jakarta/json/Json.java
@@ -1,0 +1,534 @@
+/*
+ * Copyright (c) 2011, 2024 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.json;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.Reader;
+import java.io.Writer;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Optional;
+import jakarta.json.spi.JsonProvider;
+import jakarta.json.stream.JsonGenerator;
+import jakarta.json.stream.JsonGeneratorFactory;
+import jakarta.json.stream.JsonParser;
+import jakarta.json.stream.JsonParserFactory;
+
+/**
+ * Factory class for creating JSON processing objects.
+ * This class provides the most commonly used methods for creating these
+ * objects and their corresponding factories. The factory classes provide
+ * all the various ways to create these objects.
+ *
+ * <p>
+ * The methods in this class locate a provider instance using the method
+ * {@link JsonProvider#provider()}. This class uses the provider instance
+ * to create JSON processing objects.
+ *
+ * <p>
+ * The following example shows how to create a JSON parser to parse
+ * an empty array:
+ * <pre>
+ * <code>
+ * StringReader reader = new StringReader("[]");
+ * JsonParser parser = Json.createParser(reader);
+ * </code>
+ * </pre>
+ *
+ * <p>
+ * All the methods in this class are safe for use by multiple concurrent
+ * threads.
+ */
+public final class Json {
+
+    /**
+     * No instantiation.
+     */
+    private Json() {
+    }
+
+    /**
+     * Creates a JSON parser from a character stream.
+     *
+     * @param reader i/o reader from which JSON is to be read
+     * @return a JSON parser
+     */
+    public static JsonParser createParser(Reader reader) {
+        return JsonProvider.provider().createParser(reader);
+    }
+
+    /**
+     * Creates a JSON parser from a byte stream.
+     * The character encoding of the stream is determined as specified in
+     * <a href="http://tools.ietf.org/rfc/rfc7159.txt">RFC 7159</a>.
+     *
+     * @param in i/o stream from which JSON is to be read
+     * @throws JsonException if encoding cannot be determined
+     *         or i/o error (IOException would be cause of JsonException)
+     * @return a JSON parser
+     */
+    public static JsonParser createParser(InputStream in) {
+        return JsonProvider.provider().createParser(in);
+    }
+
+    /**
+     * Creates a JSON generator for writing JSON to a character stream.
+     *
+     * @param writer a i/o writer to which JSON is written
+     * @return a JSON generator
+     */
+    public static JsonGenerator createGenerator(Writer writer) {
+        return JsonProvider.provider().createGenerator(writer);
+    }
+
+    /**
+     * Creates a JSON generator for writing JSON to a byte stream.
+     *
+     * @param out i/o stream to which JSON is written
+     * @return a JSON generator
+     */
+    public static JsonGenerator createGenerator(OutputStream out) {
+        return JsonProvider.provider().createGenerator(out);
+    }
+
+    /**
+     * Creates a parser factory for creating {@link JsonParser} objects.
+     *
+     * @return JSON parser factory.
+     *
+    public static JsonParserFactory createParserFactory() {
+        return JsonProvider.provider().createParserFactory();
+    }
+     */
+
+    /**
+     * Creates a parser factory for creating {@link JsonParser} objects.
+     * The factory is configured with the specified map of provider specific
+     * configuration properties. Provider implementations should ignore any
+     * unsupported configuration properties specified in the map.
+     *
+     * @param config a map of provider specific properties to configure the
+     *               JSON parsers. The map may be empty or null
+     * @return JSON parser factory
+     */
+    public static JsonParserFactory createParserFactory(Map<String, ?> config) {
+        return JsonProvider.provider().createParserFactory(config);
+    }
+
+    /**
+     * Creates a generator factory for creating {@link JsonGenerator} objects.
+     *
+     * @return JSON generator factory
+     *
+    public static JsonGeneratorFactory createGeneratorFactory() {
+        return JsonProvider.provider().createGeneratorFactory();
+    }
+    */
+
+    /**
+     * Creates a generator factory for creating {@link JsonGenerator} objects.
+     * The factory is configured with the specified map of provider specific
+     * configuration properties. Provider implementations should ignore any
+     * unsupported configuration properties specified in the map.
+     *
+     * @param config a map of provider specific properties to configure the
+     *               JSON generators. The map may be empty or null
+     * @return JSON generator factory
+     */
+    public static JsonGeneratorFactory createGeneratorFactory(
+            Map<String, ?> config) {
+        return JsonProvider.provider().createGeneratorFactory(config);
+    }
+
+    /**
+     * Creates a JSON writer to write a
+     * JSON {@link JsonObject object} or {@link JsonArray array}
+     * structure to the specified character stream.
+     *
+     * @param writer to which JSON object or array is written
+     * @return a JSON writer
+     */
+    public static JsonWriter createWriter(Writer writer) {
+        return JsonProvider.provider().createWriter(writer);
+    }
+
+    /**
+     * Creates a JSON writer to write a
+     * JSON {@link JsonObject object} or {@link JsonArray array}
+     * structure to the specified byte stream. Characters written to
+     * the stream are encoded into bytes using UTF-8 encoding.
+     *
+     * @param out to which JSON object or array is written
+     * @return a JSON writer
+     */
+    public static JsonWriter createWriter(OutputStream out) {
+        return JsonProvider.provider().createWriter(out);
+    }
+
+    /**
+     * Creates a JSON reader from a character stream.
+     *
+     * @param reader a reader from which JSON is to be read
+     * @return a JSON reader
+     */
+    public static JsonReader createReader(Reader reader) {
+        return JsonProvider.provider().createReader(reader);
+    }
+
+    /**
+     * Creates a JSON reader from a byte stream. The character encoding of
+     * the stream is determined as described in
+     * <a href="http://tools.ietf.org/rfc/rfc7159.txt">RFC 7159</a>.
+     *
+     * @param in a byte stream from which JSON is to be read
+     * @return a JSON reader
+     */
+    public static JsonReader createReader(InputStream in) {
+        return JsonProvider.provider().createReader(in);
+    }
+
+    /**
+     * Creates a reader factory for creating {@link JsonReader} objects.
+     * The factory is configured with the specified map of provider specific
+     * configuration properties. Provider implementations should ignore any
+     * unsupported configuration properties specified in the map.
+     *
+     * @param config a map of provider specific properties to configure the
+     *               JSON readers. The map may be empty or null
+     * @return a JSON reader factory
+     */
+    public static JsonReaderFactory createReaderFactory(Map<String, ?> config) {
+        return JsonProvider.provider().createReaderFactory(config);
+    }
+
+    /**
+     * Creates a writer factory for creating {@link JsonWriter} objects.
+     * The factory is configured with the specified map of provider specific
+     * configuration properties. Provider implementations should ignore any
+     * unsupported configuration properties specified in the map.
+     *
+     * @param config a map of provider specific properties to configure the
+     *               JSON writers. The map may be empty or null
+     * @return a JSON writer factory
+     */
+    public static JsonWriterFactory createWriterFactory(Map<String, ?> config) {
+        return JsonProvider.provider().createWriterFactory(config);
+    }
+
+    /**
+     * Creates a JSON array builder
+     *
+     * @return a JSON array builder
+     */
+    public static JsonArrayBuilder createArrayBuilder() {
+        return JsonProvider.provider().createArrayBuilder();
+    }
+
+    /**
+     * Creates a JSON array builder, initialized with the specified array
+     *
+     * @param array the initial array in the builder
+     * @return a JSON array builder
+     *
+     * @since 1.1
+     */
+    public static JsonArrayBuilder createArrayBuilder(JsonArray array) {
+        return JsonProvider.provider().createArrayBuilder(array);
+    }
+
+    /**
+     * Creates a JSON array builder, initialized with the content of specified {@code collection}.
+     * If the {@code collection} contains {@link Optional}s then resulting JSON array builder
+     * contains the value from the {@code collection} only if the {@link Optional} is not empty.
+     *
+     * @param collection the initial data for the builder
+     * @return a JSON array builder
+     * @exception IllegalArgumentException if the value from the {@code collection} cannot be converted
+     *            to the corresponding {@link JsonValue}
+     *
+     * @since 1.1
+     */
+    public static JsonArrayBuilder createArrayBuilder(Collection<?> collection) {
+        return JsonProvider.provider().createArrayBuilder(collection);
+    }
+
+    /**
+     * Creates a JSON object builder
+     *
+     * @return a JSON object builder
+     */
+    public static JsonObjectBuilder createObjectBuilder() {
+        return JsonProvider.provider().createObjectBuilder();
+    }
+
+    /**
+     * Creates a JSON object builder, initialized with the specified object.
+     *
+     * @param object the initial object in the builder
+     * @return a JSON object builder
+     *
+     * @since 1.1
+     */
+    public static JsonObjectBuilder createObjectBuilder(JsonObject object) {
+        return JsonProvider.provider().createObjectBuilder(object);
+    }
+
+    /**
+     * Creates a JSON object builder, initialized with the data from specified {@code map}.
+     * If the @{code map} contains {@link Optional}s then resulting JSON object builder
+     * contains the key from the {@code map} only if the {@link Optional} is not empty.
+     *
+     * @param map the initial object in the builder
+     * @return a JSON object builder
+     * @exception IllegalArgumentException if the value from the {@code map} cannot be converted
+     *            to the corresponding {@link JsonValue}
+     *
+     * @since 1.1
+     */
+    public static JsonObjectBuilder createObjectBuilder(Map<String, ?> map) {
+        return JsonProvider.provider().createObjectBuilder(map);
+    }
+
+    /**
+     * Creates JSON Pointer (<a href="http://tools.ietf.org/html/rfc6901">RFC 6901</a>)
+     * from given {@code jsonPointer} string.
+     * <ul>
+     *     <li>An empty {@code jsonPointer} string defines a reference to the target itself.</li>
+     *     <li>If the {@code jsonPointer} string is non-empty, it must be a sequence of '{@code /}' prefixed tokens.</li>
+     * </ul>
+     *
+     * @param jsonPointer the valid escaped JSON Pointer string
+     * @throws NullPointerException if {@code jsonPointer} is {@code null}
+     * @throws JsonException if {@code jsonPointer} is not a valid JSON Pointer
+     * @return a JSON Pointer
+     *
+     * @since 1.1
+     */
+    public static JsonPointer createPointer(String jsonPointer) {
+        return JsonProvider.provider().createPointer(jsonPointer);
+    }
+
+    /**
+     * Creates a JSON Patch builder (<a href="http://tools.ietf.org/html/rfc6902">RFC 6902</a>).
+     *
+     * @return a JSON Patch builder
+     *
+     * @since 1.1
+     */
+    public static JsonPatchBuilder createPatchBuilder() {
+        return JsonProvider.provider().createPatchBuilder();
+    }
+
+    /**
+     * Creates a JSON Patch builder
+     * (<a href="http://tools.ietf.org/html/rfc6902">RFC 6902</a>),
+     * initialized with the specified operations.
+     *
+     * @param array the initial patch operations
+     * @return a JSON Patch builder
+     *
+     * @since 1.1
+     */
+    public static JsonPatchBuilder createPatchBuilder(JsonArray array) {
+        return JsonProvider.provider().createPatchBuilder(array);
+    }
+
+    /**
+     * Creates a JSON Patch (<a href="http://tools.ietf.org/html/rfc6902">RFC 6902</a>)
+     * from the specified operations.
+     *
+     * @param array patch operations
+     * @return a JSON Patch
+     *
+     * @since 1.1
+     */
+    public static JsonPatch createPatch(JsonArray array) {
+        return JsonProvider.provider().createPatch(array);
+    }
+
+    /**
+     * Generates a JSON Patch (<a href="http://tools.ietf.org/html/rfc6902">RFC 6902</a>)
+     * from the source and target {@code JsonStructure}.
+     * The generated JSON Patch need not be unique.
+     *
+     * @param source the source
+     * @param target the target, must be the same type as the source
+     * @return a JSON Patch which when applied to the source, yields the target
+     *
+     * @since 1.1
+     */
+    public static JsonPatch createDiff(JsonStructure source, JsonStructure target) {
+        return JsonProvider.provider().createDiff(source, target);
+    }
+
+    /**
+     * Creates JSON Merge Patch (<a href="http://tools.ietf.org/html/rfc7396">RFC 7396</a>)
+     * from specified {@code JsonValue}.
+     *
+     * @param patch the patch
+     * @return a JSON Merge Patch
+     *
+     * @since 1.1
+     */
+    public static JsonMergePatch createMergePatch(JsonValue patch) {
+        return JsonProvider.provider().createMergePatch(patch);
+    }
+
+    /**
+     * Generates a JSON Merge Patch (<a href="http://tools.ietf.org/html/rfc7396">RFC 7396</a>)
+     * from the source and target {@code JsonValue}s
+     * which when applied to the {@code source}, yields the {@code target}.
+     *
+     * @param source the source
+     * @param target the target
+     * @return a JSON Merge Patch
+     *
+     * @since 1.1
+     */
+    public static JsonMergePatch createMergeDiff(JsonValue source, JsonValue target) {
+        return JsonProvider.provider().createMergeDiff(source, target);
+    }
+
+    /**
+     * Creates a builder factory for creating {@link JsonArrayBuilder}
+     * and {@link JsonObjectBuilder} objects.
+     * The factory is configured with the specified map of provider specific
+     * configuration properties. Provider implementations should ignore any
+     * unsupported configuration properties specified in the map.
+     *
+     * @param config a map of provider specific properties to configure the
+     *               JSON builders. The map may be empty or null
+     * @return a JSON builder factory
+     */
+    public static JsonBuilderFactory createBuilderFactory(
+            Map<String, ?> config) {
+        return JsonProvider.provider().createBuilderFactory(config);
+    }
+
+    /**
+     * Creates a JsonString.
+     *
+     * @param value a JSON string
+     * @return the JsonString for the string
+     *
+     * @since 1.1
+     */
+    public static JsonString createValue(String value) {
+        return JsonProvider.provider().createValue(value);
+    }
+
+    /**
+     * Creates a JsonNumber.
+     *
+     * @param value a JSON number
+     * @return the JsonNumber for the number
+     *
+     * @since 1.1
+     */
+    public static JsonNumber createValue(int value) {
+        return JsonProvider.provider().createValue(value);
+    }
+
+    /**
+     * Creates a JsonNumber.
+     *
+     * @param value a JSON number
+     * @return the JsonNumber for the number
+     *
+     * @since 1.1
+     */
+    public static JsonNumber createValue(long value) {
+        return JsonProvider.provider().createValue(value);
+    }
+
+    /**
+     * Creates a JsonNumber.
+     *
+     * @param value a JSON number
+     * @return the JsonNumber for the number
+     *
+     * @since 1.1
+     */
+    public static JsonNumber createValue(double value) {
+        return JsonProvider.provider().createValue(value);
+    }
+
+    /**
+     * Creates a JsonNumber.
+     *
+     * @param value a JSON number
+     * @return the JsonNumber for the number
+     *
+     * @since 1.1
+     */
+    public static JsonNumber createValue(BigDecimal value) {
+        return JsonProvider.provider().createValue(value);
+    }
+
+    /**
+     * Creates a JsonNumber.
+     *
+     * @param value a JSON number
+     * @return the JsonNumber for the number
+     *
+     * @since 1.1
+     */
+    public static JsonNumber createValue(BigInteger value) {
+        return JsonProvider.provider().createValue(value);
+    }
+
+    /**
+     * Encodes (escapes) a passed string as defined by <a href="http://tools.ietf.org/html/rfc6901">RFC 6901</a>.
+     * This method doesn't validate the passed JSON-pointer string.
+     *
+     * @param pointer the JSON-pointer string to encode
+     * @return encoded JSON-pointer string
+     * 
+     * @since 1.1
+     */
+    public static String encodePointer(String pointer) {
+        return pointer.replace("~", "~0").replace("/", "~1");
+    }
+
+    /**
+     * Decodes a passed JSON-pointer string as defined by <a href="http://tools.ietf.org/html/rfc6901">RFC 6901</a>.
+     * This method doesn't validate the passed JSON-pointer string.
+     *
+     * @param escaped the JSON-pointer string to decode
+     * @return decoded JSON-pointer string
+     *     
+     * @since 1.1
+     */
+    public static String decodePointer(String escaped) {
+        return escaped.replace("~1", "/").replace("~0", "~");
+    }
+
+    /**
+     * Creates a JsonNumber.
+     *
+     * @param value a JSON number
+     * @return the JsonNumber for the number
+     *
+     * @since 2.1
+     */
+    public static JsonNumber createValue(Number value) {
+        return JsonProvider.provider().createValue(value);
+    }
+}

--- a/dev/io.openliberty.jakarta.jsonp.2.2/src/jakarta/json/JsonArray.java
+++ b/dev/io.openliberty.jakarta.jsonp.2.2/src/jakarta/json/JsonArray.java
@@ -1,0 +1,274 @@
+/*
+ * Copyright (c) 2011, 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.json;
+
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * {@code JsonArray} represents an immutable JSON array
+ * (an ordered sequence of zero or more values).
+ * It also provides an unmodifiable list view of the values in the array.
+ *
+ * <p>A {@code JsonArray} object can be created by reading JSON data from
+ * an input source or it can be built from scratch using an array builder
+ * object.
+ *
+ * <p>The following example demonstrates how to create a {@code JsonArray}
+ * object from an input source using the method {@link JsonReader#readArray()}:
+ * <pre><code>
+ * JsonReader jsonReader = Json.createReader(...);
+ * JsonArray array = jsonReader.readArray();
+ * jsonReader.close();
+ * </code></pre>
+ *
+ * <p>The following example demonstrates how to build an empty JSON array
+ * using the class {@link JsonArrayBuilder}:
+ * <pre><code>
+ * JsonArray array = Json.createArrayBuilder().build();
+ * </code></pre>
+ *
+ * <p>The example code below demonstrates how to create the following JSON array:
+ * <pre><code>
+ * [
+ *     { "type": "home", "number": "212 555-1234" },
+ *     { "type": "fax", "number": "646 555-4567" }
+ * ]
+ * </code></pre>
+ * <pre><code>
+ * JsonArray value = Json.createArrayBuilder()
+ *     .add(Json.createObjectBuilder()
+ *         .add("type", "home")
+ *         .add("number", "212 555-1234"))
+ *     .add(Json.createObjectBuilder()
+ *         .add("type", "fax")
+ *         .add("number", "646 555-4567"))
+ *     .build();
+ * </code></pre>
+ *
+ * <p>The following example demonstrates how to write a {@code JsonArray} object 
+ * as JSON data:
+ * <pre><code>
+ * JsonArray arr = ...;
+ * JsonWriter writer = Json.createWriter(...)
+ * writer.writeArray(arr);
+ * writer.close();
+ * </code></pre>
+ *
+ * <p>The values in a {@code JsonArray} can be of the following types:
+ * {@link JsonObject}, {@link JsonArray},
+ * {@link JsonString}, {@link JsonNumber}, {@link JsonValue#TRUE},
+ * {@link JsonValue#FALSE}, and {@link JsonValue#NULL}. 
+ * {@code JsonArray} provides various accessor methods to access the values
+ * in an array.
+ * 
+ * <p>The following example shows how to obtain the home phone number 
+ * "212 555-1234" from the array built in the previous example:
+ * <pre><code>
+ * JsonObject home = array.getJsonObject(0);
+ * String number = home.getString("number");
+ * </code></pre>
+ *
+ * <p>{@code JsonArray} instances are list objects that provide read-only 
+ * access to the values in the JSON array. Any attempt to modify the list,
+ * whether directly or using its collection views, results in an 
+ * {@code UnsupportedOperationException}.
+ */
+public interface JsonArray extends JsonStructure, List<JsonValue> {
+
+    /**
+     * Returns the object value at the specified position in this array.
+     * This is a convenience method for {@code (JsonObject)get(index)}.
+     *
+     * @param index index of the value to be returned
+     * @return the value at the specified position in this array
+     * @throws IndexOutOfBoundsException if the index is out of range
+     * @throws ClassCastException if the value at the specified position is not
+     * assignable to the JsonObject type
+     */
+    JsonObject getJsonObject(int index);
+
+    /**
+     * Returns the array value at the specified position in this array.
+     * This is a convenience method for {@code (JsonArray)get(index)}.
+     *
+     * @param index index of the value to be returned
+     * @return the value at the specified position in this array
+     * @throws IndexOutOfBoundsException if the index is out of range
+     * @throws ClassCastException if the value at the specified position is not
+     * assignable to the JsonArray type
+     */
+    JsonArray getJsonArray(int index);
+
+    /**
+     * Returns the number value at the specified position in this array.
+     * This is a convenience method for {@code (JsonNumber)get(index)}.
+     *
+     * @param index index of the value to be returned
+     * @return the value at the specified position in this array
+     * @throws IndexOutOfBoundsException if the index is out of range
+     * @throws ClassCastException if the value at the specified position is not
+     * assignable to the JsonNumber type
+     */
+    JsonNumber getJsonNumber(int index);
+
+    /**
+     * Returns the string value at ths specified position in this array.
+     * This is a convenience method for {@code (JsonString)get(index)}.
+     *
+     * @param index index of the value to be returned
+     * @return the value at the specified position in this array
+     * @throws IndexOutOfBoundsException if the index is out of range
+     * @throws ClassCastException if the value at the specified position is not
+     * assignable to the JsonString type
+     */
+    JsonString getJsonString(int index);
+
+    /**
+     * Returns a list view of the specified type for the array. This method
+     * does not verify if there is a value of wrong type in the array. Providing
+     * this typesafe view dynamically may cause a program fail with a
+     * {@code ClassCastException}, if there is a value of wrong type in this
+     * array. Unfortunately, the exception can occur at any time after this
+     * method returns.
+     *
+     * @param <T> The type of the List for the array
+     * @param clazz a JsonValue type
+     * @return a list view of the specified type
+     */
+    <T extends JsonValue> List<T> getValuesAs(Class<T> clazz);
+
+    /**
+     * Returns a list view for the array. The value and the type of the elements
+     * in the list is specified by the {@code func} argument.
+     * <p>This method can be used to obtain a list of the unwrapped types, such as
+     * <pre>{@code
+     *     List<String> strings = ary1.getValuesAs(JsonString::getString);
+     *     List<Integer> ints = ary2.getValuesAs(JsonNumber::intValue);
+     * } </pre>
+     * or a list of simple projections, such as
+     * <pre> {@code
+     *     List<Integer> stringsizes = ary1.getValueAs((JsonString v)->v.getString().length();
+     * } </pre>
+     * @param <K> The element type (must be a subtype of JsonValue) of this JsonArray.
+     * @param <T> The element type of the returned List
+     * @param func The function that maps the elements of this JsonArray to the target elements.
+     * @return A List of the specified values and type.
+     * @throws ClassCastException if the {@code JsonArray} contains a value of wrong type
+     *
+     * @since 1.1
+     */
+    default <T, K extends JsonValue> List<T> getValuesAs(Function<K, T> func) {
+        @SuppressWarnings("unchecked")
+        Stream<K> stream = (Stream<K>) stream();
+        return stream.map(func).collect(Collectors.toList());
+    }
+
+    /**
+     * A convenience method for
+     * {@code getJsonString(index).getString()}.
+     *
+     * @param index index of the {@code JsonString} value
+     * @return the String value at the specified position
+     * @throws IndexOutOfBoundsException if the index is out of range
+     * @throws ClassCastException if the value at the specified position is not
+     * assignable to {@code JsonString}
+     */
+    String getString(int index);
+
+    /**
+     * Returns the {@code String} value of {@code JsonString} at the specified
+     * position in this JSON array values. If {@code JsonString} is found,
+     * its {@link jakarta.json.JsonString#getString()} is returned. Otherwise,
+     * the specified default value is returned.
+     *
+     * @param index index of the {@code JsonString} value
+     * @param defaultValue the String to return if the {@code JsonValue} at the
+     *    specified position is not a {@code JsonString}
+     * @return the String value at the specified position in this array,
+     * or the specified default value
+     */
+    String getString(int index, String defaultValue);
+
+    /**
+     * A convenience method for
+     * {@code getJsonNumber(index).intValue()}.
+     *
+     * @param index index of the {@code JsonNumber} value
+     * @return the int value at the specified position
+     * @throws IndexOutOfBoundsException if the index is out of range
+     * @throws ClassCastException if the value at the specified position is not
+     * assignable to {@code JsonNumber}
+     */
+    int getInt(int index);
+
+    /**
+     * Returns the int value of the {@code JsonNumber} at the specified position. 
+     * If the value at that position is a {@code JsonNumber},
+     * this method returns {@link jakarta.json.JsonNumber#intValue()}. Otherwise
+     * this method returns the specified default value.
+     *
+     * @param index index of the {@code JsonNumber} value
+     * @param defaultValue the int value to return if the {@code JsonValue} at
+     *     the specified position is not a {@code JsonNumber}
+     * @return the int value at the specified position in this array,
+     * or the specified default value
+     */
+    int getInt(int index, int defaultValue);
+
+    /**
+     * Returns the boolean value at the specified position.
+     * If the value at the specified position is {@code JsonValue.TRUE} 
+     * this method returns {@code true}. If the value at the specified position 
+     * is {@code JsonValue.FALSE} this method returns {@code false}.
+     *
+     * @param index index of the JSON boolean value
+     * @return the boolean value at the specified position
+     * @throws IndexOutOfBoundsException if the index is out of range
+     * @throws ClassCastException if the value at the specified position is not
+     * {@code JsonValue.TRUE} or {@code JsonValue.FALSE}
+     */
+    boolean getBoolean(int index);
+
+    /**
+     * Returns the boolean value at the specified position.
+     * If the value at the specified position is {@code JsonValue.TRUE}
+     * this method returns {@code true}. If the value at the specified position 
+     * is {@code JsonValue.FALSE} this method returns {@code false}. 
+     * Otherwise this method returns the specified default value.
+     *
+     * @param index index of the JSON boolean value
+     * @param defaultValue the boolean value to return if the {@code JsonValue}
+     *    at the specified position is neither TRUE nor FALSE
+     * @return the boolean value at the specified position,
+     * or the specified default value
+     */
+    boolean getBoolean(int index, boolean defaultValue);
+
+    /**
+     * Returns {@code true} if the value at the specified location in this
+     * array is {@code JsonValue.NULL}.
+     *
+     * @param index index of the JSON null value
+     * @return return true if the value at the specified location is
+     * {@code JsonValue.NULL}, otherwise false
+     * @throws IndexOutOfBoundsException if the index is out of range
+     */
+    boolean isNull(int index);
+}

--- a/dev/io.openliberty.jakarta.jsonp.2.2/src/jakarta/json/JsonArrayBuilder.java
+++ b/dev/io.openliberty.jakarta.jsonp.2.2/src/jakarta/json/JsonArrayBuilder.java
@@ -1,0 +1,622 @@
+/*
+ * Copyright (c) 2013, 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.json;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+
+/**
+ * A builder for creating {@link JsonArray} models from scratch, and for
+ * modifying a existing {@code JsonArray}.
+ * <p>A {@code JsonArrayBuilder} can start with an empty or a non-empty
+ * JSON array model. This interface provides methods to add, insert, remove
+ * and replace values in the JSON array model.</p>
+ * <p>Methods in this class can be chained to perform multiple values to
+ * the array.</p>
+ *
+ * <p>The class {@link jakarta.json.Json} contains methods to create the builder
+ * object. The example code below shows how to build an empty {@code JsonArray}
+ * instance.
+ * <pre>
+ * <code>
+ * JsonArray array = Json.createArrayBuilder().build();
+ * </code>
+ * </pre>
+ *
+ * <p>The class {@link JsonBuilderFactory} also contains methods to create
+ * {@code JsonArrayBuilder} instances. A factory instance can be used to create
+ * multiple builder instances with the same configuration. This the preferred
+ * way to create multiple instances.
+ *
+ * The example code below shows how to build a {@code JsonArray} object
+ * that represents the following JSON array:
+ *
+ * <pre>
+ * <code>
+ * [
+ *     { "type": "home", "number": "212 555-1234" },
+ *     { "type": "fax", "number": "646 555-4567" }
+ * ]
+ * </code>
+ * </pre>
+ *
+ * <p>The following code creates the JSON array above:
+ *
+ * <pre>
+ * <code>
+ * JsonBuilderFactory factory = Json.createBuilderFactory(config);
+ * JsonArray value = factory.createArrayBuilder()
+ *     .add(factory.createObjectBuilder()
+ *         .add("type", "home")
+ *         .add("number", "212 555-1234"))
+ *     .add(factory.createObjectBuilder()
+ *         .add("type", "fax")
+ *         .add("number", "646 555-4567"))
+ *     .build();
+ * </code>
+ * </pre>
+ *
+ * <p>This class does <em>not</em> allow <code>null</code> to be used as a
+ * value while building the JSON array
+ *
+ * @see JsonObjectBuilder
+ */
+public interface JsonArrayBuilder {
+
+    /**
+     * Adds a value to the array.
+     *
+     * @param value the JSON value
+     * @return this array builder
+     * @throws NullPointerException if the specified value is null
+     */
+    JsonArrayBuilder add(JsonValue value);
+
+    /**
+     * Adds a value to the array as a {@link JsonString}.
+     *
+     * @param value the string value
+     * @return this array builder
+     * @throws NullPointerException if the specified value is null
+     */
+    JsonArrayBuilder add(String value);
+
+    /**
+     * Adds a value to the array as a {@link JsonNumber}.
+     *
+     * @param value the number value
+     * @return this array builder
+     * @throws NullPointerException if the specified value is null
+     *
+     * @see JsonNumber
+     */
+    JsonArrayBuilder add(BigDecimal value);
+
+    /**
+     * Adds a value to the array as a {@link JsonNumber}.
+     *
+     * @param value the number value
+     * @return this array builder
+     * @throws NullPointerException if the specified value is null
+     *
+     * @see JsonNumber
+     */
+    JsonArrayBuilder add(BigInteger value);
+
+    /**
+     * Adds a value to the array as a {@link JsonNumber}.
+     *
+     * @param value the number value
+     * @return this array builder
+     *
+     * @see JsonNumber
+     */
+    JsonArrayBuilder add(int value);
+
+    /**
+     * Adds a value to the array as a {@link JsonNumber}.
+     *
+     * @param value the number value
+     * @return this array builder
+     *
+     * @see JsonNumber
+     */
+    JsonArrayBuilder add(long value);
+
+    /**
+     * Adds a value to the array as a {@link JsonNumber}.
+     *
+     * @param value the number value
+     * @return this array builder
+     * @throws NumberFormatException if the value is Not-a-Number (NaN) or
+     *      infinity
+     *
+     * @see JsonNumber
+     */
+    JsonArrayBuilder add(double value);
+
+    /**
+     * Adds a {@link JsonValue#TRUE}  or {@link JsonValue#FALSE} value to the
+     * array.
+     *
+     * @param value the boolean value
+     * @return this array builder
+     */
+    JsonArrayBuilder add(boolean value);
+
+    /**
+     * Adds a {@link JsonValue#NULL} value to the array.
+     *
+     * @return this array builder
+     */
+    JsonArrayBuilder addNull();
+
+    /**
+     * Adds a {@link JsonObject} from an object builder to the array.
+     *
+     * @param builder the object builder
+     * @return this array builder
+     * @throws NullPointerException if the specified builder is null
+     */
+    JsonArrayBuilder add(JsonObjectBuilder builder);
+
+    /**
+     * Adds a {@link JsonArray} from an array builder to the array.
+     *
+     * @param builder the array builder
+     * @return this array builder
+     * @throws NullPointerException if the specified builder is null
+     */
+    JsonArrayBuilder add(JsonArrayBuilder builder);
+
+    /**
+     * Adds all elements of the array in the specified array builder to the array.
+     *
+     * @param builder the array builder
+     * @return this array builder
+     * @throws NullPointerException if the specified builder is null
+     *
+     @since 1.1
+     */
+    default JsonArrayBuilder addAll(JsonArrayBuilder builder) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Inserts a value to the array at the specified position. Shifts the value
+     * currently at that position (if any) and any subsequent values to the right
+     * (adds one to their indices).  Index starts with 0.
+     *
+     * @param index the position in the array
+     * @param value the JSON value
+     * @return this array builder
+     * @throws NullPointerException if the specified value is null
+     * @throws IndexOutOfBoundsException if the index is out of range
+     *   {@code (index < 0 || index > array size)}
+     *
+     * @since 1.1
+     */
+    default JsonArrayBuilder add(int index, JsonValue value) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Adds a value to the array as a {@link JsonString} at the specified position.
+     * Shifts the value currently at that position (if any) and any subsequent values
+     * to the right (adds one to their indices).  Index starts with 0.
+     *
+     * @param index the position in the array
+     * @param value the string value
+     * @return this array builder
+     * @throws NullPointerException if the specified value is null
+     * @throws IndexOutOfBoundsException if the index is out of range
+     *   {@code (index < 0 || index > array size)}
+     *
+     * @since 1.1
+     */
+    default JsonArrayBuilder add(int index, String value) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Adds a value to the array as a {@link JsonNumber} at the specified position.
+     * Shifts the value currently at that position (if any) and any subsequent values
+     * to the right (adds one to their indices).  Index starts with 0.
+     *
+     * @param index the position in the array
+     * @param value the number value
+     * @return this array builder
+     * @throws NullPointerException if the specified value is null
+     * @throws IndexOutOfBoundsException if the index is out of range
+     *   {@code (index < 0 || index > array size)}
+     *
+     * @see JsonNumber
+     *
+     * @since 1.1
+     */
+    default JsonArrayBuilder add(int index, BigDecimal value) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Adds a value to the array as a {@link JsonNumber} at the specified position.
+     * Shifts the value currently at that position (if any) and any subsequent values
+     * to the right (adds one to their indices).  Index starts with 0.
+     *
+     * @param index the position in the array
+     * @param value the number value
+     * @return this array builder
+     * @throws NullPointerException if the specified value is null
+     * @throws IndexOutOfBoundsException if the index is out of range
+     *   {@code (index < 0 || index > array size)}
+     *
+     * @see JsonNumber
+     *
+     * @since 1.1
+     */
+    default JsonArrayBuilder add(int index, BigInteger value) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Adds a value to the array as a {@link JsonNumber} at the specified position.
+     * Shifts the value currently at that position (if any) and any subsequent values
+     * to the right (adds one to their indices).  Index starts with 0.
+     *
+     * @param index the position in the array
+     * @param value the number value
+     * @return this array builder
+     * @throws IndexOutOfBoundsException if the index is out of range
+     *   {@code (index < 0 || index > array size)}
+     *
+     * @see JsonNumber
+     *
+     * @since 1.1
+     */
+    default JsonArrayBuilder add(int index, int value) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Adds a value to the array as a {@link JsonNumber} at the specified position.
+     * Shifts the value currently at that position (if any) and any subsequent values
+     * to the right (adds one to their indices).  Index starts with 0.
+     *
+     * @param index the position in the array
+     * @param value the number value
+     * @return this array builder
+     * @throws IndexOutOfBoundsException if the index is out of range
+     *   {@code (index < 0 || index > array size)}
+     *
+     * @see JsonNumber
+     *
+     * @since 1.1
+     */
+    default JsonArrayBuilder add(int index, long value) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Adds a value to the array as a {@link JsonNumber} at the specified position.
+     * Shifts the value currently at that position (if any) and any subsequent values
+     * to the right (adds one to their indices).  Index starts with 0.
+     *
+     * @param index the position in the array
+     * @param value the number value
+     * @return this array builder
+     * @throws NumberFormatException if the value is Not-a-Number (NaN) or
+     *      infinity
+     * @throws IndexOutOfBoundsException if the index is out of range
+     *   {@code (index < 0 || index > array size)}
+     *
+     * @see JsonNumber
+     *
+     * @since 1.1
+     */
+    default JsonArrayBuilder add(int index, double value) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Adds a {@link JsonValue#TRUE}  or {@link JsonValue#FALSE} value to the
+     * array at the specified position.
+     * Shifts the value currently at that position (if any) and any subsequent values
+     * to the right (adds one to their indices).  Index starts with 0.
+     *
+     * @param index the position in the array
+     * @param value the boolean value
+     * @return this array builder
+     * @throws IndexOutOfBoundsException if the index is out of range
+     *   {@code (index < 0 || index > array size)}
+     *
+     * @since 1.1
+     */
+    default JsonArrayBuilder add(int index, boolean value) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Adds a {@link JsonValue#NULL} value to the array at the specified position.
+     * Shifts the value currently at that position (if any) and any subsequent values
+     * to the right (adds one to their indices).  Index starts with 0.
+     *
+     * @param index the position in the array
+     * @return this array builder
+     * @throws IndexOutOfBoundsException if the index is out of range
+     *   {@code (index < 0 || index > array size)}
+     *
+     * @since 1.1
+     */
+    default JsonArrayBuilder addNull(int index) {
+        return add(index, JsonValue.NULL);
+    }
+
+    /**
+     * Adds a {@link JsonObject} from an object builder to the array at the specified position.
+     * Shifts the value currently at that position (if any) and any subsequent values
+     * to the right (adds one to their indices).  Index starts with 0.
+     *
+     * @param index the position in the array
+     * @param builder the object builder
+     * @return this array builder
+     * @throws NullPointerException if the specified builder is null
+     * @throws IndexOutOfBoundsException if the index is out of range
+     *   {@code (index < 0 || index > array size)}
+     *
+     * @since 1.1
+     */
+    default JsonArrayBuilder add(int index, JsonObjectBuilder builder) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Adds a {@link JsonArray} from an array builder to the array at the specified position.
+     * Shifts the value currently at that position (if any) and any subsequent values
+     * to the right (adds one to their indices).  Index starts with 0.
+     *
+     * @param index the position in the array
+     * @param builder the array builder
+     * @return this array builder
+     * @throws NullPointerException if the specified builder is null
+     * @throws IndexOutOfBoundsException if the index is out of range
+     *   {@code (index < 0 || index > array size)}
+     *
+     * @since 1.1
+     */
+    default JsonArrayBuilder add(int index, JsonArrayBuilder builder) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Replaces a value in the array with the specified value at the
+     * specified position.
+     *
+     * @param index the position in the array
+     * @param value the JSON value
+     * @return this array builder
+     * @throws NullPointerException if the specified value is null
+     * @throws IndexOutOfBoundsException if the index is out of range
+     *   {@code (index < 0 || index >= array size)}
+     *
+     * @since 1.1
+     */
+    default JsonArrayBuilder set(int index, JsonValue value) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Replaces a value in the array with the specified value as a
+     * {@link JsonString} at the specified position.
+     *
+     * @param index the position in the array
+     * @param value the string value
+     * @return this array builder
+     * @throws NullPointerException if the specified value is null
+     * @throws IndexOutOfBoundsException if the index is out of range
+     *   {@code (index < 0 || index >= array size)}
+     *
+     * @since 1.1
+     */
+    default JsonArrayBuilder set(int index, String value) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Replaces a value in the array with the specified value as a
+     * {@link JsonNumber} at the specified position.
+     *
+     * @param index the position in the array
+     * @param value the number value
+     * @return this array builder
+     * @throws NullPointerException if the specified value is null
+     * @throws IndexOutOfBoundsException if the index is out of range
+     *   {@code (index < 0 || index >= array size)}
+     *
+     * @see JsonNumber
+     *
+     * @since 1.1
+     */
+    default JsonArrayBuilder set(int index, BigDecimal value) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Replaces a value in the array with the specified value as a
+     * {@link JsonNumber} at the specified position.
+     *
+     * @param index the position in the array
+     * @param value the number value
+     * @return this array builder
+     * @throws NullPointerException if the specified value is null
+     * @throws IndexOutOfBoundsException if the index is out of range
+     *   {@code (index < 0 || index >= array size)}
+     *
+     * @see JsonNumber
+     *
+     * @since 1.1
+     */
+    default JsonArrayBuilder set(int index, BigInteger value) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Replaces a value in the array with the specified value as a
+     * {@link JsonNumber} at the specified position.
+     *
+     * @param index the position in the array
+     * @param value the number value
+     * @return this array builder
+     * @throws IndexOutOfBoundsException if the index is out of range
+     *   {@code (index < 0 || index >= array size)}
+     *
+     * @see JsonNumber
+     *
+     * @since 1.1
+     */
+    default JsonArrayBuilder set(int index, int value) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Replaces a value in the array with the specified value as a
+     * {@link JsonNumber} at the specified position.
+     *
+     * @param index the position in the array
+     * @param value the number value
+     * @return this array builder
+     * @throws IndexOutOfBoundsException if the index is out of range
+     *   {@code (index < 0 || index >= array size)}
+     *
+     * @see JsonNumber
+     *
+     * @since 1.1
+     */
+    default JsonArrayBuilder set(int index, long value) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Replaces a value in the array with the specified value as a
+     * {@link JsonNumber} at the specified position.
+     *
+     * @param index the position in the array
+     * @param value the number value
+     * @return this array builder
+     * @throws NumberFormatException if the value is Not-a-Number (NaN) or
+     *      infinity
+     * @throws IndexOutOfBoundsException if the index is out of range
+     *   {@code (index < 0 || index >= array size)}
+     *
+     * @see JsonNumber
+     *
+     * @since 1.1
+     */
+    default JsonArrayBuilder set(int index, double value) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Replaces a value in the array with
+     * a {@link JsonValue#TRUE}  or {@link JsonValue#FALSE} value
+     * at the specified position.
+     *
+     * @param index the position in the array
+     * @param value the boolean value
+     * @return this array builder
+     * @throws IndexOutOfBoundsException if the index is out of range
+     *   {@code (index < 0 || index >= array size)}
+     *
+     * @since 1.1
+     */
+    default JsonArrayBuilder set(int index, boolean value) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Replaces a value in the array with
+     * a {@link JsonValue#NULL} value at the specified position.
+     *
+     * @param index the position in the array
+     * @return this array builder
+     * @throws IndexOutOfBoundsException if the index is out of range
+     *   {@code (index < 0 || index >= array size)}
+     *
+     * @since 1.1
+     */
+    default JsonArrayBuilder setNull(int index) {
+        return set(index, JsonValue.NULL);
+    }
+
+    /**
+     * Replaces a value in the array with the specified value as a
+     * {@link JsonObject} from an object builder at the specified position.
+     *
+     * @param index the position in the array
+     * @param builder the object builder
+     * @return this array builder
+     * @throws NullPointerException if the specified builder is null
+     * @throws IndexOutOfBoundsException if the index is out of range
+     *   {@code (index < 0 || index >= array size)}
+     *
+     * @since 1.1
+     */
+    default JsonArrayBuilder set(int index, JsonObjectBuilder builder) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Replaces a value in the array with the specified value as a
+     * {@link JsonArray} from an array builder at the specified position.
+     *
+     * @param index the position in the array
+     * @param builder the array builder
+     * @return this array builder
+     * @throws NullPointerException if the specified builder is null
+     * @throws IndexOutOfBoundsException if the index is out of range
+     *   {@code (index < 0 || index >= array size)}
+     *
+     * @since 1.1
+     */
+    default JsonArrayBuilder set(int index, JsonArrayBuilder builder) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Remove the value in the array at the specified position.
+     * Shift any subsequent values to the left (subtracts one from their
+     * indices.
+     *
+     * @param index the position in the array
+     * @return this array builder
+     * @throws IndexOutOfBoundsException if the index is out of range
+     *   {@code (index < 0 || index >= array size)}
+     *
+     * @since 1.1
+     */
+    default JsonArrayBuilder remove(int index) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Returns the current array.
+     *
+     * @return the current JSON array
+     */
+    JsonArray build();
+
+}
+

--- a/dev/io.openliberty.jakarta.jsonp.2.2/src/jakarta/json/JsonBuilderFactory.java
+++ b/dev/io.openliberty.jakarta.jsonp.2.2/src/jakarta/json/JsonBuilderFactory.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2013, 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.json;
+
+import java.util.Collection;
+import java.util.Map;
+
+/**
+ * Factory to create {@link JsonObjectBuilder} and {@link JsonArrayBuilder}
+ * instances. If a factory instance is configured with some configuration,
+ * that would be used to configure the created builder instances.
+ *
+ * <p>
+ * {@code JsonObjectBuilder} and {@code JsonArrayBuilder} can also be created
+ * using {@link Json}'s methods. If multiple builder instances are created,
+ * then creating them using a builder factory is preferred.
+ *
+ * <p>
+ * <b>For example:</b>
+ * <pre>
+ * <code>
+ * JsonBuilderFactory factory = Json.createBuilderFactory(...);
+ * JsonArray value = factory.createArrayBuilder()
+ *     .add(factory.createObjectBuilder()
+ *         .add("type", "home")
+ *         .add("number", "212 555-1234"))
+ *     .add(factory.createObjectBuilder()
+ *         .add("type", "fax")
+ *         .add("number", "646 555-4567"))
+ *     .build();
+ * </code>
+ * </pre>
+ *
+ * <p> All the methods in this class are safe for use by multiple concurrent
+ * threads.
+ */
+public interface JsonBuilderFactory {
+
+    /**
+     * Creates a {@code JsonObjectBuilder} instance that is used to build
+     * {@link JsonObject}.
+     *
+     * @return a JSON object builder
+     */
+    JsonObjectBuilder createObjectBuilder();
+
+    /**
+     * Creates a {@code JsonObjectBuilder} instance, initialized with an object.
+     *
+     * @param object the initial object in the builder
+     * @return a JSON object builder
+     * @throws NullPointerException if specified object is {@code null}
+     *
+     * @since 1.1
+     */
+    default JsonObjectBuilder createObjectBuilder(JsonObject object) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Creates a {@code JsonObjectBuilder} instance, initialized with the specified object.
+     *
+     * @param object the initial object in the builder
+     * @return a JSON object builder
+     * @throws NullPointerException if specified object is {@code null}
+     *
+     * @since 1.1
+     */
+    default JsonObjectBuilder createObjectBuilder(Map<String, Object> object) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Creates a {@code JsonArrayBuilder} instance that is used to build
+     * {@link JsonArray}
+     *
+     * @return a JSON array builder
+     */
+    JsonArrayBuilder createArrayBuilder();
+
+    /**
+     * Creates a {@code JsonArrayBuilder} instance, initialized with an array.
+     *
+     * @param array the initial array in the builder
+     * @return a JSON array builder
+     * @throws NullPointerException if specified array is {@code null}
+     *
+     * @since 1.1
+     */
+    default JsonArrayBuilder createArrayBuilder(JsonArray array) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Creates a {@code JsonArrayBuilder} instance,
+     * initialized with the content of specified collection.
+     *
+     * @param collection the initial data for the builder
+     * @return a JSON array builder
+     * @throws NullPointerException if specified collection is {@code null}
+     *
+     * @since 1.1
+     */
+    default JsonArrayBuilder createArrayBuilder(Collection<?> collection) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Returns read-only map of supported provider specific configuration
+     * properties that are used to configure the created JSON builders.
+     * If there are any specified configuration properties that are not
+     * supported by the provider, they won't be part of the returned map.
+     *
+     * @return a map of supported provider specific properties that are used
+     * to configure the builders. The map be empty but not null.
+     */
+    Map<String, ?> getConfigInUse();
+
+}

--- a/dev/io.openliberty.jakarta.jsonp.2.2/src/jakarta/json/JsonConfig.java
+++ b/dev/io.openliberty.jakarta.jsonp.2.2/src/jakarta/json/JsonConfig.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.json;
+
+/**
+ * This class contains the Json properties and values.
+ *
+ * @since 2.1
+ */
+public final class JsonConfig {
+
+    /**
+     * Configuration property to define the strategy for handling duplicate keys.
+     *
+     * See {@link KeyStrategy}
+     */
+    public static final String KEY_STRATEGY = "jakarta.json.JsonConfig.keyStrategy" ;
+
+    /**
+     * It avoids new instances of this class.
+     */
+    private JsonConfig() {}
+    
+    /**
+     * Contains the different values allowed for {@link #KEY_STRATEGY}.
+     *
+     * See {@link #KEY_STRATEGY}
+     */
+    public static enum KeyStrategy {
+        /**
+         * Configuration value that will take the value of the first match.
+         */
+        FIRST,
+        /**
+         * Configuration value that will take the value of the last match.
+         */
+        LAST,
+        /**
+         * Configuration value that will throw {@link JsonException} when duplicate key is found.
+         */
+        NONE;
+    }
+}

--- a/dev/io.openliberty.jakarta.jsonp.2.2/src/jakarta/json/JsonException.java
+++ b/dev/io.openliberty.jakarta.jsonp.2.2/src/jakarta/json/JsonException.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2011, 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.json;
+
+/**
+ * <code>JsonException</code> indicates that some exception happened during
+ * JSON processing.
+ */
+public class JsonException extends RuntimeException {
+
+    /** for serialization */
+    private static final long serialVersionUID = 359810709545392112L;
+
+    /**
+     * Constructs a new runtime exception with the specified detail message.
+     * The cause is not initialized, and may subsequently be initialized by a
+     * call to {@link #initCause}.
+     *
+     * @param message the detail message. The detail message is saved for
+     *          later retrieval by the {@link #getMessage()} method.
+     */
+    public JsonException(String message) {
+        super(message);
+    }
+
+    /**
+     * Constructs a new runtime exception with the specified detail message and
+     * cause.  <p>Note that the detail message associated with
+     * {@code cause} is <i>not</i> automatically incorporated in
+     * this runtime exception's detail message.
+     *
+     * @param message the detail message (which is saved for later retrieval
+     *         by the {@link #getMessage()} method).
+     * @param cause the cause (which is saved for later retrieval by the
+     *         {@link #getCause()} method). (A <code>null</code> value is
+     *         permitted, and indicates that the cause is nonexistent or
+     *         unknown.)
+     */
+    public JsonException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+}
+

--- a/dev/io.openliberty.jakarta.jsonp.2.2/src/jakarta/json/JsonMergePatch.java
+++ b/dev/io.openliberty.jakarta.jsonp.2.2/src/jakarta/json/JsonMergePatch.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2015, 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.json;
+
+/**
+ * <p>This interface represents an implementation of a JSON Merge Patch
+ * as defined by <a href="http://tools.ietf.org/html/rfc7396">RFC 7396</a>.
+ * </p>
+ * <p>A {@code JsonMergePatch} can be instantiated with {@link Json#createMergePatch(JsonValue)}
+ * by specifying the patch operations in a JSON Merge Patch or using {@link Json#createMergeDiff(JsonValue, JsonValue)}
+ * to create a JSON Merge Patch based on the difference between two {@code JsonValue}s.
+ * </p>
+ * The following illustrates both approaches.
+ * <p>1. Construct a JsonMergePatch with an existing JSON Merge Patch.
+ * <pre>{@code
+ *   JsonValue contacts = ... ; // The target to be patched
+ *   JsonValue patch = ...  ; // JSON Merge Patch
+ *   JsonMergePatch mergePatch = Json.createMergePatch(patch);
+ *   JsonValue result = mergePatch.apply(contacts);
+ * } </pre>
+ * 2. Construct a JsonMergePatch from a difference between two {@code JsonValue}s.
+ * <pre>{@code
+ *   JsonValue source = ... ; // The source object
+ *   JsonValue target = ... ; // The modified object
+ *   JsonMergePatch mergePatch = Json.createMergeDiff(source, target); // The diff between source and target in a Json Merge Patch format
+ * } </pre>
+ *
+ * @see <a href="http://tools.ietf.org/html/rfc7396">RFC 7396</a>
+ *
+ * @since 1.1
+ */
+public interface JsonMergePatch {
+
+    /**
+     * Applies the JSON Merge Patch to the specified {@code target}.
+     * The target is not modified by the patch.
+     *
+     * @param target the target to apply the merge patch
+     * @return the transformed target after the patch
+     */
+    JsonValue apply(JsonValue target);
+
+    /**
+     * Returns the {@code JsonMergePatch} as {@code JsonValue}.
+     *
+     * @return this {@code JsonMergePatch} as {@code JsonValue}
+     */
+    JsonValue toJsonValue();
+}

--- a/dev/io.openliberty.jakarta.jsonp.2.2/src/jakarta/json/JsonNumber.java
+++ b/dev/io.openliberty.jakarta.jsonp.2.2/src/jakarta/json/JsonNumber.java
@@ -1,0 +1,186 @@
+/*
+ * Copyright (c) 2011, 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.json;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+
+/**
+ * An immutable JSON number value.
+ *
+ * <p>
+ * Implementations may use a {@link BigDecimal} object to store the numeric
+ * value internally.
+ * The {@code BigDecimal} object can be constructed from the following types:
+ * <code>int</code> {@link BigDecimal#BigDecimal(int)},
+ * <code>long</code> {@link BigDecimal#BigDecimal(long)},
+ * <code>BigInteger</code> {@link BigDecimal#BigDecimal(BigInteger)},
+ * <code>double</code> {@link BigDecimal#valueOf(double)}, and
+ * <code>String</code> {@link BigDecimal#BigDecimal(String)}.
+ * Some of the method semantics in this class are defined using the
+ * {@code BigDecimal} semantics.
+ */
+public interface JsonNumber extends JsonValue {
+
+    /**
+     * Returns true if this JSON number is a integral number. This method
+     * semantics are defined using {@code bigDecimalValue().scale()}. If the
+     * scale is zero, then it is considered integral type. This integral type
+     * information can be used to invoke an appropriate accessor method to
+     * obtain a numeric value as in the following example:
+     *
+     * <pre>
+     * <code>
+     * JsonNumber num = ...
+     * if (num.isIntegral()) {
+     *     num.longValue();     // or other methods to get integral value
+     * } else {
+     *     num.doubleValue();   // or other methods to get decimal number value
+     * }
+     * </code>
+     * </pre>
+     *
+     * @return true if this number is a integral number, otherwise false
+     */
+    boolean isIntegral();
+
+    /**
+     * Returns this JSON number as an {@code int}. Note that this conversion
+     * can lose information about the overall magnitude and precision of the
+     * number value as well as return a result with the opposite sign.
+     *
+     * @return an {@code int} representation of the JSON number
+     * @see java.math.BigDecimal#intValue()
+     */
+    int intValue();
+
+    /**
+     * Returns this JSON number as an {@code int}.
+     *
+     * @return an {@code int} representation of the JSON number
+     * @throws ArithmeticException if the number has a nonzero fractional
+     *         part or if it does not fit in an {@code int}
+     * @see java.math.BigDecimal#intValueExact()
+     */
+    int intValueExact();
+
+    /**
+     * Returns this JSON number as a {@code long}. Note that this conversion
+     * can lose information about the overall magnitude and precision of the
+     * number value as well as return a result with the opposite sign.
+     *
+     * @return a {@code long} representation of the JSON number.
+     * @see java.math.BigDecimal#longValue()
+     */
+    long longValue();
+
+    /**
+     * Returns this JSON number as a {@code long}.
+     *
+     * @return a {@code long} representation of the JSON number
+     * @throws ArithmeticException if the number has a non-zero fractional
+     *         part or if it does not fit in a {@code long}
+     * @see java.math.BigDecimal#longValueExact()
+     */
+    long longValueExact();
+
+    /**
+     * Returns this JSON number as a {@link BigInteger} object. This is a
+     * a convenience method for {@code bigDecimalValue().toBigInteger()}.
+     * Note that this conversion can lose information about the overall
+     * magnitude and precision of the number value as well as return a result
+     * with the opposite sign.
+     *
+     * @return a {@code BigInteger} representation of the JSON number.
+     * @see java.math.BigDecimal#toBigInteger()
+     */
+    BigInteger bigIntegerValue();
+
+    /**
+     * Returns this JSON number as a {@link BigInteger} object. This is a
+     * convenience method for {@code bigDecimalValue().toBigIntegerExact()}.
+     *
+     * @return a {@link BigInteger} representation of the JSON number
+     * @throws ArithmeticException if the number has a nonzero fractional part
+     * @see java.math.BigDecimal#toBigIntegerExact()
+     */
+    BigInteger bigIntegerValueExact();
+
+    /**
+     * Returns this JSON number as a {@code double}. This is a
+     * a convenience method for {@code bigDecimalValue().doubleValue()}.
+     * Note that this conversion can lose information about the overall
+     * magnitude and precision of the number value as well as return a result
+     * with the opposite sign.
+     *
+     * @return a {@code double} representation of the JSON number
+     * @see java.math.BigDecimal#doubleValue()
+     */
+    double doubleValue();
+
+    /**
+     * Returns this JSON number as a {@link BigDecimal} object.
+     *
+     * @return a {@link BigDecimal} representation of the JSON number
+     */
+    BigDecimal bigDecimalValue();
+
+    /**
+     * Returns this JSON number as a {@link Number} object.
+     *
+     * @return a {@link Number} representation of the JSON number
+     *
+     * @since 1.1
+     */
+    default Number numberValue() {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Returns a JSON text representation of the JSON number. The
+     * representation is equivalent to {@link BigDecimal#toString()}.
+     *
+     * @return JSON text representation of the number
+     */
+    @Override
+    String toString();
+
+    /**
+     * Compares the specified object with this {@code JsonNumber} object for
+     * equality. Returns {@code true} if and only if the type of the specified
+     * object is also {@code JsonNumber} and their {@link #bigDecimalValue()}
+     * objects are <i>equal</i>
+     *
+     * @param obj the object to be compared for equality with
+     *      this {@code JsonNumber}
+     * @return {@code true} if the specified object is equal to this
+     *      {@code JsonNumber}
+     */
+    @Override
+    boolean equals(Object obj);
+
+    /**
+     * Returns the hash code value for this {@code JsonNumber} object.  The
+     * hash code of a {@code JsonNumber} object is defined as the hash code of
+     * its {@link #bigDecimalValue()} object.
+     *
+     * @return the hash code value for this {@code JsonNumber} object
+     */
+    @Override
+    int hashCode();
+
+}

--- a/dev/io.openliberty.jakarta.jsonp.2.2/src/jakarta/json/JsonObject.java
+++ b/dev/io.openliberty.jakarta.jsonp.2.2/src/jakarta/json/JsonObject.java
@@ -1,0 +1,249 @@
+/*
+ * Copyright (c) 2011, 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.json;
+
+import java.util.Map;
+
+/**
+ * {@code JsonObject} class represents an immutable JSON object value
+ * (an unordered collection of zero or more name/value pairs).
+ * It also provides unmodifiable map view to the JSON object
+ * name/value mappings.
+ *
+ * <p>A JsonObject instance can be created from an input source using
+ * {@link JsonReader#readObject()}. For example:
+ * <pre><code>
+ * JsonReader jsonReader = Json.createReader(...);
+ * JsonObject object = jsonReader.readObject();
+ * jsonReader.close();
+ * </code></pre>
+ *
+ * It can also be built from scratch using a {@link JsonObjectBuilder}.
+ *
+ * <p>For example 1: An empty JSON object can be built as follows:
+ * <pre><code>
+ * JsonObject object = Json.createObjectBuilder().build();
+ * </code></pre>
+ *
+ * For example 2: The following JSON
+ * <pre><code>
+ * {
+ *     "firstName": "John", "lastName": "Smith", "age": 25,
+ *     "address" : {
+ *         "streetAddress": "21 2nd Street",
+ *         "city": "New York",
+ *         "state": "NY",
+ *         "postalCode": "10021"
+ *     },
+ *     "phoneNumber": [
+ *         { "type": "home", "number": "212 555-1234" },
+ *         { "type": "fax", "number": "646 555-4567" }
+ *     ]
+ * }
+ * </code></pre>
+ * can be built using :
+ * <pre><code>
+ * JsonObject value = Json.createObjectBuilder()
+ *     .add("firstName", "John")
+ *     .add("lastName", "Smith")
+ *     .add("age", 25)
+ *     .add("address", Json.createObjectBuilder()
+ *         .add("streetAddress", "21 2nd Street")
+ *         .add("city", "New York")
+ *         .add("state", "NY")
+ *         .add("postalCode", "10021"))
+ *     .add("phoneNumber", Json.createArrayBuilder()
+ *         .add(Json.createObjectBuilder()
+ *             .add("type", "home")
+ *             .add("number", "212 555-1234"))
+ *         .add(Json.createObjectBuilder()
+ *             .add("type", "fax")
+ *             .add("number", "646 555-4567")))
+ *     .build();
+ * </code></pre>
+ *
+ * {@code JsonObject} can be written to JSON as follows:
+ * <pre><code>
+ * JsonWriter writer = ...
+ * JsonObject obj = ...;
+ * writer.writeObject(obj);
+ * </code></pre>
+ *
+ * {@code JsonObject} values can be {@link JsonObject}, {@link JsonArray},
+ * {@link JsonString}, {@link JsonNumber}, {@link JsonValue#TRUE},
+ * {@link JsonValue#FALSE}, {@link JsonValue#NULL}. These values can be
+ * accessed using various accessor methods.
+ *
+ * <p>In the above example 2, "John" can be got using
+ * <pre><code>
+ * String firstName = object.getString("firstName");
+ * </code></pre>
+ *
+ * This map object provides read-only access to the JSON object data,
+ * and attempts to modify the map, whether direct or via its collection
+ * views, result in an {@code UnsupportedOperationException}.
+ *
+ * <p>The map object's iteration ordering is based on the order in which
+ * name/value pairs are added to the corresponding builder or the order
+ * in which name/value pairs appear in the corresponding stream.
+ */
+public interface JsonObject extends JsonStructure, Map<String, JsonValue> {
+
+    /**
+     * Returns the array value to which the specified name is mapped.
+     * This is a convenience method for {@code (JsonArray)get(name)} to
+     * get the value.
+     *
+     * @param name the name whose associated value is to be returned
+     * @return the array value to which the specified name is mapped, or
+     *         {@code null} if this object contains no mapping for the name
+     * @throws ClassCastException if the value to which the specified name
+     * is mapped is not assignable to JsonArray type
+     */
+    JsonArray getJsonArray(String name);
+
+    /**
+     * Returns the object value to which the specified name is mapped.
+     * This is a convenience method for {@code (JsonObject)get(name)} to
+     * get the value.
+     *
+     * @param name the name whose associated value is to be returned
+     * @return the object value to which the specified name is mapped, or
+     *         {@code null} if this object contains no mapping for the name
+     * @throws ClassCastException if the value to which the specified name
+     * is mapped is not assignable to JsonObject type
+     */
+    JsonObject getJsonObject(String name);
+
+    /**
+     * Returns the number value to which the specified name is mapped.
+     * This is a convenience method for {@code (JsonNumber)get(name)} to
+     * get the value.
+     *
+     * @param name the name whose associated value is to be returned
+     * @return the number value to which the specified name is mapped, or
+     *         {@code null} if this object contains no mapping for the name
+     * @throws ClassCastException if the value to which the specified name
+     * is mapped is not assignable to JsonNumber type
+     */
+    JsonNumber getJsonNumber(String name);
+
+    /**
+     * Returns the string value to which the specified name is mapped.
+     * This is a convenience method for {@code (JsonString)get(name)} to
+     * get the value.
+     *
+     * @param name the name whose associated value is to be returned
+     * @return the string value to which the specified name is mapped, or
+     *         {@code null} if this object contains no mapping for the name
+     * @throws ClassCastException if the value to which the specified name
+     * is mapped is not assignable to JsonString type
+     */
+    JsonString getJsonString(String name);
+
+    /**
+     * A convenience method for
+     * {@code getJsonString(name).getString()}
+     *
+     * @param name whose associated value is to be returned as String
+     * @return the String value to which the specified name is mapped
+     * @throws NullPointerException if the specified name doesn't have any
+     * mapping
+     * @throws ClassCastException if the value for specified name mapping
+     * is not assignable to JsonString
+     */
+    String getString(String name);
+
+    /**
+     * Returns the string value of the associated {@code JsonString} mapping
+     * for the specified name. If {@code JsonString} is found, then its
+     * {@link jakarta.json.JsonString#getString()} is returned. Otherwise,
+     * the specified default value is returned.
+     *
+     * @param name whose associated value is to be returned as String
+     * @param defaultValue a default value to be returned
+     * @return the string value of the associated mapping for the name,
+     * or the default value
+     */
+    String getString(String name, String defaultValue);
+
+    /**
+     * A convenience method for
+     * {@code getJsonNumber(name).intValue()}
+     *
+     * @param name whose associated value is to be returned as int
+     * @return the int value to which the specified name is mapped
+     * @throws NullPointerException if the specified name doesn't have any
+     * mapping
+     * @throws ClassCastException if the value for specified name mapping
+     * is not assignable to JsonNumber
+     */
+    int getInt(String name);
+
+    /**
+     * Returns the int value of the associated {@code JsonNumber} mapping
+     * for the specified name. If {@code JsonNumber} is found, then its
+     * {@link jakarta.json.JsonNumber#intValue()} is returned. Otherwise,
+     * the specified default value is returned.
+     *
+     * @param name whose associated value is to be returned as int
+     * @param defaultValue a default value to be returned
+     * @return the int value of the associated mapping for the name,
+     * or the default value
+     */
+    int getInt(String name, int defaultValue);
+
+    /**
+     * Returns the boolean value of the associated mapping for the specified
+     * name. If the associated mapping is JsonValue.TRUE, then returns true.
+     * If the associated mapping is JsonValue.FALSE, then returns false.
+     *
+     * @param name whose associated value is to be returned as boolean
+     * @return the boolean value to which the specified name is mapped
+     * @throws NullPointerException if the specified name doesn't have any
+     * mapping
+     * @throws ClassCastException if the value for specified name mapping
+     * is not assignable to JsonValue.TRUE or JsonValue.FALSE
+     */
+    boolean getBoolean(String name);
+
+    /**
+     * Returns the boolean value of the associated mapping for the specified
+     * name. If the associated mapping is JsonValue.TRUE, then returns true.
+     * If the associated mapping is JsonValue.FALSE, then returns false.
+     * Otherwise, the specified default value is returned.
+     *
+     * @param name whose associated value is to be returned as int
+     * @param defaultValue a default value to be returned
+     * @return the boolean value of the associated mapping for the name,
+     * or the default value
+     */
+    boolean getBoolean(String name, boolean defaultValue);
+
+    /**
+     * Returns {@code true} if the associated value for the specified name is
+     * {@code JsonValue.NULL}.
+     *
+     * @param name name whose associated value is checked
+     * @return return true if the associated value is {@code JsonValue.NULL},
+     * otherwise false
+     * @throws NullPointerException if the specified name doesn't have any
+     * mapping
+     */
+    boolean isNull(String name);
+
+}

--- a/dev/io.openliberty.jakarta.jsonp.2.2/src/jakarta/json/JsonObjectBuilder.java
+++ b/dev/io.openliberty.jakarta.jsonp.2.2/src/jakarta/json/JsonObjectBuilder.java
@@ -1,0 +1,285 @@
+/*
+ * Copyright (c) 2013, 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.json;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+
+/**
+ * A builder for creating {@link JsonObject} models from scratch. This
+ * interface initializes an empty JSON object model and provides methods to add
+ * name/value pairs to the object model and to return the resulting object.
+ * The methods in this class can be chained to add multiple name/value pairs
+ * to the object.
+ *
+ * <p>The class {@link jakarta.json.Json} contains methods to create the builder
+ * object. The example code below shows how to build an empty {@code JsonObject}
+ * instance.
+ * <pre>
+ * <code>
+ * JsonObject object = Json.createObjectBuilder().build();
+ * </code>
+ * </pre>
+ *
+ * <p>The class {@link JsonBuilderFactory} also contains methods to create
+ * {@code JsonObjectBuilder} instances. A factory instance can be used to create
+ * multiple builder instances with the same configuration. This the preferred
+ * way to create multiple instances.
+ *
+ * The example code below shows how to build a {@code JsonObject} model that
+ * represents the following JSON object:
+ *
+ * <pre>
+ * <code>
+ * {
+ *     "firstName": "John", "lastName": "Smith", "age": 25,
+ *     "address" : {
+ *         "streetAddress": "21 2nd Street",
+ *         "city": "New York",
+ *         "state": "NY",
+ *         "postalCode": "10021"
+ *     },
+ *     "phoneNumber": [
+ *         { "type": "home", "number": "212 555-1234" },
+ *         { "type": "fax", "number": "646 555-4567" }
+ *     ]
+ * }
+ * </code>
+ * </pre>
+ *
+ * <p>The code to create the object shown above is the following:
+ *
+ * <pre>
+ * <code>
+ * JsonBuilderFactory factory = Json.createBuilderFactory(config);
+ * JsonObject value = factory.createObjectBuilder()
+ *     .add("firstName", "John")
+ *     .add("lastName", "Smith")
+ *     .add("age", 25)
+ *     .add("address", factory.createObjectBuilder()
+ *         .add("streetAddress", "21 2nd Street")
+ *         .add("city", "New York")
+ *         .add("state", "NY")
+ *         .add("postalCode", "10021"))
+ *     .add("phoneNumber", factory.createArrayBuilder()
+ *         .add(factory.createObjectBuilder()
+ *             .add("type", "home")
+ *             .add("number", "212 555-1234"))
+ *         .add(factory.createObjectBuilder()
+ *             .add("type", "fax")
+ *             .add("number", "646 555-4567")))
+ *     .build();
+ * </code>
+ * </pre>
+ *
+ * <p>This class does <em>not</em> allow <code>null</code> to be used as a name or
+ * value while building the JSON object
+ *
+ * @see JsonArrayBuilder
+ */
+public interface JsonObjectBuilder {
+
+    /**
+     * Adds a name/{@code JsonValue} pair to the JSON object associated with
+     * this object builder. If the object contains a mapping for the specified
+     * name, this method replaces the old value with the specified value.
+     *
+     * @param name name in the name/value pair
+     * @param value value in the name/value pair
+     * @return this object builder
+     * @throws NullPointerException if the specified name or value is null
+     */
+    JsonObjectBuilder add(String name, JsonValue value);
+
+    /**
+     * Adds a name/{@code JsonString} pair to the JSON object associated with
+     * this object builder. If the object contains a mapping for the specified
+     * name, this method replaces the old value with the specified value.
+     *
+     * @param name name in the name/value pair
+     * @param value value in the name/value pair
+     * @return this object builder
+     * @throws NullPointerException if the specified name or value is null
+     */
+    JsonObjectBuilder add(String name, String value);
+
+    /**
+     * Adds a name/{@code JsonNumber} pair to the JSON object associated with
+     * this object builder. If the object contains a mapping for the specified
+     * name, this method replaces the old value with the specified value.
+     *
+     * @param name name in the name/value pair
+     * @param value value in the name/value pair
+     * @return this object builder
+     * @throws NullPointerException if the specified name or value is null
+     *
+     * @see JsonNumber
+     */
+    JsonObjectBuilder add(String name, BigInteger value);
+
+    /**
+     * Adds a name/{@code JsonNumber} pair to the JSON object associated with
+     * this object builder. If the object contains a mapping for the specified
+     * name, this method replaces the old value with the specified value.
+     *
+     * @param name name in the name/value pair
+     * @param value value in the name/value pair
+     * @return this object builder
+     * @throws NullPointerException if the specified name or value is null
+     *
+     * @see JsonNumber
+     */
+    JsonObjectBuilder add(String name, BigDecimal value);
+
+    /**
+     * Adds a name/{@code JsonNumber} pair to the JSON object associated with
+     * this object builder. If the object contains a mapping for the specified
+     * name, this method replaces the old value with the specified value.
+     *
+     * @param name name in the name/value pair
+     * @param value value in the name/value pair
+     * @return this object builder
+     * @throws NullPointerException if the specified name is null
+     *
+     * @see JsonNumber
+     */
+    JsonObjectBuilder add(String name, int value);
+
+    /**
+     * Adds a name/{@code JsonNumber} pair to the JSON object associated with
+     * this object builder. If the object contains a mapping for the specified
+     * name, this method replaces the old value with the specified value.
+     *
+     * @param name name in the name/value pair
+     * @param value value in the name/value pair
+     * @return this object builder
+     * @throws NullPointerException if the specified name is null
+     *
+     * @see JsonNumber
+     */
+    JsonObjectBuilder add(String name, long value);
+
+    /**
+     * Adds a name/{@code JsonNumber} pair to the JSON object associated with
+     * this object builder. If the object contains a mapping for the specified
+     * name, this method replaces the old value with the specified value.
+     *
+     * @param name name in the name/value pair
+     * @param value value in the name/value pair
+     * @return this object builder
+     * @throws NumberFormatException if the value is Not-a-Number (NaN) or 
+     * infinity
+     * @throws NullPointerException if the specified name is null
+     *
+     * @see JsonNumber
+     */
+    JsonObjectBuilder add(String name, double value);
+
+    /**
+     * Adds a name/{@code JsonValue#TRUE} or name/{@code JsonValue#FALSE} pair
+     * to the JSON object associated with this object builder. If the object
+     * contains a mapping for the specified name, this method replaces the old
+     * value with the specified value.
+     *
+     * @param name name in the name/value pair
+     * @param value value in the name/value pair
+     * @return this object builder
+     * @throws NullPointerException if the specified name is null
+     */
+    JsonObjectBuilder add(String name, boolean value);
+
+    /**
+     * Adds a name/{@code JsonValue#NULL} pair to the JSON object associated
+     * with this object builder where the value is {@code null}.
+     * If the object contains a mapping for the specified name, this method
+     * replaces the old value with {@code null}.
+     *
+     * @param name name in the name/value pair
+     * @return this object builder
+     * @throws NullPointerException if the specified name is null
+     */
+    JsonObjectBuilder addNull(String name);
+
+    /**
+     * Adds a name/{@code JsonObject} pair to the JSON object associated
+     * with this object builder. The value {@code JsonObject} is built from the
+     * specified object builder. If the object contains a mapping for the
+     * specified name, this method replaces the old value with the
+     * {@code JsonObject} from the specified object builder.
+     *
+     * @param name name in the name/value pair
+     * @param builder the value is the object associated with this builder
+     * @return this object builder
+     * @throws NullPointerException if the specified name or builder is null
+     */
+    JsonObjectBuilder add(String name, JsonObjectBuilder builder);
+
+    /**
+     * Adds a name/{@code JsonArray} pair to the JSON object associated with
+     * this object builder. The value {@code JsonArray} is built from the
+     * specified array builder. If the object contains a mapping for the
+     * specified name, this method replaces the old value with the
+     * {@code JsonArray} from the specified array builder.
+     *
+     * @param name the name in the name/value pair
+     * @param builder the value is the object array with this builder
+     * @return this object builder
+     * @throws NullPointerException if the specified name or builder is null
+     */
+    JsonObjectBuilder add(String name, JsonArrayBuilder builder);
+
+    /**
+     * Adds all name/value pairs in the JSON object associated with the specified
+     * object builder to the JSON object associated with this object builder.
+     * The newly added name/value pair will replace any existing name/value pair with
+     * the same name.
+     *
+     * @param builder the specified object builder
+     * @return this object builder
+     * @throws NullPointerException if the specified builder is null
+     * @since 1.1
+     */
+    default JsonObjectBuilder addAll(JsonObjectBuilder builder) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Remove the name/value pair from the JSON object associated with this
+     * object builder if it is present.
+     *
+     * @param name the name in the name/value pair to be removed
+     * @return this object builder
+     * @throws NullPointerException if the specified name is null
+     * @since 1.1
+     */
+    default JsonObjectBuilder remove(String name) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Returns the JSON object associated with this object builder. 
+     * The iteration order for the {@code JsonObject} is based
+     * on the order in which name/value pairs are added to the object using
+     * this builder.
+     *
+     * This method clears the builder.
+     *
+     * @return JSON object that is being built
+     */
+    JsonObject build();
+
+}

--- a/dev/io.openliberty.jakarta.jsonp.2.2/src/jakarta/json/JsonPatch.java
+++ b/dev/io.openliberty.jakarta.jsonp.2.2/src/jakarta/json/JsonPatch.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) 2015, 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.json;
+
+/**
+ * <p>This interface represents an immutable implementation of a JSON Patch
+ * as defined by <a href="http://tools.ietf.org/html/rfc6902">RFC 6902</a>.
+ * </p>
+ * <p>A {@code JsonPatch} can be instantiated with {@link Json#createPatch(JsonArray)}
+ * by specifying the patch operations in a JSON Patch. Alternately, it
+ * can also be constructed with a {@link JsonPatchBuilder}.
+ * </p>
+ * The following illustrates both approaches.
+ * <p>1. Construct a JsonPatch with a JSON Patch.
+ * <pre>{@code
+ *   JsonArray contacts = ... // The target to be patched
+ *   JsonArray patch = ...  ; // JSON Patch
+ *   JsonPatch jsonpatch = Json.createPatch(patch);
+ *   JsonArray result = jsonpatch.apply(contacts);
+ * } </pre>
+ * 2. Construct a JsonPatch with JsonPatchBuilder.
+ * <pre>{@code
+ *   JsonPatchBuilder builder = Json.createPatchBuilder();
+ *   JsonArray result = builder.add("/John/phones/office", "1234-567")
+ *                             .remove("/Amy/age")
+ *                             .build()
+ *                             .apply(contacts);
+ * } </pre>
+ *
+ * @see <a href="http://tools.ietf.org/html/rfc6902">RFC 6902</a>
+ *
+ * @since 1.1
+ */
+public interface JsonPatch {
+
+    /**
+     * This enum represents the list of valid JSON Patch operations
+     * as defined by <a href="http://tools.ietf.org/html/rfc6902">RFC 6902</a>.
+     *
+     * @see <a href="http://tools.ietf.org/html/rfc6902">RFC 6902</a>
+     */
+    enum Operation {
+
+        /**
+         * "add" operation.
+         */
+        ADD("add"),
+
+        /**
+         * "remove" operation.
+         */
+        REMOVE("remove"),
+
+        /**
+         * "replace" operation.
+         */
+        REPLACE("replace"),
+
+        /**
+         * "move" operation.
+         */
+        MOVE("move"),
+
+        /**
+         * "copy" operation.
+         */
+        COPY("copy"),
+
+        /**
+         * "test" operation.
+         */
+        TEST("test");
+
+        /** Operation name */
+        private final String operationName;
+
+        /**
+         * Create an enum constant with given {@code operationName}.
+         * @param operationName the operation name for the enum constant
+         */
+        private Operation(String operationName) {
+            this.operationName = operationName;
+        }
+
+        /**
+         * Returns enum constant name as lower case string.
+         *
+         * @return lower case name of the enum constant
+         */
+        public String operationName() {
+            return operationName;
+        }
+
+        /**
+         * Returns the enum constant with the specified name.
+         *
+         * @param operationName {@code operationName} to convert to the enum constant.
+         * @return the enum constant for given {@code operationName}
+         * @throws JsonException if given {@code operationName} is not recognized
+         */
+        public static Operation fromOperationName(String operationName) {
+            for (Operation op : values()) {
+                if (op.operationName().equalsIgnoreCase(operationName)) {
+                    return op;
+                }
+            }
+            throw new JsonException("Illegal value for the operationName of the JSON patch operation: " + operationName);
+        }
+    }
+
+    /**
+     * Applies the patch operations to the specified {@code target}.
+     * The target is not modified by the patch.
+     *
+     * @param <T> the target type, must be a subtype of {@link JsonStructure}
+     * @param target the target to apply the patch operations
+     * @return the transformed target after the patch
+     * @throws JsonException if the supplied JSON Patch is malformed or if
+     *    it contains references to non-existing members
+     */
+    <T extends JsonStructure> T apply(T target);
+
+    /**
+     * Returns the {@code JsonPatch} as {@code JsonArray}.
+     *
+     * @return this {@code JsonPatch} as {@code JsonArray}
+     */
+    JsonArray toJsonArray();
+
+}

--- a/dev/io.openliberty.jakarta.jsonp.2.2/src/jakarta/json/JsonPatchBuilder.java
+++ b/dev/io.openliberty.jakarta.jsonp.2.2/src/jakarta/json/JsonPatchBuilder.java
@@ -1,0 +1,186 @@
+/*
+ * Copyright (c) 2015, 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.json;
+
+/**
+ * A builder for constructing a JSON Patch as defined by
+ * <a href="http://tools.ietf.org/html/rfc6902">RFC 6902</a> by adding
+ * JSON Patch operations incrementally.
+ * <p>
+ * The following illustrates the approach.
+ * <pre>
+ *   JsonPatchBuilder builder = Json.createPatchBuilder();
+ *   JsonPatch patch = builder.add("/John/phones/office", "1234-567")
+ *                            .remove("/Amy/age")
+ *                            .build();
+ * </pre>
+ * The result is equivalent to the following JSON Patch.
+ * <pre>
+ * [
+ *    {"op" = "add", "path" = "/John/phones/office", "value" = "1234-567"},
+ *    {"op" = "remove", "path" = "/Amy/age"}
+ * ] </pre>
+ *
+ * @see <a href="http://tools.ietf.org/html/rfc6902">RFC 6902</a>
+ *
+ * @since 1.1
+ */
+public interface JsonPatchBuilder {
+
+    /**
+     * Adds an "add" JSON Patch operation.
+     *
+     * @param path the "path" member of the operation. Must be a valid escaped JSON-Pointer.
+     * @param value the "value" member of the operation
+     * @return this JsonPatchBuilder
+     */
+    JsonPatchBuilder add(String path, JsonValue value);
+
+    /**
+     * Adds an "add" JSON Patch operation.
+     *
+     * @param path the "path" member of the operation. Must be a valid escaped JSON-Pointer.
+     * @param value the "value" member of the operation
+     * @return this JsonPatchBuilder
+     */
+    JsonPatchBuilder add(String path, String value);
+
+    /**
+     * Adds an "add" JSON Patch operation.
+     *
+     * @param path the "path" member of the operation. Must be a valid escaped JSON-Pointer.
+     * @param value the "value" member of the operation
+     * @return this JsonPatchBuilder
+     */
+    JsonPatchBuilder add(String path, int value);
+
+    /**
+     * Adds an "add" JSON Patch operation.
+     *
+     * @param path the "path" member of the operation. Must be a valid escaped JSON-Pointer.
+     * @param value the "value" member of the operation
+     * @return this JsonPatchBuilder
+     */
+    JsonPatchBuilder add(String path, boolean value);
+
+    /**
+     * Adds a "remove" JSON Patch operation.
+     *
+     * @param path the "path" member of the operation. Must be a valid escaped JSON-Pointer.
+     * @return this JsonPatchBuilder
+     */
+    JsonPatchBuilder remove(String path);
+
+    /**
+     * Adds a "replace" JSON Patch operation.
+     *
+     * @param path the "path" member of the operation. Must be a valid escaped JSON-Pointer.
+     * @param value the "value" member of the operation
+     * @return this JsonPatchBuilder
+     */
+    JsonPatchBuilder replace(String path, JsonValue value);
+
+    /**
+     * Adds a "replace" JSON Patch operation.
+     *
+     * @param path the "path" member of the operation. Must be a valid escaped JSON-Pointer string.
+     * @param value the "value" member of the operation
+     * @return this JsonPatchBuilder
+     */
+    JsonPatchBuilder replace(String path, String value);
+
+    /**
+     * Adds a "replace" JSON Patch operation.
+     *
+     * @param path the "path" member of the operation. Must be a valid escaped JSON-Pointer string.
+     * @param value the "value" member of the operation
+     * @return this JsonPatchBuilder
+     */
+    JsonPatchBuilder replace(String path, int value);
+
+    /**
+     * Adds a "replace" JSON Patch operation.
+     *
+     * @param path the "path" member of the operation. Must be a valid escaped JSON-Pointer string.
+     * @param value the "value" member of the operation
+     * @return this JsonPatchBuilder
+     */
+    JsonPatchBuilder replace(String path, boolean value);
+
+    /**
+     * Adds a "move" JSON Patch operation.
+     *
+     * @param path the "path" member of the operation. Must be a valid escaped JSON-Pointer string.
+     * @param from the "from" member of the operation
+     * @return this JsonPatchBuilder
+     */
+    JsonPatchBuilder move(String path, String from);
+
+    /**
+     * Adds a "copy" JSON Patch operation.
+     *
+     * @param path the "path" member of the operation. Must be a valid escaped JSON-Pointer string.
+     * @param from the "from" member of the operation
+     * @return this JsonPatchBuilder
+     */
+    JsonPatchBuilder copy(String path, String from);
+
+    /**
+     * Adds a "test" JSON Patch operation.
+     *
+     * @param path the "path" member of the operation. Must be a valid escaped JSON-Pointer string.
+     * @param value the "value" member of the operation
+     * @return this JsonPatchBuilder
+     */
+    JsonPatchBuilder test(String path, JsonValue value);
+
+    /**
+     * Adds a "test" JSON Patch operation.
+     *
+     * @param path the "path" member of the operation. Must be a valid escaped JSON-Pointer string.
+     * @param value the "value" member of the operation
+     * @return this JsonPatchBuilder
+     */
+    JsonPatchBuilder test(String path, String value);
+
+    /**
+     * Adds a "test" JSON Patch operation.
+     *
+     * @param path the "path" member of the operation. Must be a valid escaped JSON-Pointer string.
+     * @param value the "value" member of the operation
+     * @return this JsonPatchBuilder
+     */
+    JsonPatchBuilder test(String path, int value);
+
+    /**
+     * Adds a "test" JSON Patch operation.
+     *
+     * @param path the "path" member of the operation. Must be a valid escaped JSON-Pointer string.
+     * @param value the "value" member of the operation
+     * @return this JsonPatchBuilder
+     */
+    JsonPatchBuilder test(String path, boolean value);
+
+
+    /**
+     * Returns the JSON Patch.
+     *
+     * @return a JSON Patch
+     */
+    JsonPatch build();
+
+}

--- a/dev/io.openliberty.jakarta.jsonp.2.2/src/jakarta/json/JsonPointer.java
+++ b/dev/io.openliberty.jakarta.jsonp.2.2/src/jakarta/json/JsonPointer.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2015, 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.json;
+
+/**
+ * <p>This interface represents an immutable implementation of a JSON Pointer
+ * as defined by <a href="http://tools.ietf.org/html/rfc6901">RFC 6901</a>.
+ * </p>
+ * <p> A JSON Pointer, when applied to a target {@link JsonValue},
+ * defines a reference location in the target.</p>
+ * <p> An empty JSON Pointer string defines a reference to the target itself.</p>
+ * <p> If the JSON Pointer string is non-empty, it must be a sequence
+ * of '/' prefixed tokens, and the target must either be a {@link JsonArray}
+ * or {@link JsonObject}. If the target is a {@code JsonArray}, the pointer
+ * defines a reference to an array element, and the last token specifies the index.
+ * If the target is a {@link JsonObject}, the pointer defines a reference to a
+ * name/value pair, and the last token specifies the name.
+ * </p>
+ * <p> The method {@link #getValue getValue()} returns the referenced value.
+ * Methods {@link #add add()}, {@link #replace replace()},
+ * and {@link #remove remove()} execute operations specified in
+ * <a href="http://tools.ietf.org/html/rfc6902">RFC 6902</a>. </p>
+ *
+ * @see <a href="http://tools.ietf.org/html/rfc6901">RFC 6901</a>
+ * @see <a href="http://tools.ietf.org/html/rfc6902">RFC 6902</a>
+ *
+ * @since 1.1
+ */
+public interface JsonPointer {
+
+    /**
+     * Adds or replaces a value at the referenced location in the specified
+     * {@code target} with the specified {@code value}.
+     * <ol>
+     * <li>If the reference is the target (empty JSON Pointer string),
+     * the specified {@code value}, which must be the same type as
+     * specified {@code target}, is returned.</li>
+     * <li>If the reference is an array element, the specified {@code value} is inserted
+     * into the array, at the referenced index. The value currently at that location, and
+     * any subsequent values, are shifted to the right (adds one to the indices).
+     * Index starts with 0. If the reference is specified with a "-", or if the
+     * index is equal to the size of the array, the value is appended to the array.</li>
+     * <li>If the reference is a name/value pair of a {@code JsonObject}, and the
+     * referenced value exists, the value is replaced by the specified {@code value}.
+     * If the value does not exist, a new name/value pair is added to the object.</li>
+     * </ol>
+     *
+     * @param <T> the target type, must be a subtype of {@link JsonValue}
+     * @param target the target referenced by this {@code JsonPointer}
+     * @param value the value to be added
+     * @return the transformed {@code target} after the value is added.
+     * @throws NullPointerException if {@code target} is {@code null}
+     * @throws JsonException if the reference is an array element and
+     * the index is out of range ({@code index < 0 || index > array size}),
+     * or if the pointer contains references to non-existing objects or arrays.
+     */
+    <T extends JsonStructure> T add(T target, JsonValue value);
+
+    /**
+     * Removes the value at the reference location in the specified {@code target}.
+     *
+     * @param <T> the target type, must be a subtype of {@link JsonValue}
+     * @param target the target referenced by this {@code JsonPointer}
+     * @return the transformed {@code target} after the value is removed.
+     * @throws NullPointerException if {@code target} is {@code null}
+     * @throws JsonException if the referenced value does not exist,
+     *    or if the reference is the target.
+     */
+    <T extends JsonStructure> T remove(T target);
+
+    /**
+     * Replaces the value at the referenced location in the specified
+     * {@code target} with the specified {@code value}.
+     *
+     * @param <T> the target type, must be a subtype of {@link JsonValue}
+     * @param target the target referenced by this {@code JsonPointer}
+     * @param value the value to be stored at the referenced location
+     * @return the transformed {@code target} after the value is replaced.
+     * @throws NullPointerException if {@code target} is {@code null}
+     * @throws JsonException if the referenced value does not exist,
+     *    or if the reference is the target.
+     */
+    <T extends JsonStructure> T replace(T target, JsonValue value);
+
+    /**
+     * Returns {@code true} if there is a value at the referenced location in the specified {@code target}.
+     *
+     * @param target the target referenced by this {@code JsonPointer}
+     * @return {@code true} if this pointer points to a value in a specified {@code target}.
+     */
+    boolean containsValue(JsonStructure target);
+
+    /**
+     * Returns the value at the referenced location in the specified {@code target}.
+     *
+     * @param target the target referenced by this {@code JsonPointer}
+     * @return the referenced value in the target.
+     * @throws NullPointerException if {@code target} is null
+     * @throws JsonException if the referenced value does not exist
+     */
+    JsonValue getValue(JsonStructure target);
+
+    /**
+     * Returns the string representation of this JSON Pointer.
+     * The value to be returned is an empty string or a sequence of '{@code /}' prefixed tokens.
+     *
+     * @return the valid escaped JSON Pointer string.
+     */
+    @Override
+    String toString();
+}

--- a/dev/io.openliberty.jakarta.jsonp.2.2/src/jakarta/json/JsonReader.java
+++ b/dev/io.openliberty.jakarta.jsonp.2.2/src/jakarta/json/JsonReader.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2012, 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.json;
+
+import java.io.Closeable;
+
+/**
+ * Reads a JSON {@link JsonObject object} or an {@link JsonArray array}
+ * structure from an input source.
+ *
+ * <p>The class {@link jakarta.json.Json} contains methods to create readers from
+ * input sources ({@link java.io.InputStream} and {@link java.io.Reader}).
+ *
+ * <p>
+ * The following example demonstrates how to read an empty JSON array from
+ * a string:
+ * <pre>
+ * <code>
+ * JsonReader jsonReader = Json.createReader(new StringReader("[]"));
+ * JsonArray array = jsonReader.readArray();
+ * jsonReader.close();
+ * </code>
+ * </pre>
+ *
+ * <p>
+ * The class {@link JsonReaderFactory} also contains methods to create
+ * {@code JsonReader} instances. A factory instance can be used to create
+ * multiple reader instances with the same configuration. This the preferred
+ * way to create multiple instances. A sample usage is shown in the following
+ * example:
+ * <pre>
+ * <code>
+ * JsonReaderFactory factory = Json.createReaderFactory(config);
+ * JsonReader reader1 = factory.createReader(...);
+ * JsonReader reader2 = factory.createReader(...);
+ * </code>
+ * </pre>
+ */
+public interface JsonReader extends  /*Auto*/Closeable {
+
+    /**
+     * Returns a JSON array or object that is represented in
+     * the input source. This method needs to be called
+     * only once for a reader instance.
+     *
+     * @return a JSON object or array
+     * @throws JsonException if a JSON object or array cannot
+     *     be created due to i/o error (IOException would be
+     * cause of JsonException)
+     * @throws jakarta.json.stream.JsonParsingException if a JSON object or array
+     *     cannot be created due to incorrect representation
+     * @throws IllegalStateException if read, readObject, readArray,
+     *     readValue or close method is already called
+     */
+    JsonStructure read();
+
+    /**
+     * Returns a JSON object that is represented in
+     * the input source. This method needs to be called
+     * only once for a reader instance.
+     *
+     * @return a JSON object
+     * @throws JsonException if a JSON object cannot
+     *     be created due to i/o error (IOException would be
+     *     cause of JsonException)
+     * @throws jakarta.json.stream.JsonParsingException if a JSON object cannot
+     *     be created due to incorrect representation
+     * @throws IllegalStateException if read, readObject, readArray,
+     *     readValue or close method is already called
+     */
+    JsonObject readObject();
+
+    /**
+     * Returns a JSON array that is represented in
+     * the input source. This method needs to be called
+     * only once for a reader instance.
+     *
+     * @return a JSON array
+     * @throws JsonException if a JSON array cannot
+     *     be created due to i/o error (IOException would be
+     *     cause of JsonException)
+     * @throws jakarta.json.stream.JsonParsingException if a JSON array cannot
+     *     be created due to incorrect representation
+     * @throws IllegalStateException if read, readObject, readArray,
+     *     readValue or close method is already called
+     */
+    JsonArray readArray();
+
+    /**
+     * Returns a JSON value that is represented in
+     * the input source. This method needs to be called
+     * only once for a reader instance.
+     *
+     * @return a JSON value
+     * @throws JsonException if a JSON value
+     *     be created due to i/o error (IOException would be
+     *     cause of JsonException)
+     * @throws jakarta.json.stream.JsonParsingException if a JSON value
+     *     cannot be created due to incorrect representation
+     * @throws IllegalStateException if read, readObject, readArray,
+     *     readValue or close method is already called
+     *
+     * @since 1.1
+     */
+    default JsonValue readValue() {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Closes this reader and frees any resources associated with the
+     * reader. This method closes the underlying input source.
+     *
+     * @throws JsonException if an i/o error occurs (IOException would be
+     * cause of JsonException)
+     */
+    @Override
+    void close();
+
+}

--- a/dev/io.openliberty.jakarta.jsonp.2.2/src/jakarta/json/JsonReaderFactory.java
+++ b/dev/io.openliberty.jakarta.jsonp.2.2/src/jakarta/json/JsonReaderFactory.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2013, 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.json;
+
+import java.io.InputStream;
+import java.io.Reader;
+import java.nio.charset.Charset;
+import java.util.Map;
+
+/**
+ * Factory to create {@link jakarta.json.JsonReader} instances. If a factory
+ * instance is configured with some configuration, that would be
+ * used to configure the created reader instances.
+ *
+ * <p>
+ * {@link jakarta.json.JsonReader} can also be created using {@link Json}'s
+ * {@code createReader} methods. If multiple reader instances are created,
+ * then creating them using a reader factory is preferred.
+ *
+ * <p>
+ * <b>For example:</b>
+ * <pre>
+ * <code>
+ * JsonReaderFactory factory = Json.createReaderFactory(...);
+ * JsonReader reader1 = factory.createReader(...);
+ * JsonReader reader2 = factory.createReader(...);
+ * </code>
+ * </pre>
+ *
+ * <p> All the methods in this class are safe for use by multiple concurrent
+ * threads.
+ */
+public interface JsonReaderFactory {
+
+    /**
+     * Creates a JSON reader from a character stream. The reader is configured
+     * with the factory configuration.
+     *
+     * @param reader a reader from which JSON is to be read
+     * @return a JSON reader
+     */
+    JsonReader createReader(Reader reader);
+
+    /**
+     * Creates a JSON reader from a byte stream. The character encoding of
+     * the stream is determined as described in
+     * <a href="http://tools.ietf.org/rfc/rfc7159.txt">RFC 7159</a>.
+     * The reader is configured with the factory configuration.
+     *
+     * @param in a byte stream from which JSON is to be read
+     * @return a JSON reader
+     */
+    JsonReader createReader(InputStream in);
+
+    /**
+     * Creates a JSON reader from a byte stream. The bytes of the stream
+     * are decoded to characters using the specified charset. The reader is
+     * configured with the factory configuration.
+     *
+     * @param in a byte stream from which JSON is to be read
+     * @param charset a charset
+     * @return a JSON reader
+     */
+    JsonReader createReader(InputStream in, Charset charset);
+
+    /**
+     * Returns read-only map of supported provider specific configuration
+     * properties that are used to configure the created JSON readers.
+     * If there are any specified configuration properties that are not
+     * supported by the provider, they won't be part of the returned map.
+     *
+     * @return a map of supported provider specific properties that are used
+     * to configure the readers. The map be empty but not null.
+     */
+    Map<String, ?> getConfigInUse();
+
+}

--- a/dev/io.openliberty.jakarta.jsonp.2.2/src/jakarta/json/JsonString.java
+++ b/dev/io.openliberty.jakarta.jsonp.2.2/src/jakarta/json/JsonString.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2011, 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.json;
+
+/**
+ * An immutable JSON string value.
+ */
+public interface JsonString extends JsonValue {
+
+    /**
+     * Returns the JSON string value.
+     *
+     * @return a JSON string value
+     */
+    String getString();
+
+
+    /**
+     * Returns the char sequence for the JSON String value
+     *
+     * @return a char sequence for the JSON String value
+     */
+    CharSequence getChars();
+
+    /**
+     * Compares the specified object with this {@code JsonString} for equality.
+     * Returns {@code true} if and only if the specified object is also a
+     * {@code JsonString}, and their {@link #getString()} objects are
+     * <i>equal</i>.
+     *
+     * @param obj the object to be compared for equality with this 
+     *      {@code JsonString}
+     * @return {@code true} if the specified object is equal to this 
+     *      {@code JsonString}
+     */
+    @Override
+    boolean equals(Object obj);
+
+    /**
+     * Returns the hash code value for this {@code JsonString} object.  
+     * The hash code of a {@code JsonString} object is defined to be its 
+     * {@link #getString()} object's hash code.
+     *
+     * @return the hash code value for this {@code JsonString} object
+     */
+    @Override
+    int hashCode();
+
+}

--- a/dev/io.openliberty.jakarta.jsonp.2.2/src/jakarta/json/JsonStructure.java
+++ b/dev/io.openliberty.jakarta.jsonp.2.2/src/jakarta/json/JsonStructure.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2012, 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.json;
+
+/**
+ * Super type for the two structured types in JSON ({@link JsonObject object}s
+ * and {@link JsonArray array}s).
+ */
+public interface JsonStructure extends JsonValue {
+
+    /**
+     * Get the value referenced by the provided JSON Pointer in the JsonStructure.
+     *
+     * @param jsonPointer the JSON Pointer
+     * @return the {@code JsonValue} at the referenced location
+     * @throws JsonException if the JSON Pointer is malformed, or if it references
+     *     a non-existing member or value.
+     *
+     * @since 1.1
+     */
+    default public JsonValue getValue(String jsonPointer) {
+        return Json.createPointer(jsonPointer).getValue(this);
+    }
+}

--- a/dev/io.openliberty.jakarta.jsonp.2.2/src/jakarta/json/JsonValue.java
+++ b/dev/io.openliberty.jakarta.jsonp.2.2/src/jakarta/json/JsonValue.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2011, 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.json;
+
+/**
+ * <code>JsonValue</code> represents an immutable JSON value.
+ *
+ *
+ * <p>A JSON value is one of the following:
+ * an object ({@link JsonObject}), an array ({@link JsonArray}),
+ * a number ({@link JsonNumber}), a string ({@link JsonString}),
+ * {@code true} ({@link JsonValue#TRUE JsonValue.TRUE}), {@code false}
+ * ({@link JsonValue#FALSE JsonValue.FALSE}),
+ * or {@code null} ({@link JsonValue#NULL JsonValue.NULL}).
+ */
+public interface JsonValue {
+
+    /**
+     * The empty JSON object.
+     *
+     * @since 1.1
+     */
+    static final JsonObject EMPTY_JSON_OBJECT = new EmptyObject();
+
+    /**
+     * The empty JSON array.
+     *
+     * @since 1.1
+     */
+    static final JsonArray EMPTY_JSON_ARRAY = new EmptyArray();
+
+    /**
+     * Indicates the type of a {@link JsonValue} object.
+     */
+    enum ValueType {
+        /**
+         * JSON array.
+         */
+        ARRAY,
+
+        /**
+         * JSON object.
+         */
+        OBJECT,
+
+        /**
+         * JSON string.
+         */
+        STRING,
+
+        /**
+         * JSON number.
+         */
+        NUMBER,
+
+        /**
+         * JSON true.
+         */
+        TRUE,
+
+        /**
+         * JSON false.
+         */
+        FALSE,
+
+        /**
+         * JSON null.
+         */
+        NULL
+    }
+
+    /**
+     * JSON null value.
+     */
+    static final JsonValue NULL = new JsonValueImpl(ValueType.NULL);
+
+    /**
+     * JSON true value.
+     */
+    static final JsonValue TRUE = new JsonValueImpl(ValueType.TRUE);
+
+    /**
+     * JSON false value.
+     */
+    static final JsonValue FALSE = new JsonValueImpl(ValueType.FALSE);
+
+    /**
+     * Returns the value type of this JSON value.
+     *
+     * @return JSON value type
+     */
+    ValueType getValueType();
+
+    /**
+     * Return the JsonValue as a JsonObject
+     *
+     * @return the JsonValue as a JsonObject
+     * @throws ClassCastException if the JsonValue is not a JsonObject
+     *
+     * @since 1.1
+     */
+    default JsonObject asJsonObject() {
+        return JsonObject.class.cast(this);
+    }
+
+    /**
+     * Return the JsonValue as a JsonArray
+     *
+     * @return the JsonValue as a JsonArray
+     * @throws ClassCastException if the JsonValue is not a JsonArray
+     *
+     * @since 1.1
+     */
+    default JsonArray asJsonArray() {
+        return JsonArray.class.cast(this);
+    }
+
+    /**
+     * Returns JSON text for this JSON value.
+     *
+     * @return JSON text
+     */
+    @Override
+    String toString();
+
+}

--- a/dev/io.openliberty.jakarta.jsonp.2.2/src/jakarta/json/JsonValueImpl.java
+++ b/dev/io.openliberty.jakarta.jsonp.2.2/src/jakarta/json/JsonValueImpl.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2016, 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.json;
+
+import java.io.Serializable;
+
+/**
+ * Private implementation of {@link JsonValue} for simple {@link ValueType}s
+ * allowing their usage in constants which are better to implement {@link Serializable}.
+ *
+ * @author Lukas Jungmann
+ */
+final class JsonValueImpl implements JsonValue, Serializable {
+
+    /** for serialization */
+    private static final long serialVersionUID = 83723433120886104L;
+
+    /** Type of this JsonValue. */
+    private final ValueType valueType;
+
+    /**
+     * Default constructor.
+     * @param valueType Type of this JsonValue
+     */
+    JsonValueImpl(ValueType valueType) {
+        this.valueType = valueType;
+    }
+
+    /**
+     * Returns the value type of this JSON value.
+     *
+     * @return JSON value type
+     */
+    @Override
+    public ValueType getValueType() {
+        return valueType;
+    }
+
+    /**
+     * Compares the specified object with this {@link JsonValue}
+     * object for equality. Returns {@code true} if and only if the
+     * specified object is also a JsonValue, and their
+     * {@link #getValueType()} objects are <i>equal</i>.
+     *
+     * @param obj the object to be compared for equality with this JsonValue
+     * @return {@code true} if the specified object is equal to this
+     * JsonValue
+     */
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj instanceof JsonValue) {
+            return getValueType().equals(((JsonValue) obj).getValueType());
+        }
+        return false;
+    }
+
+    /**
+     * Returns the hash code value for this {@link JsonValue} object.
+     * The hash code of the {@link JsonValue} object is defined to be
+     * its {@link #getValueType()} object's hash code.
+     *
+     * @return the hash code value for this {@link JsonValue} object
+     */
+    @Override
+    public int hashCode() {
+        return valueType.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return valueType.name().toLowerCase();
+    }
+
+}

--- a/dev/io.openliberty.jakarta.jsonp.2.2/src/jakarta/json/JsonWriter.java
+++ b/dev/io.openliberty.jakarta.jsonp.2.2/src/jakarta/json/JsonWriter.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2012, 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.json;
+
+import java.io.Closeable;
+
+/**
+ * Writes a JSON {@link JsonObject object} or {@link JsonArray array} structure
+ * to an output source.
+ *
+ * <p>The class {@link jakarta.json.Json} contains methods to create writers from
+ * output sources ({@link java.io.OutputStream} and {@link java.io.Writer}).
+ *
+ * <p>
+ * The following example demonstrates how write an empty JSON object:
+ * <pre>
+ * <code>
+ * JsonWriter jsonWriter = Json.createWriter(...);
+ * jsonWriter.writeObject(Json.createObjectBuilder().build());
+ * jsonWriter.close();
+ * </code>
+ * </pre>
+ *
+ * <p>
+ * The class {@link JsonWriterFactory} also contains methods to create
+ * {@code JsonWriter} instances. A factory instance can be used to create
+ * multiple writer instances with the same configuration. This the preferred
+ * way to create multiple instances. A sample usage is shown in the following
+ * example:
+ * <pre>
+ * <code>
+ * JsonWriterFactory factory = Json.createWriterFactory(config);
+ * JsonWriter writer1 = factory.createWriter(...);
+ * JsonWriter writer2 = factory.createWriter(...);
+ * </code>
+ * </pre>
+ */
+public interface JsonWriter extends  /*Auto*/Closeable {
+
+    /**
+     * Writes the specified JSON {@link JsonArray array} to the output
+     * source. This method needs to be called only once for a writer instance.
+     *
+     * @param array JSON array that is to be written to the output source
+     * @throws JsonException if the specified JSON object cannot be
+     *     written due to i/o error (IOException would be cause of
+     *     JsonException)
+     * @throws IllegalStateException if writeArray, writeObject, write or close
+     *     method is already called
+     */
+    void writeArray(JsonArray array);
+
+    /**
+     * Writes the specified JSON {@link JsonObject object} to the output
+     * source. This method needs to be called only once for a writer instance.
+     *
+     * @param object JSON object that is to be written to the output source
+     * @throws JsonException if the specified JSON object cannot be
+     *     written due to i/o error (IOException would be cause of JsonException)
+     * @throws IllegalStateException if writeArray, writeObject, write or close
+     *     method is already called
+     */
+    void writeObject(JsonObject object);
+
+    /**
+     * Writes the specified JSON {@link JsonObject object} or
+     * {@link JsonArray array} to the output source. This method needs
+     * to be called only once for a writer instance.
+     *
+     * @param value JSON array or object that is to be written to the output
+     *              source
+     * @throws JsonException if the specified JSON object cannot be
+     *     written due to i/o error (IOException would be cause of
+     *     JsonException)
+     * @throws IllegalStateException if writeArray, writeObject, write
+     *     or close method is already called
+     */
+    void write(JsonStructure value);
+
+    /**
+     * Closes this JSON writer and frees any resources associated with the
+     * writer. This method closes the underlying output source.
+     *
+     * @throws JsonException if an i/o error occurs (IOException would be
+     * cause of JsonException)
+     */
+
+    /**
+     * Writes the specified {@link JsonValue} to the output source.
+     * method needs to be called only once for a write instance.
+     *
+     * @param value a {@code JsonValue} to be written to the output
+     *              source
+     * @throws JsonException if the specified JSON object cannot be
+     *     written due to i/o error (IOException would be cause of
+     *     JsonException)
+     * @throws IllegalStateException if writeArray, writeObject, write
+     *     or close method is already called
+     *
+     * @since 1.1
+     */
+    default void write(JsonValue value) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    void close();
+
+}

--- a/dev/io.openliberty.jakarta.jsonp.2.2/src/jakarta/json/JsonWriterFactory.java
+++ b/dev/io.openliberty.jakarta.jsonp.2.2/src/jakarta/json/JsonWriterFactory.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2013, 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.json;
+
+import java.io.OutputStream;
+import java.io.Writer;
+import java.nio.charset.Charset;
+import java.util.Map;
+
+/**
+ * Factory to create {@link jakarta.json.JsonWriter} instances. If a factory
+ * instance is configured with some configuration, that would be
+ * used to configure the created writer instances.
+ *
+ * <p>
+ * {@link jakarta.json.JsonWriter} can also be created using {@link Json}'s
+ * {@code createWriter} methods. If multiple writer instances are created,
+ * then creating them using a writer factory is preferred.
+ *
+ * <p>
+ * <b>For example:</b>
+ * <pre>
+ * <code>
+ * JsonWriterFactory factory = Json.createWriterFactory(...);
+ * JsonWriter writer1 = factory.createWriter(...);
+ * JsonWriter writer2 = factory.createWriter(...);
+ * </code>
+ * </pre>
+ *
+ * <p> All the methods in this class are safe for use by multiple concurrent
+ * threads.
+ */
+public interface JsonWriterFactory {
+
+    /**
+     * Creates a JSON writer to write a JSON {@link JsonObject object} or
+     * {@link JsonArray array} structure to the specified character stream.
+     * The writer is configured with the factory configuration.
+     *
+     * @param writer to which JSON object or array is written
+     * @return a JSON writer
+     */
+    JsonWriter createWriter(Writer writer);
+
+    /**
+     * Creates a JSON writer to write a JSON {@link JsonObject object} or
+     * {@link JsonArray array} structure to the specified byte stream.
+     * Characters written to the stream are encoded into bytes using UTF-8
+     * encoding. The writer is configured with the factory configuration.
+     *
+     * @param out to which JSON object or array is written
+     * @return a JSON writer
+     */
+    JsonWriter createWriter(OutputStream out);
+
+    /**
+     * Creates a JSON writer to write a JSON {@link JsonObject object} or
+     * {@link JsonArray array} structure to the specified byte stream.
+     * Characters written to the stream are encoded into bytes using the
+     * specified charset. The writer is configured with the factory
+     * configuration.
+     *
+     * @param out to which JSON object or array is written
+     * @param charset a charset
+     * @return a JSON writer
+     */
+    JsonWriter createWriter(OutputStream out, Charset charset);
+
+    /**
+     * Returns read-only map of supported provider specific configuration
+     * properties that are used to configure the created JSON writer objects.
+     * If there are any specified configuration properties that are not
+     * supported by the provider, they won't be part of the returned map.
+     *
+     * @return a map of supported provider specific properties that are used
+     * to configure the created writers. The map may be empty but not null.
+     */
+    Map<String, ?> getConfigInUse();
+
+}

--- a/dev/io.openliberty.jakarta.jsonp.2.2/src/jakarta/json/package-info.java
+++ b/dev/io.openliberty.jakarta.jsonp.2.2/src/jakarta/json/package-info.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2011, 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+/**
+ * Provides an object model API to process <a href="http://json.org/">JSON</a>.
+ *
+ * <p>The object model API is a high-level API that provides immutable object
+ * models for JSON object and array structures. These JSON structures are
+ * represented as object models using the Java types {@link jakarta.json.JsonObject}
+ * and {@link jakarta.json.JsonArray}. The interface {@code jakarta.json.JsonObject} provides
+ * a {@link java.util.Map} view to access the unordered collection of zero or
+ * more name/value pairs from the model. Similarly, the interface
+ * {@code JsonArray} provides a {@link java.util.List} view to access the
+ * ordered sequence of zero or more values from the model.
+ *
+ * <p>The object model API uses builder patterns to create and modify
+ * these object models. The classes {@link jakarta.json.JsonObjectBuilder} and 
+ * {@link jakarta.json.JsonArrayBuilder} provide methods to create and modify models
+ * of type {@code JsonObject} and {@code JsonArray} respectively.
+ *
+ * <p>These object models can also be created from an input source using
+ * the class {@link jakarta.json.JsonReader}. Similarly, these object models
+ * can be written to an output source using the class {@link jakarta.json.JsonWriter}.
+ * <p>
+ * This package includes several classes that implement other JSON related
+ * standards: <a href="http://tools.ietf.org/html/rfc6901">JSON Pointer</a>,
+ * <a Href="http://tools.ietf.org/html/rfc6902">JSON Patch</a>, and
+ * <a Href="http://tools.ietf.org/html/rfc7396">JSON Merge Patch</a>.
+ * They can be used to retrieve, transform or manipulate values in an
+ * object model.
+ */
+package jakarta.json;

--- a/dev/io.openliberty.jakarta.jsonp.2.2/src/jakarta/json/spi/JsonProvider.java
+++ b/dev/io.openliberty.jakarta.jsonp.2.2/src/jakarta/json/spi/JsonProvider.java
@@ -25,7 +25,6 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.Collection;
 import java.lang.ref.WeakReference;
-import java.util.Collections;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Optional;
@@ -83,14 +82,17 @@ public abstract class JsonProvider {
     private static final Logger LOG = Logger.getLogger(JsonProvider.class.getName());
 
     /**
-     * Cache of discovered providers keyed by the context classloader. Both keys and values are
-     * weakly referenced: weak keys allow the entry to be GC'd when the classloader is no longer
-     * reachable, and weak values break the strong reference cycle that would otherwise exist
-     * because a {@code JsonProvider} instance holds a strong reference back to its loading
-     * classloader (via its {@code Class}).
+     * Cache of discovered providers keyed by the context classloader. Weak keys allow the entry
+     * to be GC'd when the classloader is no longer reachable. Weak values break the strong
+     * reference cycle that would otherwise exist because a {@code JsonProvider} instance holds a
+     * strong reference back to its loading classloader (via its {@code Class}), which would
+     * otherwise prevent the weak key from ever being collected.
+     *
+     * <p>All accesses are guarded by explicit {@code synchronized (CLASSLOADER_CACHE)} blocks in
+     * {@link #provider()}.
      */
     private static final Map<ClassLoader, WeakReference<JsonProvider>> CLASSLOADER_CACHE =
-            Collections.synchronizedMap(new WeakHashMap<>());
+            new WeakHashMap<>();
 
     /**
      * Default constructor.

--- a/dev/io.openliberty.jakarta.jsonp.2.2/src/jakarta/json/spi/JsonProvider.java
+++ b/dev/io.openliberty.jakarta.jsonp.2.2/src/jakarta/json/spi/JsonProvider.java
@@ -169,9 +169,10 @@ public abstract class JsonProvider {
             }
         }
 
-        // else no provider found
+        // else no provider found — load the platform default via the spec bundle's own classloader
         LOG.fine("Trying to create the platform default provider");
-        return newInstance(DEFAULT_PROVIDER, cl);
+        ClassLoader specCL = JsonProvider.class.getClassLoader();
+        return newInstance(DEFAULT_PROVIDER, specCL != null ? specCL : cl);
     }
 
     /**

--- a/dev/io.openliberty.jakarta.jsonp.2.2/src/jakarta/json/spi/JsonProvider.java
+++ b/dev/io.openliberty.jakarta.jsonp.2.2/src/jakarta/json/spi/JsonProvider.java
@@ -1,0 +1,663 @@
+/*
+ * Copyright (c) 2011, 2022 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.json.spi;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.Reader;
+import java.io.Writer;
+import java.lang.reflect.Method;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.Collection;
+import java.lang.ref.WeakReference;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Optional;
+import java.util.ServiceLoader;
+import java.util.WeakHashMap;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import jakarta.json.JsonArray;
+import jakarta.json.JsonArrayBuilder;
+import jakarta.json.JsonBuilderFactory;
+import jakarta.json.JsonException;
+import jakarta.json.JsonMergePatch;
+import jakarta.json.JsonNumber;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonObjectBuilder;
+import jakarta.json.JsonPatch;
+import jakarta.json.JsonPatchBuilder;
+import jakarta.json.JsonPointer;
+import jakarta.json.JsonReader;
+import jakarta.json.JsonReaderFactory;
+import jakarta.json.JsonString;
+import jakarta.json.JsonStructure;
+import jakarta.json.JsonValue;
+import jakarta.json.JsonWriter;
+import jakarta.json.JsonWriterFactory;
+import jakarta.json.stream.JsonGenerator;
+import jakarta.json.stream.JsonGeneratorFactory;
+import jakarta.json.stream.JsonParser;
+import jakarta.json.stream.JsonParserFactory;
+
+/**
+ * Service provider for JSON processing objects.
+ *
+ * <p>All the methods in this class are safe for use by multiple concurrent
+ * threads.
+ *
+ * @see ServiceLoader
+ */
+public abstract class JsonProvider {
+
+    /**
+     * The name of the property that contains the name of the class capable of creating new JsonProvider objects.
+     */
+    public static final String JSONP_PROVIDER_FACTORY = "jakarta.json.provider";
+
+    /**
+     * A constant representing the name of the default
+     * {@code JsonProvider} implementation class.
+     */
+    private static final String DEFAULT_PROVIDER
+            = "org.eclipse.parsson.JsonProviderImpl";
+
+    /** A logger */
+    private static final Logger LOG = Logger.getLogger(JsonProvider.class.getName());
+
+    /**
+     * Cache of discovered providers keyed by the context classloader. Both keys and values are
+     * weakly referenced: weak keys allow the entry to be GC'd when the classloader is no longer
+     * reachable, and weak values break the strong reference cycle that would otherwise exist
+     * because a {@code JsonProvider} instance holds a strong reference back to its loading
+     * classloader (via its {@code Class}).
+     */
+    private static final Map<ClassLoader, WeakReference<JsonProvider>> CLASSLOADER_CACHE =
+            Collections.synchronizedMap(new WeakHashMap<>());
+
+    /**
+     * Default constructor.
+     */
+    protected JsonProvider() {
+    }
+
+    /**
+     * Creates a JSON provider object.
+     *
+     * <p>Implementation discovery consists of following steps:
+     * <ol>
+     * <li>If the system property {@value #JSONP_PROVIDER_FACTORY} exists,
+     *    then its value is assumed to be the provider factory class.
+     *    This phase of the look up enables per-JVM override of the JsonProvider implementation.
+     *    The system property path is <em>not</em> cached; the property is re-read on every call
+     *    so that dynamic changes at runtime are always reflected.</li>
+     * <li>The provider is loaded using the
+     *    {@link ServiceLoader#load(Class, ClassLoader)} method with the thread
+     *    context classloader captured at the start of this call.</li>
+     * <li>If all the steps above fail, then the rest of the look up is unspecified. The recommended
+     *    behavior is to look for a hard-coded platform default Jakarta JSON Processing
+     *    implementation. This phase of the look up allows a platform to have
+     *    its own Jakarta JSON Processing implementation as the last resort.</li>
+     * </ol>
+     *
+     *
+     * @see ServiceLoader
+     * @return a JSON provider
+     */
+    public static JsonProvider provider() {
+        ClassLoader cl = Thread.currentThread().getContextClassLoader();
+        if (cl == null) {
+            cl = JsonProvider.class.getClassLoader();
+        }
+
+        final String factoryClassName = System.getProperty(JSONP_PROVIDER_FACTORY);
+        if (factoryClassName != null) {
+            return newInstance(factoryClassName, cl);
+        }
+
+        synchronized (CLASSLOADER_CACHE) {
+            WeakReference<JsonProvider> ref = CLASSLOADER_CACHE.get(cl);
+            JsonProvider cached = (ref != null) ? ref.get() : null;
+            if (cached != null) {
+                return cached;
+            }
+        }
+        LOG.log(Level.FINE, "Cache miss for classloader [{0}]; starting discovery", cl);
+        JsonProvider discovered = discover(cl);
+        synchronized (CLASSLOADER_CACHE) {
+            WeakReference<JsonProvider> existing = CLASSLOADER_CACHE.putIfAbsent(cl, new WeakReference<>(discovered));
+            return (existing != null && existing.get() != null) ? existing.get() : discovered;
+        }
+    }
+
+    private static JsonProvider discover(ClassLoader cl) {
+        LOG.log(Level.FINE, "Checking ServiceLoader");
+        ServiceLoader<JsonProvider> loader = ServiceLoader.load(JsonProvider.class, cl);
+        Iterator<JsonProvider> it = loader.iterator();
+        if (it.hasNext()) {
+            JsonProvider provider = it.next();
+            LOG.log(Level.FINE, "ServiceLoader loading Facility used; returning object [{0}]",
+                    provider.getClass().getName());
+            return provider;
+        }
+
+        // handling OSGi (specific default)
+        if (isOsgi()) {
+            LOG.log(Level.FINE, "Checking OSGi");
+            JsonProvider provider = lookupUsingOSGiServiceLoader(JsonProvider.class);
+            if (provider != null) {
+                LOG.log(Level.FINE, "OSGi loading facility used; returning object [{0}].",
+                        provider.getClass().getName());
+                return provider;
+            }
+        }
+
+        // else no provider found
+        LOG.fine("Trying to create the platform default provider");
+        return newInstance(DEFAULT_PROVIDER, cl);
+    }
+
+    /**
+     * Creates a new instance from the specified class
+     * @param className name of the class to instantiate
+     * @param cl the classloader to use for resolving the provider class
+     * @return the JsonProvider instance
+     * @throws JsonException for issues during creation of an instance of the JsonProvider
+     */
+    private static JsonProvider newInstance(String className, ClassLoader cl) {
+        try {
+            @SuppressWarnings("unchecked")
+            Class<JsonProvider> clazz = (Class<JsonProvider>) Class.forName(className, true, cl);
+            return clazz.getConstructor().newInstance();
+        } catch (ClassNotFoundException x) {
+            throw new JsonException(
+                    "Provider " + className + " not found", x);
+        } catch (Exception x) {
+            throw new JsonException(
+                    "Provider " + className + " could not be instantiated: " + x,
+                    x);
+        }
+    }
+
+    /**
+     * Creates a JSON parser from a character stream.
+     *
+     * @param reader i/o reader from which JSON is to be read
+     * @return a JSON parser
+     */
+    public abstract JsonParser createParser(Reader reader);
+
+    /**
+     * Creates a JSON parser from the specified byte stream.
+     * The character encoding of the stream is determined
+     * as defined in <a href="http://tools.ietf.org/rfc/rfc7159.txt">RFC 7159
+     * </a>.
+     *
+     * @param in i/o stream from which JSON is to be read
+     * @throws JsonException if encoding cannot be determined
+     *         or i/o error (IOException would be cause of JsonException)
+     * @return a JSON parser
+     */
+    public abstract JsonParser createParser(InputStream in);
+
+    /**
+     * Creates a parser factory for creating {@link JsonParser} instances.
+     *
+     * @return a JSON parser factory
+     *
+    public abstract JsonParserFactory createParserFactory();
+     */
+
+    /**
+     * Creates a parser factory for creating {@link JsonParser} instances.
+     * The factory is configured with the specified map of
+     * provider specific configuration properties. Provider implementations
+     * should ignore any unsupported configuration properties specified in
+     * the map.
+     *
+     * @param config a map of provider specific properties to configure the
+     *               JSON parsers. The map may be empty or null
+     * @return a JSON parser factory
+     */
+    public abstract JsonParserFactory createParserFactory(Map<String, ?> config);
+
+    /**
+     * Creates a JSON generator for writing JSON text to a character stream.
+     *
+     * @param writer a i/o writer to which JSON is written
+     * @return a JSON generator
+     */
+    public abstract JsonGenerator createGenerator(Writer writer);
+
+    /**
+     * Creates a JSON generator for writing JSON text to a byte stream.
+     *
+     * @param out i/o stream to which JSON is written
+     * @return a JSON generator
+     */
+    public abstract JsonGenerator createGenerator(OutputStream out);
+
+    /**
+     * Creates a generator factory for creating {@link JsonGenerator} instances.
+     *
+     * @return a JSON generator factory
+     *
+    public abstract JsonGeneratorFactory createGeneratorFactory();
+     */
+
+    /**
+     * Creates a generator factory for creating {@link JsonGenerator} instances.
+     * The factory is configured with the specified map of provider specific
+     * configuration properties. Provider implementations should
+     * ignore any unsupported configuration properties specified in the map.
+     *
+     * @param config a map of provider specific properties to configure the
+     *               JSON generators. The map may be empty or null
+     * @return a JSON generator factory
+     */
+    public abstract JsonGeneratorFactory createGeneratorFactory(Map<String, ?> config);
+
+    /**
+     * Creates a JSON reader from a character stream.
+     *
+     * @param reader a reader from which JSON is to be read
+     * @return a JSON reader
+     */
+    public abstract JsonReader createReader(Reader reader);
+
+    /**
+     * Creates a JSON reader from a byte stream. The character encoding of
+     * the stream is determined as described in
+     * <a href="http://tools.ietf.org/rfc/rfc7159.txt">RFC 7159</a>.
+     *
+     * @param in a byte stream from which JSON is to be read
+     * @return a JSON reader
+     */
+    public abstract JsonReader createReader(InputStream in);
+
+    /**
+     * Creates a JSON writer to write a
+     * JSON {@link JsonObject object} or {@link JsonArray array}
+     * structure to the specified character stream.
+     *
+     * @param writer to which JSON object or array is written
+     * @return a JSON writer
+     */
+    public abstract JsonWriter createWriter(Writer writer);
+
+    /**
+     * Creates a JSON writer to write a
+     * JSON {@link JsonObject object} or {@link JsonArray array}
+     * structure to the specified byte stream. Characters written to
+     * the stream are encoded into bytes using UTF-8 encoding.
+     *
+     * @param out to which JSON object or array is written
+     * @return a JSON writer
+     */
+    public abstract JsonWriter createWriter(OutputStream out);
+
+    /**
+     * Creates a writer factory for creating {@link JsonWriter} objects.
+     * The factory is configured with the specified map of provider specific
+     * configuration properties. Provider implementations should ignore any
+     * unsupported configuration properties specified in the map.
+     *
+     * @param config a map of provider specific properties to configure the
+     *               JSON writers. The map may be empty or null
+     * @return a JSON writer factory
+     */
+    public abstract JsonWriterFactory createWriterFactory(Map<String,?> config);
+
+    /**
+     * Creates a reader factory for creating {@link JsonReader} objects.
+     * The factory is configured with the specified map of provider specific
+     * configuration properties. Provider implementations should ignore any
+     * unsupported configuration properties specified in the map.
+     *
+     * @param config a map of provider specific properties to configure the
+     *               JSON readers. The map may be empty or null
+     * @return a JSON reader factory
+     */
+    public abstract JsonReaderFactory createReaderFactory(Map<String,?> config);
+
+    /**
+     * Creates a JSON object builder.
+     *
+     * @return a JSON object builder
+     */
+    public abstract JsonObjectBuilder createObjectBuilder();
+
+    /**
+     * Creates a JSON object builder, initialized with the specified object.
+     *
+     * @param object the initial JSON object in the builder
+     * @return a JSON object builder
+     *
+     * @since 1.1
+     */
+    public JsonObjectBuilder createObjectBuilder(JsonObject object) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Creates a JSON object builder, initialized with the data from specified {@code map}.
+     * If the @{code map} contains {@link Optional}s then resulting JSON object builder
+     * contains the key from the {@code map} only if the {@link Optional} is not empty.
+     *
+     * @param map the initial object in the builder
+     * @return a JSON object builder
+     * @exception IllegalArgumentException if the value from the {@code map} cannot be converted
+     *            to the corresponding {@link JsonValue}
+     *
+     * @since 1.1
+     */
+    public JsonObjectBuilder createObjectBuilder(Map<String, ?> map) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Creates a JSON array builder.
+     *
+     * @return a JSON array builder
+     */
+    public abstract JsonArrayBuilder createArrayBuilder();
+
+    /**
+     * Creates a JSON array builder, initialized with the specified array.
+     *
+     * @param array the initial JSON array in the builder
+     * @return a JSON array builder
+     *
+     * @since 1.1
+     */
+    public JsonArrayBuilder createArrayBuilder(JsonArray array) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Creates JSON Pointer (<a href="http://tools.ietf.org/html/rfc6901">RFC 6901</a>)
+     * from given {@code jsonPointer} string.
+     * <ul>
+     *     <li>An empty {@code jsonPointer} string defines a reference to the target itself.</li>
+     *     <li>If the {@code jsonPointer} string is non-empty, it must be a sequence of '{@code /}' prefixed tokens.</li>
+     * </ul>
+     *
+     * @param jsonPointer the JSON Pointer string
+     * @throws NullPointerException if {@code jsonPointer} is {@code null}
+     * @throws JsonException if {@code jsonPointer} is not a valid JSON Pointer
+     * @return a JSON Pointer
+     *
+     * @since 1.1
+     */
+    public JsonPointer createPointer(String jsonPointer) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Creates a JSON Patch builder (<a href="http://tools.ietf.org/html/rfc6902">RFC 6902</a>).
+     *
+     * @return a JSON Patch builder
+     *
+     * @since 1.1
+     */
+    public JsonPatchBuilder createPatchBuilder() {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Creates a JSON Patch builder
+     * (<a href="http://tools.ietf.org/html/rfc6902">RFC 6902</a>),
+     * initialized with the specified operations.
+     *
+     * @param array the initial patch operations
+     * @return a JSON Patch builder
+     *
+     * @since 1.1
+     */
+    public JsonPatchBuilder createPatchBuilder(JsonArray array) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Creates a JSON Patch (<a href="http://tools.ietf.org/html/rfc6902">RFC 6902</a>)
+     * from the specified operations.
+     *
+     * @param array patch operations
+     * @return a JSON Patch
+     *
+     * @since 1.1
+     */
+    public JsonPatch createPatch(JsonArray array) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Generates a JSON Patch (<a href="http://tools.ietf.org/html/rfc6902">RFC 6902</a>)
+     * from the source and target {@code JsonStructure}.
+     * The generated JSON Patch need not be unique.
+     *
+     * @param source the source
+     * @param target the target, must be the same type as the source
+     * @return a JSON Patch which when applied to the source, yields the target
+     *
+     * @since 1.1
+     */
+    public JsonPatch createDiff(JsonStructure source, JsonStructure target) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Creates JSON Merge Patch (<a href="http://tools.ietf.org/html/rfc7396">RFC 7396</a>)
+     * from specified {@code JsonValue}.
+     *
+     * @param patch the patch
+     * @return a JSON Merge Patch
+     *
+     * @since 1.1
+     */
+    public JsonMergePatch createMergePatch(JsonValue patch) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Generates a JSON Merge Patch (<a href="http://tools.ietf.org/html/rfc7396">RFC 7396</a>)
+     * from the source and target {@code JsonValue}s
+     * which when applied to the {@code source}, yields the {@code target}.
+     *
+     * @param source the source
+     * @param target the target
+     * @return a JSON Merge Patch
+     *
+     * @since 1.1
+     */
+    public JsonMergePatch createMergeDiff(JsonValue source, JsonValue target) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Creates a JSON array builder, initialized with the content of specified {@code collection}.
+     * If the @{code collection} contains {@link Optional}s then resulting JSON array builder
+     * contains the value from the {@code collection} only if the {@link Optional} is not empty.
+     *
+     * @param collection the initial data for the builder
+     * @return a JSON array builder
+     * @exception IllegalArgumentException if the value from the {@code collection} cannot be converted
+     *            to the corresponding {@link JsonValue}
+     *
+     * @since 1.1
+     */
+    public JsonArrayBuilder createArrayBuilder(Collection<?> collection) {
+        throw new UnsupportedOperationException();
+    }
+
+
+    /**
+     * Creates a builder factory for creating {@link JsonArrayBuilder}
+     * and {@link JsonObjectBuilder} objects.
+     * The factory is configured with the specified map of provider specific
+     * configuration properties. Provider implementations should ignore any
+     * unsupported configuration properties specified in the map.
+     *
+     * @param config a map of provider specific properties to configure the
+     *               JSON builders. The map may be empty or null
+     * @return a JSON builder factory
+     */
+    public abstract JsonBuilderFactory createBuilderFactory(Map<String,?> config);
+
+    /**
+     * Creates a JsonString.
+     *
+     * @param value a JSON string
+     * @return the JsonString for the string
+     *
+     * @since 1.1
+     */
+    public JsonString createValue(String value) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Creates a JsonNumber.
+     *
+     * @param value a JSON number
+     * @return the JsonNumber for the number
+     *
+     * @since 1.1
+     */
+    public JsonNumber createValue(int value) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Creates a JsonNumber.
+     *
+     * @param value a JSON number
+     * @return the JsonNumber for the number
+     *
+     * @since 1.1
+     */
+    public JsonNumber createValue(long value) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Creates a JsonNumber.
+     *
+     * @param value a JSON number
+     * @return the JsonNumber for the number
+     *
+     * @since 1.1
+     */
+    public JsonNumber createValue(double value) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Creates a JsonNumber.
+     *
+     * @param value a JSON number
+     * @return the JsonNumber for the number
+     *
+     * @since 1.1
+     */
+    public JsonNumber createValue(BigDecimal value) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Creates a JsonNumber.
+     *
+     * @param value a JSON number
+     * @return the JsonNumber for the number
+     *
+     * @since 1.1
+     */
+    public JsonNumber createValue(BigInteger value) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Creates a JsonNumber.
+     *
+     * When it is not implemented it checks the type and delegates
+     * to an existing method that already handles that type. It throws
+     * UnsupportedOperationException in case the type is not known.
+     *
+     * @param number a JSON number
+     * @return the JsonNumber for the number
+     *
+     * @since 2.1
+     */
+    public JsonNumber createValue(Number number) {
+        if (number instanceof Integer) {
+            return createValue(number.intValue());
+        } else if (number instanceof Long) {
+            return createValue(number.longValue());
+        } else if (number instanceof Double) {
+            return createValue(number.doubleValue());
+        } else if (number instanceof BigInteger) {
+            return createValue((BigInteger) number);
+        } else if (number instanceof BigDecimal) {
+            return createValue((BigDecimal) number);
+        } else {
+            throw new UnsupportedOperationException(number + " type is not known");
+        }
+    }
+
+    /** OSGI aware service loader by HK2 */
+    private static final String OSGI_SERVICE_LOADER_CLASS_NAME = "org.glassfish.hk2.osgiresourcelocator.ServiceLoader";
+
+    /**
+     * Check availability of HK2 service loader.
+     *
+     * @return true if HK2 service locator is available
+     */
+    private static boolean isOsgi() {
+        try {
+            Class.forName(OSGI_SERVICE_LOADER_CLASS_NAME);
+            return true;
+        } catch (ClassNotFoundException ignored) {
+        }
+        return false;
+    }
+
+    /**
+     * Lookup the service class by the HK2 service locator.
+     *
+     * @param serviceClass service class
+     * @param <T> type of the service
+     * @return a provider
+     */
+    private static <T> T lookupUsingOSGiServiceLoader(Class<? extends T> serviceClass) {
+        try {
+            // Use reflection to avoid having any dependendcy on HK2 ServiceLoader class
+            Class<?>[] args = new Class<?>[]{serviceClass};
+            Class<?> target = Class.forName(OSGI_SERVICE_LOADER_CLASS_NAME);
+            Method m = target.getMethod("lookupProviderInstances", Class.class);
+            @SuppressWarnings({"unchecked"})
+            Iterator<? extends T> iter = ((Iterable<? extends T>) m.invoke(null, (Object[]) args)).iterator();
+            return iter.hasNext() ? iter.next() : null;
+        } catch (Exception ex) {
+            LOG.log(Level.FINE, "Unable to find from OSGi: [" + serviceClass.getName() + "]", ex);
+            return null;
+        }
+    }
+
+}

--- a/dev/io.openliberty.jakarta.jsonp.2.2/src/jakarta/json/spi/package-info.java
+++ b/dev/io.openliberty.jakarta.jsonp.2.2/src/jakarta/json/spi/package-info.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2012, 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+/**
+ * Service Provider Interface (SPI) to plug in implementations for
+ * JSON processing objects.
+ *
+ * <p> {@link jakarta.json.spi.JsonProvider JsonProvider} is an abstract class 
+ * that provides a service for creating JSON processing instances.
+ * A <i>service provider</i> for {@code JsonProvider} provides an 
+ * specific implementation by subclassing and implementing the methods in
+ * {@code JsonProvider}. This enables using custom, efficient JSON processing
+ * implementations (for e.g. parser and generator) other than the default ones.
+ *
+ * <p>The API locates and loads providers using {@link java.util.ServiceLoader}.
+ *
+ * Unless otherwise noted, passing a null argument to a constructor or method
+ * in any class or interface in this package will cause a NullPointerException
+ * to be thrown.
+ *
+ * @since JSON Processing 1.0
+ */
+package jakarta.json.spi;

--- a/dev/io.openliberty.jakarta.jsonp.2.2/src/jakarta/json/stream/JsonCollectors.java
+++ b/dev/io.openliberty.jakarta.jsonp.2.2/src/jakarta/json/stream/JsonCollectors.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright (c) 2015, 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.json.stream;
+
+import java.util.Map;
+import java.util.HashMap;
+import java.util.stream.Collector;
+import java.util.function.BinaryOperator;
+import java.util.function.Function;
+import java.util.function.BiConsumer;
+
+import jakarta.json.Json;
+import jakarta.json.JsonArray;
+import jakarta.json.JsonArrayBuilder;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonObjectBuilder;
+import jakarta.json.JsonValue;
+import jakarta.json.JsonException;
+
+/**
+ * This class contains some implementations of {@code java.util.stream.Collector} for accumulating
+ * {@link JsonValue}s into {@link JsonArray} and {@link JsonObject}.
+ *
+ * @since 1.1
+ */
+
+public final class JsonCollectors {
+
+    /**
+     * No instantiation.
+     */
+    private JsonCollectors() {
+    }
+
+    /**
+     * Constructs a {@code java.util.stream.Collector} that accumulates the input {@code JsonValue}
+     * elements into a {@code JsonArray}.
+     *
+     * @return the constructed Collector
+     */
+    public static Collector<JsonValue, JsonArrayBuilder, JsonArray> toJsonArray() {
+        return Collector.of(
+                Json::createArrayBuilder,
+                JsonArrayBuilder::add,
+                JsonArrayBuilder::addAll,
+                JsonArrayBuilder::build);
+    }
+
+    /**
+     * Constructs a {@code java.util.stream.Collector} that accumulates the input {@code Map.Entry<String,JsonValue>}
+     * elements into a {@code JsonObject}.
+     *
+     * @return the constructed Collector
+     */
+    public static Collector<Map.Entry<String, JsonValue>, JsonObjectBuilder, JsonObject> toJsonObject() {
+        return Collector.of(
+                Json::createObjectBuilder,
+                (JsonObjectBuilder b, Map.Entry<String, JsonValue> v) -> b.add(v.getKey(), v.getValue()),
+                JsonObjectBuilder::addAll,
+                JsonObjectBuilder::build);
+    }
+
+    /**
+     * Constructs a {@code java.util.stream.Collector} that accumulates the input {@code JsonValue}
+     * elements into a {@code JsonObject}.  The name/value pairs of the {@code JsonObject} are computed
+     * by applying the provided mapping functions.
+     *
+     * @param keyMapper a mapping function to produce names.
+     * @param valueMapper a mapping function to produce values
+     * @return the constructed Collector
+     */
+    public static Collector<JsonValue, JsonObjectBuilder, JsonObject>
+                toJsonObject(Function<JsonValue, String> keyMapper,
+                             Function<JsonValue, JsonValue> valueMapper) {
+        return Collector.of(
+                Json::createObjectBuilder,
+                (b, v) -> b.add(keyMapper.apply(v), valueMapper.apply(v)),
+                JsonObjectBuilder::addAll,
+                JsonObjectBuilder::build,
+                Collector.Characteristics.UNORDERED);
+    }
+
+    /**
+     * Constructs a {@code java.util.stream.Collector} that implements a "group by" operation on the
+     * input {@code JsonValue} elements. A classifier function maps the input {@code JsonValue}s to keys, and
+     * the {@code JsonValue}s are partitioned into groups according to the value of the key.
+     * A reduction operation is performed on the {@code JsonValue}s in each group, using the
+     * downstream {@code Collector}. For each group, the key and the results of the reduction operation
+     * become the name/value pairs of the resultant {@code JsonObject}.
+     *
+     * @param <T> the intermediate accumulation {@code JsonArrayBuilder} of the downstream collector
+     * @param classifier a function mapping the input {@code JsonValue}s to a String, producing keys
+     * @param downstream a {@code Collector} that implements a reduction operation on the
+     *        {@code JsonValue}s in each group.
+     * @return the constructed {@code Collector}
+     */
+    public static <T extends JsonArrayBuilder> Collector<JsonValue, Map<String, T>, JsonObject>
+                groupingBy(Function<JsonValue, String> classifier,
+                           Collector<JsonValue, T, JsonArray> downstream) {
+
+        BiConsumer<Map<String, T>, JsonValue> accumulator =
+            (map, value) -> {
+                String key = classifier.apply(value);
+                if (key == null) {
+                    throw new JsonException("element cannot be mapped to a null key");
+                }
+                // Build a map of key to JsonArrayBuilder
+                T arrayBuilder =
+                    map.computeIfAbsent(key, v->downstream.supplier().get());
+                // Add elements from downstream Collector to the arrayBuilder.
+                downstream.accumulator().accept(arrayBuilder, value);
+            };
+        Function<Map<String, T>, JsonObject> finisher =
+            map -> {
+                // transform the map of name: JsonArrayBuilder to
+                //                      name: JsonArray
+                // using the downstream collector for reducing the JsonArray
+                JsonObjectBuilder objectBuilder = Json.createObjectBuilder();
+                map.forEach((k, v) -> {
+                    JsonArray array = downstream.finisher().apply(v);
+                    objectBuilder.add(k, array);
+                });
+                return objectBuilder.build();
+            };
+        BinaryOperator<Map<String, T>> combiner =
+            (map1, map2) -> {
+                map1.putAll(map2);
+                return map1;
+            };
+        return Collector.of(HashMap::new, accumulator, combiner, finisher,
+            Collector.Characteristics.UNORDERED);
+    }
+
+    /**
+     * Constructs a {@code java.util.stream.Collector} that implements a "group by" operation on the
+     * input {@code JsonValue} elements. A classifier function maps the input {@code JsonValue}s to keys, and
+     * the {@code JsonValue}s are partitioned into groups according to the value of the key.
+     * The {@code JsonValue}s in each group are added to a {@code JsonArray}.  The key and the
+     * {@code JsonArray} in each group becomes the name/value pair of the resultant {@code JsonObject}.
+     *
+     * @param classifier a function mapping the input {@code JsonValue}s to a String, producing keys
+     * @return the constructed {@code Collector}
+     */
+    public static Collector<JsonValue, Map<String, JsonArrayBuilder>, JsonObject>
+                groupingBy(Function<JsonValue, String> classifier) {
+        return groupingBy(classifier, toJsonArray());
+    }
+}
+

--- a/dev/io.openliberty.jakarta.jsonp.2.2/src/jakarta/json/stream/JsonGenerationException.java
+++ b/dev/io.openliberty.jakarta.jsonp.2.2/src/jakarta/json/stream/JsonGenerationException.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2012, 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.json.stream;
+
+import jakarta.json.JsonException;
+
+/**
+ * {@code JsonGenerationException} indicates an incorrect JSON is
+ * being generated.
+ */
+public class JsonGenerationException extends JsonException {
+
+    /** for serialization */
+    private static final long serialVersionUID = -207609100806940680L;
+
+    /**
+     * Constructs a new runtime exception with the specified detail message.
+     * The cause is not initialized, and may subsequently be initialized by a
+     * call to {@link #initCause}.
+     *
+     * @param message the detail message. The detail message is saved for
+     *                later retrieval by the {@link #getMessage()} method.
+     */
+    public JsonGenerationException(String message) {
+        super(message);
+    }
+
+    /**
+     * Constructs a new runtime exception with the specified detail message and
+     * cause.  <p>Note that the detail message associated with
+     * {@code cause} is <i>not</i> automatically incorporated in
+     * this runtime exception's detail message.
+     *
+     * @param message the detail message (which is saved for later retrieval
+     *                by the {@link #getMessage()} method).
+     * @param cause the cause (which is saved for later retrieval by the
+     *              {@link #getCause()} method). (A <code>null</code> value is
+     *              permitted, and indicates that the cause is nonexistent or
+     *              unknown.)
+     */
+    public JsonGenerationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+}
+

--- a/dev/io.openliberty.jakarta.jsonp.2.2/src/jakarta/json/stream/JsonGenerator.java
+++ b/dev/io.openliberty.jakarta.jsonp.2.2/src/jakarta/json/stream/JsonGenerator.java
@@ -1,0 +1,543 @@
+/*
+ * Copyright (c) 2011, 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.json.stream;
+
+import jakarta.json.JsonValue;
+import java.io.Closeable;
+import java.io.Flushable;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+
+/**
+ * Writes JSON data to an output source in a streaming way. The class
+ * {@link jakarta.json.Json} contains methods to create generators for character
+ * or output streams ({@link java.io.Writer} and {@link java.io.OutputStream}).
+ *
+ * <p>
+ * The following example shows how to create a JSON generator:
+ * <pre>
+ * <code>
+ * JsonGenerator generator = Json.createGenerator(...);
+ * </code>
+ * </pre>
+ *
+ * <p>
+ * The class {@link JsonGeneratorFactory} also contains methods to create
+ * {@code JsonGenerator} instances. {@link JsonGeneratorFactory} should be used
+ * when creating multiple generator instances, as in the following example:
+ * <pre>
+ * <code>
+ * JsonGeneratorFactory factory = Json.createGeneratorFactory();
+ * JsonGenerator generator1 = factory.createGenerator(...);
+ * JsonGenerator generator2 = factory.createGenerator(...);
+ * </code>
+ * </pre>
+ *
+ * <p>
+ * JSON objects can be created using {@code JsonGenerator} by calling the
+ * {@link #writeStartObject()} method and then adding name/value pairs with the
+ * {@code write} method.
+ * <p>
+ * The following example shows how to generate an empty JSON object:
+ * <pre>
+ * <code>
+ * JsonGenerator generator = ...;
+ * generator.writeStartObject().writeEnd().close();
+ * </code>
+ * </pre>
+ *
+ * JSON arrays can be created using {@code JsonGenerator} by calling the
+ * {@link #writeStartArray()} method and then adding values with the
+ * {@code write} method.
+ *
+ * <p>
+ * The following example shows how to generate an empty JSON array:
+ * <pre>
+ * <code>
+ * JsonGenerator generator = ...;
+ * generator.writeStartArray().writeEnd().close();
+ * </code>
+ * </pre>
+ *
+ * <p>
+ * Other JSON values (that are not JSON objects or arrays) can be created
+ * by calling the appropiate {@code write} methods.
+ * <p>
+ * The following example shows how to generate a JSON string:
+ * <pre><code>
+ * JsonGenerator generator = ...;
+ * generator.write("message").close();
+ * </code></pre>
+ *
+ * {@code JsonGenerator} methods can be chained as in the following example:
+ * <pre>
+ * <code>
+ * generator
+ *     .writeStartObject()
+ *         .write("firstName", "John")
+ *         .write("lastName", "Smith")
+ *         .write("age", 25)
+ *         .writeStartObject("address")
+ *             .write("streetAddress", "21 2nd Street")
+ *             .write("city", "New York")
+ *             .write("state", "NY")
+ *             .write("postalCode", "10021")
+ *         .writeEnd()
+ *         .writeStartArray("phoneNumber")
+ *             .writeStartObject()
+ *                 .write("type", "home")
+ *                 .write("number", "212 555-1234")
+ *             .writeEnd()
+ *             .writeStartObject()
+ *                 .write("type", "fax")
+ *                 .write("number", "646 555-4567")
+ *             .writeEnd()
+ *         .writeEnd()
+ *     .writeEnd();
+ * generator.close();
+ * </code>
+ * </pre>
+ *
+ * The example code above generates the following JSON (or equivalent):
+ * <pre>
+ * <code>
+ * {
+ *   "firstName": "John", "lastName": "Smith", "age": 25,
+ *   "address" : {
+ *       "streetAddress": "21 2nd Street",
+ *       "city": "New York",
+ *       "state": "NY",
+ *       "postalCode": "10021"
+ *   },
+ *   "phoneNumber": [
+ *       {"type": "home", "number": "212 555-1234"},
+ *       {"type": "fax", "number": "646 555-4567"}
+ *    ]
+ * }
+ * </code>
+ * </pre>
+ *
+ * The generated JSON text must strictly conform to the grammar defined in
+ * <a href="http://www.ietf.org/rfc/rfc7159.txt">RFC 7159</a>.
+ *
+ * @see jakarta.json.Json
+ * @see JsonGeneratorFactory
+ */
+public interface JsonGenerator extends Flushable, /*Auto*/Closeable {
+    /**
+     * Configuration property to generate JSON prettily. All providers
+     * must support this property. The value of the property could be
+     * be anything.
+     */
+    String PRETTY_PRINTING = "jakarta.json.stream.JsonGenerator.prettyPrinting" ;
+
+    /**
+     * Writes the JSON start object character. It starts a new child object
+     * context within which JSON name/value pairs can be written to the object.
+     * This method is valid only in an array context, field context or in no context (when a
+     * context is not yet started). This method can only be called once in
+     * no context.
+     *
+     * @return this generator
+     * @throws jakarta.json.JsonException if an i/o error occurs (IOException
+     * would be cause of JsonException)
+     * @throws JsonGenerationException if this method is called within an
+     *      object context or if it is called more than once in no context.
+     */
+    JsonGenerator writeStartObject();
+
+    /**
+     * Writes the JSON name/start object character pair in the current
+     * object context. It starts a new child object context within which JSON
+     * name/value pairs can be written to the object.
+     *
+     * @param name a name within the JSON name/object pair to be written
+     * @return this generator
+     * @throws jakarta.json.JsonException if an i/o error occurs (IOException
+     * would be cause of JsonException)
+     * @throws JsonGenerationException if this method is not called within an
+     *     object context
+     */
+    JsonGenerator writeStartObject(String name);
+
+    /**
+     * Writes the JSON name with a colon. It starts a field context, in which valid
+     * options are writing a value, starting an object or an array.
+     *
+     * Writing value closes field context, if object or array is started after field name,
+     * field context will be closed after object/array close.
+     *
+     * @param name name of json field
+     * @return this generator
+     * @throws jakarta.json.JsonException if an i/o error occurs (IOException
+     * would be cause of JsonException)
+     * @throws JsonGenerationException if this method is not called within an
+     *     object context
+     *
+     * @since 1.1
+     */
+    JsonGenerator writeKey(String name);
+
+    /**
+     * Writes the JSON start array character. It starts a new child array
+     * context within which JSON values can be written to the array. This
+     * method is valid only in an array context, field context or in no context (when a
+     * context is not yet started). This method can only be called once in
+     * no context.
+     *
+     * @return this generator
+     * @throws jakarta.json.JsonException if an i/o error occurs (IOException
+     * would be cause of JsonException)
+     * @throws JsonGenerationException if this method is called within an
+     *      object context or if called more than once in no context
+     */
+    JsonGenerator writeStartArray();
+
+    /**
+     * Writes the JSON name/start array character pair with in the current
+     * object context. It starts a new child array context within which JSON
+     * values can be written to the array.
+     *
+     * @param name a name within the JSON name/array pair to be written
+     * @return this generator
+     * @throws jakarta.json.JsonException if an i/o error occurs (IOException
+     * would be cause of JsonException)
+     * @throws JsonGenerationException if this method is not called within
+     *      an object context
+     */
+    JsonGenerator writeStartArray(String name);
+
+    /**
+     * Writes a JSON name/value pair in the current object context.
+     *
+     * @param name a name in the JSON name/value pair to be written in
+     *             current JSON object
+     * @param value a value in the JSON name/value pair to be written in
+     *             current JSON object
+     * @return this generator
+     * @throws jakarta.json.JsonException if an i/o error occurs (IOException
+     * would be cause of JsonException)
+     * @throws JsonGenerationException if this method is not called within an
+     *      object context
+     */
+    JsonGenerator write(String name, JsonValue value);
+
+    /**
+     * Writes a JSON name/string value pair in the current object context.
+     * The specified value is written as JSON string value.
+     *
+     * @param name a name in the JSON name/string pair to be written in
+     *             current JSON object
+     * @param value a value in the JSON name/string pair to be written in
+     *             current JSON object
+     * @return this generator
+     * @throws jakarta.json.JsonException if an i/o error occurs (IOException
+     * would be cause of JsonException)
+     * @throws JsonGenerationException if this method is not called within an
+     *      object context
+     */
+    JsonGenerator write(String name, String value);
+
+    /**
+     * Writes a JSON name/number value pair in the current object context.
+     * The specified value is written as a JSON number value. The string
+     * {@code new BigDecimal(value).toString()}
+     * is used as the text value for writing.
+     *
+     * @param name a name in the JSON name/number pair to be written in
+     *             current JSON object
+     * @param value a value in the JSON name/number pair to be written in
+     *             current JSON object
+     * @return this generator
+     * @throws jakarta.json.JsonException if an i/o error occurs (IOException
+     * would be cause of JsonException)
+     * @throws JsonGenerationException if this method is not called within an
+     *      object context.
+     */
+    JsonGenerator write(String name, BigInteger value);
+
+    /**
+     * Writes a JSON name/number value pair in the current object context.
+     * The specified value is written as a JSON number value. The specified
+     * value's {@code toString()} is used as the text value for writing.
+     *
+     * @param name a name in the JSON name/number pair to be written in
+     *             current JSON object
+     * @param value a value in the JSON name/number pair to be written in
+     *             current JSON object
+     * @return this generator
+     * @throws jakarta.json.JsonException if an i/o error occurs (IOException
+     * would be cause of JsonException)
+     * @throws JsonGenerationException if this method is not called within an
+     *      object context.
+     */
+    JsonGenerator write(String name, BigDecimal value);
+
+    /**
+     * Writes a JSON name/number value pair in the current object context.
+     * The specified value is written as a JSON number value. The string
+     * {@code new BigDecimal(value).toString()} is used as the text value
+     * for writing.
+     *
+     * @param name a name in the JSON name/number pair to be written in
+     *             current JSON object
+     * @param value a value in the JSON name/number pair to be written in
+     *             current JSON object
+     * @return this generator
+     * @throws jakarta.json.JsonException if an i/o error occurs (IOException
+     * would be cause of JsonException)
+     * @throws JsonGenerationException if this method is not called within an
+     *      object context.
+     */
+    JsonGenerator write(String name, int value);
+
+    /**
+     * Writes a JSON name/number value pair in the current object context.
+     * The specified value is written as a JSON number value. The string
+     * {@code new BigDecimal(value).toString()} is used as the text
+     * value for writing.
+     *
+     * @param name a name in the JSON name/number pair to be written in
+     *             current JSON object
+     * @param value a value in the JSON name/number pair to be written in
+     *             current JSON object
+     * @return this generator
+     * @throws jakarta.json.JsonException if an i/o error occurs (IOException
+     * would be cause of JsonException)
+     * @throws JsonGenerationException if this method is not called within an
+     *      object context.
+     */
+    JsonGenerator write(String name, long value);
+
+    /**
+     * Writes a JSON name/number value pair in the current object context.
+     * The specified value is written as a JSON number value. The string
+     * {@code BigDecimal.valueOf(double).toString()}
+     * is used as the text value for writing.
+     *
+     * @param name a name in the JSON name/number pair to be written in
+     *             current JSON object
+     * @param value a value in the JSON name/number pair to be written in
+     *             current JSON object
+     * @return this generator
+     * @throws jakarta.json.JsonException if an i/o error occurs (IOException
+     * would be cause of JsonException)
+     * @throws NumberFormatException if the value is Not-a-Number (NaN) or infinity.
+     * @throws JsonGenerationException if this method is not called within an
+     *      object context
+     */
+    JsonGenerator write(String name, double value);
+
+    /**
+     * Writes a JSON name/boolean value pair in the current object context.
+     * If value is true, it writes the JSON {@code true} value, otherwise
+     * it writes the JSON {@code false} value.
+     *
+     * @param name a name in the JSON name/boolean pair to be written in
+     *             current JSON object
+     * @param value a value in the JSON name/boolean pair to be written in
+     *             current JSON object
+     * @return this generator
+     * @throws jakarta.json.JsonException if an i/o error occurs (IOException
+     * would be cause of JsonException)
+     * @throws JsonGenerationException if this method is not called within an
+     *      object context.
+     */
+    JsonGenerator write(String name, boolean value);
+
+
+    /**
+     * Writes a JSON name/null value pair in an current object context.
+     *
+     * @param name a name in the JSON name/null pair to be written in
+     *             current JSON object
+     * @return this generator
+     * @throws jakarta.json.JsonException if an i/o error occurs (IOException
+     * would be cause of JsonException)
+     * @throws JsonGenerationException if this method is not called within an
+     *      object context
+     */
+    JsonGenerator writeNull(String name);
+
+    /**
+     * Writes the end of the current context. If the current context is
+     * an array context, this method writes the end-of-array character (']').
+     * If the current context is an object context, this method writes the
+     * end-of-object character ('}'). After writing the end of the current
+     * context, the parent context becomes the new current context.
+     * If parent context is field context, it is closed.
+     *
+     * @return this generator
+     * @throws jakarta.json.JsonException if an i/o error occurs (IOException
+     * would be cause of JsonException)
+     * @throws JsonGenerationException if this method is called in no context.
+     */
+    JsonGenerator writeEnd();
+
+    /**
+     * Writes the specified value as a JSON value within
+     * the current array, field or root context.
+     *
+     * @param value a value to be written in current JSON array
+     * @return this generator
+     * @throws jakarta.json.JsonException if an i/o error occurs (IOException
+     * would be cause of JsonException)
+     * @throws JsonGenerationException if this method is not called within an
+     *      array, root or field context.
+     */
+    JsonGenerator write(JsonValue value);
+
+    /**
+     * Writes the specified value as a JSON string value within
+     * the current array, field or root context.
+     *
+     * @param value a value to be written in current JSON array
+     * @return this generator
+     * @throws jakarta.json.JsonException if an i/o error occurs (IOException
+     * would be cause of JsonException)
+     * @throws JsonGenerationException if this method is not called within an
+     *      array, root or field context.
+     */
+    JsonGenerator write(String value);
+
+    /**
+     * Writes the specified value as a JSON number value within
+     * the current array, field or root context. The specified value's {@code toString()}
+     * is used as the the text value for writing.
+     *
+     * @param value a value to be written in current JSON array
+     * @return this generator
+     * @throws jakarta.json.JsonException if an i/o error occurs (IOException
+     * would be cause of JsonException)
+     * @throws JsonGenerationException if this method is not called within an
+     *      array, root or field context.
+     *
+     * @see jakarta.json.JsonNumber
+     */
+    JsonGenerator write(BigDecimal value);
+
+    /**
+     * Writes the specified value as a JSON number value within
+     * the current array, field or root context. The string {@code new BigDecimal(value).toString()}
+     * is used as the text value for writing.
+     *
+     * @param value a value to be written in current JSON array
+     * @return this generator.
+     * @throws jakarta.json.JsonException if an i/o error occurs (IOException
+     * would be cause of JsonException)
+     * @throws JsonGenerationException if this method is not called within an
+     *      array, root or field context.
+     *
+     * @see jakarta.json.JsonNumber
+     */
+    JsonGenerator write(BigInteger value);
+
+    /**
+     * Writes the specified value as a JSON number value within
+     * the current array, field or root context. The string {@code new BigDecimal(value).toString()}
+     * is used as the text value for writing.
+     *
+     * @param value a value to be written in current JSON array
+     * @return this generator
+     * @throws jakarta.json.JsonException if an i/o error occurs (IOException
+     * would be cause of JsonException)
+     * @throws JsonGenerationException if this method is not called within an
+     *      array, root or field context.
+     */
+    JsonGenerator write(int value);
+
+    /**
+     * Writes the specified value as a JSON number value within
+     * the current array, field or root context. The string {@code new BigDecimal(value).toString()}
+     * is used as the text value for writing.
+     *
+     * @param value a value to be written in current JSON array
+     * @return this generator
+     * @throws jakarta.json.JsonException if an i/o error occurs (IOException
+     * would be cause of JsonException)
+     * @throws JsonGenerationException if this method is not called within an
+     *      array, root or field context.
+     */
+    JsonGenerator write(long value);
+
+    /**
+     * Writes the specified value as a JSON number value within the current
+     * array, field or root context. The string {@code BigDecimal.valueOf(value).toString()}
+     * is used as the text value for writing.
+     *
+     * @param value a value to be written in current JSON array
+     * @return this generator
+     * @throws jakarta.json.JsonException if an i/o error occurs (IOException
+     * would be cause of JsonException)
+     * @throws JsonGenerationException if this method is not called within an
+     *      array, root or field context.
+     * @throws NumberFormatException if the value is Not-a-Number (NaN) or infinity.
+     */
+    JsonGenerator write(double value);
+
+    /**
+     * Writes a JSON true or false value within the current array, field or root context.
+     * If value is true, this method writes the JSON {@code true} value,
+     * otherwise it writes the JSON {@code false} value.
+     *
+     * @param value a {@code boolean} value
+     * @return this generator
+     * @throws jakarta.json.JsonException if an i/o error occurs (IOException
+     * would be cause of JsonException)
+     * @throws JsonGenerationException if this method is not called within an
+     *      array, root or field context.
+     */
+    JsonGenerator write(boolean value);
+
+    /**
+     * Writes a JSON null value within the current array, field or root context.
+     *
+     * @return this generator
+     * @throws jakarta.json.JsonException if an i/o error occurs (IOException
+     * would be cause of JsonException)
+     * @throws JsonGenerationException if this method is not called within an
+     *      array, root or field context.
+     */
+    JsonGenerator writeNull();
+
+    /**
+     * Closes this generator and frees any resources associated with it.
+     * This method closes the underlying output source.
+     *
+     * The underlying stream is closed only if complete JSON object is written. In case
+     * of incomplete object JsonGenerationException is thrown and underlying stream is
+     * not closed.
+     *
+     * @throws jakarta.json.JsonException if an i/o error occurs (IOException
+     * would be cause of JsonException)
+     * @throws JsonGenerationException if an incomplete JSON is generated
+     */
+    @Override
+    void close();
+
+    /**
+     * Flushes the underlying output source. If the generator has saved
+     * any characters in a buffer, writes them immediately to the underlying
+     * output source before flushing it.
+     *
+     * @throws jakarta.json.JsonException if an i/o error occurs (IOException
+     * would be cause of JsonException)
+     */
+    @Override
+    void flush();
+
+}

--- a/dev/io.openliberty.jakarta.jsonp.2.2/src/jakarta/json/stream/JsonGeneratorFactory.java
+++ b/dev/io.openliberty.jakarta.jsonp.2.2/src/jakarta/json/stream/JsonGeneratorFactory.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2011, 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.json.stream;
+
+import java.io.OutputStream;
+import java.io.Writer;
+import java.nio.charset.Charset;
+import java.util.Map;
+
+/**
+ * Factory to create {@link JsonGenerator} instances. If a factory
+ * instance is configured with some configuration, the configuration applies
+ * to all generator instances created using that factory instance.
+ *
+ * <p>
+ * The class {@link jakarta.json.Json Json} also provides methods to create
+ * {@link JsonGenerator} instances, but using {@code JsonGeneratorFactory} is
+ * preferred when creating multiple generator instances as shown in the
+ * following example:
+ *
+ * <pre>
+ * <code>
+ * JsonGeneratorFactory factory = Json.createGeneratorFactory();
+ * JsonGenerator generator1 = factory.createGenerator(...);
+ * JsonGenerator generator2 = factory.createGenerator(...);
+ * </code>
+ * </pre>
+ *
+ * <p> All the methods in this class are safe for use by multiple concurrent
+ * threads.
+ */
+public interface JsonGeneratorFactory {
+
+    /**
+     * Creates a JSON generator to write JSON text to a character stream.
+     * The generator is configured with the factory configuration.
+     *
+     * @param writer i/o writer to which JSON is written
+     * @return the created JSON generator
+     */
+    JsonGenerator createGenerator(Writer writer);
+
+    /**
+     * Creates a JSON generator to write JSON text to a byte stream. Characters 
+     * written to the stream are encoded into bytes using UTF-8 encoding. 
+     * The generator is configured with the factory's configuration.
+     *
+     * @param out i/o stream to which JSON is written
+     * @return the created JSON generator
+     */
+    JsonGenerator createGenerator(OutputStream out);
+
+    /**
+     * Creates a JSON generator to write JSON text to a byte stream. Characters 
+     * written to the stream are encoded into bytes using the specified charset. 
+     * The generator is configured with the factory's configuration.
+     *
+     * @param out i/o stream to which JSON is written
+     * @param charset a charset
+     * @return the created JSON generator
+     */
+    JsonGenerator createGenerator(OutputStream out, Charset charset);
+
+    /**
+     * Returns a read-only map of supported provider specific configuration
+     * properties that are used to configure the JSON generators.
+     * If there are any specified configuration properties that are not
+     * supported by the provider, they won't be part of the returned map.
+     *
+     * @return a map of supported provider specific properties that are used
+     * to configure the created generators. The map may be empty but not null
+     */
+    Map<String, ?> getConfigInUse();
+
+}

--- a/dev/io.openliberty.jakarta.jsonp.2.2/src/jakarta/json/stream/JsonLocation.java
+++ b/dev/io.openliberty.jakarta.jsonp.2.2/src/jakarta/json/stream/JsonLocation.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2013, 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.json.stream;
+
+/**
+ * Provides the location information of a JSON event in an input source. The
+ * {@code JsonLocation} information can be used to identify incorrect JSON
+ * or can be used by higher frameworks to know about the processing location.
+ *
+ * <p>All the information provided by a {@code JsonLocation} is optional. For
+ * example, a provider may only report line numbers. Also, there may not be any
+ * location information for an input source. For example, if a
+ * {@code JsonParser} is created using
+ * {@link jakarta.json.JsonArray JsonArray} input source, all the methods in
+ * this class return -1.
+ * @see JsonParser
+ * @see JsonParsingException
+ */
+public interface JsonLocation {
+
+    /**
+     * Return the line number (starts with 1 for the first line) for the current JSON event in the input source.
+     *
+     * @return the line number (starts with 1 for the first line) or -1 if none is available
+     */
+    long getLineNumber();
+
+    /**
+     * Return the column number (starts with 1 for the first column) for the current JSON event in the input source.
+     *
+     * @return the column number (starts with 1 for the first column) or -1 if none is available
+     */
+    long getColumnNumber();
+
+    /**
+     * Return the stream offset into the input source this location
+     * is pointing to. If the input source is a file or a byte stream then
+     * this is the byte offset into that stream, but if the input source is
+     * a character media then the offset is the character offset.
+     * Returns -1 if there is no offset available.
+     *
+     * @return the offset of input source stream, or -1 if there is
+     * no offset available
+     */
+    long getStreamOffset();
+
+}

--- a/dev/io.openliberty.jakarta.jsonp.2.2/src/jakarta/json/stream/JsonParser.java
+++ b/dev/io.openliberty.jakarta.jsonp.2.2/src/jakarta/json/stream/JsonParser.java
@@ -1,0 +1,514 @@
+/*
+ * Copyright (c) 2011, 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.json.stream;
+
+
+import java.io.Closeable;
+import java.math.BigDecimal;
+import java.util.stream.Stream;
+import java.util.Map;
+
+import jakarta.json.JsonValue;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonArray;
+
+/**
+ * Provides forward, read-only access to JSON data in a streaming way. This
+ * is the most efficient way for reading JSON data.
+ * This is the only way to parse and process JSON data that are too big to be loaded in memory.
+ * <p>The class
+ * {@link jakarta.json.Json} contains methods to create parsers from input
+ * sources ({@link java.io.InputStream} and {@link java.io.Reader}).
+ *
+ * <p>
+ * The following example demonstrates how to create a parser from a string
+ * that contains an empty JSON array:
+ * <pre>
+ * <code>
+ * JsonParser parser = Json.createParser(new StringReader("[]"));
+ * </code>
+ * </pre>
+ *
+ * <p>
+ * The class {@link JsonParserFactory} also contains methods to create
+ * {@code JsonParser} instances. {@link JsonParserFactory} is preferred
+ * when creating multiple parser instances. A sample usage is shown
+ * in the following example:
+ * <pre>
+ * <code>
+ * JsonParserFactory factory = Json.createParserFactory();
+ * JsonParser parser1 = factory.createParser(...);
+ * JsonParser parser2 = factory.createParser(...);
+ * </code>
+ * </pre>
+ *
+ * <p>
+ * {@code JsonParser} parses JSON using the pull parsing programming model.
+ * In this model the client code controls the thread and calls the method
+ * {@code next()} to advance the parser to the next state after
+ * processing each element. The parser can generate the following events:
+ * {@code START_OBJECT}, {@code END_OBJECT}, {@code START_ARRAY},
+ * {@code END_ARRAY}, {@code KEY_NAME}, {@code VALUE_STRING},
+ * {@code VALUE_NUMBER}, {@code VALUE_TRUE}, {@code VALUE_FALSE},
+ * and {@code VALUE_NULL}.
+ *
+ * <p>
+ * <b>For example</b>, for an empty JSON object ({ }), the parser generates the event
+ * {@code START_OBJECT} with the first call to the method {@code next()} and the
+ * event {@code END_OBJECT} with the second call to the method {@code next()}.
+ * The following code demonstrates how to access these events:
+ *
+ * <pre>
+ * <code>
+ * Event event = parser.next(); // START_OBJECT
+ * event = parser.next();       // END_OBJECT
+ * </code>
+ * </pre>
+ *
+ * <p>
+ * <b>For example</b>, for the following JSON:
+ * <pre>
+ * {
+ *   "firstName": "John", "lastName": "Smith", "age": 25,
+ *   "phoneNumber": [
+ *       { "type": "home", "number": "212 555-1234" },
+ *       { "type": "fax", "number": "646 555-4567" }
+ *    ]
+ * }
+ * </pre>
+ *
+ * <p>calls to the method {@code next()} result in parse events at the specified
+ * locations below (marked in bold):
+ *
+ * <pre>
+ * {<B>START_OBJECT</B>
+ *   "firstName"<B>KEY_NAME</B>: "John"<B>VALUE_STRING</B>, "lastName"<B>KEY_NAME</B>: "Smith"<B>VALUE_STRING</B>, "age"<B>KEY_NAME</B>: 25<B>VALUE_NUMBER</B>,
+ *   "phoneNumber"<B>KEY_NAME</B> : [<B>START_ARRAY</B>
+ *       {<B>START_OBJECT</B> "type"<B>KEY_NAME</B>: "home"<B>VALUE_STRING</B>, "number"<B>KEY_NAME</B>: "212 555-1234"<B>VALUE_STRING</B> }<B>END_OBJECT</B>,
+ *       {<B>START_OBJECT</B> "type"<B>KEY_NAME</B>: "fax"<B>VALUE_STRING</B>, "number"<B>KEY_NAME</B>: "646 555-4567"<B>VALUE_STRING</B> }<B>END_OBJECT</B>
+ *    ]<B>END_ARRAY</B>
+ * }<B>END_OBJECT</B>
+ * </pre>
+ *
+ * The methods {@link #next()} and {@link #hasNext()} enable iteration over
+ * parser events to process JSON data. {@code JsonParser} provides get methods
+ * to obtain the value at the current state of the parser. For example, the
+ * following code shows how to obtain the value "John" from the JSON above:
+ *
+ * <pre>
+ * <code>
+ * Event event = parser.next(); // START_OBJECT
+ * event = parser.next();       // KEY_NAME
+ * event = parser.next();       // VALUE_STRING
+ * parser.getString();          // "John"
+ * </code>
+ * </pre>
+ *
+ * Starting in version 1.1, it is possible to build a partial JSON object
+ * model from the stream, at the current parser position.
+ * The methods {@link #getArray} and {@link #getObject} can be used to read in
+ * a {@code JsonArray} or {@code JsonObject}.  For example, the following code
+ * shows how to obtain the phoneNumber in a JsonArray, from the JSON above:
+ *
+ * <pre><code>
+ * while (parser.hasNext() {
+ *     Event event = parser.next();
+ *     if (event == JsonParser.Event.KEY_NAME ) {
+ *         String key = parser.getString();
+ *         event = parser.next();
+ *         if (key.equals("phoneNumber") {
+ *             JsonArray phones = parser.getArray();
+ *         }
+ *     }
+ * }
+ * </code></pre>
+ *
+ * The methods {@link #getArrayStream} and {@link #getObjectStream} can be used
+ * to get a stream of the elements of a {@code JsonArray} or {@code JsonObject}.
+ * For example, the following code shows another way to obtain John's phoneNumber
+ * in a {@code JsonArray} :
+ *
+ * <pre>{@code
+ * Event event = parser.next(); // START_OBJECT
+ * JsonArray phones = (JsonArray)
+ *     parser.getObjectStream().filter(e->e.getKey().equals("phoneNumber"))
+ *                             .map(e->e.getValue())
+ *                             .findFirst()
+ *                             .get();
+ * }</pre>
+ *
+ * The methods {@link #skipArray} and {@link #skipObject} can be used to
+ * skip tokens and position the parser to {@code END_ARRAY} or
+ * {@code END_OBJECT}.
+ * <p>
+ * {@code JsonParser} can be used to parse sequence of JSON values that are not
+ * enclosed in a JSON array, e.g. { } { }. The following code demonstrates how
+ * to parse such sequence.
+ * <pre><code>
+ * JsonParser parser = Json.createParser(...);
+ * while (parser.hasNext) {
+ *     parser.next(); // advance parser state
+ *     JsonValue value = parser.getValue();
+ * }
+ * </code></pre>
+ *
+ * @see jakarta.json.Json
+ * @see JsonParserFactory
+ */
+public interface JsonParser extends /*Auto*/Closeable {
+
+    /**
+     * An event from {@code JsonParser}.
+     */
+    enum Event {
+        /**
+         * Start of a JSON array. The position of the parser is after '['.
+         */
+        START_ARRAY,
+        /**
+         * Start of a JSON object. The position of the parser is after '{'.
+         */
+        START_OBJECT,
+        /**
+         * Name in a name/value pair of a JSON object. The position of the parser
+         * is after the key name. The method {@link #getString} returns the key
+         * name.
+         */
+        KEY_NAME,
+        /**
+         * String value in a JSON array or object. The position of the parser is
+         * after the string value. The method {@link #getString}
+         * returns the string value.
+         */
+        VALUE_STRING,
+        /**
+         * Number value in a JSON array or object. The position of the parser is
+         * after the number value. {@code JsonParser} provides the following
+         * methods to access the number value: {@link #getInt},
+         * {@link #getLong}, and {@link #getBigDecimal}.
+         */
+        VALUE_NUMBER,
+        /**
+         * {@code true} value in a JSON array or object. The position of the
+         * parser is after the {@code true} value.
+         */
+        VALUE_TRUE,
+        /**
+         * {@code false} value in a JSON array or object. The position of the
+         * parser is after the {@code false} value.
+         */
+        VALUE_FALSE,
+        /**
+         * {@code null} value in a JSON array or object. The position of the
+         * parser is after the {@code null} value.
+         */
+        VALUE_NULL,
+        /**
+         * End of a JSON object. The position of the parser is after '}'.
+         */
+        END_OBJECT,
+        /**
+         * End of a JSON array. The position of the parser is after ']'.
+         */
+        END_ARRAY
+    }
+
+    /**
+     * Returns {@code true} if there are more parsing states. This method returns
+     * {@code false} if the parser reaches the end of the JSON text.
+     *
+     * @return {@code true} if there are more parsing states.
+     * @throws jakarta.json.JsonException if an i/o error occurs (IOException
+     * would be cause of JsonException)
+     * @throws JsonParsingException if the parser encounters invalid JSON
+     * when advancing to next state.
+     */
+    boolean hasNext();
+
+    /**
+     * Returns the event for the next parsing state.
+     *
+     * @throws jakarta.json.JsonException if an i/o error occurs (IOException
+     * would be cause of JsonException)
+     * @throws JsonParsingException if the parser encounters invalid JSON
+     * when advancing to next state.
+     * @throws java.util.NoSuchElementException if there are no more parsing
+     * states.
+     * @return the event for the next parsing state
+     */
+    Event next();
+
+    /**
+     * Returns the event for the current parsing state.
+     *
+     * @return the event for the current parsing state
+     *
+     * @since 2.1
+     */
+    default public Event currentEvent() {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Returns a {@code String} for the name in a name/value pair,
+     * for a string value or a number value. This method should only be called
+     * when the parser state is {@link Event#KEY_NAME}, {@link Event#VALUE_STRING},
+     * or {@link Event#VALUE_NUMBER}.
+     *
+     * @return a name when the parser state is {@link Event#KEY_NAME}
+     *         a string value when the parser state is {@link Event#VALUE_STRING}
+     *         a number value when the parser state is {@link Event#VALUE_NUMBER}
+     * @throws IllegalStateException when the parser state is not
+     *      {@code KEY_NAME}, {@code VALUE_STRING}, or {@code VALUE_NUMBER}
+     */
+    String getString();
+
+    /**
+     * Returns true if the JSON number at the current parser state is a
+     * integral number. A {@link BigDecimal} may be used to store the value
+     * internally and this method semantics are defined using its
+     * {@code scale()}. If the scale is zero, then it is considered integral
+     * type. This integral type information can be used to invoke an
+     * appropriate accessor method to obtain a numeric value as in the
+     * following example:
+     *
+     * <pre>
+     * <code>
+     * JsonParser parser = ...
+     * if (parser.isIntegralNumber()) {
+     *     parser.getInt();     // or other methods to get integral value
+     * } else {
+     *     parser.getBigDecimal();
+     * }
+     * </code>
+     * </pre>
+     *
+     * @return true if this number is a integral number, otherwise false
+     * @throws IllegalStateException when the parser state is not
+     *      {@code VALUE_NUMBER}
+     */
+    boolean isIntegralNumber();
+
+    /**
+     * Returns a JSON number as an integer. The returned value is equal
+     * to {@code new BigDecimal(getString()).intValue()}. Note that
+     * this conversion can lose information about the overall magnitude
+     * and precision of the number value as well as return a result with
+     * the opposite sign. This method should only be called when the parser
+     * state is {@link Event#VALUE_NUMBER}.
+     *
+     * @return an integer for a JSON number
+     * @throws IllegalStateException when the parser state is not
+     *      {@code VALUE_NUMBER}
+     * @see java.math.BigDecimal#intValue()
+     */
+    int getInt();
+
+    /**
+     * Returns a JSON number as a long. The returned value is equal
+     * to {@code new BigDecimal(getString()).longValue()}. Note that this
+     * conversion can lose information about the overall magnitude and
+     * precision of the number value as well as return a result with
+     * the opposite sign. This method is only called when the parser state is
+     * {@link Event#VALUE_NUMBER}.
+     *
+     * @return a long for a JSON number
+     * @throws IllegalStateException when the parser state is not
+     *      {@code VALUE_NUMBER}
+     * @see java.math.BigDecimal#longValue()
+     */
+    long getLong();
+
+    /**
+     * Returns a JSON number as a {@code BigDecimal}. The {@code BigDecimal}
+     * is created using {@code new BigDecimal(getString())}. This
+     * method should only called when the parser state is
+     * {@link Event#VALUE_NUMBER}.
+     *
+     * @return a {@code BigDecimal} for a JSON number
+     * @throws IllegalStateException when the parser state is not
+     *      {@code VALUE_NUMBER}
+     */
+    BigDecimal getBigDecimal();
+
+    /**
+     * Return the location that corresponds to the parser's current state in
+     * the JSON input source. The location information is only valid in the
+     * current parser state (or until the parser is advanced to a next state).
+     *
+     * @return a non-null location corresponding to the current parser state
+     * in JSON input source
+     */
+    JsonLocation getLocation();
+
+    /**
+     * Returns a {@code JsonObject} and advances the parser to the
+     * corresponding {@code END_OBJECT}.
+     *
+     * @return the {@code JsonObject} at the current parser position
+     * @throws jakarta.json.JsonException if an i/o error occurs (IOException
+     * would be cause of JsonException)
+     * @throws IllegalStateException when the parser state is not
+     *     {@code START_OBJECT}
+     * @throws JsonParsingException if the parser encounters invalid JSON
+     * when advancing to next state.
+     * @throws java.util.NoSuchElementException if there are no more parsing
+     * states.
+     *
+     * @since 1.1
+     */
+    default public JsonObject getObject() {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Returns a {@code JsonValue} at the current parser position.
+     * If the parser state is {@code START_ARRAY}, the behavior is
+     * the same as {@link #getArray}. If the parser state is
+     * {@code START_OBJECT}, the behavior is the same as
+     * {@link #getObject}. For all other cases, if applicable, the JSON value is
+     * read and returned.
+     *
+     * @return the {@code JsonValue} at the current parser position.
+     * @throws jakarta.json.JsonException if an i/o error occurs (IOException
+     * would be cause of JsonException)
+     * @throws IllegalStateException when the parser state is
+     *     {@code END_OBJECT} or {@code END_ARRAY}
+     * @throws JsonParsingException if the parser encounters invalid JSON
+     * when advancing to next state.
+     * @throws java.util.NoSuchElementException if there are no more parsing
+     * states.
+     *
+     * @since 1.1
+     */
+    default public JsonValue getValue() {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Returns a {@code JsonArray} and advance the parser to the
+     * the corresponding {@code END_ARRAY}.
+     *
+     * @return the {@code JsonArray} at the current parser position
+     * @throws jakarta.json.JsonException if an i/o error occurs (IOException
+     * would be cause of JsonException)
+     * @throws IllegalStateException when the parser state is not
+     *     {@code START_ARRAY}
+     * @throws JsonParsingException if the parser encounters invalid JSON
+     * when advancing to next state.
+     * @throws java.util.NoSuchElementException if there are no more parsing
+     * states.
+     *
+     * @since 1.1
+     */
+    default public JsonArray getArray() {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Returns a stream of the {@code JsonArray} elements.
+     * The parser state must be {@code START_ARRAY}.
+     * The elements are read lazily, on an as-needed basis, as
+     * required by the stream operations.
+     * If the stream operations do not consume
+     * all of the array elements, {@link skipArray} can be used to
+     * skip the unprocessed array elements.
+     *
+     * @return a stream of elements of the {@code JsonArray}
+     *
+     * @throws IllegalStateException when the parser state is not
+     *     {@code START_ARRAY}
+     *
+     * @since 1.1
+     */
+    default public Stream<JsonValue> getArrayStream() {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Returns a stream of the {@code JsonObject}'s
+     * name/value pairs. The parser state must be {@code START_OBJECT}.
+     * The name/value pairs are read lazily, on an as-needed basis, as
+     * required by the stream operations.
+     * If the stream operations do not consume
+     * all of the object's name/value pairs, {@link skipObject} can be
+     * used to skip the unprocessed elements.
+     *
+     * @return a stream of name/value pairs of the {@code JsonObject}
+     *
+     * @throws IllegalStateException when the parser state is not
+     *     {@code START_OBJECT}
+     *
+     * @since 1.1
+     */
+    default public Stream<Map.Entry<String,JsonValue>> getObjectStream() {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Returns a stream of {@code JsonValue} from a sequence of
+     * JSON values. The values are read lazily, on an as-needed basis,
+     * as needed by the stream operations.
+     *
+     * @return a Stream of {@code JsonValue}
+     *
+     * @throws IllegalStateException if the parser is in an array or object.
+     *
+     * @since 1.1
+     */
+    default public Stream<JsonValue> getValueStream() {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Advance the parser to {@code END_ARRAY}.
+     * If the parser is in array context, i.e. it has previously
+     * encountered a {@code START_ARRAY} without encountering the
+     * corresponding {@code END_ARRAY}, the parser is advanced to
+     * the corresponding {@code END_ARRAY}.
+     * If the parser is not in any array context, nothing happens.
+     *
+     * @since 1.1
+     */
+    default public void skipArray() {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Advance the parser to {@code END_OBJECT}.
+     * If the parser is in object context, i.e. it has previously
+     * encountered a {@code START_OBJECT} without encountering the
+     * corresponding {@code END_OBJECT}, the parser is advanced to
+     * the corresponding {@code END_OBJECT}.
+     * If the parser is not in any object context, nothing happens.
+     *
+     * @since 1.1
+     */
+    default public void skipObject() {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Closes this parser and frees any resources associated with the
+     * parser. This method closes the underlying input source.
+     *
+     * @throws jakarta.json.JsonException if an i/o error occurs (IOException
+     * would be cause of JsonException)
+     */
+    @Override
+    void close();
+}

--- a/dev/io.openliberty.jakarta.jsonp.2.2/src/jakarta/json/stream/JsonParserFactory.java
+++ b/dev/io.openliberty.jakarta.jsonp.2.2/src/jakarta/json/stream/JsonParserFactory.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2011, 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.json.stream;
+
+import jakarta.json.JsonArray;
+import jakarta.json.JsonObject;
+import java.io.InputStream;
+import java.io.Reader;
+import java.nio.charset.Charset;
+import java.util.Map;
+
+/**
+ * Factory for creating {@link JsonParser} instances. If a factory
+ * instance is configured with a configuration, the configuration applies
+ * to all parser instances created using that factory instance.
+ *
+ * <p>
+ * The class {@link jakarta.json.Json Json} also provides methods to create
+ * {@link JsonParser} instances, but using {@code JsonParserFactory} is 
+ * preferred when creating multiple parser instances as shown in the following
+ * example:
+ *
+ * <pre>
+ * <code>
+ * JsonParserFactory factory = Json.createParserFactory();
+ * JsonParser parser1 = factory.createParser(...);
+ * JsonParser parser2 = factory.createParser(...);
+ * </code>
+ * </pre>
+ *
+ * <p> All the methods in this class are safe for use by multiple concurrent
+ * threads.
+ */
+public interface JsonParserFactory {
+
+    /**
+     * Creates a JSON parser from a character stream.
+     *
+     * @param reader a i/o reader from which JSON is to be read
+     * @return the created JSON parser
+     */
+    JsonParser createParser(Reader reader);
+
+    /**
+     * Creates a JSON parser from the specified byte stream.
+     * The character encoding of the stream is determined
+     * as specified in <a href="http://tools.ietf.org/rfc/rfc7159.txt">RFC 7159</a>.
+     *
+     * @param in i/o stream from which JSON is to be read
+     * @return the created JSON parser
+     * @throws jakarta.json.JsonException if encoding cannot be determined
+     *         or i/o error (IOException would be cause of JsonException)
+     */
+    JsonParser createParser(InputStream in);
+
+    /**
+     * Creates a JSON parser from the specified byte stream.
+     * The bytes of the stream are decoded to characters using the
+     * specified charset.
+     *
+     * @param in i/o stream from which JSON is to be read
+     * @param charset a charset
+     * @return the created JSON parser
+     */
+    JsonParser createParser(InputStream in, Charset charset);
+
+    /**
+     * Creates a JSON parser from the specified JSON object.
+     *
+     * @param obj a JSON object
+     * @return the created JSON parser
+     */
+    JsonParser createParser(JsonObject obj);
+
+    /**
+     * Creates a JSON parser from the specified JSON array.
+     *
+     * @param array a JSON array
+     * @return the created JSON parser
+     */
+    JsonParser createParser(JsonArray array);
+
+    /**
+     * Returns a read-only map of supported provider specific configuration
+     * properties that are used to configure the JSON parsers.
+     * If there are any specified configuration properties that are not
+     * supported by the provider, they won't be part of the returned map.
+     *
+     * @return a map of supported provider specific properties that are used
+     * to configure the created parsers. The map may be empty but not null
+     */
+    Map<String, ?> getConfigInUse();
+
+}

--- a/dev/io.openliberty.jakarta.jsonp.2.2/src/jakarta/json/stream/JsonParsingException.java
+++ b/dev/io.openliberty.jakarta.jsonp.2.2/src/jakarta/json/stream/JsonParsingException.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2012, 2022 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.json.stream;
+
+import jakarta.json.JsonException;
+
+/**
+ * {@code JsonParsingException} is used when an incorrect JSON is
+ * being parsed.
+ */
+public class JsonParsingException extends JsonException {
+
+    /** for serialization */
+    private static final long serialVersionUID = 9073566598484238797L;
+
+    /**
+     * The location of the incorrect JSON.
+     */
+    private transient final JsonLocation location;
+
+    /**
+     * Constructs a new runtime exception with the specified detail message.
+     * The cause is not initialized, and may subsequently be initialized by a
+     * call to {@link #initCause}.
+     *
+     * @param message the detail message. The detail message is saved for
+     *                later retrieval by the {@link #getMessage()} method.
+     * @param location the location of the incorrect JSON
+     */
+    public JsonParsingException(String message, JsonLocation location) {
+        super(message);
+        this.location = location;
+    }
+
+    /**
+     * Constructs a new runtime exception with the specified detail message and
+     * cause.  <p>Note that the detail message associated with
+     * {@code cause} is <i>not</i> automatically incorporated in
+     * this runtime exception's detail message.
+     *
+     * @param message the detail message (which is saved for later retrieval
+     *                by the {@link #getMessage()} method).
+     * @param cause the cause (which is saved for later retrieval by the
+     *              {@link #getCause()} method). (A <code>null</code> value is
+     *              permitted, and indicates that the cause is nonexistent or
+     *              unknown.)
+     * @param location the location of the incorrect JSON
+     */
+    public JsonParsingException(String message, Throwable cause, JsonLocation location) {
+        super(message, cause);
+        this.location = location;
+    }
+
+    /**
+     * Return the location of the incorrect JSON.
+     *
+     * @return the non-null location of the incorrect JSON
+     */
+    public JsonLocation getLocation() {
+        return location;
+    }
+
+}
+

--- a/dev/io.openliberty.jakarta.jsonp.2.2/src/jakarta/json/stream/package-info.java
+++ b/dev/io.openliberty.jakarta.jsonp.2.2/src/jakarta/json/stream/package-info.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2012, 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+/**
+ * Provides a streaming API to parse and generate
+ * <a href="http://json.org/">JSON</a>.
+ *
+ * <p>
+ * The streaming API consists of the interfaces
+ * {@link jakarta.json.stream.JsonParser} and
+ * {@link jakarta.json.stream.JsonGenerator}. The interface {@code JsonParser}
+ * contains methods to parse JSON in a streaming way. The interface
+ * {@code JsonGenerator} contains methods to write JSON to an output source
+ * in a streaming way.
+ *
+ * <p>
+ * {@code JsonParser} provides forward, read-only access to JSON data using the
+ * pull parsing programming model. In this model the application code controls
+ * the thread and calls methods in the parser interface to move the parser
+ * forward or to obtain JSON data from the current state of the parser.
+ *
+ * <p>
+ * {@code JsonGenerator} provides methods to write JSON to an output source.
+ * The generator writes name/value pairs in JSON objects and values in JSON
+ * arrays.
+ * 
+ * <p>
+ * The streaming API is a low-level API designed to process large amounts of
+ * JSON data efficiently. Other JSON frameworks (such as JSON binding) can be
+ * implemented using this API.
+ *
+ * @since JSON Processing 1.0
+ */
+package jakarta.json.stream;

--- a/dev/io.openliberty.jsonp.2.2_fat/.classpath
+++ b/dev/io.openliberty.jsonp.2.2_fat/.classpath
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="src" path="fat/src"/>
+	<classpathentry kind="src" path="test-applications/CustomProviderApp/src"/>
+	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21"/>
+	<classpathentry kind="output" path="bin"/>
+</classpath>

--- a/dev/io.openliberty.jsonp.2.2_fat/.project
+++ b/dev/io.openliberty.jsonp.2.2_fat/.project
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>io.openliberty.jsonp.2.2_fat</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>bndtools.core.bndbuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>bndtools.core.bndnature</nature>
+	</natures>
+</projectDescription>

--- a/dev/io.openliberty.jsonp.2.2_fat/bnd.bnd
+++ b/dev/io.openliberty.jsonp.2.2_fat/bnd.bnd
@@ -1,0 +1,34 @@
+#*******************************************************************************
+# Copyright (c) 2026 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-2.0/
+# 
+# SPDX-License-Identifier: EPL-2.0
+#*******************************************************************************
+-include= ~../cnf/resources/bnd/bundle.props
+bVersion=1.0
+
+# TODO: Reset to 17 once eeCompatible-12.0 constraint is resolved
+javac.source: 21
+javac.target: 21
+
+src: \
+	fat/src,\
+	test-applications/CustomProviderApp/src
+
+fat.project: true
+
+tested.features: \
+    servlet-6.2
+
+# To define a global minimum java level for the FAT, use the following property.
+# If unspecified, the default value is ${javac.source}
+# TODO: Reset to 17 once eeCompatible-12.0 constraint is resolved
+fat.minimum.java.level: 21
+
+-buildpath: \
+        com.ibm.ws.componenttest.2.0;version=latest,\
+	io.openliberty.jakarta.jsonp.2.2;version=latest,\
+	io.openliberty.jakarta.servlet.6.0;version=latest

--- a/dev/io.openliberty.jsonp.2.2_fat/bnd.bnd
+++ b/dev/io.openliberty.jsonp.2.2_fat/bnd.bnd
@@ -16,7 +16,10 @@ javac.target: 21
 
 src: \
 	fat/src,\
-	test-applications/CustomProviderApp/src
+	test-applications/CustomProviderApp/src,\
+	test-applications/BundledProviderApp/src,\
+	test-applications/CacheCheckerApp/src,\
+	test-applications/GCTestLib/src
 
 fat.project: true
 

--- a/dev/io.openliberty.jsonp.2.2_fat/build.gradle
+++ b/dev/io.openliberty.jsonp.2.2_fat/build.gradle
@@ -1,0 +1,29 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+configurations {
+  johnzon21 {transitive = false}
+}
+
+dependencies {
+  johnzon21 'org.apache.johnzon:johnzon-core:2.1.0'
+}
+
+task addJohnzon21(type: Copy) {
+  from configurations.johnzon21
+  into new File(autoFvtDir, 'publish/shared/resources/johnzon/2.1.0/')
+  rename "johnzon-core-.*.jar", "johnzon-core.jar"
+}
+
+addRequiredLibraries {
+  dependsOn addJohnzon21
+}

--- a/dev/io.openliberty.jsonp.2.2_fat/cognitiveMetadata.yml
+++ b/dev/io.openliberty.jsonp.2.2_fat/cognitiveMetadata.yml
@@ -1,0 +1,6 @@
+---
+# YML metadata file made use of by the Cognitive Ecosystem.
+# Reference Cognitive Metadata is available at: https://github.com/OpenLiberty/open-liberty/tree/integration/dev/build.example_fat/cognitiveMetadata.yml
+# description: Uncomment this field and add a description to give some notes about this bucket.
+# triageNotes: Uncomment this field if there are some short notes you would like Pipeline Monitors to see when triaging this bucket.
+functionalArea: JSON

--- a/dev/io.openliberty.jsonp.2.2_fat/fat/src/io/openliberty/jsonp22/fat/FATSuite.java
+++ b/dev/io.openliberty.jsonp.2.2_fat/fat/src/io/openliberty/jsonp22/fat/FATSuite.java
@@ -1,0 +1,27 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.jsonp22.fat;
+
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+import org.junit.runners.Suite.SuiteClasses;
+
+import componenttest.custom.junit.runner.AlwaysPassesTest;
+
+@RunWith(Suite.class)
+@SuiteClasses({
+                AlwaysPassesTest.class,
+                JSONP22CustomProviderTest.class
+})
+public class FATSuite {
+}

--- a/dev/io.openliberty.jsonp.2.2_fat/fat/src/io/openliberty/jsonp22/fat/FATSuite.java
+++ b/dev/io.openliberty.jsonp.2.2_fat/fat/src/io/openliberty/jsonp22/fat/FATSuite.java
@@ -21,7 +21,8 @@ import componenttest.custom.junit.runner.AlwaysPassesTest;
 @RunWith(Suite.class)
 @SuiteClasses({
                 AlwaysPassesTest.class,
-                JSONP22CustomProviderTest.class
+                JSONP22CustomProviderTest.class,
+                JSONP22ProviderCacheGCTest.class
 })
 public class FATSuite {
 }

--- a/dev/io.openliberty.jsonp.2.2_fat/fat/src/io/openliberty/jsonp22/fat/JSONP22CustomProviderTest.java
+++ b/dev/io.openliberty.jsonp.2.2_fat/fat/src/io/openliberty/jsonp22/fat/JSONP22CustomProviderTest.java
@@ -1,0 +1,97 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.jsonp22.fat;
+
+import java.io.File;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.ibm.websphere.simplicity.ShrinkHelper;
+
+import componenttest.annotation.Server;
+import componenttest.annotation.TestServlet;
+import componenttest.annotation.TestServlets;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.utils.FATServletClient;
+import io.openliberty.jsonp22.fat.provider.NoopJsonProvider;
+import io.openliberty.jsonp22.fat.web.BundledProviderServlet;
+import io.openliberty.jsonp22.fat.web.FeatureProviderServlet;
+import io.openliberty.jsonp22.fat.web.SystemPropertyProviderServlet;
+
+@RunWith(FATRunner.class)
+public class JSONP22CustomProviderTest extends FATServletClient {
+
+    @Server("jsonp2.2.customProvider.fat")
+    @TestServlets({
+                    @TestServlet(servlet = FeatureProviderServlet.class, contextRoot = "ProviderFeatureApp"),
+                    @TestServlet(servlet = BundledProviderServlet.class, contextRoot = "BundledProviderApp")
+    })
+    public static LibertyServer server;
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        // Guard against stale system property from a prior test run on this JVM.
+        System.clearProperty("jakarta.json.provider");
+
+        WebArchive providerFeatureApp = ShrinkWrap.create(WebArchive.class, "ProviderFeatureApp.war")
+                        .addClass(FeatureProviderServlet.class)
+                        .addClass(SystemPropertyProviderServlet.class)
+                        .addClass(NoopJsonProvider.class);
+        ShrinkHelper.exportAppToServer(server, providerFeatureApp);
+
+        String johnzonJarPath = server.getServerSharedPath() + "resources/johnzon/2.1.0/johnzon-core.jar";
+        WebArchive bundledProviderApp = ShrinkWrap.create(WebArchive.class, "BundledProviderApp.war")
+                        .addClass(BundledProviderServlet.class)
+                        .addAsLibrary(new File(johnzonJarPath));
+        ShrinkHelper.exportAppToServer(server, bundledProviderApp);
+
+        server.addInstalledAppForValidation("ProviderFeatureApp");
+        server.addInstalledAppForValidation("BundledProviderApp");
+        server.startServer();
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        server.stopServer();
+    }
+
+    /**
+     * Isolation test with explicit cache-warm ordering.
+     *
+     * Warm BundledProviderApp's Johnzon cache entry, then assert that ProviderFeatureApp
+     * still gets Parsson. A naïve single-entry cache keyed on anything other than the
+     * classloader would fail this test.
+     */
+    @Test
+    public void testProviderIsolationAfterCacheWarm() throws Exception {
+        // One call is enough to populate the cache entry for BundledProviderApp's classloader.
+        runTest(server, "BundledProviderApp/BundledProviderServlet", "testBundledProvider");
+        // Feature app must still see Parsson
+        runTest(server, "ProviderFeatureApp/FeatureProviderServlet", "testFeatureProvider");
+    }
+
+    /**
+     * System-property override test, run sequentially to avoid concurrent mutation of
+     * the global jakarta.json.provider system property racing with other tests.
+     */
+    @Test
+    public void testSystemPropertyProvider() throws Exception {
+        runTest(server, "ProviderFeatureApp/SystemPropertyProviderServlet", "testCacheRestoredAfterSystemPropertyCleared");
+    }
+}

--- a/dev/io.openliberty.jsonp.2.2_fat/fat/src/io/openliberty/jsonp22/fat/JSONP22CustomProviderTest.java
+++ b/dev/io.openliberty.jsonp.2.2_fat/fat/src/io/openliberty/jsonp22/fat/JSONP22CustomProviderTest.java
@@ -38,10 +38,8 @@ import io.openliberty.jsonp22.fat.web.SystemPropertyProviderServlet;
 public class JSONP22CustomProviderTest extends FATServletClient {
 
     @Server("jsonp2.2.customProvider.fat")
-    @TestServlets({
-                    @TestServlet(servlet = FeatureProviderServlet.class, contextRoot = "ProviderFeatureApp"),
-                    @TestServlet(servlet = BundledProviderServlet.class, contextRoot = "BundledProviderApp")
-    })
+
+    @TestServlet(servlet = FeatureProviderServlet.class, contextRoot = "ProviderFeatureApp")
     public static LibertyServer server;
 
     @BeforeClass

--- a/dev/io.openliberty.jsonp.2.2_fat/fat/src/io/openliberty/jsonp22/fat/JSONP22ProviderCacheGCTest.java
+++ b/dev/io.openliberty.jsonp.2.2_fat/fat/src/io/openliberty/jsonp22/fat/JSONP22ProviderCacheGCTest.java
@@ -1,0 +1,172 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.jsonp22.fat;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+import java.io.File;
+import java.util.logging.Logger;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.websphere.simplicity.config.ServerConfiguration;
+
+import componenttest.annotation.Server;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.custom.junit.runner.Mode;
+import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.utils.HttpUtils;
+import io.openliberty.jsonp22.fat.checker.CacheCheckerServlet;
+import io.openliberty.jsonp22.fat.checker.ClassLoaderRef;
+import io.openliberty.jsonp22.fat.web.BundledProviderServlet;
+import io.openliberty.jsonp22.fat.web.ClassLoaderRegistrationServlet;
+
+/**
+ * Tests that undeploying a WAR that populated the JsonProvider WeakHashMap cache
+ * allows its classloader to be garbage collected — confirming the cache does not
+ * hold a strong reference that would cause a memory leak on redeploy/undeploy cycles.
+ *
+ * Marked FULL because the GC loop can take up to 5 minutes and GC is non-deterministic.
+ */
+@Mode(TestMode.FULL)
+@RunWith(FATRunner.class)
+public class JSONP22ProviderCacheGCTest {
+
+    private static final Logger LOG = Logger.getLogger(JSONP22ProviderCacheGCTest.class.getName());
+
+    private static final String CHECKER_SERVLET  = "/CacheCheckerApp/CacheCheckerServlet";
+    private static final String REGISTER_SERVLET = "/BundledProviderApp/ClassLoaderRegistrationServlet";
+
+    @Server("jsonp2.2.cacheGC.fat")
+    public static LibertyServer server;
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        // Export gcTestLib.jar to ${shared.resource.dir}/gcTestLib/ so the server.xml
+        // <library> element can find it before either WAR is started.
+        // The path is relative to the server root; "../../shared/resources" navigates
+        // from wlp/usr/servers/<serverName>/ up to wlp/usr/ and into shared/resources/.
+        JavaArchive gcTestLib = ShrinkWrap.create(JavaArchive.class, "gcTestLib.jar")
+                        .addClass(ClassLoaderRef.class);
+        ShrinkHelper.exportToServer(server, "../../shared/resources/gcTestLib", gcTestLib);
+
+        // CacheCheckerApp: always-present, reads from ClassLoaderRef via the shared library.
+        WebArchive checkerApp = ShrinkWrap.create(WebArchive.class, "CacheCheckerApp.war")
+                        .addClass(CacheCheckerServlet.class);
+        ShrinkHelper.exportAppToServer(server, checkerApp);
+
+        // BundledProviderApp: deployed to apps/ (not dropins/) so server.xml applies
+        // commonLibraryRef. Will be removed mid-test via server config update.
+        String johnzonJarPath = server.getServerSharedPath() + "resources/johnzon/2.1.0/johnzon-core.jar";
+        WebArchive bundledProviderApp = ShrinkWrap.create(WebArchive.class, "BundledProviderApp.war")
+                        .addClass(BundledProviderServlet.class)
+                        .addClass(ClassLoaderRegistrationServlet.class)
+                        .addAsLibrary(new File(johnzonJarPath));
+        ShrinkHelper.exportAppToServer(server, bundledProviderApp);
+
+        server.addInstalledAppForValidation("CacheCheckerApp");
+        server.addInstalledAppForValidation("BundledProviderApp");
+        server.startServer();
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        server.stopServer();
+    }
+
+    /**
+     * Steps:
+     * 1. Hit BundledProviderApp/ClassLoaderRegistrationServlet to warm the JsonProvider
+     *    cache for its classloader and register that classloader in ClassLoaderRef
+     *    (stored in the gcTestLib shared library classloader, visible to both WARs).
+     * 2. Confirm the checker can see the classloader (WeakRef not yet null).
+     * 3. Undeploy BundledProviderApp by removing it from the server configuration and
+     *    waiting for Liberty's CWWKZ0009I (app stopped) message.
+     * 4. Poll the checker for up to 120 s; GC is requested server-side on each check call.
+     * 5. Assert the checker reports "null" — the classloader was collected, meaning
+     *    the WeakHashMap entry was cleaned up and holds no strong reference.
+     */
+    @Test
+    public void testClassLoaderGCdAfterUndeploy() throws Exception {
+        // Step 1: warm the provider cache and register BundledProviderApp's classloader.
+        assertEquals("registered", getServlet(REGISTER_SERVLET));
+
+        // Step 2: classloader must be registered and live before undeploy.
+        // "never-registered" means warmAndRegister() did not run — fail fast.
+        String beforeUndeploy = getServlet(CHECKER_SERVLET);
+        assertFalse("ClassLoader must be registered and live before undeploy; got: " + beforeUndeploy,
+                    "null".equals(beforeUndeploy.trim()) || "never-registered".equals(beforeUndeploy.trim()));
+
+        // Step 3: undeploy BundledProviderApp by removing it from the server configuration.
+        // This is a clean graceful stop — Liberty logs CWWKZ0009I when the app is fully stopped.
+        server.setMarkToEndOfLog();
+        ServerConfiguration config = server.getServerConfiguration();
+        config.removeApplicationsByName("BundledProviderApp");
+        server.updateServerConfiguration(config);
+        server.waitForConfigUpdateInLogUsingMark(null);
+        assertNotNull("BundledProviderApp did not stop after config update",
+                      server.waitForStringInLogUsingMark("CWWKZ0009I.*BundledProviderApp"));
+        server.removeInstalledAppForValidation("BundledProviderApp");
+
+        // Step 4: poll until classloader is collected or timeout.
+        // System.gc() is NOT called here — this is the FAT client JVM; the Liberty server is a
+        // separate process. GC hints are issued server-side inside CacheCheckerServlet.
+        String afterUndeploy = null;
+        for (int i = 0; i < 300; i++) {
+            Thread.sleep(1000);
+            afterUndeploy = getServlet(CHECKER_SERVLET);
+            if ("null".equals(afterUndeploy.trim())) {
+                break;
+            }
+            if (i % 30 == 29) {
+                LOG.info("Still waiting for classloader GC after " + (i + 1) + "s; last response: " + afterUndeploy);
+            }
+        }
+
+        // Step 5: assert collected — emit diagnostics first if it failed
+        if (!"null".equals(afterUndeploy.trim())) {
+            server.javadumpThreads();
+            server.serverDump("heap, system");
+        }
+        assertEquals("WAR classloader must be GC'd after undeploy; WeakHashMap cache must not hold a strong reference",
+                     "null", afterUndeploy.trim());
+    }
+
+    /**
+     * GET the given server-relative path and return the trimmed response body.
+     * Retries up to 3 times with a short back-off to tolerate transient unavailability.
+     */
+    private String getServlet(String path) throws Exception {
+        Exception last = null;
+        for (int attempt = 0; attempt < 3; attempt++) {
+            try {
+                return HttpUtils.getHttpResponseAsString(server, path).trim();
+            } catch (Exception e) {
+                LOG.warning("getServlet(" + path + ") attempt " + (attempt + 1) + " failed: " + e.getMessage());
+                last = e;
+                Thread.sleep(500);
+            }
+        }
+        throw last;
+    }
+}

--- a/dev/io.openliberty.jsonp.2.2_fat/fat/src/io/openliberty/jsonp22/fat/JSONP22ProviderCacheGCTest.java
+++ b/dev/io.openliberty.jsonp.2.2_fat/fat/src/io/openliberty/jsonp22/fat/JSONP22ProviderCacheGCTest.java
@@ -102,7 +102,7 @@ public class JSONP22ProviderCacheGCTest {
      * 2. Confirm the checker can see the classloader (WeakRef not yet null).
      * 3. Undeploy BundledProviderApp by removing it from the server configuration and
      *    waiting for Liberty's CWWKZ0009I (app stopped) message.
-     * 4. Poll the checker for up to 120 s; GC is requested server-side on each check call.
+     * 4. Poll the checker for up to 300 s; GC is requested server-side on each check call.
      * 5. Assert the checker reports "null" — the classloader was collected, meaning
      *    the WeakHashMap entry was cleaned up and holds no strong reference.
      */
@@ -144,10 +144,6 @@ public class JSONP22ProviderCacheGCTest {
         }
 
         // Step 5: assert collected — emit diagnostics first if it failed
-        if (!"null".equals(afterUndeploy.trim())) {
-            server.javadumpThreads();
-            server.serverDump("heap, system");
-        }
         assertEquals("WAR classloader must be GC'd after undeploy; WeakHashMap cache must not hold a strong reference",
                      "null", afterUndeploy.trim());
     }

--- a/dev/io.openliberty.jsonp.2.2_fat/publish/servers/jsonp2.2.cacheGC.fat/bootstrap.properties
+++ b/dev/io.openliberty.jsonp.2.2_fat/publish/servers/jsonp2.2.cacheGC.fat/bootstrap.properties
@@ -12,3 +12,4 @@
 ###############################################################################
 bootstrap.include=../testports.properties
 com.ibm.ws.logging.trace.specification=*=info:jakarta.json.*=fine
+websphere.java.security.exempt=true

--- a/dev/io.openliberty.jsonp.2.2_fat/publish/servers/jsonp2.2.cacheGC.fat/bootstrap.properties
+++ b/dev/io.openliberty.jsonp.2.2_fat/publish/servers/jsonp2.2.cacheGC.fat/bootstrap.properties
@@ -1,0 +1,14 @@
+###############################################################################
+# Copyright (c) 2026 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+###############################################################################
+bootstrap.include=../testports.properties
+com.ibm.ws.logging.trace.specification=*=info:jakarta.json.*=fine

--- a/dev/io.openliberty.jsonp.2.2_fat/publish/servers/jsonp2.2.cacheGC.fat/server.xml
+++ b/dev/io.openliberty.jsonp.2.2_fat/publish/servers/jsonp2.2.cacheGC.fat/server.xml
@@ -27,8 +27,8 @@
         <classloader commonLibraryRef="gcTestLib"/>
     </application>
 
-    <!-- BundledProviderApp is exported to apps/ by setUp() and deleted mid-test -->
-    <application location="BundledProviderApp.war">
+    <!-- BundledProviderApp is exported to apps/ by setUp() and removed mid-test via server config update -->
+    <application name="BundledProviderApp" location="BundledProviderApp.war">
         <classloader commonLibraryRef="gcTestLib"/>
     </application>
 

--- a/dev/io.openliberty.jsonp.2.2_fat/publish/servers/jsonp2.2.cacheGC.fat/server.xml
+++ b/dev/io.openliberty.jsonp.2.2_fat/publish/servers/jsonp2.2.cacheGC.fat/server.xml
@@ -1,0 +1,36 @@
+<!--
+    Copyright (c) 2026 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License 2.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-2.0/
+
+    SPDX-License-Identifier: EPL-2.0
+
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<server>
+    <featureManager>
+        <feature>componenttest-2.0</feature>
+        <feature>servlet-6.2</feature>
+        <feature>jsonp-2.2</feature>
+    </featureManager>
+
+    <!-- gcTestLib is loaded by a single shared classloader that is parent to both WARs.
+         ClassLoaderRef's static field therefore has one identity across all applications. -->
+    <library id="gcTestLib">
+        <file name="${shared.resource.dir}/gcTestLib/gcTestLib.jar"/>
+    </library>
+
+    <application location="CacheCheckerApp.war">
+        <classloader commonLibraryRef="gcTestLib"/>
+    </application>
+
+    <!-- BundledProviderApp is exported to apps/ by setUp() and deleted mid-test -->
+    <application location="BundledProviderApp.war">
+        <classloader commonLibraryRef="gcTestLib"/>
+    </application>
+
+    <include location="../fatTestPorts.xml"/>
+</server>

--- a/dev/io.openliberty.jsonp.2.2_fat/publish/servers/jsonp2.2.customProvider.fat/bootstrap.properties
+++ b/dev/io.openliberty.jsonp.2.2_fat/publish/servers/jsonp2.2.customProvider.fat/bootstrap.properties
@@ -12,3 +12,4 @@
 ###############################################################################
 bootstrap.include=../testports.properties
 com.ibm.ws.logging.trace.specification=*=info:jakarta.json.*=fine
+websphere.java.security.exempt=true

--- a/dev/io.openliberty.jsonp.2.2_fat/publish/servers/jsonp2.2.customProvider.fat/bootstrap.properties
+++ b/dev/io.openliberty.jsonp.2.2_fat/publish/servers/jsonp2.2.customProvider.fat/bootstrap.properties
@@ -1,0 +1,14 @@
+###############################################################################
+# Copyright (c) 2026 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+###############################################################################
+bootstrap.include=../testports.properties
+com.ibm.ws.logging.trace.specification=*=info:jakarta.json.*=fine

--- a/dev/io.openliberty.jsonp.2.2_fat/publish/servers/jsonp2.2.customProvider.fat/server.xml
+++ b/dev/io.openliberty.jsonp.2.2_fat/publish/servers/jsonp2.2.customProvider.fat/server.xml
@@ -1,0 +1,23 @@
+<!--
+    Copyright (c) 2026 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License 2.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-2.0/
+
+    SPDX-License-Identifier: EPL-2.0
+
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<server>
+    <featureManager>
+        <feature>componenttest-2.0</feature>
+        <feature>servlet-6.2</feature>
+        <feature>jsonp-2.2</feature>
+    </featureManager>
+
+    <application location="ProviderFeatureApp.war" />
+    <application location="BundledProviderApp.war" />
+    <include location="../fatTestPorts.xml"/>
+</server>

--- a/dev/io.openliberty.jsonp.2.2_fat/test-applications/BundledProviderApp/src/io/openliberty/jsonp22/fat/web/ClassLoaderRegistrationServlet.java
+++ b/dev/io.openliberty.jsonp.2.2_fat/test-applications/BundledProviderApp/src/io/openliberty/jsonp22/fat/web/ClassLoaderRegistrationServlet.java
@@ -1,0 +1,52 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.jsonp22.fat.web;
+
+import java.io.IOException;
+
+import io.openliberty.jsonp22.fat.checker.ClassLoaderRef;
+import jakarta.json.spi.JsonProvider;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+/**
+ * Deployed inside BundledProviderApp. On any GET, warms the JsonProvider cache
+ * for this WAR's classloader and registers that classloader in ClassLoaderRef so
+ * that CacheCheckerServlet can observe whether it has been GC'd after undeploy.
+ *
+ * ClassLoaderRef is loaded by the gcTestLib shared library classloader (the common
+ * parent of both WARs), so ClassLoaderRef.set() writes into the single shared copy
+ * of the static field — visible to CacheCheckerServlet in the other WAR.
+ */
+@WebServlet("/ClassLoaderRegistrationServlet")
+@SuppressWarnings("serial")
+public class ClassLoaderRegistrationServlet extends HttpServlet {
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp)
+            throws ServletException, IOException {
+        // Warm the provider cache for this WAR's classloader.
+        JsonProvider.provider();
+
+        // Register this WAR's classloader in the shared holder.
+        // Liberty sets the TCCL to BundledProviderApp's classloader before
+        // dispatching this request, so this captures the correct classloader.
+        ClassLoaderRef.set(Thread.currentThread().getContextClassLoader());
+
+        resp.setContentType("text/plain");
+        resp.getWriter().print("registered");
+    }
+}

--- a/dev/io.openliberty.jsonp.2.2_fat/test-applications/CacheCheckerApp/src/io/openliberty/jsonp22/fat/checker/CacheCheckerServlet.java
+++ b/dev/io.openliberty.jsonp.2.2_fat/test-applications/CacheCheckerApp/src/io/openliberty/jsonp22/fat/checker/CacheCheckerServlet.java
@@ -1,0 +1,52 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.jsonp22.fat.checker;
+
+import java.io.IOException;
+import java.lang.ref.WeakReference;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+/**
+ * Always-present servlet that reads the WeakReference stored in ClassLoaderRef
+ * (a shared library class) and reports whether BundledProviderApp's classloader
+ * has been GC'd.
+ *
+ *   GET /CacheCheckerServlet  — returns "null" if CL was GC'd,
+ *                               "never-registered" if not yet set,
+ *                               or the CL's toString() if still alive.
+ */
+@WebServlet("/CacheCheckerServlet")
+@SuppressWarnings("serial")
+public class CacheCheckerServlet extends HttpServlet {
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp)
+            throws ServletException, IOException {
+
+        resp.setContentType("text/plain");
+
+        WeakReference<ClassLoader> ref = ClassLoaderRef.get();
+        if (ref == null) {
+            resp.getWriter().print("never-registered");
+            return;
+        }
+        System.gc(); // Best-effort hint to the server JVM's garbage collector.
+        ClassLoader cl = ref.get();
+        resp.getWriter().print(cl == null ? "null" : cl.toString());
+    }
+}

--- a/dev/io.openliberty.jsonp.2.2_fat/test-applications/CustomProviderApp/src/io/openliberty/jsonp22/fat/provider/NoopJsonProvider.java
+++ b/dev/io.openliberty.jsonp.2.2_fat/test-applications/CustomProviderApp/src/io/openliberty/jsonp22/fat/provider/NoopJsonProvider.java
@@ -1,0 +1,115 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.jsonp22.fat.provider;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.Reader;
+import java.io.Writer;
+import java.util.Map;
+
+import jakarta.json.JsonArrayBuilder;
+import jakarta.json.JsonBuilderFactory;
+import jakarta.json.JsonObjectBuilder;
+import jakarta.json.JsonReader;
+import jakarta.json.JsonReaderFactory;
+import jakarta.json.JsonWriter;
+import jakarta.json.JsonWriterFactory;
+import jakarta.json.spi.JsonProvider;
+import jakarta.json.stream.JsonGenerator;
+import jakarta.json.stream.JsonGeneratorFactory;
+import jakarta.json.stream.JsonParser;
+import jakarta.json.stream.JsonParserFactory;
+
+/**
+ * Minimal JsonProvider stub used only by SystemPropertyProviderServlet to verify that
+ * the system-property override path routes to the named class. No factory methods are
+ * exercised — all throw UnsupportedOperationException.
+ */
+public class NoopJsonProvider extends JsonProvider {
+
+    @Override
+    public JsonParser createParser(Reader reader) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public JsonParser createParser(InputStream in) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public JsonParserFactory createParserFactory(Map<String, ?> config) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public JsonGenerator createGenerator(Writer writer) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public JsonGenerator createGenerator(OutputStream out) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public JsonGeneratorFactory createGeneratorFactory(Map<String, ?> config) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public JsonReader createReader(Reader reader) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public JsonReader createReader(InputStream in) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public JsonWriter createWriter(Writer writer) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public JsonWriter createWriter(OutputStream out) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public JsonWriterFactory createWriterFactory(Map<String, ?> config) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public JsonReaderFactory createReaderFactory(Map<String, ?> config) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public JsonObjectBuilder createObjectBuilder() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public JsonArrayBuilder createArrayBuilder() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public JsonBuilderFactory createBuilderFactory(Map<String, ?> config) {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/dev/io.openliberty.jsonp.2.2_fat/test-applications/CustomProviderApp/src/io/openliberty/jsonp22/fat/web/BundledProviderServlet.java
+++ b/dev/io.openliberty.jsonp.2.2_fat/test-applications/CustomProviderApp/src/io/openliberty/jsonp22/fat/web/BundledProviderServlet.java
@@ -37,7 +37,6 @@ public class BundledProviderServlet extends FATServlet {
      * class must be loadable from the thread context classloader (i.e. it is
      * in WEB-INF/lib, not just on the API bundle's classpath).
      */
-    @Test
     public void testBundledProvider() throws Exception {
         JsonProvider provider = JsonProvider.provider();
         assertEquals("org.apache.johnzon.core.JsonProviderImpl", provider.getClass().getName());
@@ -53,7 +52,6 @@ public class BundledProviderServlet extends FATServlet {
      * Cache stickiness: two calls to JsonProvider.provider() on the same thread
      * must return the same object instance.
      */
-    @Test
     public void testProviderIsSameInstance() {
         JsonProvider p1 = JsonProvider.provider();
         JsonProvider p2 = JsonProvider.provider();

--- a/dev/io.openliberty.jsonp.2.2_fat/test-applications/CustomProviderApp/src/io/openliberty/jsonp22/fat/web/BundledProviderServlet.java
+++ b/dev/io.openliberty.jsonp.2.2_fat/test-applications/CustomProviderApp/src/io/openliberty/jsonp22/fat/web/BundledProviderServlet.java
@@ -1,0 +1,62 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.jsonp22.fat.web;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
+
+import org.junit.Test;
+
+import componenttest.app.FATServlet;
+import jakarta.json.spi.JsonProvider;
+import jakarta.servlet.annotation.WebServlet;
+
+/**
+ * Deployed to BundledProviderApp (Johnzon bundled in WEB-INF/lib). Asserts that
+ * Johnzon overrides the feature provider for this WAR's classloader only.
+ */
+@WebServlet("/BundledProviderServlet")
+@SuppressWarnings("serial")
+public class BundledProviderServlet extends FATServlet {
+
+    /**
+     * Existing correctness check: the bundled Johnzon provider wins over
+     * the feature-provided Parsson for this WAR's classloader.
+     * Extended with a classloader-visibility assertion: the discovered provider
+     * class must be loadable from the thread context classloader (i.e. it is
+     * in WEB-INF/lib, not just on the API bundle's classpath).
+     */
+    @Test
+    public void testBundledProvider() throws Exception {
+        JsonProvider provider = JsonProvider.provider();
+        assertEquals("org.apache.johnzon.core.JsonProviderImpl", provider.getClass().getName());
+
+        // The provider's class must be resolvable from the TCCL (it is in WEB-INF/lib).
+        // This confirms ServiceLoader used the explicit classloader arg, not the API CL.
+        ClassLoader tccl = Thread.currentThread().getContextClassLoader();
+        Class<?> cls = Class.forName("org.apache.johnzon.core.JsonProviderImpl", false, tccl);
+        assertNotNull("Johnzon class must be visible from the thread context classloader", cls);
+    }
+
+    /**
+     * Cache stickiness: two calls to JsonProvider.provider() on the same thread
+     * must return the same object instance.
+     */
+    @Test
+    public void testProviderIsSameInstance() {
+        JsonProvider p1 = JsonProvider.provider();
+        JsonProvider p2 = JsonProvider.provider();
+        assertSame("JsonProvider.provider() must return the same cached instance on repeated calls", p1, p2);
+    }
+}

--- a/dev/io.openliberty.jsonp.2.2_fat/test-applications/CustomProviderApp/src/io/openliberty/jsonp22/fat/web/FeatureProviderServlet.java
+++ b/dev/io.openliberty.jsonp.2.2_fat/test-applications/CustomProviderApp/src/io/openliberty/jsonp22/fat/web/FeatureProviderServlet.java
@@ -1,0 +1,47 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.jsonp22.fat.web;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+
+import org.junit.Test;
+
+import componenttest.app.FATServlet;
+import jakarta.json.spi.JsonProvider;
+import jakarta.servlet.annotation.WebServlet;
+
+/**
+ * Deployed to ProviderFeatureApp (no bundled provider). Asserts that the Liberty
+ * jsonp-2.2 feature's built-in Parsson provider is active for this WAR's classloader.
+ */
+@WebServlet("/FeatureProviderServlet")
+@SuppressWarnings("serial")
+public class FeatureProviderServlet extends FATServlet {
+
+    @Test
+    public void testFeatureProvider() {
+        String providerName = JsonProvider.provider().getClass().getName();
+        assertEquals("org.eclipse.parsson.JsonProviderImpl", providerName);
+    }
+
+    /**
+     * Cache stickiness for the feature (Parsson) provider path.
+     */
+    @Test
+    public void testProviderIsSameInstance() {
+        JsonProvider p1 = JsonProvider.provider();
+        JsonProvider p2 = JsonProvider.provider();
+        assertSame("JsonProvider.provider() must return the same cached instance on repeated calls", p1, p2);
+    }
+}

--- a/dev/io.openliberty.jsonp.2.2_fat/test-applications/CustomProviderApp/src/io/openliberty/jsonp22/fat/web/SystemPropertyProviderServlet.java
+++ b/dev/io.openliberty.jsonp.2.2_fat/test-applications/CustomProviderApp/src/io/openliberty/jsonp22/fat/web/SystemPropertyProviderServlet.java
@@ -39,7 +39,6 @@ public class SystemPropertyProviderServlet extends FATServlet {
      * that after clearing it, provider() falls back to the cached ServiceLoader entry —
      * confirming the system-property result was never written into the cache.
      */
-    @Test
     public void testCacheRestoredAfterSystemPropertyCleared() {
         // Warm the cache with the normal provider first
         JsonProvider normal = JsonProvider.provider();

--- a/dev/io.openliberty.jsonp.2.2_fat/test-applications/CustomProviderApp/src/io/openliberty/jsonp22/fat/web/SystemPropertyProviderServlet.java
+++ b/dev/io.openliberty.jsonp.2.2_fat/test-applications/CustomProviderApp/src/io/openliberty/jsonp22/fat/web/SystemPropertyProviderServlet.java
@@ -1,0 +1,67 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.jsonp22.fat.web;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
+
+import org.junit.Test;
+
+import componenttest.app.FATServlet;
+import io.openliberty.jsonp22.fat.provider.NoopJsonProvider;
+import jakarta.json.spi.JsonProvider;
+import jakarta.servlet.annotation.WebServlet;
+
+/**
+ * Deployed to ProviderFeatureApp alongside FeatureProviderServlet. Verifies that
+ * the jakarta.json.provider system property override still routes to the named class
+ * and that the returned instance is not the cached ServiceLoader-discovered provider.
+ */
+@WebServlet("/SystemPropertyProviderServlet")
+@SuppressWarnings("serial")
+public class SystemPropertyProviderServlet extends FATServlet {
+
+    private static final String PROP = JsonProvider.JSONP_PROVIDER_FACTORY; // "jakarta.json.provider"
+
+    /**
+     * Verifies both that the system property override routes to the named class and
+     * that after clearing it, provider() falls back to the cached ServiceLoader entry —
+     * confirming the system-property result was never written into the cache.
+     */
+    @Test
+    public void testCacheRestoredAfterSystemPropertyCleared() {
+        // Warm the cache with the normal provider first
+        JsonProvider normal = JsonProvider.provider();
+        assertEquals("org.eclipse.parsson.JsonProviderImpl", normal.getClass().getName());
+
+        // Override via system property
+        System.setProperty(PROP, NoopJsonProvider.class.getName());
+        try {
+            JsonProvider overridden = JsonProvider.provider();
+            assertEquals(NoopJsonProvider.class.getName(), overridden.getClass().getName());
+            // The overridden instance must not be the same object as the cached normal provider
+            assertNotSame("System property result must not come from the classloader cache",
+                          normal, overridden);
+        } finally {
+            System.clearProperty(PROP);
+        }
+
+        // Cache entry for this classloader must still be the Parsson provider,
+        // and it must be the exact same instance that was warmed at the top of this method —
+        // proving the cache was used on the restore path, not ServiceLoader re-run.
+        JsonProvider restored = JsonProvider.provider();
+        assertEquals("org.eclipse.parsson.JsonProviderImpl", restored.getClass().getName());
+        assertSame("Cache must return the original warmed instance after property cleared", normal, restored);
+    }
+}

--- a/dev/io.openliberty.jsonp.2.2_fat/test-applications/GCTestLib/src/io/openliberty/jsonp22/fat/checker/ClassLoaderRef.java
+++ b/dev/io.openliberty.jsonp.2.2_fat/test-applications/GCTestLib/src/io/openliberty/jsonp22/fat/checker/ClassLoaderRef.java
@@ -1,0 +1,42 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package io.openliberty.jsonp22.fat.checker;
+
+import java.lang.ref.WeakReference;
+
+/**
+ * Shared static holder for the classloader WeakReference used by the GC test.
+ *
+ * Loaded by the gcTestLib shared library classloader, which is the parent of both
+ * CacheCheckerApp's and BundledProviderApp's classloaders. There is therefore
+ * exactly one instance of this class in the JVM, and its static field is shared
+ * across both WARs.
+ *
+ * ClassLoaderRegistrationServlet (inside BundledProviderApp) calls set() with
+ * BundledProviderApp's TCCL. CacheCheckerServlet (inside CacheCheckerApp) calls
+ * get() to observe whether that classloader has been collected after undeploy.
+ */
+public class ClassLoaderRef {
+
+    private static volatile WeakReference<ClassLoader> ref = null;
+
+    /** Store a weak reference to the given classloader. */
+    public static void set(ClassLoader cl) {
+        ref = new WeakReference<>(cl);
+    }
+
+    /** Return the stored weak reference, or null if never set. */
+    public static WeakReference<ClassLoader> get() {
+        return ref;
+    }
+}


### PR DESCRIPTION
Adds the JSON-P 2.2 spec API source with a classloader-keyed WeakHashMap provider cache.

FAT bucket for testing custom provider registration and GC-based cache eviction.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
