### PR TITLE
handles null default value in dynamic tools with unit + fat tests

### DIFF
--- a/dev/io.openliberty.mcp.internal/src/io/openliberty/mcp/internal/ToolMetadata.java
+++ b/dev/io.openliberty.mcp.internal/src/io/openliberty/mcp/internal/ToolMetadata.java
@@ -290,7 +290,8 @@ public record ToolMetadata(String name,
         String argName = resolveArgumentName(param, argAnnotation);
         String description = argAnnotation != null ? argAnnotation.description() : "";
         boolean required = isArgumentRequired(argAnnotation, param.getBaseType());
-        String defaultValue = argAnnotation != null ? argAnnotation.defaultValue() : "";
+        String rawDefault = argAnnotation != null ? argAnnotation.defaultValue() : "";
+        String defaultValue = (rawDefault == null || rawDefault.isEmpty()) ? null : rawDefault;
 
         result.add(new ToolMethodArgument(param,
                                           new ToolArgumentImpl(argName,

--- a/dev/io.openliberty.mcp.internal/src/io/openliberty/mcp/internal/requests/DefaultValueResolver.java
+++ b/dev/io.openliberty.mcp.internal/src/io/openliberty/mcp/internal/requests/DefaultValueResolver.java
@@ -52,7 +52,7 @@ public class DefaultValueResolver {
      * @throws IllegalArgumentException if default value conversion fails
      */
     public static Object resolveDefaultValue(String toolName, ToolArgument argMetadata, ConverterRegistry converterRegistry) {
-        if (!argMetadata.defaultValue().isEmpty()) {
+        if (argMetadata.defaultValue() != null && !argMetadata.defaultValue().isEmpty()) {
             try {
                 return convertDefaultValue(toolName, argMetadata.defaultValue(), argMetadata.name(), argMetadata.type(), converterRegistry);
             } catch (Exception e) {

--- a/dev/io.openliberty.mcp.internal/test/io/openliberty/mcp/internal/test/ToolArgDefaultValueConverterTest.java
+++ b/dev/io.openliberty.mcp.internal/test/io/openliberty/mcp/internal/test/ToolArgDefaultValueConverterTest.java
@@ -105,6 +105,10 @@ public class ToolArgDefaultValueConverterTest {
                                                                         "ToolArg with a default value of a Obj type without a custom converter");
         List<ToolArgument> defaultValObjWithoutConverterToolArgs = List.of(new ToolArgumentImpl("person", "Person value", false, Person.class, "Joe::35"));
         registry.addTool(ToolMetadataTestUtility.createFrom(defaultValueObjArgWithoutConverterTestTool, defaultValObjWithoutConverterToolArgs, Collections.emptyList()));
+
+        Tool nullDefaultValueTool = Literals.tool("nullDefaultValue", "Null Default Value", "ToolArg with a null default value");
+        List<ToolArgument> nullDefaultValueToolArgs = List.of(new ToolArgumentImpl("value", "String value", false, String.class, null));
+        registry.addTool(ToolMetadataTestUtility.createFrom(nullDefaultValueTool, nullDefaultValueToolArgs, Collections.emptyList()));
     }
 
     @Test
@@ -275,6 +279,27 @@ public class ToolArgDefaultValueConverterTest {
         assertThrows(() -> DefaultValueResolver.resolveDefaultValue(toolName, argMetadata, testConverterRegistry),
                      exception()
                                 .ofType(IllegalArgumentException.class));
+    }
+
+    @Test
+    public void testArgumentNullDefaultValueReturnsNull() {
+        // null defaultValue on a programmatically registered argument must not cause a NullPointerException in DefaultValueResolver.
+        StringReader reader = new StringReader("""
+                        {
+                          "jsonrpc": "2.0",
+                          "id": "2",
+                          "method": "tools/call",
+                          "params": {
+                            "name": "nullDefaultValue",
+                            "arguments": {}
+                          }
+                        }
+                        """);
+        McpRequest request = jsonb.fromJson(reader, McpRequest.class);
+        McpToolCallParams toolCallRequest = request.getParams(McpToolCallParams.class, jsonb);
+        ToolArgument argMetadata = getArgument(toolCallRequest.getMetadata(), "value");
+        String toolName = toolCallRequest.getMetadata().name();
+        assertThat(DefaultValueResolver.resolveDefaultValue(toolName, argMetadata, testConverterRegistry), equalTo(null));
     }
 
     private static ToolArgument getArgument(ToolInfo toolInfo, String argName) {

--- a/dev/io.openliberty.mcp.internal/test/io/openliberty/mcp/internal/test/ToolMetadataTest.java
+++ b/dev/io.openliberty.mcp.internal/test/io/openliberty/mcp/internal/test/ToolMetadataTest.java
@@ -39,6 +39,7 @@ import io.openliberty.mcp.internal.ToolMetadata;
 import io.openliberty.mcp.internal.schemas.SchemaRegistry;
 import io.openliberty.mcp.internal.schemas.TypeUtility;
 import io.openliberty.mcp.internal.testutils.TestUtils;
+import io.openliberty.mcp.tools.ToolManager.ToolArgument;
 import io.openliberty.mcp.internal.typeimpl.ParameterizedTypeImpl;
 import jakarta.json.JsonObject;
 import jakarta.json.bind.Jsonb;
@@ -441,6 +442,18 @@ public class ToolMetadataTest {
     public void testOutputSchemaFromIgnoredWhenStructuredContentFalse() {
         ToolMetadata metadata = TestUtils.findTool(ToolMetadataTest.class, "toolResponseWithOutputSchemaFromNoStructuredContent");
         assertNull(metadata.outputSchema());
+    }
+
+    @Tool
+    public String toolWithNoDefaultValue(@ToolArg(name = "value") String value) {
+        return value;
+    }
+
+    @Test
+    public void testAnnotationArgWithNoDefaultValueIsNormalisedToNull() {
+        ToolMetadata metadata = TestUtils.findTool(ToolMetadataTest.class, "toolWithNoDefaultValue");
+        ToolArgument arg = metadata.arguments().get(0);
+        assertNull("defaultValue should be null when @ToolArg has no defaultValue set", arg.defaultValue());
     }
 
     @MetaField(name = "foo", value = "bar")

--- a/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/tool/ToolManagerTest.java
+++ b/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/tool/ToolManagerTest.java
@@ -628,6 +628,41 @@ public class ToolManagerTest extends FATServletClient {
     }
 
     /**
+     * A dynamically registered tool with a non-required
+     * argument that has no default value (null) must succeed when called without supplying
+     * that argument
+     * <p>
+     * Tool defined in {@link ToolManagerStartupTestBean#createNullDefaultValueTool}
+     *
+     * @throws Exception on error
+     */
+    @Test
+    public void testCallToolWithNullDefaultArgOmitted() throws Exception {
+        String request = """
+                        {
+                          "jsonrpc": "2.0",
+                          "id": 20,
+                          "method": "tools/call",
+                          "params": {
+                            "name": "tool-with-null-default",
+                            "arguments": {}
+                          }
+                        }
+                        """;
+        String expected = """
+                        {
+                          "jsonrpc": "2.0",
+                          "id": 20,
+                          "result": {
+                            "content": [{"type": "text", "text": "null"}],
+                            "isError": false
+                          }
+                        }
+                        """;
+        JSONAssert.assertEquals(expected, client.callMCP(request), STRICT);
+    }
+
+    /**
      * Calls tools/list and returns all the tools from the server as a map.
      *
      * @return a map from tool name to the JSON descriptor for the tool

--- a/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/tool/toolManagerApp/ToolManagerStartupTestBean.java
+++ b/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/tool/toolManagerApp/ToolManagerStartupTestBean.java
@@ -122,6 +122,18 @@ public class ToolManagerStartupTestBean {
                    .register();
     }
 
+    @SuppressWarnings("unused")
+    private void createNullDefaultValueTool(@Observes Startup startup) {
+        toolManager.newTool("tool-with-null-default")
+                   .addArgument("value", null, false, String.class)
+                   .setDescription("Tool with a non-required arg that has no default value")
+                   .setHandler(a -> {
+                       String val = (String) a.args().get("value");
+                       return ToolResponse.ofText(val == null ? "null" : val);
+                   })
+                   .register();
+    }
+
     private static record PojoInput(String foo, int bar) {};
 
     private static record PojoOutput(String baz, List<Boolean> qux) {}


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

Resolves #35620 
