### PR TITLE
Cancel scheduled methods when app stopping

### DIFF
--- a/dev/com.ibm.websphere.appserver.features/visibility/public/concurrent-1.0/com.ibm.websphere.appserver.concurrent-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/concurrent-1.0/com.ibm.websphere.appserver.concurrent-1.0.feature
@@ -9,8 +9,7 @@ IBM-API-Service: javax.enterprise.concurrent.ContextService; id="DefaultContextS
  javax.enterprise.concurrent.ManagedExecutorService; id="DefaultManagedExecutorService", \
  javax.enterprise.concurrent.ManagedScheduledExecutorService; id="DefaultManagedScheduledExecutorService"
 Subsystem-Name: Concurrency Utilities for Java EE 1.0
--features=com.ibm.websphere.appserver.containerServices-1.0, \
-  com.ibm.websphere.appserver.classloading-1.0, \
+-features=com.ibm.websphere.appserver.classloading-1.0, \
   com.ibm.websphere.appserver.contextService-1.0, \
   com.ibm.websphere.appserver.eeCompatible-7.0; ibm.tolerates:="6.0,8.0", \
   com.ibm.websphere.appserver.concurrencyPolicy-1.0, \

--- a/dev/com.ibm.websphere.appserver.features/visibility/public/concurrent-1.0/com.ibm.websphere.appserver.concurrent-1.0.feature
+++ b/dev/com.ibm.websphere.appserver.features/visibility/public/concurrent-1.0/com.ibm.websphere.appserver.concurrent-1.0.feature
@@ -10,6 +10,7 @@ IBM-API-Service: javax.enterprise.concurrent.ContextService; id="DefaultContextS
  javax.enterprise.concurrent.ManagedScheduledExecutorService; id="DefaultManagedScheduledExecutorService"
 Subsystem-Name: Concurrency Utilities for Java EE 1.0
 -features=com.ibm.websphere.appserver.containerServices-1.0, \
+  com.ibm.websphere.appserver.classloading-1.0, \
   com.ibm.websphere.appserver.contextService-1.0, \
   com.ibm.websphere.appserver.eeCompatible-7.0; ibm.tolerates:="6.0,8.0", \
   com.ibm.websphere.appserver.concurrencyPolicy-1.0, \

--- a/dev/com.ibm.ws.concurrent/bnd.bnd
+++ b/dev/com.ibm.ws.concurrent/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2017,2024 IBM Corporation and others.
+# Copyright (c) 2017,2026 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -60,6 +60,7 @@ instrument.classesExcludes: com/ibm/ws/concurrent/resources/*.class
 	com.ibm.websphere.org.osgi.service.component,\
 	com.ibm.ws.app.manager.lifecycle;version=latest,\
 	com.ibm.ws.bnd.annotations;version=latest, \
+	com.ibm.ws.classloading;version=latest, \
 	com.ibm.ws.concurrency.policy;version=latest,\
 	com.ibm.ws.container.service;version=latest,\
 	com.ibm.ws.context;version=latest,\

--- a/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/WSManagedExecutorService.java
+++ b/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/WSManagedExecutorService.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2017,2022 IBM Corporation and others.
+ * Copyright (c) 2017,2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -12,9 +12,12 @@
  *******************************************************************************/
 package com.ibm.ws.concurrent;
 
+import java.lang.reflect.Method;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiFunction;
 
 import com.ibm.ws.threading.PolicyExecutor;
@@ -69,4 +72,18 @@ public interface WSManagedExecutorService {
      * @return CompletableFuture that represents the invocation of the asynchronous method.
      */
     <I, T> CompletableFuture<T> newAsyncMethod(BiFunction<I, CompletableFuture<T>, CompletionStage<T>> invoker, I invocation);
+
+    /**
+     * Construct a CompletableFuture that represents the completion of all
+     * executions of a scheduled method, to be performed asynchronously.
+     *
+     * @param <T>            type of result
+     * @param method         the scheduled method
+     * @param nextExecFuture reference that is periodically updated with the future
+     *                           for the next execution of the scheduled method
+     * @return CompletableFuture that represents the completion of all executions
+     */
+    <T> CompletableFuture<T> newScheduledMethod(Method method,
+                                                AtomicReference<Future<?>> nextExecFuture);
+
 }

--- a/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/ext/ManagedExecutorExtension.java
+++ b/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/ext/ManagedExecutorExtension.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2020,2021 IBM Corporation and others.
+ * Copyright (c) 2020,2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package com.ibm.ws.concurrent.ext;
 
+import java.lang.reflect.Method;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -23,6 +24,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiFunction;
 import java.util.function.Supplier;
 
@@ -159,6 +161,12 @@ public class ManagedExecutorExtension implements CompletionStageExecutor, Manage
     @Override
     public final <T> CompletableFuture<T> newIncompleteFuture() {
         return ((ManagedExecutor) executor).newIncompleteFuture();
+    }
+
+    @Override
+    public <T> CompletableFuture<T> newScheduledMethod(Method method,
+                                                       AtomicReference<Future<?>> nextExecFuture) {
+        throw new UnsupportedOperationException();
     }
 
     @Override

--- a/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/ConcurrencyService.java
+++ b/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/ConcurrencyService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020,2023 IBM Corporation and others.
+ * Copyright (c) 2020,2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -15,8 +15,9 @@ package com.ibm.ws.concurrent.internal;
 import java.security.AccessController;
 import java.util.Collection;
 
-import javax.enterprise.concurrent.ManagedScheduledExecutorService;
+import javax.enterprise.concurrent.ManagedExecutorService;
 
+import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.FrameworkUtil;
 import org.osgi.framework.InvalidSyntaxException;
@@ -30,21 +31,37 @@ import org.osgi.service.component.annotations.ReferencePolicy;
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.websphere.ras.annotation.Trivial;
+import com.ibm.ws.classloading.ClassLoaderIdentifierService;
 import com.ibm.ws.concurrent.TriggerService;
 import com.ibm.ws.concurrent.ext.ConcurrencyExtensionProvider;
+import com.ibm.ws.container.service.app.deploy.ApplicationInfo;
 import com.ibm.ws.container.service.metadata.ApplicationMetaDataListener;
 import com.ibm.ws.container.service.metadata.MetaDataEvent;
 import com.ibm.ws.container.service.metadata.MetaDataException;
+import com.ibm.ws.container.service.state.ApplicationStateListener;
 import com.ibm.ws.kernel.service.util.SecureAction;
 import com.ibm.ws.runtime.metadata.ApplicationMetaData;
+import com.ibm.ws.runtime.metadata.ComponentMetaData;
+import com.ibm.ws.threadContext.ComponentMetaDataAccessorImpl;
 
-@Component(configurationPolicy = ConfigurationPolicy.REQUIRE, service = { ConcurrencyService.class, ApplicationMetaDataListener.class })
-public class ConcurrencyService implements ApplicationMetaDataListener {
+@Component(configurationPolicy = ConfigurationPolicy.REQUIRE, //
+           service = { ConcurrencyService.class,
+                       ApplicationMetaDataListener.class,
+                       ApplicationStateListener.class })
+public class ConcurrencyService implements //
+                ApplicationMetaDataListener, //
+                ApplicationStateListener {
+
+    private static final String FILTER_MES_EXCLUDE_OSGI_JNDI = //
+                    "(&(service.factoryPid=com.ibm.ws.concurrent.managed*ExecutorService)(!(osgi.jndi.service.name=*)))";
     static final SecureAction priv = AccessController.doPrivileged(SecureAction.get());
     private static final TraceComponent tc = Tr.register(ConcurrencyService.class);
 
     @Reference(policy = ReferencePolicy.STATIC, cardinality = ReferenceCardinality.OPTIONAL, target = "(id=unbound)")
     ConcurrencyExtensionProvider extensionProvider;
+
+    @Reference
+    ClassLoaderIdentifierService classLoaderIdentifierService;
 
     @Reference
     TriggerService triggerSvc;
@@ -60,23 +77,139 @@ public class ConcurrencyService implements ApplicationMetaDataListener {
     @Trivial
     public void applicationMetaDataDestroyed(MetaDataEvent<ApplicationMetaData> event) {
         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
-            Tr.debug(this, tc, "applicationMetaDataDestroyed: " + event.getMetaData().getJ2EEName());
+            Tr.debug(this, tc, "applicationMetaDataDestroyed: " +
+                               event.getMetaData().getJ2EEName());
 
-        BundleContext bc = priv.getBundleContext(FrameworkUtil.getBundle(getClass()));
+        Bundle bundle = FrameworkUtil.getBundle(getClass());
+        BundleContext bc = bundle == null ? null : priv.getBundleContext(bundle);
+        Collection<ServiceReference<ManagedExecutorService>> refs;
         try {
-            Collection<ServiceReference<ManagedScheduledExecutorService>> refs = //
-                            priv.getServiceReferences(bc, ManagedScheduledExecutorService.class,
-                                                      "(service.factoryPid=com.ibm.ws.concurrent.managedScheduledExecutorService)");
-            for (ServiceReference<ManagedScheduledExecutorService> ref : refs) {
-                ManagedScheduledExecutorService executor = priv.getService(bc, ref);
-                if (executor instanceof ManagedScheduledExecutorServiceImpl) {
+            refs = priv.getServiceReferences(bc,
+                                             ManagedExecutorService.class,
+                                             FILTER_MES_EXCLUDE_OSGI_JNDI);
+            for (ServiceReference<ManagedExecutorService> ref : refs) {
+                ManagedExecutorService executor = priv.getService(bc, ref);
+                if (executor instanceof ManagedExecutorServiceImpl) {
                     if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
                         Tr.debug(this, tc, "purge futures list for " + executor);
-                    ((ManagedScheduledExecutorServiceImpl) executor).purgeFutures();
+                    ((ManagedExecutorServiceImpl) executor).purgeFutures();
                 }
             }
         } catch (InvalidSyntaxException x) {
             throw new RuntimeException(x); // should never occur because a valid filter is hard-coded
         }
+    }
+
+    @Override
+    @Trivial
+    public void applicationStarted(ApplicationInfo appInfo) {
+        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
+            Tr.debug(this, tc, "applicationStarted " + appInfo.getDeploymentName() +
+                               " (" + appInfo.getName() + ')');
+    }
+
+    @Override
+    @Trivial
+    public void applicationStarting(ApplicationInfo appInfo) {
+        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
+            Tr.debug(this, tc, "applicationStarting " + appInfo.getDeploymentName() +
+                               " (" + appInfo.getName() + ')');
+    }
+
+    @Override
+    @Trivial
+    public void applicationStopping(ApplicationInfo appInfo) {
+        final boolean trace = TraceComponent.isAnyTracingEnabled();
+        if (trace && tc.isEntryEnabled())
+            Tr.entry(this, tc, "applicationStopping " + appInfo.getDeploymentName() +
+                               " (" + appInfo.getName() + ')');
+
+        // Use deployment name but fall back to generated name
+        String appName = appInfo.getDeploymentName() == null //
+                        ? appInfo.getName() //
+                        : appInfo.getDeploymentName();
+
+        Bundle bundle = FrameworkUtil.getBundle(getClass());
+        BundleContext bc = bundle == null ? null : priv.getBundleContext(bundle);
+        Collection<ServiceReference<ManagedExecutorService>> refs;
+        try {
+            refs = priv.getServiceReferences(bc,
+                                             ManagedExecutorService.class,
+                                             FILTER_MES_EXCLUDE_OSGI_JNDI);
+            for (ServiceReference<ManagedExecutorService> ref : refs) {
+                ManagedExecutorService executor = priv.getService(bc, ref);
+                if (executor instanceof ManagedExecutorServiceImpl) {
+                    ((ManagedExecutorServiceImpl) executor).cancelFutures(appName);
+                }
+            }
+        } catch (InvalidSyntaxException x) {
+            throw new RuntimeException(x); // should never occur
+        }
+
+        if (trace && tc.isEntryEnabled())
+            Tr.exit(this, tc, "applicationStopping");
+    }
+
+    @Override
+    @Trivial
+    public void applicationStopped(ApplicationInfo appInfo) {
+        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
+            Tr.debug(this, tc, "applicationStoppied " + appInfo.getDeploymentName() +
+                               " (" + appInfo.getName() + ')');
+    }
+
+    /**
+     * Determines the name of the application that is running on the thread.
+     * If unavailable, determines the name of the application that provides the
+     * given class. Returns null if an application name cannot be determined.
+     *
+     * @param taskClass class of a task submitted by the application
+     * @return the application name or null if unable to determine
+     */
+    @Trivial
+    String findAppName(Class<?> taskClass) {
+        // Primary: use the component metadata already on the thread. This is
+        // available whenever findAppName is called during task submission from
+        // application code, which is the normal case.
+        ComponentMetaData cmd = ComponentMetaDataAccessorImpl //
+                        .getComponentMetaDataAccessor() //
+                        .getComponentMetaData();
+        if (cmd != null) {
+            String appName = cmd.getJ2EEName().getApplication();
+            if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
+                Tr.debug(this, tc, taskClass.getName() +
+                                   " submitted by application " + appName);
+            return appName;
+        }
+
+        // Fallback: infer the application name from the class loader of the
+        // task class. The identifier string for an application class loader has
+        // the form "domain:appName#moduleName", so the app name is the portion
+        // between the first colon and the first '#' (or end of string).
+        for (ClassLoader cl = taskClass.getClassLoader(); //
+                        cl != null; //
+                        cl = cl.getParent()) {
+            String identifier = classLoaderIdentifierService //
+                            .getClassLoaderIdentifier(cl);
+            if (identifier != null) {
+                int colon = identifier.indexOf(':');
+                if (colon >= 0) {
+                    int hash = identifier.indexOf('#', colon);
+                    String appName = identifier //
+                                    .substring(colon + 1,
+                                               hash > 0 ? hash : identifier.length());
+                    if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
+                        Tr.debug(this, tc, taskClass.getName() +
+                                           " provided by application " + appName);
+                    return appName;
+                }
+            }
+        }
+
+        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
+            Tr.debug(this, tc, taskClass + " not associated with any application",
+                     cmd,
+                     taskClass.getClassLoader());
+        return null;
     }
 }

--- a/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/ConcurrencyService.java
+++ b/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/ConcurrencyService.java
@@ -154,7 +154,7 @@ public class ConcurrencyService implements //
     @Trivial
     public void applicationStopped(ApplicationInfo appInfo) {
         if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
-            Tr.debug(this, tc, "applicationStoppied " + appInfo.getDeploymentName() +
+            Tr.debug(this, tc, "applicationStopped " + appInfo.getDeploymentName() +
                                " (" + appInfo.getName() + ')');
     }
 

--- a/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/ContextualDefaultExecutor.java
+++ b/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/ContextualDefaultExecutor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020,2024 IBM Corporation and others.
+ * Copyright (c) 2020,2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package com.ibm.ws.concurrent.internal;
 
+import java.lang.reflect.Method;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.Collection;
@@ -19,6 +20,8 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.Executor;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiFunction;
 
 import org.eclipse.microprofile.context.ManagedExecutor;
@@ -97,6 +100,12 @@ class ContextualDefaultExecutor implements Executor, WSManagedExecutorService {
 
     @Override
     public <I, T> CompletableFuture<T> newAsyncMethod(BiFunction<I, CompletableFuture<T>, CompletionStage<T>> invoker, I invocation) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public <T> CompletableFuture<T> newScheduledMethod(Method method,
+                                                       AtomicReference<Future<?>> nextExecFuture) {
         throw new UnsupportedOperationException();
     }
 

--- a/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/ManagedCompletableFuture.java
+++ b/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/ManagedCompletableFuture.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2022 IBM Corporation and others.
+ * Copyright (c) 2017, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -15,6 +15,7 @@ package com.ibm.ws.concurrent.internal;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
+import java.lang.reflect.Method;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.Collection;
@@ -135,6 +136,14 @@ public class ManagedCompletableFuture<T> extends CompletableFuture<T> {
     };
 
     /**
+     * Name of the application that provides a scheduled method for which the
+     * completion of all execution is represented by this completable future.
+     * Null if the application is unknown or this completable future does not
+     * represent a scheduled method.
+     */
+    final String appName;
+
+    /**
      * For the Java SE 8 implementation, the real completable future to which meaningful operations are delegated.
      * For greater than Java SE 8, this value must be NULL.
      */
@@ -148,9 +157,10 @@ public class ManagedCompletableFuture<T> extends CompletableFuture<T> {
     final Executor defaultExecutor;
 
     /**
-     * Reference to the policy executor Future (if any) upon which the action runs.
-     * Reference is null when the action cannot be async.
-     * Value is null when an async action has not yet been submitted.
+     * Reference to the policy executor Future upon which the action runs (or,
+     * in the case of a scheduled method, to a Liberty scheduled executor future).
+     * The reference is null when the action cannot be async.
+     * The value is null when an async action has not yet been submitted.
      */
     final AtomicReference<Future<?>> futureRef;
 
@@ -222,6 +232,7 @@ public class ManagedCompletableFuture<T> extends CompletableFuture<T> {
     ManagedCompletableFuture(CompletableFuture<T> completableFuture, Executor managedExecutor, FutureRefExecutor futureRef) {
         super();
 
+        this.appName = null;
         this.completableFuture = completableFuture;
         this.defaultExecutor = managedExecutor;
         this.futureRef = futureRef;
@@ -249,12 +260,33 @@ public class ManagedCompletableFuture<T> extends CompletableFuture<T> {
     ManagedCompletableFuture(Executor managedExecutor, FutureRefExecutor futureRef) {
         super();
 
+        this.appName = null;
         this.completableFuture = null;
         this.defaultExecutor = managedExecutor;
         this.futureRef = futureRef;
 
         if (futureRef != null)
             futureRef.cancellableStage.set(this);
+    }
+
+    /**
+     * Construct a completable future that represents the completion of all
+     * executions of a scheduled method.
+     *
+     * @param managedExecutor the managed scheduled executor
+     * @param method          the scheduled method
+     * @param nextExecFuture  reference to the future for the next execution
+     *                            of the scheduled method
+     */
+    ManagedCompletableFuture(ManagedExecutorServiceImpl managedExecutor,
+                             Method method,
+                             AtomicReference<Future<?>> nextExecFuture) {
+        this.appName = managedExecutor.concurrencySvc //
+                        .findAppName(method.getDeclaringClass());
+        this.completableFuture = null;
+        this.defaultExecutor = managedExecutor;
+        this.futureRef = nextExecFuture;
+        managedExecutor.trackFuture(this);
     }
 
     // static method equivalents for CompletableFuture, plus other static methods for ManagedExecutorImpl to use
@@ -1087,27 +1119,39 @@ public class ManagedCompletableFuture<T> extends CompletableFuture<T> {
      * @see java.util.concurrent.CompletableFuture#isCancelled()
      */
     @Override
+    @Trivial
     public boolean isCancelled() {
-        return JAVA8 ? completableFuture.isCancelled() : //
+        boolean cancelled = JAVA8 ? completableFuture.isCancelled() : //
                         super.isCancelled();
+        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
+            Tr.debug(this, tc, "isCancelled? " + cancelled);
+        return cancelled;
     }
 
     /**
      * @see java.util.concurrent.CompletableFuture#isCompletedExceptionally()
      */
     @Override
+    @Trivial
     public boolean isCompletedExceptionally() {
-        return JAVA8 ? completableFuture.isCompletedExceptionally() : //
+        boolean xcomplete = JAVA8 ? completableFuture.isCompletedExceptionally() : //
                         super.isCompletedExceptionally();
+        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
+            Tr.debug(this, tc, "isCompletedExceptionally? " + xcomplete);
+        return xcomplete;
     }
 
     /**
      * @see java.util.concurrent.CompletableFuture#isDone()
      */
     @Override
+    @Trivial
     public boolean isDone() {
-        return JAVA8 ? completableFuture.isDone() : //
+        boolean done = JAVA8 ? completableFuture.isDone() : //
                         super.isDone();
+        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
+            Tr.debug(this, tc, "isDone? " + done);
+        return done;
     }
 
     /**

--- a/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/ManagedExecutorServiceImpl.java
+++ b/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/ManagedExecutorServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2022 IBM Corporation and others.
+ * Copyright (c) 2012, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package com.ibm.ws.concurrent.internal;
 
+import java.lang.reflect.Method;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.AbstractMap.SimpleEntry;
@@ -21,6 +22,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -30,6 +32,7 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ForkJoinPool;
@@ -81,10 +84,15 @@ import com.ibm.wsspi.threadcontext.ThreadContextDescriptor;
 import com.ibm.wsspi.threadcontext.ThreadContextProvider;
 import com.ibm.wsspi.threadcontext.WSContextService;
 
-@Component(configurationPid = "com.ibm.ws.concurrent.managedExecutorService", configurationPolicy = ConfigurationPolicy.REQUIRE,
-           service = { ExecutorService.class, ManagedExecutor.class, ManagedExecutorService.class, //
-                       ResourceFactory.class, ApplicationRecycleComponent.class },
-           reference = @Reference(name = "ApplicationRecycleCoordinator", service = ApplicationRecycleCoordinator.class))
+@Component(configurationPid = "com.ibm.ws.concurrent.managedExecutorService",
+           configurationPolicy = ConfigurationPolicy.REQUIRE,
+           service = { ExecutorService.class,
+                       ManagedExecutor.class,
+                       ManagedExecutorService.class,
+                       ResourceFactory.class,
+                       ApplicationRecycleComponent.class },
+           reference = @Reference(name = "ApplicationRecycleCoordinator",
+                                  service = ApplicationRecycleCoordinator.class))
 public class ManagedExecutorServiceImpl implements ExecutorService, //
                 ManagedExecutor, ManagedExecutorService, CompletionStageExecutor, //
                 ResourceFactory, ApplicationRecycleComponent, WSManagedExecutorService {
@@ -108,6 +116,11 @@ public class ManagedExecutorServiceImpl implements ExecutorService, //
      * Name of reference to the ApplicationRecycleCoordinator
      */
     static final String APP_RECYCLE_SERVICE = "ApplicationRecycleCoordinator";
+
+    /**
+     * Controls how often we purge the list of tracked futures.
+     */
+    private static final int FUTURE_PURGE_INTERVAL = 20;
 
     /**
      * Jakarta EE Concurrency execution properties that specify to suspend the current transaction.
@@ -159,6 +172,22 @@ public class ManagedExecutorServiceImpl implements ExecutorService, //
      * Tracks the most recently bound EE version service reference. Only use this within the set/unsetEEVersion methods.
      */
     private ServiceReference<JavaEEVersion> eeVersionRef;
+
+    /**
+     * Count of tracked futures. In combination with FUTURE_PURGE_INTERVAL,
+     * this determines when to purge completed futures from the list.
+     */
+    private volatile int futureCount;
+
+    /**
+     * List of futures for tasks. Not all tasks are tracked.
+     * Currently this includes futures for scheduled tasks and scheduled methods.
+     * These are tracked to be canceled when an application is stopping or the
+     * managed executor service goes away. The latter is done always. The former
+     * is contingent on being Jakarta EE 12 or higher to avoid changing behavior.
+     */
+    private final ConcurrentLinkedQueue<Future<?>> futures = //
+                    new ConcurrentLinkedQueue<>();
 
     /**
      * Hash code for this instance.
@@ -294,6 +323,14 @@ public class ManagedExecutorServiceImpl implements ExecutorService, //
      */
     @Deactivate
     protected void deactivate(ComponentContext context) {
+        final boolean trace = TraceComponent.isAnyTracingEnabled();
+
+        // Cancel scheduled or running tasks
+        for (Future<?> future = futures.poll(); future != null; future = futures.poll())
+            if (!future.isDone() && future.cancel(true))
+                if (trace && tc.isDebugEnabled())
+                    Tr.debug(this, tc, "canceled scheduled task", future);
+
         // Cancel submitted or running tasks
         int count = 0;
         PolicyAndExecutor normal = normalPolicyAndExecutorRef.get();
@@ -322,6 +359,35 @@ public class ManagedExecutorServiceImpl implements ExecutorService, //
             return getNormalPolicyExecutor().awaitTermination(timeout, unit);
         else // Section 3.1.6.1 of the Concurrency Utilities spec requires IllegalStateException
             throw new IllegalStateException(new UnsupportedOperationException("awaitTermination"));
+    }
+
+    /**
+     * Cancel scheduled futures associated with the given application
+     * that have not yet completed.
+     *
+     * @param appName name of an application that is stopping
+     */
+    @Trivial
+    final void cancelFutures(String appName) {
+        final boolean trace = TraceComponent.isAnyTracingEnabled();
+        for (Iterator<Future<?>> it = futures.iterator(); it.hasNext();) {
+            Future<?> future = it.next();
+            String name = future instanceof ManagedCompletableFuture //
+                            ? ((ManagedCompletableFuture<?>) future).appName //
+                            : future instanceof ScheduledTask //
+                                            ? ((ScheduledTask<?>) future).appName //
+                                            : null;
+            if (appName.equals(name)) {
+                if (!future.isDone()) {
+                    if (trace && tc.isDebugEnabled())
+                        Tr.debug(this, tc, "cancel due to application " + appName +
+                                           " stopping");
+                    future.cancel(true);
+                }
+                // also purge tracking of the future
+                it.remove();
+            }
+        }
     }
 
     @Override
@@ -734,6 +800,29 @@ public class ManagedExecutorServiceImpl implements ExecutorService, //
     }
 
     @Override
+    public <T> CompletableFuture<T> newScheduledMethod(Method method,
+                                                       AtomicReference<Future<?>> nextExecFuture) {
+        // Ideally, we would always cancel scheduled methods when the application
+        // stops. However, this could possibly break an application, so it is done
+        // only at the Jakarta EE 12 (Concurrency 3.2) version and above.
+        if (eeVersion >= 12)
+            return new ManagedCompletableFuture<T>(this, method, nextExecFuture);
+        else
+            return new ManagedCompletableFuture<T>(this, null);
+    }
+
+    /**
+     * Purge completed futures from the list we are tracking.
+     * This method should be invoked every so often so that we don't leak memory.
+     */
+    @Trivial
+    final void purgeFutures() {
+        for (Iterator<Future<?>> it = futures.iterator(); it.hasNext();)
+            if (it.next().isDone())
+                it.remove();
+    }
+
+    @Override
     public CompletableFuture<Void> runAsync(Runnable runnable) {
         return ManagedCompletableFuture.runAsync(runnable, this);
     }
@@ -900,6 +989,20 @@ public class ManagedExecutorServiceImpl implements ExecutorService, //
     public String toString() {
         String s = name.get();
         return s != null && s.startsWith("ManagedExecutor@") ? s : ("ManagedExecutor@" + Integer.toHexString(hashCode()) + ' ' + s);
+    }
+
+    /**
+     * Add tracking of the given future, such that it can be canceled when the
+     * managed executor deactivates, and, if the application is recorded, can be
+     * canceled when the application is stopping. This method periodically purges
+     * already completed futures.
+     *
+     * @param future future to track
+     */
+    @Trivial
+    final void trackFuture(Future<?> future) {
+        if (futures.add(future) && ++futureCount % FUTURE_PURGE_INTERVAL == 0)
+            purgeFutures();
     }
 
     /**

--- a/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/ManagedScheduledExecutorServiceImpl.java
+++ b/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/ManagedScheduledExecutorServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2023 IBM Corporation and others.
+ * Copyright (c) 2013, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -12,11 +12,8 @@
  *******************************************************************************/
 package com.ibm.ws.concurrent.internal;
 
-import java.util.Iterator;
 import java.util.concurrent.Callable;
-import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
@@ -31,38 +28,24 @@ import org.osgi.service.component.annotations.ConfigurationPolicy;
 import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Reference;
 
-import com.ibm.websphere.ras.Tr;
-import com.ibm.websphere.ras.TraceComponent;
 import com.ibm.websphere.ras.annotation.Trivial;
 import com.ibm.wsspi.application.lifecycle.ApplicationRecycleComponent;
 import com.ibm.wsspi.application.lifecycle.ApplicationRecycleCoordinator;
 import com.ibm.wsspi.resource.ResourceFactory;
 
-@Component(configurationPid = "com.ibm.ws.concurrent.managedScheduledExecutorService", configurationPolicy = ConfigurationPolicy.REQUIRE,
-           service = { ExecutorService.class, ManagedExecutorService.class, //
-                       ResourceFactory.class, ApplicationRecycleComponent.class, //
-                       ScheduledExecutorService.class, ManagedScheduledExecutorService.class },
-           reference = @Reference(name = "ApplicationRecycleCoordinator", service = ApplicationRecycleCoordinator.class))
-public class ManagedScheduledExecutorServiceImpl extends ManagedExecutorServiceImpl implements ManagedScheduledExecutorService {
-
-    private static final TraceComponent tc = Tr.register(ManagedScheduledExecutorServiceImpl.class);
-
-    /**
-     * Controls how often we purge the list of tracked futures.
-     */
-    private static final int FUTURE_PURGE_INTERVAL = 20;
-
-    /**
-     * Count of futures. In combination with FUTURE_PURGE_INTERVAL, this determines when to purge completed futures from the list.
-     */
-    private volatile int futureCount;
-
-    /**
-     * Futures for tasks that might be scheduled or running. These are tracked so that we can meet the requirement
-     * of canceling or interrupting tasks that are scheduled or running when the managed executor service goes away.
-     * Futures from execute/submit/invokeAll/invokeAny methods are not tracked in this structure.
-     */
-    private final ConcurrentLinkedQueue<ScheduledFuture<?>> futures = new ConcurrentLinkedQueue<ScheduledFuture<?>>();
+@Component(configurationPid = "com.ibm.ws.concurrent.managedScheduledExecutorService",
+           configurationPolicy = ConfigurationPolicy.REQUIRE,
+           service = { ExecutorService.class,
+                       ManagedExecutorService.class,
+                       ResourceFactory.class,
+                       ApplicationRecycleComponent.class,
+                       ScheduledExecutorService.class,
+                       ManagedScheduledExecutorService.class },
+           reference = @Reference(name = "ApplicationRecycleCoordinator",
+                                  service = ApplicationRecycleCoordinator.class))
+public class ManagedScheduledExecutorServiceImpl //
+                extends ManagedExecutorServiceImpl //
+                implements ManagedScheduledExecutorService {
 
     /**
      * Reference to the (unmanaged) scheduled executor service for this managed scheduled executor service.
@@ -71,27 +54,9 @@ public class ManagedScheduledExecutorServiceImpl extends ManagedExecutorServiceI
 
     @Deactivate
     @Override
-    protected void deactivate(ComponentContext context) {
-        final boolean trace = TraceComponent.isAnyTracingEnabled();
-
-        // Cancel scheduled or running tasks
-        for (Future<?> future = futures.poll(); future != null; future = futures.poll())
-            if (!future.isDone() && future.cancel(true))
-                if (trace && tc.isDebugEnabled())
-                    Tr.debug(this, tc, "canceled scheduled task", future);
-
-        super.deactivate(context);
-    }
-
-    /**
-     * Purge completed futures from the list we are tracking.
-     * This method should be invoked every so often so that we don't leak memory.
-     */
     @Trivial
-    final void purgeFutures() {
-        for (Iterator<ScheduledFuture<?>> it = futures.iterator(); it.hasNext();)
-            if (it.next().isDone())
-                it.remove();
+    protected void deactivate(ComponentContext context) {
+        super.deactivate(context);
     }
 
     /**
@@ -100,8 +65,7 @@ public class ManagedScheduledExecutorServiceImpl extends ManagedExecutorServiceI
     @Override
     public <V> ScheduledFuture<V> schedule(Callable<V> task, long delay, TimeUnit unit) {
         ScheduledTask<V> scheduledTask = new ScheduledTask<V>(this, task, true, delay, null, null, unit);
-        if (futures.add(scheduledTask.future) && ++futureCount % FUTURE_PURGE_INTERVAL == 0)
-            purgeFutures();
+        trackFuture(scheduledTask.future);
         return scheduledTask.future;
     }
 
@@ -114,8 +78,7 @@ public class ManagedScheduledExecutorServiceImpl extends ManagedExecutorServiceI
             throw new NullPointerException(Trigger.class.getName());
 
         ScheduledTask<V> scheduledTask = new ScheduledTask<V>(this, task, true, trigger);
-        if (futures.add(scheduledTask.future) && ++futureCount % FUTURE_PURGE_INTERVAL == 0)
-            purgeFutures();
+        trackFuture(scheduledTask.future);
         return scheduledTask.future;
     }
 
@@ -125,8 +88,7 @@ public class ManagedScheduledExecutorServiceImpl extends ManagedExecutorServiceI
     @Override
     public ScheduledFuture<?> schedule(Runnable task, long delay, TimeUnit unit) {
         ScheduledTask<Void> scheduledTask = new ScheduledTask<Void>(this, task, false, delay, null, null, unit);
-        if (futures.add(scheduledTask.future) && ++futureCount % FUTURE_PURGE_INTERVAL == 0)
-            purgeFutures();
+        trackFuture(scheduledTask.future);
         return scheduledTask.future;
     }
 
@@ -139,8 +101,7 @@ public class ManagedScheduledExecutorServiceImpl extends ManagedExecutorServiceI
             throw new NullPointerException(Trigger.class.getName());
 
         ScheduledTask<?> scheduledTask = new ScheduledTask<Void>(this, task, false, trigger);
-        if (futures.add(scheduledTask.future) && ++futureCount % FUTURE_PURGE_INTERVAL == 0)
-            purgeFutures();
+        trackFuture(scheduledTask.future);
         return scheduledTask.future;
     }
 
@@ -153,8 +114,7 @@ public class ManagedScheduledExecutorServiceImpl extends ManagedExecutorServiceI
             throw new IllegalArgumentException(Long.toString(period));
 
         ScheduledTask<Void> scheduledTask = new ScheduledTask<Void>(this, task, false, initialDelay < 0 ? 0 : initialDelay, null, period, unit);
-        if (futures.add(scheduledTask.future) && ++futureCount % FUTURE_PURGE_INTERVAL == 0)
-            purgeFutures();
+        trackFuture(scheduledTask.future);
         return scheduledTask.future;
     }
 
@@ -167,8 +127,7 @@ public class ManagedScheduledExecutorServiceImpl extends ManagedExecutorServiceI
             throw new IllegalArgumentException(Long.toString(delay));
 
         ScheduledTask<Void> scheduledTask = new ScheduledTask<Void>(this, task, false, initialDelay < 0 ? 0 : initialDelay, delay, null, unit);
-        if (futures.add(scheduledTask.future) && ++futureCount % FUTURE_PURGE_INTERVAL == 0)
-            purgeFutures();
+        trackFuture(scheduledTask.future);
         return scheduledTask.future;
     }
 

--- a/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/ScheduledTask.java
+++ b/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/ScheduledTask.java
@@ -282,7 +282,12 @@ public class ScheduledTask<T> implements Callable<T>, ScheduledCustomExecutorTas
             }
         }
 
-        this.appName = managedExecSvc.concurrencySvc.findAppName(task.getClass());
+        // Ideally, we would always cancel scheduled methods when the application
+        // stops. However, this could possibly break an application, so it is done
+        // only at the Jakarta EE 12 (Concurrency 3.2) version and above.
+        this.appName = managedExecSvc.eeVersion >= 12 //
+                        ? managedExecSvc.concurrencySvc.findAppName(task.getClass()) //
+                        : null;
 
         // Cap the maximum delay at what is supported by ScheduledThreadPoolExecutor, upon which Liberty ScheduledExecutorService is built
         Duration delay = Duration.of(initialDelay, unit);
@@ -356,7 +361,12 @@ public class ScheduledTask<T> implements Callable<T>, ScheduledCustomExecutorTas
             }
         }
 
-        this.appName = managedExecSvc.concurrencySvc.findAppName(task.getClass());
+        // Ideally, we would always cancel scheduled methods when the application
+        // stops. However, this could possibly break an application, so it is done
+        // only at the Jakarta EE 12 (Concurrency 3.2) version and above.
+        this.appName = managedExecSvc.eeVersion >= 12 //
+                        ? managedExecSvc.concurrencySvc.findAppName(task.getClass()) //
+                        : null;
 
         try {
             nextExecutionTime = triggerSvc.getNextRunTime(null, taskScheduledTime, trigger);

--- a/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/ScheduledTask.java
+++ b/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/ScheduledTask.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2024 IBM Corporation and others.
+ * Copyright (c) 2013, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -155,6 +155,11 @@ public class ScheduledTask<T> implements Callable<T>, ScheduledCustomExecutorTas
     }
 
     /**
+     * Name of the application that schedules or provides the task. Null if unknown.
+     */
+    final String appName;
+
+    /**
      * Fixed delay between executions of the task. Only available if using fixed delay.
      */
     private final Long fixedDelay;
@@ -277,6 +282,8 @@ public class ScheduledTask<T> implements Callable<T>, ScheduledCustomExecutorTas
             }
         }
 
+        this.appName = managedExecSvc.concurrencySvc.findAppName(task.getClass());
+
         // Cap the maximum delay at what is supported by ScheduledThreadPoolExecutor, upon which Liberty ScheduledExecutorService is built
         Duration delay = Duration.of(initialDelay, unit);
         if (delay.compareTo(MAX_DELAY) > 0)
@@ -348,6 +355,8 @@ public class ScheduledTask<T> implements Callable<T>, ScheduledCustomExecutorTas
                 throw new RejectedExecutionException(x);
             }
         }
+
+        this.appName = managedExecSvc.concurrencySvc.findAppName(task.getClass());
 
         try {
             nextExecutionTime = triggerSvc.getNextRunTime(null, taskScheduledTime, trigger);

--- a/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/UnusableExecutor.java
+++ b/dev/com.ibm.ws.concurrent/src/com/ibm/ws/concurrent/internal/UnusableExecutor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018,2024 IBM Corporation and others.
+ * Copyright (c) 2018,2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -12,10 +12,13 @@
  *******************************************************************************/
 package com.ibm.ws.concurrent.internal;
 
+import java.lang.reflect.Method;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.Executor;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiFunction;
 
 import com.ibm.websphere.ras.annotation.Trivial;
@@ -66,6 +69,12 @@ class UnusableExecutor implements Executor, WSManagedExecutorService {
 
     @Override
     public <I, T> CompletableFuture<T> newAsyncMethod(BiFunction<I, CompletableFuture<T>, CompletionStage<T>> invoker, I invocation) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public <T> CompletableFuture<T> newScheduledMethod(Method method,
+                                                       AtomicReference<Future<?>> nextExecFuture) {
         throw new UnsupportedOperationException();
     }
 

--- a/dev/io.openliberty.concurrent.internal.cdi/src/io/openliberty/concurrent/internal/cdi/ScheduledMethod.java
+++ b/dev/io.openliberty.concurrent.internal.cdi/src/io/openliberty/concurrent/internal/cdi/ScheduledMethod.java
@@ -62,8 +62,10 @@ public class ScheduledMethod<T> extends ScheduledMethodAbstract {
 
         // Intentionally placed as last line of constructuor to ensure
         // intialization is complete before the first task execution runs
-        ConcurrencyExtensionMetadata.scheduledExecutor //
-                        .schedule(this, computeDelayNanos(), TimeUnit.NANOSECONDS);
+        nextExecutionFuture.set(ConcurrencyExtensionMetadata //
+                        .scheduledExecutor.schedule(this,
+                                                    computeDelayNanos(),
+                                                    TimeUnit.NANOSECONDS));
     }
 
     /**

--- a/dev/io.openliberty.concurrent.internal.cdi/src/io/openliberty/concurrent/internal/cdi/ScheduledMethod.java
+++ b/dev/io.openliberty.concurrent.internal.cdi/src/io/openliberty/concurrent/internal/cdi/ScheduledMethod.java
@@ -17,6 +17,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.List;
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
 import com.ibm.ws.concurrent.WSManagedExecutorService;
@@ -62,10 +63,13 @@ public class ScheduledMethod<T> extends ScheduledMethodAbstract {
 
         // Intentionally placed as last line of constructuor to ensure
         // intialization is complete before the first task execution runs
-        nextExecutionFuture.set(ConcurrencyExtensionMetadata //
+        ScheduledFuture<?> nextExec = ConcurrencyExtensionMetadata //
                         .scheduledExecutor.schedule(this,
                                                     computeDelayNanos(),
-                                                    TimeUnit.NANOSECONDS));
+                                                    TimeUnit.NANOSECONDS);
+        nextExecutionFuture.set(nextExec);
+        if (future.isCancelled())
+            nextExec.cancel(true);
     }
 
     /**

--- a/dev/io.openliberty.concurrent.internal.cdi/src/io/openliberty/concurrent/internal/cdi/ScheduledMethodAbstract.java
+++ b/dev/io.openliberty.concurrent.internal.cdi/src/io/openliberty/concurrent/internal/cdi/ScheduledMethodAbstract.java
@@ -117,11 +117,13 @@ public abstract class ScheduledMethodAbstract implements //
                                ChronoUnit.SECONDS);
         if (secondsLate > nextExecutionSkipIfLateBySeconds) {
             try {
-                long delayNanos = computeDelayNanos();
-                nextExecutionFuture.set(ConcurrencyExtensionMetadata //
+                Future<?> nextExecFuture = ConcurrencyExtensionMetadata //
                                 .scheduledExecutor.schedule(this, //
-                                                            delayNanos, //
-                                                            TimeUnit.NANOSECONDS));
+                                                            computeDelayNanos(), //
+                                                            TimeUnit.NANOSECONDS);
+                nextExecutionFuture.set(nextExecFuture);
+                if (future.isCancelled())
+                    nextExecFuture.cancel(true);
                 if (trace && tc.isEntryEnabled())
                     Tr.exit(this, tc, "call: skip because late by " + secondsLate +
                                       " seconds");
@@ -175,10 +177,13 @@ public abstract class ScheduledMethodAbstract implements //
         if (!future.isDone())
             if (cs == null)
                 try { // reschedule next execution
-                    nextExecutionFuture.set(ConcurrencyExtensionMetadata //
+                    Future<?> nextExecFuture = ConcurrencyExtensionMetadata //
                                     .scheduledExecutor.schedule(this, //
                                                                 computeDelayNanos(), //
-                                                                TimeUnit.NANOSECONDS));
+                                                                TimeUnit.NANOSECONDS);
+                    nextExecutionFuture.set(nextExecFuture);
+                    if (future.isCancelled())
+                        nextExecFuture.cancel(true);
                 } catch (Exception x) {
                     future.completeExceptionally(x);
                 }

--- a/dev/io.openliberty.concurrent.internal.cdi/src/io/openliberty/concurrent/internal/cdi/ScheduledMethodAbstract.java
+++ b/dev/io.openliberty.concurrent.internal.cdi/src/io/openliberty/concurrent/internal/cdi/ScheduledMethodAbstract.java
@@ -24,7 +24,9 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.Executor;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 
 import com.ibm.websphere.ras.Tr;
 import com.ibm.websphere.ras.TraceComponent;
@@ -35,8 +37,6 @@ import com.ibm.ws.ffdc.annotation.FFDCIgnore;
 import com.ibm.ws.threading.ScheduledCustomExecutorTask;
 import com.ibm.wsspi.threadcontext.ThreadContext;
 import com.ibm.wsspi.threadcontext.ThreadContextDescriptor;
-
-import jakarta.enterprise.concurrent.ManagedExecutorService;
 
 /**
  * A task that can be scheduled to run a method at the appropriate time.
@@ -54,6 +54,8 @@ public abstract class ScheduledMethodAbstract implements //
     private final ThreadContextDescriptor contextDescriptor;
     public final CompletableFuture<Object> future;
     protected final Method method;
+    protected final AtomicReference<Future<?>> nextExecutionFuture = //
+                    new AtomicReference<>();
     private long nextExecutionSkipIfLateBySeconds;
     private ZonedDateTime nextExecutionTime;
     private final List<Long> skipIfLateBySeconds;
@@ -78,7 +80,8 @@ public abstract class ScheduledMethodAbstract implements //
                                       List<ScheduleCronTrigger> triggers,
                                       List<Long> skipIfLateBySeconds) {
         this.contextDescriptor = contextDescriptor;
-        this.future = ((ManagedExecutorService) managedExecutor).newIncompleteFuture();
+        this.future = managedExecutor.newScheduledMethod(method,
+                                                         nextExecutionFuture);
         this.method = method;
         this.skipIfLateBySeconds = skipIfLateBySeconds;
         this.triggers = triggers;
@@ -115,8 +118,10 @@ public abstract class ScheduledMethodAbstract implements //
         if (secondsLate > nextExecutionSkipIfLateBySeconds) {
             try {
                 long delayNanos = computeDelayNanos();
-                ConcurrencyExtensionMetadata.scheduledExecutor //
-                                .schedule(this, delayNanos, TimeUnit.NANOSECONDS);
+                nextExecutionFuture.set(ConcurrencyExtensionMetadata //
+                                .scheduledExecutor.schedule(this, //
+                                                            delayNanos, //
+                                                            TimeUnit.NANOSECONDS));
                 if (trace && tc.isEntryEnabled())
                     Tr.exit(this, tc, "call: skip because late by " + secondsLate +
                                       " seconds");
@@ -170,8 +175,10 @@ public abstract class ScheduledMethodAbstract implements //
         if (!future.isDone())
             if (cs == null)
                 try { // reschedule next execution
-                    ConcurrencyExtensionMetadata.scheduledExecutor //
-                                    .schedule(this, computeDelayNanos(), TimeUnit.NANOSECONDS);
+                    nextExecutionFuture.set(ConcurrencyExtensionMetadata //
+                                    .scheduledExecutor.schedule(this, //
+                                                                computeDelayNanos(), //
+                                                                TimeUnit.NANOSECONDS));
                 } catch (Exception x) {
                     future.completeExceptionally(x);
                 }

--- a/dev/io.openliberty.concurrent.internal.cdi/src/io/openliberty/concurrent/internal/cdi/interceptor/ScheduledAsyncMethod.java
+++ b/dev/io.openliberty.concurrent.internal.cdi/src/io/openliberty/concurrent/internal/cdi/interceptor/ScheduledAsyncMethod.java
@@ -16,6 +16,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
 import com.ibm.websphere.ras.Tr;

--- a/dev/io.openliberty.concurrent.internal.cdi/src/io/openliberty/concurrent/internal/cdi/interceptor/ScheduledAsyncMethod.java
+++ b/dev/io.openliberty.concurrent.internal.cdi/src/io/openliberty/concurrent/internal/cdi/interceptor/ScheduledAsyncMethod.java
@@ -90,10 +90,13 @@ class ScheduledAsyncMethod extends ScheduledMethodAbstract {
 
         // Intentionally placed as last line of constructuor to ensure
         // intialization is complete before the first task execution runs
-        nextExecutionFuture.set(ConcurrencyExtensionMetadata //
+        ScheduledFuture<?> nextExec = ConcurrencyExtensionMetadata //
                         .scheduledExecutor.schedule(this,
                                                     computeDelayNanos(),
-                                                    TimeUnit.NANOSECONDS));
+                                                    TimeUnit.NANOSECONDS);
+        nextExecutionFuture.set(nextExec);
+        if (future.isCancelled())
+            nextExec.cancel(true);
     }
 
     /**

--- a/dev/io.openliberty.concurrent.internal.cdi/src/io/openliberty/concurrent/internal/cdi/interceptor/ScheduledAsyncMethod.java
+++ b/dev/io.openliberty.concurrent.internal.cdi/src/io/openliberty/concurrent/internal/cdi/interceptor/ScheduledAsyncMethod.java
@@ -90,8 +90,10 @@ class ScheduledAsyncMethod extends ScheduledMethodAbstract {
 
         // Intentionally placed as last line of constructuor to ensure
         // intialization is complete before the first task execution runs
-        ConcurrencyExtensionMetadata.scheduledExecutor //
-                        .schedule(this, computeDelayNanos(), TimeUnit.NANOSECONDS);
+        nextExecutionFuture.set(ConcurrencyExtensionMetadata //
+                        .scheduledExecutor.schedule(this,
+                                                    computeDelayNanos(),
+                                                    TimeUnit.NANOSECONDS));
     }
 
     /**


### PR DESCRIPTION
Repurpose and expand the existing future tracking mechanism to cover the completable futures for Scheduled methods and Asynchronous Scheduled methods.  Add in the ability to identify an application name associated with the scheduled method and track this information along with the ScheduledFuture for repeated execution, so that we can observe application stopping events and react by canceling the respective futures.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
