### PR TITLE
Return the registry user name from BasicRegistry.checkPassword when ignoring case

### DIFF
--- a/dev/com.ibm.ws.security.registry.basic/src/com/ibm/ws/security/registry/basic/internal/BasicRegistry.java
+++ b/dev/com.ibm.ws.security.registry.basic/src/com/ibm/ws/security/registry/basic/internal/BasicRegistry.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011,2021 IBM Corporation and others.
+ * Copyright (c) 2011,2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -311,12 +311,21 @@ public class BasicRegistry implements UserRegistry {
         }
         boolean valid = false;
 
+        // The name to hand back to the caller. When authenticating case
+        // insensitively this is the name as it is spelled in the registry
+        // rather than the name as it was supplied, so that the security name
+        // established at login matches the user and group entries. Group
+        // membership is resolved by an exact name match, so returning the
+        // supplied spelling leaves the user authenticated but in no groups.
+        String matchedUserName = userSecurityName;
+
         BasicPassword storedPassObj = null;
         if (state.ignoreCaseForAuthentication) {
             for (Map.Entry<String, BasicPassword> entry : state.users.entrySet()) {
                 String keyUserName = entry.getKey();
                 if (keyUserName.equalsIgnoreCase(userSecurityName)) {
                     storedPassObj = entry.getValue();
+                    matchedUserName = keyUserName;
                 }
             }
         } else {
@@ -349,7 +358,7 @@ public class BasicRegistry implements UserRegistry {
             }
         }
         if (valid) {
-            return userSecurityName;
+            return matchedUserName;
         } else {
             return null;
         }

--- a/dev/com.ibm.ws.security.registry.basic/test/com/ibm/ws/security/registry/basic/internal/BasicRegistryTest.java
+++ b/dev/com.ibm.ws.security.registry.basic/test/com/ibm/ws/security/registry/basic/internal/BasicRegistryTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011,2018 IBM Corporation and others.
+ * Copyright (c) 2011,2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -320,7 +320,25 @@ public class BasicRegistryTest {
             }
             @Override
             public Group[] group() {
-                return new Group[] {};
+                return new Group[] {
+                                     new Group() {
+                                         @Override
+                                         public String name() {
+                                             return "group2";
+                                         }
+                                         @Override
+                                         public Member[] member() {
+                                             return new Member[] {
+                                                                   new Member() {
+                                                                       @Override
+                                                                       public String name() {
+                                                                           return "USER2";
+                                                                       }
+                                                                   }
+                                             };
+                                         }
+                                     }
+                };
             }
             @Override
             public String config_id() {
@@ -409,6 +427,35 @@ public class BasicRegistryTest {
     public void checkPassword_validCredentials() throws Exception {
         assertEquals("user1", fullBasicRegistry().checkPassword("user1", "pass1"));
         assertEquals("user 2", fullBasicRegistry().checkPassword("user 2", "pass 2"));
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.security.registry.basic.internal.BasicRegistry#checkPassword(String, String)}.
+     * When ignoreCaseForAuthentication is enabled, checkPassword() shall return
+     * the user name as it is defined in the registry rather than the name as it
+     * was supplied by the caller.
+     */
+    @Test
+    public void checkPassword_ignoreCaseReturnsRegistryUserName() throws Exception {
+        assertEquals("USER2", ignoreCaseBasicRegistry().checkPassword("user2", "pass2"));
+        assertEquals("USER2", ignoreCaseBasicRegistry().checkPassword("UsEr2", "pass2"));
+        assertEquals("user1", ignoreCaseBasicRegistry().checkPassword("USER1", "pass1"));
+    }
+
+    /**
+     * Test method for {@link com.ibm.ws.security.registry.basic.internal.BasicRegistry#getUniqueGroupIdsForUser(String)}.
+     * Group membership is resolved by an exact name match, so the name returned
+     * by checkPassword() must resolve the groups of the user that was
+     * authenticated, whatever spelling the caller used.
+     */
+    @Test
+    public void getUniqueGroupIdsForUser_afterIgnoreCaseAuthentication() throws Exception {
+        BasicRegistry reg = ignoreCaseBasicRegistry();
+        String authenticatedName = reg.checkPassword("user2", "pass2");
+        List<String> groups = reg.getUniqueGroupIdsForUser(authenticatedName);
+        assertNotNull("Group list must never be null", groups);
+        assertEquals("Should be 1 entry", 1, groups.size());
+        assertTrue("Should contain group2", groups.contains("group2"));
     }
 
     /**


### PR DESCRIPTION
## Problem

`basicRegistry` with `ignoreCaseForAuthentication="true"` will happily authenticate a user and then leave them in no groups at all, silently

`checkPassword()` matches the supplied name case insensitively, but hands back the name exactly as the caller typed it:

```java
if (keyUserName.equalsIgnoreCase(userSecurityName)) {
    storedPassObj = entry.getValue();
}
...
return userSecurityName;   // the caller's spelling, not the registry's
```

That name becomes the security name on the authenticated subject, and from there the `WSCredential` and its group access IDs

Group membership is an exact match though - `getGroupsForUser()` does `List.contains` on the member names. So given this:

```xml
<basicRegistry realm="defaultRealm" ignoreCaseForAuthentication="true">
    <user name="DEV_USER" password="..."/>
    <group name="ROLE_EXAMPLE">
        <member name="DEV_USER"/>
    </group>
</basicRegistry>
```

logging in as `dev_user` succeeds, and comes back with zero groups. `isValidUser()` honours the flag so there's no `EntryNotFoundException`, and nothing gets logged - the user simply has no authorities and every authorization check fails

It's a horrible one to diagnose, because authentication working makes the registry look correct

## Fix

Return the name as it's spelled in the registry, so the security name established at login lines up with the user and group entries

That's what the federated repository registry already does - membership there resolves by entity identifier, so the caller's casing never mattered. Anything moving from full profile onto `basicRegistry` hits this

## Tests

`ignoreCaseBasicRegistry()` had no groups defined, so membership was never exercised - given it one, plus two tests:

- `checkPassword_ignoreCaseReturnsRegistryUserName` - the returned name is the registry's spelling, whatever spelling was supplied
- `getUniqueGroupIdsForUser_afterIgnoreCaseAuthentication` - feeding `checkPassword()` into `getUniqueGroupIdsForUser()` resolves the user's groups, which is the case that breaks today

## Note

`mapCertificate()` returns a name that isn't canonicalised against the registry either, so certificate logins can mismatch the same way - left alone to keep this one focused
