### PR TITLE
Adds mcp operation metrics for `200+json-rpc errors` response. Adds bug fix 

### DIFF
--- a/dev/io.openliberty.mcp.internal.monitor/src/io/openliberty/mcp/internal/monitor/McpStatsMonitorImpl.java
+++ b/dev/io.openliberty.mcp.internal.monitor/src/io/openliberty/mcp/internal/monitor/McpStatsMonitorImpl.java
@@ -389,35 +389,24 @@ public class McpStatsMonitorImpl extends StatisticActions implements McpStatsMon
 
         McpSessionStatAttributes.Builder builder = McpSessionStatAttributes.builder();
 
-        if (metrics.getTransport() != null) {
-            try {
-                if (metrics.getTransport().getMcpRequest() != null) {
-                    String jsonrpcVersion = metrics.getTransport().getMcpRequest().jsonrpc();
-                    if (jsonrpcVersion != null) {
-                        builder.withJsonrpcProtocolVersion(jsonrpcVersion);
-                    }
-                }
+        if (metrics.getJsonrpcProtocolVersion() != null) {
+            builder.withJsonrpcProtocolVersion(metrics.getJsonrpcProtocolVersion());
+        }
 
-                if (metrics.getTransport().getProtocolVersion() != null) {
-                    builder.withMcpProtocolVersion(metrics.getTransport().getProtocolVersion().getVersion());
-                }
+        if (metrics.getMcpProtocolVersion() != null) {
+            builder.withMcpProtocolVersion(metrics.getMcpProtocolVersion());
+        }
 
-                String protocol = metrics.getProtocol();
-                if (protocol != null) {
-                    String[] protocolParts = protocol.split("/");
-                    if (protocolParts.length >= 2) {
-                        builder.withNetworkProtocolName(protocolParts[0]);
-                        builder.withNetworkProtocolVersion(protocolParts[1]);
-                    }
-                }
-
-                builder.withNetworkTransport("tcp");
-            } catch (Exception e) {
-                if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
-                    Tr.debug(this, tc, "Error extracting transport information: " + e.getMessage());
-                }
+        String protocol = metrics.getProtocol();
+        if (protocol != null) {
+            String[] protocolParts = protocol.split("/");
+            if (protocolParts.length >= 2) {
+                builder.withNetworkProtocolName(protocolParts[0]);
+                builder.withNetworkProtocolVersion(protocolParts[1]);
             }
         }
+
+        builder.withNetworkTransport("tcp");
 
         long elapsedNanos = metrics.getDurationNanos();
         Duration duration = Duration.ofNanos(elapsedNanos);

--- a/dev/io.openliberty.mcp.internal/src/io/openliberty/mcp/internal/McpServlet.java
+++ b/dev/io.openliberty.mcp.internal/src/io/openliberty/mcp/internal/McpServlet.java
@@ -139,11 +139,8 @@ public class McpServlet extends HttpServlet {
 
             metrics.setTransport(transport);
             McpRequest mcpRequest = transport.getMcpRequest();
-            if (mcpRequest != null && mcpRequest.method() != null) {
-                metrics.setMethodName(mcpRequest.method());
-            }
-
             RequestMethod method = mcpRequest.getRequestMethod();
+            metrics.setMethodName(method.getMethodName());
 
             if (!isServerStateless() && method != RequestMethod.INITIALIZE && method != RequestMethod.PING) {
                 McpSession session = transport.getSession();

--- a/dev/io.openliberty.mcp.internal/src/io/openliberty/mcp/internal/McpServlet.java
+++ b/dev/io.openliberty.mcp.internal/src/io/openliberty/mcp/internal/McpServlet.java
@@ -137,7 +137,13 @@ public class McpServlet extends HttpServlet {
         try {
             transport.init(sessionStores.getCurrent());
 
-            RequestMethod method = transport.getMcpRequest().getRequestMethod();
+            metrics.setTransport(transport);
+            McpRequest mcpRequest = transport.getMcpRequest();
+            if (mcpRequest != null && mcpRequest.method() != null) {
+                metrics.setMethodName(mcpRequest.method());
+            }
+
+            RequestMethod method = mcpRequest.getRequestMethod();
 
             if (!isServerStateless() && method != RequestMethod.INITIALIZE && method != RequestMethod.PING) {
                 McpSession session = transport.getSession();
@@ -146,8 +152,6 @@ public class McpServlet extends HttpServlet {
                                                     "Missing Mcp-Session-Id header");
                 }
             }
-
-            metrics.setTransport(transport);
 
             callRequest(transport, metrics);
         } catch (JSONRPCException e) {
@@ -162,6 +166,12 @@ public class McpServlet extends HttpServlet {
 
             traceEvent("The following error was returned to the user: '" + jsonRpcErrorMsg + "'");
 
+            // JSONRPCExceptions are sent as HTTP 200, so HTTP metrics will not record errors.
+            // Use "_OTHER" as the method name fallback when the method could not be determined
+            // (e.g. PARSE_ERROR, INVALID_REQUEST) so the MCP metric is always emitted.
+            if (metrics.getMethodName() == null) {
+                metrics.setMethodName("_OTHER");
+            }
             metrics.setOutcome("error", e.getErrorCode().name());
             McpOperationMetrics.operationEnded(metrics);
 
@@ -244,6 +254,7 @@ public class McpServlet extends HttpServlet {
         if (sessionStores.getCurrent().deleteSession(sessionId)) {
             resp.setStatus(HttpServletResponse.SC_OK);
         } else {
+            traceEvent("DELETE request received for unknown or already-expired session: " + sessionIdStr);
             resp.sendError(HttpServletResponse.SC_NOT_FOUND, "Session not found");
         }
     }

--- a/dev/io.openliberty.mcp.internal/src/io/openliberty/mcp/internal/McpServlet.java
+++ b/dev/io.openliberty.mcp.internal/src/io/openliberty/mcp/internal/McpServlet.java
@@ -180,6 +180,10 @@ public class McpServlet extends HttpServlet {
             }
             traceEvent("The following error was returned to the user: '" + errorMsg + "'");
 
+            if (metrics.getMethodName() == null) {
+                metrics.setTransport(transport);
+                trySetMethodNameFromTransport(metrics, transport);
+            }
             metrics.setOutcome("error", "http_error");
             McpOperationMetrics.operationEnded(metrics);
 
@@ -191,10 +195,31 @@ public class McpServlet extends HttpServlet {
             }
             traceEvent("The following error was returned to the user: '" + errorMsg + "'");
 
+            if (metrics.getMethodName() == null) {
+                metrics.setTransport(transport);
+                trySetMethodNameFromTransport(metrics, transport);
+            }
             metrics.setOutcome("error", "internal_error");
             McpOperationMetrics.operationEnded(metrics);
 
             transport.sendError(e);
+        }
+    }
+
+    /**
+     * Attempts to set the method name on metrics from the parsed request in the transport.
+     * Falls back to "_OTHER" if the method name cannot be determined or is not a known method.
+     */
+    private static void trySetMethodNameFromTransport(McpOperationMetrics metrics, McpTransport transport) {
+        try {
+            McpRequest mcpRequest = transport.getMcpRequest();
+            if (mcpRequest != null) {
+                metrics.setMethodName(mcpRequest.getRequestMethod().getMethodName());
+            } else {
+                metrics.setMethodName("_OTHER");
+            }
+        } catch (JSONRPCException e) {
+            metrics.setMethodName("_OTHER");
         }
     }
 

--- a/dev/io.openliberty.mcp.internal/src/io/openliberty/mcp/internal/metrics/McpSessionMetrics.java
+++ b/dev/io.openliberty.mcp.internal/src/io/openliberty/mcp/internal/metrics/McpSessionMetrics.java
@@ -88,8 +88,8 @@ public final class McpSessionMetrics {
     public void setTransport(McpTransport transport) {
         if (transport != null) {
             this.appName = transport.getAppName();
-            // Extract all required info now the transport holds HttpServletRequest/Response
-            // which must not be retained for the session lifetime to avoid a memory leak
+            // Extract all required info eagerly since there is no need to hold onto the
+            // transport for the session lifetime
             this.protocol = transport.getReq().getProtocol();
             if (transport.getMcpRequest() != null) {
                 this.jsonrpcProtocolVersion = transport.getMcpRequest().jsonrpc();

--- a/dev/io.openliberty.mcp.internal/src/io/openliberty/mcp/internal/metrics/McpSessionMetrics.java
+++ b/dev/io.openliberty.mcp.internal/src/io/openliberty/mcp/internal/metrics/McpSessionMetrics.java
@@ -49,8 +49,9 @@ import io.openliberty.mcp.internal.sessions.McpSession;
  */
 public final class McpSessionMetrics {
     private McpSession mcpSession;
-    private McpTransport transport;
     private String protocol;
+    private String jsonrpcProtocolVersion;
+    private String mcpProtocolVersion;
 
     private long startTimeNanos;
 
@@ -84,20 +85,33 @@ public final class McpSessionMetrics {
         this.errorType = errorType;
     }
 
-    /**
-     * @return the transport
-     */
-    public McpTransport getTransport() {
-        return transport;
-    }
-
     public void setTransport(McpTransport transport) {
-        this.transport = transport;
         if (transport != null) {
             this.appName = transport.getAppName();
-            // Request will be long gone when the session ends, so extract necessary info now
+            // Extract all required info now the transport holds HttpServletRequest/Response
+            // which must not be retained for the session lifetime to avoid a memory leak
             this.protocol = transport.getReq().getProtocol();
+            if (transport.getMcpRequest() != null) {
+                this.jsonrpcProtocolVersion = transport.getMcpRequest().jsonrpc();
+            }
+            if (transport.getProtocolVersion() != null) {
+                this.mcpProtocolVersion = transport.getProtocolVersion().getVersion();
+            }
         }
+    }
+
+    /**
+     * @return the JSON-RPC protocol version extracted at session initialization time
+     */
+    public String getJsonrpcProtocolVersion() {
+        return jsonrpcProtocolVersion;
+    }
+
+    /**
+     * @return the MCP protocol version extracted at session initialization time
+     */
+    public String getMcpProtocolVersion() {
+        return mcpProtocolVersion;
     }
 
     /**

--- a/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/monitor/McpMonitorTest.java
+++ b/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/monitor/McpMonitorTest.java
@@ -98,6 +98,22 @@ public class McpMonitorTest {
                     }
                     """;
 
+    private static final String UNKNOWN_METHOD_REQUEST = """
+                    {
+                      "jsonrpc": "2.0",
+                      "id": 5,
+                      "method": "unknown/method"
+                    }
+                    """;
+
+    private static final String INVALID_JSONRPC_VERSION_REQUEST = """
+                    {
+                      "jsonrpc": "1.0",
+                      "id": 6,
+                      "method": "tools/list"
+                    }
+                    """;
+
     @BeforeClass
     public static void setup() throws Exception {
         WebArchive war = ShrinkWrap.create(WebArchive.class, APP_NAME + ".war")
@@ -141,11 +157,18 @@ public class McpMonitorTest {
      * @throws AssertionError if more than one matching MBean is found
      */
     private ObjectName findOperationMBean(String methodName, String toolName) throws Exception {
+        return findOperationMBean(methodName, toolName, null);
+    }
+
+    private ObjectName findOperationMBean(String methodName, String toolName, String errorType) throws Exception {
         // Build query pattern with individual properties instead of a single name property
         StringBuilder pattern = new StringBuilder(MBEAN_DOMAIN + ":type=" + MBEAN_TYPE_OPERATION);
         pattern.append(",mcpMethod=").append(methodName);
         if (toolName != null) {
             pattern.append(",genAiTool=").append(toolName);
+        }
+        if (errorType != null) {
+            pattern.append(",errorType=").append(errorType);
         }
         pattern.append(",*");
 
@@ -155,7 +178,7 @@ public class McpMonitorTest {
         return switch (mbeans.size()) {
             case 0 -> null;
             case 1 -> mbeans.iterator().next();
-            default -> throw new AssertionError("More than one operation mbean found for " + methodName + (toolName != null ? "/" + toolName : ""));
+            default -> throw new AssertionError("More than one operation mbean found for " + methodName + (toolName != null ? "/" + toolName : "") + (errorType != null ? "/" + errorType : ""));
         };
     }
 
@@ -754,6 +777,49 @@ public class McpMonitorTest {
 
         // Verify MBean exists with correct attributes (null errorType for success, "ok" status)
         verifyOperationMBeanAttributes("ping", null, null, "ok");
+    }
+
+    /**
+     * Test that a PARSE_ERROR emits an MBean with method name "_OTHER".
+     */
+    @Test
+    public void testParseErrorMetrics() throws Exception {
+        client.callMCP("this is not json");
+
+        ObjectName mbean = findOperationMBean("_OTHER", null, "PARSE_ERROR");
+        assertNotNull("MBean for _OTHER/PARSE_ERROR should exist after parse error", mbean);
+
+        String statusCode = (String) mbeanServer.getAttribute(mbean, "RpcResponseStatusCode");
+        assertEquals("Status code should be error", "error", statusCode);
+    }
+
+    /**
+     * Test that an INVALID_REQUEST emits an MBean with method name "_OTHER".
+     */
+    @Test
+    public void testInvalidRequestMetrics() throws Exception {
+        client.callMCP(INVALID_JSONRPC_VERSION_REQUEST);
+
+        ObjectName mbean = findOperationMBean("_OTHER", null, "INVALID_REQUEST");
+        assertNotNull("MBean for _OTHER/INVALID_REQUEST should exist after invalid request", mbean);
+
+        String statusCode = (String) mbeanServer.getAttribute(mbean, "RpcResponseStatusCode");
+        assertEquals("Status code should be error", "error", statusCode);
+    }
+
+    /**
+     * Test that a METHOD_NOT_FOUND error emits an MBean with method name "_OTHER".
+     * Unknown method names must not be used as metric attributes directly to limit cardinality.
+     */
+    @Test
+    public void testMethodNotFoundMetrics() throws Exception {
+        client.callMCP(UNKNOWN_METHOD_REQUEST);
+
+        ObjectName mbean = findOperationMBean("_OTHER", null, "METHOD_NOT_FOUND");
+        assertNotNull("MBean for _OTHER/METHOD_NOT_FOUND should exist after unknown method call", mbean);
+
+        String statusCode = (String) mbeanServer.getAttribute(mbean, "RpcResponseStatusCode");
+        assertEquals("Status code should be error", "error", statusCode);
     }
 
     /**

--- a/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/observability/telemetry/McpMetricReader.java
+++ b/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/observability/telemetry/McpMetricReader.java
@@ -30,7 +30,15 @@ public class McpMetricReader {
     InMemoryMetricReader reader = PullExporterAutoConfigurationCustomizerProvider.exporter;
 
     // Helper method to get cancel operation with specific status
+    public HistogramPointData getCancelOperationPoint(String status) {
+        return getCancelOperationPoint(status, null, false);
+    }
+
     public HistogramPointData getCancelOperationPoint(String status, String errorType) {
+        return getCancelOperationPoint(status, errorType, true);
+    }
+
+    private HistogramPointData getCancelOperationPoint(String status, String errorType, boolean filterOnErrorType) {
         Optional<MetricData> metric = getMetricData("mcp.server.operation.duration");
         assertTrue("mcp.server.operation.duration metric not found", metric.isPresent());
 
@@ -41,6 +49,7 @@ public class McpMetricReader {
                                                       .filter(point -> "notifications/cancelled".equals(getStringAttribute(point.getAttributes(), "mcp.method.name")))
                                                       .filter(point -> status.equals(getStringAttribute(point.getAttributes(), "rpc.response.status_code")))
                                                       .filter(point -> {
+                                                          if (!filterOnErrorType) return true;
                                                           String actualErrorType = getStringAttribute(point.getAttributes(), "error.type");
                                                           return errorType == null ? actualErrorType == null : errorType.equals(actualErrorType);
                                                       })
@@ -49,22 +58,6 @@ public class McpMetricReader {
         assertTrue("Expected at least one cancel point with status=" + status + ", errorType=" + errorType,
                    !cancelPoints.isEmpty());
         return cancelPoints.get(0);
-    }
-
-    // Helper to find cancel operation point (returns Optional)
-    public Optional<HistogramPointData> findCancelOperationPoint(String status) {
-        Optional<MetricData> metric = getMetricData("mcp.server.operation.duration");
-        if (metric.isEmpty()) {
-            return Optional.empty();
-        }
-
-        return metric.get()
-                     .getHistogramData()
-                     .getPoints()
-                     .stream()
-                     .filter(point -> "notifications/cancelled".equals(getStringAttribute(point.getAttributes(), "mcp.method.name")))
-                     .filter(point -> status.equals(getStringAttribute(point.getAttributes(), "rpc.response.status_code")))
-                     .findFirst();
     }
 
     public HistogramPointData getOperationPoint(String methodName) {

--- a/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/observability/telemetry/McpOperationMetricServlet.java
+++ b/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/observability/telemetry/McpOperationMetricServlet.java
@@ -244,6 +244,50 @@ public class McpOperationMetricServlet extends FATServlet {
                         .runCompareAgainst(capturedMetricData);
     }
 
+    public void testParseErrorMetrics() {
+        HistogramPointData point = reader.getOperationPoint("_OTHER");
+
+        Attributes attributes = point.getAttributes();
+        assertEquals("_OTHER", getStringAttribute(attributes, "mcp.method.name"));
+        assertEquals("error", getStringAttribute(attributes, "rpc.response.status_code"));
+        assertEquals("PARSE_ERROR", getStringAttribute(attributes, "error.type"));
+    }
+
+    public void testInvalidRequestMetrics() {
+        // INVALID_REQUEST and PARSE_ERROR both use "_OTHER" 
+        Optional<MetricData> metric = reader.getMetricData("mcp.server.operation.duration");
+        assertTrue("mcp.server.operation.duration metric not found", metric.isPresent());
+
+        List<HistogramPointData> points = metric.get()
+                                                .getHistogramData()
+                                                .getPoints()
+                                                .stream()
+                                                .filter(p -> "_OTHER".equals(getStringAttribute(p.getAttributes(), "mcp.method.name")))
+                                                .filter(p -> "INVALID_REQUEST".equals(getStringAttribute(p.getAttributes(), "error.type")))
+                                                .toList();
+
+        assertTrue("Expected at least one _OTHER/INVALID_REQUEST metric point", !points.isEmpty());
+        HistogramPointData point = points.get(0);
+        assertEquals("error", getStringAttribute(point.getAttributes(), "rpc.response.status_code"));
+    }
+
+    public void testMethodNotFoundMetrics() {
+        Optional<MetricData> metric = reader.getMetricData("mcp.server.operation.duration");
+        assertTrue("mcp.server.operation.duration metric not found", metric.isPresent());
+
+        List<HistogramPointData> points = metric.get()
+                                                .getHistogramData()
+                                                .getPoints()
+                                                .stream()
+                                                .filter(p -> "unknown/method".equals(getStringAttribute(p.getAttributes(), "mcp.method.name")))
+                                                .toList();
+
+        assertTrue("Expected at least one metric point for unknown/method", !points.isEmpty());
+        HistogramPointData point = points.get(0);
+        assertEquals("error", getStringAttribute(point.getAttributes(), "rpc.response.status_code"));
+        assertEquals("METHOD_NOT_FOUND", getStringAttribute(point.getAttributes(), "error.type"));
+    }
+
     public void captureOperationDurationMetrics() {
         capturedMetricData = reader.getMetricData("mcp.server.operation.duration").get();
     }

--- a/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/observability/telemetry/McpOperationMetricServlet.java
+++ b/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/observability/telemetry/McpOperationMetricServlet.java
@@ -279,13 +279,13 @@ public class McpOperationMetricServlet extends FATServlet {
                                                 .getHistogramData()
                                                 .getPoints()
                                                 .stream()
-                                                .filter(p -> "unknown/method".equals(getStringAttribute(p.getAttributes(), "mcp.method.name")))
+                                                .filter(p -> "_OTHER".equals(getStringAttribute(p.getAttributes(), "mcp.method.name"))
+                                                             && "METHOD_NOT_FOUND".equals(getStringAttribute(p.getAttributes(), "error.type")))
                                                 .toList();
 
-        assertTrue("Expected at least one metric point for unknown/method", !points.isEmpty());
+        assertTrue("Expected at least one metric point for METHOD_NOT_FOUND", !points.isEmpty());
         HistogramPointData point = points.get(0);
         assertEquals("error", getStringAttribute(point.getAttributes(), "rpc.response.status_code"));
-        assertEquals("METHOD_NOT_FOUND", getStringAttribute(point.getAttributes(), "error.type"));
     }
 
     public void captureOperationDurationMetrics() {

--- a/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/observability/telemetry/McpOperationMetricServlet.java
+++ b/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/observability/telemetry/McpOperationMetricServlet.java
@@ -140,7 +140,7 @@ public class McpOperationMetricServlet extends FATServlet {
     }
 
     public void testCancelRequestErrorMetrics() {
-        HistogramPointData point = reader.getCancelOperationPoint("error", null);
+        HistogramPointData point = reader.getCancelOperationPoint("error");
 
         Attributes attributes = point.getAttributes();
         assertEquals("notifications/cancelled", getStringAttribute(attributes, "mcp.method.name"));

--- a/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/observability/telemetry/McpOperationMetricServlet.java
+++ b/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/observability/telemetry/McpOperationMetricServlet.java
@@ -245,47 +245,21 @@ public class McpOperationMetricServlet extends FATServlet {
     }
 
     public void testParseErrorMetrics() {
-        HistogramPointData point = reader.getOperationPoint("_OTHER");
-
-        Attributes attributes = point.getAttributes();
-        assertEquals("_OTHER", getStringAttribute(attributes, "mcp.method.name"));
-        assertEquals("error", getStringAttribute(attributes, "rpc.response.status_code"));
-        assertEquals("PARSE_ERROR", getStringAttribute(attributes, "error.type"));
+        MetricComparator.compareOperationDuration(reader)
+                        .expectChange(otherOperationWithErrorType("PARSE_ERROR"), countIncreasedBy(1))
+                        .runCompareAgainst(capturedMetricData);
     }
 
     public void testInvalidRequestMetrics() {
-        // INVALID_REQUEST and PARSE_ERROR both use "_OTHER" 
-        Optional<MetricData> metric = reader.getMetricData("mcp.server.operation.duration");
-        assertTrue("mcp.server.operation.duration metric not found", metric.isPresent());
-
-        List<HistogramPointData> points = metric.get()
-                                                .getHistogramData()
-                                                .getPoints()
-                                                .stream()
-                                                .filter(p -> "_OTHER".equals(getStringAttribute(p.getAttributes(), "mcp.method.name")))
-                                                .filter(p -> "INVALID_REQUEST".equals(getStringAttribute(p.getAttributes(), "error.type")))
-                                                .toList();
-
-        assertTrue("Expected at least one _OTHER/INVALID_REQUEST metric point", !points.isEmpty());
-        HistogramPointData point = points.get(0);
-        assertEquals("error", getStringAttribute(point.getAttributes(), "rpc.response.status_code"));
+        MetricComparator.compareOperationDuration(reader)
+                        .expectChange(otherOperationWithErrorType("INVALID_REQUEST"), countIncreasedBy(1))
+                        .runCompareAgainst(capturedMetricData);
     }
 
     public void testMethodNotFoundMetrics() {
-        Optional<MetricData> metric = reader.getMetricData("mcp.server.operation.duration");
-        assertTrue("mcp.server.operation.duration metric not found", metric.isPresent());
-
-        List<HistogramPointData> points = metric.get()
-                                                .getHistogramData()
-                                                .getPoints()
-                                                .stream()
-                                                .filter(p -> "_OTHER".equals(getStringAttribute(p.getAttributes(), "mcp.method.name"))
-                                                             && "METHOD_NOT_FOUND".equals(getStringAttribute(p.getAttributes(), "error.type")))
-                                                .toList();
-
-        assertTrue("Expected at least one metric point for METHOD_NOT_FOUND", !points.isEmpty());
-        HistogramPointData point = points.get(0);
-        assertEquals("error", getStringAttribute(point.getAttributes(), "rpc.response.status_code"));
+        MetricComparator.compareOperationDuration(reader)
+                        .expectChange(otherOperationWithErrorType("METHOD_NOT_FOUND"), countIncreasedBy(1))
+                        .runCompareAgainst(capturedMetricData);
     }
 
     public void captureOperationDurationMetrics() {
@@ -341,6 +315,12 @@ public class McpOperationMetricServlet extends FATServlet {
 
         assertTrue("Expected at least one point for " + toolName + " with status " + status, !toolCallPoints.isEmpty());
         return toolCallPoints.get(0);
+    }
+
+    private static Predicate<HistogramPointData> otherOperationWithErrorType(String errorType) {
+        return point -> "_OTHER".equals(getStringAttribute(point.getAttributes(), "mcp.method.name"))
+                        && "error".equals(getStringAttribute(point.getAttributes(), "rpc.response.status_code"))
+                        && errorType.equals(getStringAttribute(point.getAttributes(), "error.type"));
     }
 
     private static Predicate<HistogramPointData> toolCallWithStatus(String toolName, String status) {

--- a/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/observability/telemetry/McpOperationMetricServlet.java
+++ b/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/observability/telemetry/McpOperationMetricServlet.java
@@ -140,22 +140,15 @@ public class McpOperationMetricServlet extends FATServlet {
     }
 
     public void testCancelRequestErrorMetrics() {
-        Optional<HistogramPointData> errorPoint = reader.findCancelOperationPoint("error");
+        HistogramPointData point = reader.getCancelOperationPoint("error", null);
 
-        if (errorPoint.isPresent()) {
-            HistogramPointData point = errorPoint.get();
-            Attributes attributes = point.getAttributes();
-
-            assertEquals("notifications/cancelled", getStringAttribute(attributes, "mcp.method.name"));
-            assertInvariantOperationAttributes(attributes);
-            assertEquals("error", getStringAttribute(attributes, "rpc.response.status_code"));
-            assertNotNull("Expected error.type for failed cancel",
-                          getStringAttribute(attributes, "error.type"));
-            assertTimingAttributes(point);
-        } else {
-            assertTrue("At least success case should exist",
-                       reader.findCancelOperationPoint("ok").isPresent());
-        }
+        Attributes attributes = point.getAttributes();
+        assertEquals("notifications/cancelled", getStringAttribute(attributes, "mcp.method.name"));
+        assertInvariantOperationAttributes(attributes);
+        assertEquals("error", getStringAttribute(attributes, "rpc.response.status_code"));
+        assertNotNull("Expected error.type for failed cancel",
+                      getStringAttribute(attributes, "error.type"));
+        assertTimingAttributes(point);
     }
 
     public void testBusinessErrorToolMetrics() {

--- a/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/tool/TelemetryOperationsTest.java
+++ b/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/tool/TelemetryOperationsTest.java
@@ -369,6 +369,40 @@ public class TelemetryOperationsTest extends FATServletClient {
         FATServletClient.runTest(server, APP_NAME + "/McpOperationMetricServlet", "testAsyncFailedStageToolMetrics");
     }
 
+    @Test
+    public void testParseErrorMetrics() throws Exception {
+        // Send a request with invalid JSON body
+        client.callMCP("this is not json");
+        FATServletClient.runTest(server, APP_NAME + "/McpOperationMetricServlet", "testParseErrorMetrics");
+    }
+
+    @Test
+    public void testInvalidRequestMetrics() throws Exception {
+        // Send valid JSON but invalid JSON-RPC
+        client.callMCP("""
+                        {
+                          "jsonrpc": "1.0",
+                          "id": 99,
+                          "method": "tools/list"
+                        }
+                        """);
+        FATServletClient.runTest(server, APP_NAME + "/McpOperationMetricServlet", "testInvalidRequestMetrics");
+    }
+
+    @Test
+    public void testMethodNotFoundMetrics() throws Exception {
+        // Send a valid JSON-RPC request for an unknown method
+        client.callMCP("""
+                        {
+                          "jsonrpc": "2.0",
+                          "id": 100,
+                          "method": "unknown/method",
+                          "params": {}
+                        }
+                        """);
+        FATServletClient.runTest(server, APP_NAME + "/McpOperationMetricServlet", "testMethodNotFoundMetrics");
+    }
+
     /**
      * Call McpMetricDurationServlet and get the recorded total duration for executions of a tool
      */

--- a/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/tool/TelemetryOperationsTest.java
+++ b/dev/io.openliberty.mcp.internal_fat/fat/src/io/openliberty/mcp/internal/fat/tool/TelemetryOperationsTest.java
@@ -371,14 +371,14 @@ public class TelemetryOperationsTest extends FATServletClient {
 
     @Test
     public void testParseErrorMetrics() throws Exception {
-        // Send a request with invalid JSON body
+        captureMetrics();
         client.callMCP("this is not json");
         FATServletClient.runTest(server, APP_NAME + "/McpOperationMetricServlet", "testParseErrorMetrics");
     }
 
     @Test
     public void testInvalidRequestMetrics() throws Exception {
-        // Send valid JSON but invalid JSON-RPC
+        captureMetrics();
         client.callMCP("""
                         {
                           "jsonrpc": "1.0",
@@ -391,7 +391,7 @@ public class TelemetryOperationsTest extends FATServletClient {
 
     @Test
     public void testMethodNotFoundMetrics() throws Exception {
-        // Send a valid JSON-RPC request for an unknown method
+        captureMetrics();
         client.callMCP("""
                         {
                           "jsonrpc": "2.0",


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

Resolves #35563 

+bug fix of  holding McpTransport after session initialize to avoid memory leak
