### PR TITLE
adding missing authentication connection props for SQL server

### DIFF
--- a/dev/com.ibm.ws.jdbc.metatype/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.jdbc.metatype/resources/OSGI-INF/metatype/metatype.xml
@@ -1208,12 +1208,15 @@
   </AD>
   <AD id="applicationName"                    ibmui:group="Advanced" required="false" type="String"  name="%applicationName" description="%applicationName.desc"/>
   <AD id="authentication"                     ibmui:group="Advanced" required="false" type="String"  name="%authentication" description="%authentication.desc">
-   <Option value="ActiveDirectoryDefault"    label="ActiveDirectoryDefault"/>
-   <Option value="ActiveDirectoryMSI"        label="ActiveDirectoryMSI"/>
-   <Option value="ActiveDirectoryIntegrated" label="ActiveDirectoryIntegrated"/>
-   <Option value="ActiveDirectoryPassword"   label="ActiveDirectoryPassword"/>
-   <Option value="SqlPassword"               label="SqlPassword"/>
-   <Option value="NotSpecified"              label="NotSpecified"/>
+   <Option value="ActiveDirectoryInteractive"                 label="ActiveDirectoryInteractive"/>
+   <Option value="ActiveDirectoryServicePrincipal"            label="ActiveDirectoryServicePrincipal"/>
+   <Option value="ActiveDirectoryServicePrincipalCertificate" label="ActiveDirectoryServicePrincipalCertificate"/>
+   <Option value="ActiveDirectoryDefault"                     label="ActiveDirectoryDefault"/>
+   <Option value="ActiveDirectoryMSI"                         label="ActiveDirectoryMSI"/>
+   <Option value="ActiveDirectoryIntegrated"                  label="ActiveDirectoryIntegrated"/>
+   <Option value="ActiveDirectoryPassword"                    label="ActiveDirectoryPassword"/>
+   <Option value="SqlPassword"                                label="SqlPassword"/>
+   <Option value="NotSpecified"                               label="NotSpecified"/>
   </AD>
   <AD id="authenticationScheme"               ibmui:group="Advanced" required="false" type="String"  name="%authenticationScheme" description="%authenticationScheme.desc">
    <Option value="JavaKerberos"         label="JavaKerberos"/>


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

Adding missing authentication connection properties from doc
https://learn.microsoft.com/en-us/sql/connect/jdbc/connecting-using-azure-active-directory-authentication?view=sql-server-ver17

Fixes #35690