### PR TITLE
Disallow concurrency schedule on EJBs

### DIFF
--- a/dev/com.ibm.ws.concurrent_fat_jakarta_12/fat/src/test/jakarta/concurrency32/Concurrency32WithCDITest.java
+++ b/dev/com.ibm.ws.concurrent_fat_jakarta_12/fat/src/test/jakarta/concurrency32/Concurrency32WithCDITest.java
@@ -12,22 +12,32 @@
  *******************************************************************************/
 package test.jakarta.concurrency32;
 
+import static org.junit.Assert.assertEquals;
+
+import java.util.List;
+
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
+import com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions;
 
+import componenttest.annotation.AllowedFFDC;
 import componenttest.annotation.MinimumJavaLevel;
 import componenttest.annotation.Server;
 import componenttest.annotation.TestServlet;
 import componenttest.custom.junit.runner.FATRunner;
+import componenttest.custom.junit.runner.Mode;
+import componenttest.custom.junit.runner.Mode.TestMode;
 import componenttest.topology.impl.LibertyServer;
 import componenttest.topology.utils.FATServletClient;
+import test.jakarta.concurrency32cdi.ejb.error.ScheduleMethodBean;
 import test.jakarta.concurrency32cdi.web.Concurrency32CDITestServlet;
 
 @RunWith(FATRunner.class)
@@ -74,6 +84,49 @@ public class Concurrency32WithCDITest extends FATServletClient {
     @AfterClass
     public static void tearDown() throws Exception {
         if (server.isStarted())
-            server.stopServer();
+            server.stopServer("CNTR0344E", // @Schedule on EJB method
+                              "CNTR4006E" // @Schedule on EJB method
+            );
+    }
+
+    @Test
+    @Mode(TestMode.FULL)
+    @AllowedFFDC({ "com.ibm.ejs.container.EJBConfigurationException",
+                   "com.ibm.wsspi.injectionengine.InjectionException",
+                   "jakarta.ejb.EJBException",
+                   "jakarta.servlet.UnavailableException",
+                   "org.jboss.weld.exceptions.CreationException"
+    })
+    public void testScheduleOnEJBMethodFailsToInstall() throws Exception {
+        JavaArchive scheduleOnEJBErrorEJB = ShrinkWrap
+                        .create(JavaArchive.class, "ScheduleOnEJBErrorEJB.jar")
+                        .addClass(ScheduleMethodBean.class);
+
+        EnterpriseArchive scheduleOnEJBErrorApp = ShrinkWrap
+                        .create(EnterpriseArchive.class, "ScheduleOnEJBError.ear")
+                        .addAsModule(scheduleOnEJBErrorEJB);
+
+        server.setTraceMarkToEndOfDefaultTrace();
+        ShrinkHelper.exportDropinAppToServer(server,
+                                             scheduleOnEJBErrorApp,
+                                             DeployOptions.DISABLE_VALIDATION);
+
+        boolean testRan = false;
+        try {
+            runTest(server, APP_NAME, "testMethod");
+            testRan = true;
+        } catch (AssertionError e) {
+            // Expected: application should not have deployed
+        }
+
+        assertEquals("Test application should not have been installed and allowed to run.",
+                     false,
+                     testRan);
+
+        // EJB container should have rejected the @Schedule annotation
+        // Also wait for FFDC so it doen't interfere with subsequent tests
+        server.waitForStringsInLogUsingMark(List.of("CNTR0344E",
+                                                    "CNTR4006E",
+                                                    "FFDC1015I.*WELD-000079"));
     }
 }

--- a/dev/com.ibm.ws.concurrent_fat_jakarta_12/test-applications/Concurrency32CDITestApp/src/test/jakarta/concurrency32cdi/ejb/error/ScheduleMethodBean.java
+++ b/dev/com.ibm.ws.concurrent_fat_jakarta_12/test-applications/Concurrency32CDITestApp/src/test/jakarta/concurrency32cdi/ejb/error/ScheduleMethodBean.java
@@ -1,0 +1,30 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package test.jakarta.concurrency32cdi.ejb.error;
+
+import jakarta.ejb.Stateless;
+import jakarta.enterprise.concurrent.Schedule;
+
+/**
+ * This EJB has a method annotated with the Jakarta Concurrency @Schedule annotation.
+ * This annotation is only allowed on CDI bean methods, not EJB methods.
+ * This application should not be installed.
+ */
+@Stateless
+public class ScheduleMethodBean {
+
+    @Schedule(cron = "* * * * * *")
+    public void scheduledTask() {
+        System.out.println("This EJB method should never run.");
+    }
+}

--- a/dev/com.ibm.ws.ejbcontainer.core/resources/com/ibm/ejs/container/container.nlsprops
+++ b/dev/com.ibm.ws.ejbcontainer.core/resources/com/ibm/ejs/container/container.nlsprops
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 1997, 2022 IBM Corporation and others.
+# Copyright (c) 1997, 2026 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -1575,6 +1575,17 @@ CNTR0342E_INCORRECT_ASYNC_ANNO.useraction=Remove the jakarta.enterprise.concurre
 CNTR0343W_INCORRECT_ASYNC_ANNO_INTERFACE=CNTR0343W: The {0} business interface contains a jakarta.enterprise.concurrent.Asynchronous annotation. Asynchronous annotations are not valid on any interface, and the Jakarta Enterprise Beans container ignores them.
 CNTR0343W_INCORRECT_ASYNC_ANNO_INTERFACE.explanation=The jakarta.enterprise.concurrent.Asynchronous annotation must not be used with Jakarta Enterprise Beans. The Jakarta Enterprise Beans container ignores these annotations on interfaces. Unless the methods are declared asynchronous in the ejb-jar.xml deployment descriptor or the jakarta.ejb.Asynchronous annotation is specified on the bean class or a bean class method, the bean methods run synchronously.
 CNTR0343W_INCORRECT_ASYNC_ANNO_INTERFACE.useraction=Remove any jakarta.enterprise.concurrent.Asynchronous annotation from the specified business interface and verify that the jakarta.ejb.Asynchronous annotation is specified correctly in the bean class.
+
+CNTR0344E_INCORRECT_SCHEDULE_ANNO=CNTR0344E: The {0} bean in the {1} module of \
+ the {2} application has one or more methods with the \
+ jakarta.enterprise.concurrent.Schedule annotation, which must not be used on \
+ enterprise beans.
+CNTR0344E_INCORRECT_SCHEDULE_ANNO.explanation=The Jakarta Concurrency \
+ specification does not allow the jakarta.enterprise.concurrent.Schedule \
+ annotation to be used on Jakarta Enterprise Beans.
+CNTR0344E_INCORRECT_SCHEDULE_ANNO.useraction=Remove the \
+ jakarta.enterprise.concurrent.Asynchronous annotation from the method. Use the \
+ jakarta.ejb.Schedule annotation to identify timeout methods on enterprise beans.
 
 #-------------------------------------------------------------------------------
 #

--- a/dev/com.ibm.ws.ejbcontainer.core/resources/com/ibm/ejs/container/container.nlsprops
+++ b/dev/com.ibm.ws.ejbcontainer.core/resources/com/ibm/ejs/container/container.nlsprops
@@ -1578,8 +1578,8 @@ CNTR0343W_INCORRECT_ASYNC_ANNO_INTERFACE.useraction=Remove any jakarta.enterpris
 
 CNTR0344E_INCORRECT_SCHEDULE_ANNO=CNTR0344E: The {0} bean in the {1} module of \
  the {2} application has one or more methods with the \
- jakarta.enterprise.concurrent.Schedule annotation, which must not be used on \
- enterprise beans.
+ jakarta.enterprise.concurrent.Schedule annotation. This annotation cannot be \
+ used on enterprise beans.
 CNTR0344E_INCORRECT_SCHEDULE_ANNO.explanation=The Jakarta Concurrency \
  specification does not allow the jakarta.enterprise.concurrent.Schedule \
  annotation to be used on Jakarta Enterprise Beans.

--- a/dev/com.ibm.ws.ejbcontainer.core/src/com/ibm/ejs/container/util/MethodAttribUtils.java
+++ b/dev/com.ibm.ws.ejbcontainer.core/src/com/ibm/ejs/container/util/MethodAttribUtils.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 1998, 2019 IBM Corporation and others.
+ * Copyright (c) 1998, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -346,9 +346,10 @@ public class MethodAttribUtils {
     } // getAsynchronousMethods
 
     /**
-     * <code>verifyNoConcurrentAsynchronousMethods<code> checks all beanMethods to determine
-     * if any beans are annotated with the Jakarta Concurrent Asynchronous annotation.
-     * Will return if no annotation is found, otherwise exception is thrown.
+     * {@code rejectInvalidConcurrencyAnnos} checks all beanMethods to determine
+     * if any beans are annotated with the Jakarta Concurrency Asynchronous or
+     * Schedule annotations, which must not be used on enterprise beans.
+     * Will return if no such annotations are found, otherwise an exception is thrown.
      *
      * @param beanMethods Input array of Method objects representing the methods of this EJB.
      * @param component   Name of the component
@@ -357,14 +358,17 @@ public class MethodAttribUtils {
      *
      * @throws EJBConfigurationException
      */
-    public static void verifyNoConcurrentAsynchronousMethods(Method[] beanMethods, //
-                                                             String component, String module, String app) throws EJBConfigurationException {
+    public static void rejectInvalidConcurrencyAnnos(Method[] beanMethods,
+                                                     String component,
+                                                     String module,
+                                                     String app) //
+                    throws EJBConfigurationException {
         if (beanMethods == null || beanMethods.length == 0) {
             return; //Nothing to check
         }
 
         final boolean isTraceOn = TraceComponent.isAnyTracingEnabled();
-        final String m = "verifyNoConcurrentAsynchronousMethods";
+        final String m = "rejectInvalidConcurrencyAnnos";
 
         if (isTraceOn && tc.isEntryEnabled())
             Tr.entry(tc, m, Arrays.asList(beanMethods).toString());
@@ -377,53 +381,52 @@ public class MethodAttribUtils {
             Set<Class<?>> classesToCheck = new HashSet<Class<?>>();
 
             //Check method level annotations
-            Annotation[] asynchMethodAnnotations = null;
             for (Method beanMethod : beanMethods) {
 
                 if (beanMethod == null)
                     continue; //onto next method
 
-                //First compile a list of classes to check
+                // First compile a list of classes to check for @Asynchronous
                 Class<?> beanClass = beanMethod.getDeclaringClass();
                 if (beanClass != null) {
                     classesToCheck.add(beanClass);
                 }
 
-                asynchMethodAnnotations = beanMethod.getAnnotations();
-
-                if (asynchMethodAnnotations == null)
-                    continue; //onto next method
-
-                for (Annotation beanAnno : asynchMethodAnnotations) {
-                    if ("jakarta.enterprise.concurrent.Asynchronous".equals(beanAnno.annotationType().getName())) {
+                for (Annotation beanAnno : beanMethod.getAnnotations()) {
+                    String annoName = beanAnno.annotationType().getName();
+                    if ("jakarta.enterprise.concurrent.Asynchronous".equals(annoName)) {
                         // Concurrent Asynch annotations are not allowed on EJBs
                         Tr.error(tc, "CNTR0342E_INCORRECT_ASYNC_ANNO",
-                                 new Object[] { component, module, app });
+                                 component, module, app);
 
                         throw new EJBConfigurationException( //
                                         Tr.formatMessage(tc, "CNTR0342E_INCORRECT_ASYNC_ANNO",
-                                                         new Object[] { component, module, app }));
+                                                         component, module, app));
+                    }
+                    if ("jakarta.enterprise.concurrent.Schedule".equals(annoName)) {
+                        // Concurrent Schedule annotations are not allowed on EJBs
+                        Tr.error(tc, "CNTR0344E_INCORRECT_SCHEDULE_ANNO",
+                                 component, module, app);
+
+                        throw new EJBConfigurationException( //
+                                        Tr.formatMessage(tc, "CNTR0344E_INCORRECT_SCHEDULE_ANNO",
+                                                         component, module, app));
                     }
                 }
             }
 
-            //Check class level annotations
-            Annotation[] asynchClassAnnotations = null;
+            // Check class level annotations for @Asynchronous
+            // (@Schedule targets methods only)
             for (Class<?> beanClass : classesToCheck) {
-                asynchClassAnnotations = beanClass.getAnnotations();
-
-                if (asynchClassAnnotations == null)
-                    continue; //onto next beanClass
-
-                for (Annotation classAnno : asynchClassAnnotations) {
+                for (Annotation classAnno : beanClass.getAnnotations()) {
                     if ("jakarta.enterprise.concurrent.Asynchronous".equals(classAnno.annotationType().getName())) {
                         // Concurrent Asynch annotations are not allowed on EJBs
                         Tr.error(tc, "CNTR0342E_INCORRECT_ASYNC_ANNO",
-                                 new Object[] { component, module, app });
+                                 component, module, app);
 
                         throw new EJBConfigurationException( //
                                         Tr.formatMessage(tc, "CNTR0342E_INCORRECT_ASYNC_ANNO",
-                                                         new Object[] { component, module, app }));
+                                                         component, module, app));
                     }
                 }
             }
@@ -433,7 +436,7 @@ public class MethodAttribUtils {
             }
         }
 
-    } // verifyNoConcurrentAsynchronousMethods
+    } // verifyNoConcurrentAnnotations
 
     /**
      * Check all methods for method-level Security annotations. Specifically

--- a/dev/com.ibm.ws.ejbcontainer.core/src/com/ibm/ws/metadata/ejb/EJBMDOrchestrator.java
+++ b/dev/com.ibm.ws.ejbcontainer.core/src/com/ibm/ws/metadata/ejb/EJBMDOrchestrator.java
@@ -1302,11 +1302,13 @@ public abstract class EJBMDOrchestrator {
                                                                               asynchMethodFlags,
                                                                               methodInterface); //d599046
 
-            //If any business methods or classes contain the concurrent asynchronous annotation then this call WILL throw an EJBConfigurationException
-            MethodAttribUtils.verifyNoConcurrentAsynchronousMethods(ejbMethods,
-                                                                    bmd.j2eeName.getComponent(),
-                                                                    bmd.j2eeName.getModule(),
-                                                                    bmd.j2eeName.getApplication());
+            // If any business methods or classes contain a Jakarta Concurrency
+            // annotation that is not permitted, then this call WILL throw an
+            // EJBConfigurationException
+            MethodAttribUtils.rejectInvalidConcurrencyAnnos(ejbMethods,
+                                                            bmd.j2eeName.getComponent(),
+                                                            bmd.j2eeName.getModule(),
+                                                            bmd.j2eeName.getApplication());
         }
 
         // F743-1752.1 start


### PR DESCRIPTION
Detect and disallow Jakarta Concurrency's `@Schedule` on EJB methods and
add automated test coverage.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
