### PR TITLE
Replace 1 minute timeout with warning and later timeout

### DIFF
--- a/dev/io.openliberty.data.internal/resources/io/openliberty/data/internal/resources/CWWKDMessages.nlsprops
+++ b/dev/io.openliberty.data.internal/resources/io/openliberty/data/internal/resources/CWWKDMessages.nlsprops
@@ -1255,3 +1255,11 @@ CWWKD1123.sort.incompat.with.cursor.explanation=To automatically \
 CWWKD1123.sort.incompat.with.cursor.useraction=Supply a cursor that is consistent \
  with the sort criteria. Alternatively, switch to offset-based pagination or \
  modify the sort criteria to only sort by entity attributes.
+
+CWWKD1124.resource.unavailable=CWWKD1124W: One or more repositories ({0}) are \
+ waiting to initialize because the {1} resource did not become available within \
+ {2} seconds. Repository initialization will continue waiting up to {3} seconds.
+CWWKD1124.resource.unavailable.explanation=A resource that the repositories \
+ require did not become available.
+CWWKD1124.resource.unavailable.useraction=Verify the configuration of resources \
+ that the repositories use.

--- a/dev/io.openliberty.data.internal/resources/io/openliberty/data/internal/resources/CWWKDMessages.nlsprops
+++ b/dev/io.openliberty.data.internal/resources/io/openliberty/data/internal/resources/CWWKDMessages.nlsprops
@@ -1257,9 +1257,14 @@ CWWKD1123.sort.incompat.with.cursor.useraction=Supply a cursor that is consisten
  modify the sort criteria to only sort by entity attributes.
 
 CWWKD1124.resource.unavailable=CWWKD1124W: One or more repositories ({0}) are \
- waiting to initialize because the {1} resource did not become available within \
- {2} seconds. Repository initialization will continue waiting up to {3} seconds.
+ waiting to initialize because the {1} resource is not available within \
+ {2} seconds. Repository initialization continues to wait up to {3} seconds.
 CWWKD1124.resource.unavailable.explanation=A resource that the repositories \
- require did not become available.
-CWWKD1124.resource.unavailable.useraction=Verify the configuration of resources \
- that the repositories use.
+ require is not yet available. This condition can occur because of a \
+ misconfiguration or because the resource is taking longer than expected to \
+ start. If the resource does not become available before the maximum wait time \
+ expires, repository initialization fails.
+CWWKD1124.resource.unavailable.useraction=To prevent this warning, verify that \
+ the configuration of the named resource is correct in the server.xml file. \
+ Check that the resource is configured and that all required dependencies are \
+ available.

--- a/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/cdi/FutureEHFactory.java
+++ b/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/cdi/FutureEHFactory.java
@@ -51,8 +51,8 @@ import com.ibm.wsspi.persistence.DDLGenerationParticipant;
 import io.openliberty.data.internal.DataProvider;
 import io.openliberty.data.internal.EntityHandlerFactory;
 import io.openliberty.data.internal.Util;
-import io.openliberty.data.internal.provider.PUnitEHFactory;
-import io.openliberty.data.internal.service.DBStoreEHFactory;
+import io.openliberty.data.internal.ds.DBStoreEHFactory;
+import io.openliberty.data.internal.jpa.PUnitEHFactory;
 import jakarta.data.exceptions.DataException;
 import jakarta.persistence.EntityManagerFactory;
 

--- a/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/ds/ClassDefiner.java
+++ b/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/ds/ClassDefiner.java
@@ -10,7 +10,7 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-package io.openliberty.data.internal.service;
+package io.openliberty.data.internal.ds;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;

--- a/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/ds/DBStoreEHFactory.java
+++ b/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/ds/DBStoreEHFactory.java
@@ -10,7 +10,7 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-package io.openliberty.data.internal.service;
+package io.openliberty.data.internal.ds;
 
 import static io.openliberty.data.internal.cdi.DataExtension.exc;
 

--- a/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/ds/RecordTransformer.java
+++ b/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/ds/RecordTransformer.java
@@ -7,7 +7,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  *******************************************************************************/
-package io.openliberty.data.internal.service;
+package io.openliberty.data.internal.ds;
 
 import static io.openliberty.data.internal.EntityHandlerFactory.getClassNames;
 import static io.openliberty.data.internal.cdi.DataExtension.exc;

--- a/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/ds/ResRefDelegator.java
+++ b/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/ds/ResRefDelegator.java
@@ -10,7 +10,7 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-package io.openliberty.data.internal.service;
+package io.openliberty.data.internal.ds;
 
 import javax.naming.InitialContext;
 

--- a/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/ds/package-info.java
+++ b/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/ds/package-info.java
@@ -15,6 +15,6 @@
  */
 @org.osgi.annotation.versioning.Version("1.0")
 @TraceOptions(traceGroup = "data", messageBundle = "io.openliberty.data.internal.resources.CWWKDMessages")
-package io.openliberty.data.internal.service;
+package io.openliberty.data.internal.ds;
 
 import com.ibm.websphere.ras.annotation.TraceOptions;

--- a/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/jpa/PUnitEHFactory.java
+++ b/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/jpa/PUnitEHFactory.java
@@ -10,7 +10,7 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-package io.openliberty.data.internal.provider;
+package io.openliberty.data.internal.jpa;
 
 import static io.openliberty.data.internal.cdi.DataExtension.exc;
 

--- a/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/jpa/package-info.java
+++ b/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/jpa/package-info.java
@@ -15,6 +15,6 @@
  */
 @org.osgi.annotation.versioning.Version("1.0")
 @TraceOptions(traceGroup = "data", messageBundle = "io.openliberty.data.internal.resources.CWWKDMessages")
-package io.openliberty.data.internal.provider;
+package io.openliberty.data.internal.jpa;
 
 import com.ibm.websphere.ras.annotation.TraceOptions;

--- a/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/service/DBStoreEHFactory.java
+++ b/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/service/DBStoreEHFactory.java
@@ -83,8 +83,20 @@ import jakarta.persistence.EntityManager;
  * It uses a PersistenceServiceUnit from the persistence service to create
  * EntityAgent and EntityManager instances.
  */
-public class DBStoreEHFactory extends EntityHandlerFactory implements DDLGenerationParticipant {
-    private static final long MAX_WAIT_FOR_SERVICE_NS = TimeUnit.SECONDS.toNanos(60);
+public class DBStoreEHFactory extends EntityHandlerFactory //
+                implements DDLGenerationParticipant {
+
+    /**
+     * Time (in nanoseconds) after which to raise an error and stop retrying when
+     * the databaseStore for the repository is still not available.
+     */
+    private static final long DBSTORE_WAIT_MAX_NS = TimeUnit.MINUTES.toNanos(3);
+
+    /**
+     * Time (in nanoseconds) after which to log a warning that the databaseStore
+     * for the repository is not available.
+     */
+    private static final long DBSTORE_WAIT_WARN_NS = TimeUnit.MINUTES.toNanos(1);
 
     private static final TraceComponent tc = Tr.register(DBStoreEHFactory.class);
 
@@ -324,6 +336,7 @@ public class DBStoreEHFactory extends EntityHandlerFactory implements DDLGenerat
         databaseStoreId = dbStoreId;
 
         ServiceReference<DatabaseStore> ref = null;
+        boolean warned = false;
         for (long start = System.nanoTime(), poll_ms = 125L; //
                         ref == null; //
                         poll_ms = poll_ms < 1000L ? poll_ms * 2 : 1000L) {
@@ -331,10 +344,20 @@ public class DBStoreEHFactory extends EntityHandlerFactory implements DDLGenerat
             Collection<ServiceReference<DatabaseStore>> refs = //
                             bc.getServiceReferences(DatabaseStore.class, filter);
             if (refs.isEmpty()) {
-                if (System.nanoTime() - start < MAX_WAIT_FOR_SERVICE_NS) {
+                long waited_ns = System.nanoTime() - start;
+                if (waited_ns < DBSTORE_WAIT_MAX_NS) {
+                    if (!warned && waited_ns > DBSTORE_WAIT_WARN_NS) {
+                        Tr.warning(tc, "CWWKD1124.resource.unavailable",
+                                   Util.names(repositoryInterfaces),
+                                   dataStore,
+                                   TimeUnit.NANOSECONDS.toSeconds(DBSTORE_WAIT_WARN_NS),
+                                   TimeUnit.NANOSECONDS.toSeconds(DBSTORE_WAIT_MAX_NS));
+                        warned = true;
+                    }
+
                     if (trace && tc.isDebugEnabled())
-                        Tr.debug(this, tc, "Wait " + poll_ms +
-                                           " ms for service reference to become available...");
+                        Tr.debug(this, tc, "Wait " + poll_ms + " ms for " + filter +
+                                           " to become available...");
                     TimeUnit.MILLISECONDS.sleep(poll_ms);
 
                     abortIfStopping(bc, application, repositoryInterfaces);
@@ -342,8 +365,8 @@ public class DBStoreEHFactory extends EntityHandlerFactory implements DDLGenerat
                     throw exc(IllegalStateException.class,
                               "CWWKD1116.resource.unavailable",
                               Util.names(repositoryInterfaces),
-                              configDisplayId,
-                              TimeUnit.NANOSECONDS.toSeconds(MAX_WAIT_FOR_SERVICE_NS));
+                              dataStore,
+                              TimeUnit.NANOSECONDS.toSeconds(DBSTORE_WAIT_MAX_NS));
                 }
             } else {
                 ref = refs.iterator().next();

--- a/dev/io.openliberty.data.internal/test/io/openliberty/data/internal/ds/GenerateEntityClassBytesTest.java
+++ b/dev/io.openliberty.data.internal/test/io/openliberty/data/internal/ds/GenerateEntityClassBytesTest.java
@@ -7,7 +7,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  *******************************************************************************/
-package io.openliberty.data.internal.service;
+package io.openliberty.data.internal.ds;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -24,6 +24,8 @@ import org.junit.Test;
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.util.CheckClassAdapter;
 
+import io.openliberty.data.internal.ds.ClassDefiner;
+import io.openliberty.data.internal.ds.RecordTransformer;
 import io.openliberty.data.internal.models.Ambiguous;
 import io.openliberty.data.internal.models.Boxed;
 import io.openliberty.data.internal.models.Empty;
@@ -32,8 +34,6 @@ import io.openliberty.data.internal.models.GenericInfer;
 import io.openliberty.data.internal.models.Naming;
 import io.openliberty.data.internal.models.Primitive;
 import io.openliberty.data.internal.models.Special;
-import io.openliberty.data.internal.service.ClassDefiner;
-import io.openliberty.data.internal.service.RecordTransformer;
 import jakarta.data.exceptions.DataException;
 
 /**


### PR DESCRIPTION
Given that an internal user ran into the 1 minute timeout and thought it was too small, let's significantly increase the timeout and issue a warning prior to it so that the user can know about the delay.

I also noticed that packages `service` and `provider` don't make sense after these were moved from the `io.openliberty.data.internal.persistence` project to the `io.openliberty.data.internal` project.  A second commit under this PR switches them to names that match up with the style of configuration that they are supporting: either a data source or a JPA persistence unit.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
