### PR TITLE
httpAccessLogging enabled="false" still schedules rollover and causes NullPointerException

### DIFF
--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/logging/internal/AccessLogger.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/logging/internal/AccessLogger.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2004, 2025 IBM Corporation and others.
+ * Copyright (c) 2004, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/logging/internal/AccessLogger.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/logging/internal/AccessLogger.java
@@ -164,14 +164,7 @@ public class AccessLogger extends LoggerOffThread implements AccessLog {
     @Deactivate
     protected void deactivate(ComponentContext ctx) {
         if (this.isLogRolloverScheduled) {
-            if (timedLogRollover_Timer != null) {
-                timedLogRollover_Timer.cancel();
-                timedLogRollover_Timer.purge();
-                this.isLogRolloverScheduled = false;
-                timedLogRollover_Timer = null;
-
-            }
-
+           cancelTimeBasedLogRollover();
         }
         stop();
     }
@@ -234,11 +227,13 @@ public class AccessLogger extends LoggerOffThread implements AccessLog {
 
         if (enabled) {
             start();
+            scheduleTimeBasedLogRollover(config);
+
         } else {
+            cancelTimeBasedLogRollover();
             stop();
         }
 
-        scheduleTimeBasedLogRollover(config);
     }
 
     /**
@@ -790,6 +785,14 @@ public class AccessLogger extends LoggerOffThread implements AccessLog {
 
     }
 
+    private void cancelTimeBasedLogRollover() {
+        if (timedLogRollover_Timer != null) {
+            timedLogRollover_Timer.cancel();
+            timedLogRollover_Timer.purge();
+            timedLogRollover_Timer = null;
+            this.isLogRolloverScheduled = false;
+        }
+    }
     /**
      * LogRoller task to be run/scheduled in timed log rollover.
      */

--- a/dev/io.openliberty.transport.http_fat/fat/src/io/openliberty/transport/http_fat/AccessLogRolloverTest.java
+++ b/dev/io.openliberty.transport.http_fat/fat/src/io/openliberty/transport/http_fat/AccessLogRolloverTest.java
@@ -11,6 +11,7 @@
 package io.openliberty.transport.http_fat;
 
 import static componenttest.custom.junit.runner.Mode.TestMode.FULL;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
@@ -203,6 +204,41 @@ public class AccessLogRolloverTest {
         assertTrue("Expected at most " + maxFiles + " log files, but found " + logCount + ": " +
                    (logs != null ? Arrays.toString(logs) : "No logs found"),
                    logCount == maxFiles);
+    }
+
+    /*
+     * Tests no NPE when enabled="false" and rolloverInterval is set.
+     * Verifies no NullPointerException in logs and no rolled log files are created.
+     */
+    @Test
+    @Mode(FULL)
+    public void testNoNPEWhenAccessLoggingDisabledWithRolloverInterval() throws Exception {
+        LOG.info("Applying test-specific server configuration for disabled access logging with rolloverInterval.");
+        serverXml.setServerConfigurationFile("accessLogging/server-rollover-disabled.xml");
+        serverXml.waitForStringInLogUsingMark("CWWKG0017I", 5000);
+
+        // Avoid timing issues near the top of a minute
+        avoidTopOfMinute();
+
+        // Wait for one full rollover interval (1 minute) plus padding so the timer would have fired
+        Calendar cal = getNextRolloverTime(0, 1);
+        long timeToRollover = cal.getTimeInMillis() - Calendar.getInstance().getTimeInMillis();
+        if (timeToRollover > 0) {
+            Thread.sleep(timeToRollover + FILE_WAIT_SECONDS_PADDING);
+        }
+
+        // No NullPointerException should appear in the logs
+        List<String> npeLines = serverInUse.findStringsInLogs("NullPointerException");
+        assertTrue("NullPointerException found in logs when access logging is disabled: " + npeLines,
+                   npeLines.isEmpty());
+
+        // No rolled access log backup files should exist since logging is disabled.
+        // Backup files have a timestamp suffix matching: http_access_yy.MM.dd_HH.mm.ss.log
+        File logsDir = new File(getLogsDirPath());
+        String[] rolledLogs = logsDir.list((dir, name) -> name.matches(ACCESS_LOG_PREFIX + "_\\d{2}\\.\\d{2}\\.\\d{2}_\\d{2}\\.\\d{2}\\.\\d{2}" + LOG_EXT));
+        int rolledCount = (rolledLogs != null) ? rolledLogs.length : 0;
+        assertFalse("Rolled access log files were created even though access logging is disabled: "
+                    + Arrays.toString(rolledLogs), rolledCount > 0);
     }
 
     private static String getLogsDirPath() throws Exception {

--- a/dev/io.openliberty.transport.http_fat/publish/files/accessLogging/server-rollover-disabled.xml
+++ b/dev/io.openliberty.transport.http_fat/publish/files/accessLogging/server-rollover-disabled.xml
@@ -1,0 +1,24 @@
+<!--
+    Copyright (c) 2026 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License 2.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-2.0/
+    
+    SPDX-License-Identifier: EPL-2.0
+ -->
+<server>
+    <include location="common.xml"/>
+
+    <!-- Reproduces: NPE in TimedLogRoller.run() when enabled="false" and rolloverInterval is set. -->
+    <httpAccessLogging id="accessLogging"
+            filePath="${server.output.dir}/logs/http_access.log"
+            rolloverInterval="1m"
+            logFormat='%h %u %{t}W "%r" %s %b %D %{R}W'
+            enabled="false" />
+
+    <httpEndpoint id="defaultHttpEndpoint"
+            host="*"
+            accessLoggingRef="accessLogging" />
+
+</server>


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).

resolves #35613 
