### PR TITLE
Fix JSF23WebSocketTests.testPushWebsocket timing failure

### DIFF
--- a/dev/com.ibm.ws.jsfContainer_fat_2.3/fat/src/com/ibm/ws/jsf/container/fat/tests/JSF23WebSocketTests.java
+++ b/dev/com.ibm.ws.jsfContainer_fat_2.3/fat/src/com/ibm/ws/jsf/container/fat/tests/JSF23WebSocketTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2025 IBM Corporation and others.
+ * Copyright (c) 2018, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -122,11 +122,10 @@ public class JSF23WebSocketTests extends FATServletClient {
 
         // Verify that the page contains the expected messages.
         assertTrue(page.isInPage("JSF 2.3 WebSocket - Test message pushed from server to client"));
-        assertTrue(page.isInPage("Called onopen listener"));
-
-        String result1 = jsf23CDIWSOCServer.waitForStringInLogUsingMark("Channel myChannel was opened successfully!");
+        page.waitForCondition(driver -> page.isInPage("Called onopen listener"));
 
         // Verify that the correct message is found in the logs
+        String result1 = jsf23CDIWSOCServer.waitForStringInLogUsingMark("Channel myChannel was opened successfully!");
         assertNotNull("Message not found. Channel was not opened succesfully.", result1);
 
         // Now click the button and get the resulted page.


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".



The same issue was fixed in the base JSF 2.3 FAT here: https://github.com/OpenLiberty/open-liberty/pull/32437 this is bringing the container FAT in sync.

Fixes #35667