### PR TITLE
Fixes for RFC 7231 two digit year rules

### DIFF
--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/internal/HttpDateFormatImpl.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/internal/HttpDateFormatImpl.java
@@ -1,14 +1,11 @@
 /*******************************************************************************
- * Copyright (c) 2009, 2025 IBM Corporation and others.
+ * Copyright (c) 2009, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package com.ibm.ws.http.internal;
 
@@ -17,6 +14,7 @@ import java.text.ParsePosition;
 import java.time.DateTimeException;
 import java.time.Instant;
 import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
 import java.time.temporal.ChronoField;
@@ -28,7 +26,6 @@ import java.util.HashSet;
 import java.util.Locale;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
-import java.time.ZoneOffset;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.ConfigurationPolicy;
@@ -463,9 +460,9 @@ public class HttpDateFormatImpl implements HttpDateFormat {
      *
      * @param format
      * @param input
-     * @return Date
+     * @return Instant
      */
-    private Date attemptParse(DateTimeFormatter format, String input) {
+    private Instant attemptParse(DateTimeFormatter format, String input) {
         ParsePosition pos = new ParsePosition(0);
         try {
             TemporalAccessor accessor = format.parse(input, pos);
@@ -473,7 +470,7 @@ public class HttpDateFormatImpl implements HttpDateFormat {
                 // invalid format matching
                 return null;
             }
-            return Date.from(Instant.from(accessor));
+            return Instant.from(accessor);
         } catch (DateTimeException e) {
             return null;
         }
@@ -487,11 +484,11 @@ public class HttpDateFormatImpl implements HttpDateFormat {
         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
             Tr.debug(tc, "rfc1123 parsing [" + input + "]");
         }
-        Date d = attemptParse(c1123Time.formatter, input);
-        if (null == d) {
+        Instant instant = attemptParse(c1123Time.formatter, input);
+        if (null == instant) {
             throw new ParseException("Unparseable [" + input + "]", 0);
         }
-        return d;
+        return Date.from(instant);
     }
 
     /*
@@ -502,11 +499,11 @@ public class HttpDateFormatImpl implements HttpDateFormat {
         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
             Tr.debug(tc, "rfc1036 parsing [" + input + "]");
         }
-        Date d = attemptParse(c1036Time.formatter, input);
-        if (null == d) {
+        Instant instant = attemptParse(c1036Time.formatter, input);
+        if (null == instant) {
             throw new ParseException("Unparseable [" + input + "]", 0);
         }
-        return correctTwoDigitYear(d);
+        return Date.from(correctTwoDigitYear(instant));
     }
 
     /*
@@ -517,11 +514,11 @@ public class HttpDateFormatImpl implements HttpDateFormat {
         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
             Tr.debug(tc, "rfc2109 parsing [" + input + "]");
         }
-        Date d = attemptParse(c2109Time.formatter, input);
-        if (null == d) {
+        Instant instant = attemptParse(c2109Time.formatter, input);
+        if (null == instant) {
             throw new ParseException("Unparseable [" + input + "]", 0);
         }
-        return correctTwoDigitYear(d);
+        return Date.from(correctTwoDigitYear(instant));
     }
 
     /*
@@ -532,11 +529,11 @@ public class HttpDateFormatImpl implements HttpDateFormat {
         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
             Tr.debug(tc, "ascii parsing [" + input + "]");
         }
-        Date d = attemptParse(cAsciiTime.formatter, input);
-        if (null == d) {
+        Instant instant = attemptParse(cAsciiTime.formatter, input);
+        if (null == instant) {
             throw new ParseException("Unparseable [" + input + "]", 0);
         }
-        return d;
+        return Date.from(instant);
     }
 
     /*
@@ -570,14 +567,14 @@ public class HttpDateFormatImpl implements HttpDateFormat {
             data = input.substring(0, i);
         }
 
-        Date parsedDate = attemptParse(c1123Time.formatter, data);
-        if (null == parsedDate) {
-            parsedDate = correctTwoDigitYear(attemptParse(c1036Time.formatter, data));
-            if (null == parsedDate) {
-                parsedDate = attemptParse(cAsciiTime.formatter, data);
-                if (null == parsedDate) {
-                    parsedDate = correctTwoDigitYear(attemptParse(c2109Time.formatter, data));
-                    if (null == parsedDate) {
+        Instant parsedInstant = attemptParse(c1123Time.formatter, data);
+        if (null == parsedInstant) {
+            parsedInstant = correctTwoDigitYear(attemptParse(c1036Time.formatter, data));
+            if (null == parsedInstant) {
+                parsedInstant = attemptParse(cAsciiTime.formatter, data);
+                if (null == parsedInstant) {
+                    parsedInstant = correctTwoDigitYear(attemptParse(c2109Time.formatter, data));
+                    if (null == parsedInstant) {
                         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
                             Tr.debug(tc, "Time does not match supported formats");
                         }
@@ -586,7 +583,7 @@ public class HttpDateFormatImpl implements HttpDateFormat {
                 }
             }
         }
-        return parsedDate;
+        return Date.from(parsedInstant);
     }
 
     /*
@@ -597,18 +594,16 @@ public class HttpDateFormatImpl implements HttpDateFormat {
         return parseTime(GenericUtils.getEnglishString(inBytes));
     }
 
-    private Date correctTwoDigitYear(Date parsed){
-        return correctTwoDigitYear(parsed, Instant.now());
-    }
-
-    Date correctTwoDigitYear(Date parsed, Instant now){
-        if (null == parsed){
+    private Instant correctTwoDigitYear(Instant parsed) {
+        if (null == parsed) {
             return null;
         }
-
-        Instant fiftyYearsOut = now.atZone(ZoneOffset.UTC).plusYears(50).toInstant();
-        if (parsed.toInstant().isAfter(fiftyYearsOut)) {
-            return Date.from(parsed.toInstant().atZone(ZoneOffset.UTC).minusYears(100).toInstant());
+        ZonedDateTime parsedDateTime = parsed.atZone(CachedTime.gmt);
+        ZonedDateTime now = Instant.now().atZone(CachedTime.gmt);
+        // Do quick check on the year and only fall through to the more expensive logic if needed
+        if (parsedDateTime.getYear() - now.getYear() >= 50 && 
+        		parsedDateTime.isAfter(now.plusYears(50))) {
+            return parsedDateTime.minusYears(100).toInstant();
         }
 
         return parsed;

--- a/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/internal/HttpDateFormatImpl.java
+++ b/dev/com.ibm.ws.transport.http/src/com/ibm/ws/http/internal/HttpDateFormatImpl.java
@@ -28,6 +28,7 @@ import java.util.HashSet;
 import java.util.Locale;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
+import java.time.ZoneOffset;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.ConfigurationPolicy;
@@ -505,7 +506,7 @@ public class HttpDateFormatImpl implements HttpDateFormat {
         if (null == d) {
             throw new ParseException("Unparseable [" + input + "]", 0);
         }
-        return d;
+        return correctTwoDigitYear(d);
     }
 
     /*
@@ -520,7 +521,7 @@ public class HttpDateFormatImpl implements HttpDateFormat {
         if (null == d) {
             throw new ParseException("Unparseable [" + input + "]", 0);
         }
-        return d;
+        return correctTwoDigitYear(d);
     }
 
     /*
@@ -571,11 +572,11 @@ public class HttpDateFormatImpl implements HttpDateFormat {
 
         Date parsedDate = attemptParse(c1123Time.formatter, data);
         if (null == parsedDate) {
-            parsedDate = attemptParse(c1036Time.formatter, data);
+            parsedDate = correctTwoDigitYear(attemptParse(c1036Time.formatter, data));
             if (null == parsedDate) {
                 parsedDate = attemptParse(cAsciiTime.formatter, data);
                 if (null == parsedDate) {
-                    parsedDate = attemptParse(c2109Time.formatter, data);
+                    parsedDate = correctTwoDigitYear(attemptParse(c2109Time.formatter, data));
                     if (null == parsedDate) {
                         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
                             Tr.debug(tc, "Time does not match supported formats");
@@ -594,5 +595,22 @@ public class HttpDateFormatImpl implements HttpDateFormat {
     @Override
     public Date parseTime(byte[] inBytes) throws ParseException {
         return parseTime(GenericUtils.getEnglishString(inBytes));
+    }
+
+    private Date correctTwoDigitYear(Date parsed){
+        return correctTwoDigitYear(parsed, Instant.now());
+    }
+
+    Date correctTwoDigitYear(Date parsed, Instant now){
+        if (null == parsed){
+            return null;
+        }
+
+        Instant fiftyYearsOut = now.atZone(ZoneOffset.UTC).plusYears(50).toInstant();
+        if (parsed.toInstant().isAfter(fiftyYearsOut)) {
+            return Date.from(parsed.toInstant().atZone(ZoneOffset.UTC).minusYears(100).toInstant());
+        }
+
+        return parsed;
     }
 }

--- a/dev/com.ibm.ws.transport.http/test/com/ibm/ws/http/internal/HttpDateFormatTest.java
+++ b/dev/com.ibm.ws.transport.http/test/com/ibm/ws/http/internal/HttpDateFormatTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 IBM Corporation and others.
+ * Copyright (c) 2023, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -15,18 +15,16 @@ import static org.junit.Assert.fail;
 
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.time.Instant;
+import java.time.Year;
+import java.time.ZoneId;
 import java.util.Date;
 import java.util.Locale;
 import java.util.TimeZone;
-import java.time.Instant;
-import java.time.ZoneOffset;
-import java.time.ZonedDateTime;
 
 import org.junit.Test;
 
 import com.ibm.wsspi.http.HttpDateFormat;
-
-
 
 /**
  * After changing from using SimpleDateFormat to DateTimeFormatter, this test was created
@@ -261,26 +259,88 @@ public class HttpDateFormatTest {
         }
     }
 
+    /**
+     * RFC 7231 §7.1.1.1: a 2-digit year that appears more than 50 years in the
+     * future must be interpreted as the most recent past year with the same digits.
+     */
     @Test
-    public void testRFC1036TwoDigitYearRollover() throws Exception{
-        Instant fixedNow = Instant.parse("2026-08-04T00:00:00Z");
+    public void testRFC1036TwoDigitYearRollover() throws Exception {
+        Date oneMinuteAgo = new Date(Instant.now().minusSeconds(60).toEpochMilli());
+        assertTwoDigitYearWindow((String input) -> formatter.parseRFC1036Time(input),
+                                 getSubstituteYearString(formatter.getRFC1036Time(oneMinuteAgo)), false);
 
-        Date parsed = ((HttpDateFormatImpl) formatter).parseRFC1036Time(
-                "Saturday, 28-Sep-99 16:11:14 GMT");
+        Date oneMinuteFromNow = new Date(Instant.now().plusSeconds(60).toEpochMilli());
+        assertTwoDigitYearWindow((String input) -> formatter.parseRFC1036Time(input),
+                                 getSubstituteYearString(formatter.getRFC1036Time(oneMinuteFromNow)), true);
+    }
 
-        Date expected = Date.from(
-                ZonedDateTime.of(1999, 9, 28, 16, 11, 14, 0, ZoneOffset.UTC).toInstant());
-
-        assertEquals(expected, parsed);
+    /**
+     * Converts an actual two digit Data string to use %s for the year so the
+     * year can be substituted.
+     */
+    private String getSubstituteYearString(String actualFormattedString) {
+        int hyphenIndex = actualFormattedString.lastIndexOf('-');
+        int spaceIndex = actualFormattedString.indexOf(' ', hyphenIndex);
+        assertEquals(3, spaceIndex - hyphenIndex);
+        String returnString = actualFormattedString.substring(0, hyphenIndex + 1) + "%s" + actualFormattedString.substring(spaceIndex);
+        assertEquals(actualFormattedString,
+                     String.format(returnString, String.format("%02d", Integer.parseInt(actualFormattedString.substring(hyphenIndex + 1, spaceIndex)))));
+        return returnString;
     }
 
     @Test
     public void testRFC2109TwoDigitYearRollover() throws Exception {
-        Date parsed = formatter.parseRFC2109Time("Sat, 28-Sep-99 16:11:14 GMT");
+        Date oneMinuteAgo = new Date(Instant.now().minusSeconds(60).toEpochMilli());
+        assertTwoDigitYearWindow((String input) -> formatter.parseRFC2109Time(input),
+                                 getSubstituteYearString(formatter.getRFC2109Time(oneMinuteAgo)), false);
 
-        Date expected = Date.from(
-                ZonedDateTime.of(1999, 9, 28, 16, 11, 14, 0, ZoneOffset.UTC).toInstant());
+        Date oneMinuteFromNow = new Date(Instant.now().plusSeconds(60).toEpochMilli());
+        assertTwoDigitYearWindow((String input) -> formatter.parseRFC2109Time(input),
+                                 getSubstituteYearString(formatter.getRFC2109Time(oneMinuteFromNow)), true);
+    }
 
-        assertEquals(expected, parsed);
+    /**
+     * Verifies the full RFC 7231 §7.1.1.1 window for a 2-digit-year parser.
+     * The formatter base is (currentYear - 49), giving the window [currentYear-49, currentYear+50].
+     * RFC 7231 requires roll-back only for dates *more than* 50 years in the future (strict),
+     * so exactly 50 years out must NOT roll back.
+     * Iterates all 100 possible 2-digit values and checks each maps to the correct full year.
+     */
+    private void assertTwoDigitYearWindow(ParseFunction parser, String inputTemplate, boolean isFuture) throws Exception {
+        int fullCurrentYear = Year.now().getValue();
+        // If isFuture is true, we need to treat it like it is next year because it is more than 50 years since the date
+        // is already in the future from now.
+        int baseYear = fullCurrentYear - (isFuture ? 50 : 49); // formatter base: window is [currentYear-49, currentYear+50]
+
+        for (int i = 0; i < 100; ++i) {
+            int twoDigitValue = (fullCurrentYear + i) % 100; // wraps at 100
+            int expectedYear = baseYear + ((twoDigitValue - (baseYear % 100) + 100) % 100);
+            String input = String.format(inputTemplate, String.format("%02d", twoDigitValue));
+            Date parsed = parser.parse(input);
+            assertEquals("Mismatch for 2-digit year " + String.format("%02d", twoDigitValue), expectedYear, parsed.toInstant().atZone(ZoneId.of("GMT")).getYear());
+        }
+
+        // Explicit boundary checks per RFC 7231 §7.1.1.1:
+        // exactly 50 years out must NOT roll back; 51 years out must roll back.
+        int twoDigitAt49 = (fullCurrentYear + 49) % 100;
+        int twoDigitAt50 = (fullCurrentYear + 50) % 100;
+        int twoDigitAt51 = (fullCurrentYear + 51) % 100;
+
+        Date parsedAt49 = parser.parse(String.format(inputTemplate, String.format("%02d", twoDigitAt49)));
+        assertEquals("Exactly 49 / 50 years out must not roll back", fullCurrentYear + 49, parsedAt49.toInstant().atZone(ZoneId.of("GMT")).getYear());
+
+        Date parsedAt50 = parser.parse(String.format(inputTemplate, String.format("%02d", twoDigitAt50)));
+        // If isFuture is true, we need to treat it like it is next year because it is more than 50 years since the date
+        // is already in the future from now.
+        int expectedYear = isFuture ? fullCurrentYear - 50 : fullCurrentYear + 50;
+        assertEquals("Exactly 50 / 51 years out must not roll back or rollback depending on time", expectedYear, parsedAt50.toInstant().atZone(ZoneId.of("GMT")).getYear());
+
+        Date parsedAt51 = parser.parse(String.format(inputTemplate, String.format("%02d", twoDigitAt51)));
+        assertEquals("Exactly 51 / 52 years out must not roll back", fullCurrentYear - 49, parsedAt51.toInstant().atZone(ZoneId.of("GMT")).getYear());
+    }
+
+    @FunctionalInterface
+    private interface ParseFunction {
+        Date parse(String input) throws Exception;
     }
 }

--- a/dev/com.ibm.ws.transport.http/test/com/ibm/ws/http/internal/HttpDateFormatTest.java
+++ b/dev/com.ibm.ws.transport.http/test/com/ibm/ws/http/internal/HttpDateFormatTest.java
@@ -18,10 +18,15 @@ import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Locale;
 import java.util.TimeZone;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 
 import org.junit.Test;
 
 import com.ibm.wsspi.http.HttpDateFormat;
+
+
 
 /**
  * After changing from using SimpleDateFormat to DateTimeFormatter, this test was created
@@ -254,5 +259,28 @@ public class HttpDateFormatTest {
                 Thread.sleep(50);
             }
         }
+    }
+
+    @Test
+    public void testRFC1036TwoDigitYearRollover() throws Exception{
+        Instant fixedNow = Instant.parse("2026-08-04T00:00:00Z");
+
+        Date parsed = ((HttpDateFormatImpl) formatter).parseRFC1036Time(
+                "Saturday, 28-Sep-99 16:11:14 GMT");
+
+        Date expected = Date.from(
+                ZonedDateTime.of(1999, 9, 28, 16, 11, 14, 0, ZoneOffset.UTC).toInstant());
+
+        assertEquals(expected, parsed);
+    }
+
+    @Test
+    public void testRFC2109TwoDigitYearRollover() throws Exception {
+        Date parsed = formatter.parseRFC2109Time("Sat, 28-Sep-99 16:11:14 GMT");
+
+        Date expected = Date.from(
+                ZonedDateTime.of(1999, 9, 28, 16, 11, 14, 0, ZoneOffset.UTC).toInstant());
+
+        assertEquals(expected, parsed);
     }
 }


### PR DESCRIPTION
- Expands upon what was started in #35581, but does the logic differently to require less work happening on each request since this is a performance critical area since it is invoked on every http request.
- Add a test to do all two digit years and validate that the right behavior happens.

Co-authored-by-AI: IBM Bob 2.0.1

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

Fixes #35271