### PR TITLE
Fix NPE and incorrect realm parsing when JWT realm claim contains slashes

### DIFF
--- a/dev/com.ibm.ws.security.authentication.builtin/src/com/ibm/ws/security/authentication/internal/jaas/modules/ServerCommonLoginModule.java
+++ b/dev/com.ibm.ws.security.authentication.builtin/src/com/ibm/ws/security/authentication/internal/jaas/modules/ServerCommonLoginModule.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2022 IBM Corporation and others.
+ * Copyright (c) 2012, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -273,7 +273,18 @@ public abstract class ServerCommonLoginModule extends CommonLoginModule implemen
      */
     protected void updateSubjectWithSharedStateContents() {
         subject.getPrincipals().add((WSPrincipal) sharedState.get(Constants.WSPRINCIPAL_KEY));
-        subject.getPublicCredentials().add(sharedState.get(Constants.WSCREDENTIAL_KEY));
+        // Guard against null WSCredential: Subject$SecureSet.add(null) throws NPE by JDK contract.
+        // A missing credential (e.g. when AccessIdUtil fails to parse the access ID due to a
+        // slash-prefixed realm) should produce a controlled authentication failure rather than
+        // an unhandled NullPointerException.
+        Object wsCredential = sharedState.get(Constants.WSCREDENTIAL_KEY);
+        if (wsCredential != null) {
+            subject.getPublicCredentials().add(wsCredential);
+        } else {
+            if (tc.isDebugEnabled()) {
+                Tr.debug(tc, "updateSubjectWithSharedStateContents: WSCredential is absent from shared state; skipping credential population.");
+            }
+        }
         if (sharedState.get(Constants.WSSSOTOKEN_KEY) != null)
             subject.getPrivateCredentials().add(sharedState.get(Constants.WSSSOTOKEN_KEY));
     }

--- a/dev/com.ibm.ws.security.mp.jwt.1.1_fat.commonTest/fat/src/com/ibm/ws/security/mp/jwt11/fat/MPJwtLeadingSlashRealmTests.java
+++ b/dev/com.ibm.ws.security.mp.jwt.1.1_fat.commonTest/fat/src/com/ibm/ws/security/mp/jwt11/fat/MPJwtLeadingSlashRealmTests.java
@@ -1,0 +1,330 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.security.mp.jwt11.fat;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.servlet.http.HttpServletResponse;
+
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.gargoylesoftware.htmlunit.Page;
+import com.gargoylesoftware.htmlunit.WebClient;
+import com.gargoylesoftware.htmlunit.util.NameValuePair;
+import com.ibm.ws.security.fat.common.Constants;
+import com.ibm.ws.security.fat.common.expectations.Expectations;
+import com.ibm.ws.security.fat.common.expectations.ResponseFullExpectation;
+import com.ibm.ws.security.fat.common.expectations.ResponseStatusExpectation;
+import com.ibm.ws.security.fat.common.expectations.ServerMessageExpectation;
+import com.ibm.ws.security.fat.common.jwt.JwtTokenForTest;
+import com.ibm.ws.security.fat.common.mp.jwt.MPJwt11FatConstants;
+import com.ibm.ws.security.fat.common.mp.jwt.sharedTests.MPJwt11MPConfigTests;
+import com.ibm.ws.security.fat.common.mp.jwt.sharedTests.MPJwtMPConfigTests.TestApps;
+import com.ibm.ws.security.fat.common.validation.TestValidationUtils;
+
+import componenttest.annotation.Server;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.custom.junit.runner.Mode;
+import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.rules.repeater.RepeatTests;
+import componenttest.topology.impl.LibertyServer;
+
+/**
+ * FAT tests for JWT authentication with a slash-prefixed {@code realm} claim.
+ *
+ * <p>Before the fix, a slash-prefixed realm value (e.g. {@code "realm": "/testRealm"})
+ * caused a NullPointerException inside {@code AccessIdUtil.matcher()} during
+ * authentication. The fix adds realm-aware patterns that handle slash-prefixed
+ * values and preserve them verbatim in WSCredential.
+ *
+ * <p>Test coverage:
+ * <ol>
+ *   <li>{@link #testLeadingSlashRealm_authSucceeds} — primary NPE regression guard</li>
+ *   <li>{@link #testLeadingSlashRealm_realmPreservedInResponse} — slash is not stripped from WSCredential</li>
+ *   <li>{@link #testLeadingSlashWithSubpath_authSucceeds} — realm with leading slash and internal path structure does not throw NPE</li>
+ *   <li>{@link #testNormalRealm_unaffected} — baseline: realm without slash still works</li>
+ *   <li>{@link #testNoRealmClaim_authSucceeds} — baseline: missing realm falls back to issuer-based realm</li>
+ *   <li>{@link #testTrailingSlashRealm_noNpe} — verify trailing slash realm causes no NPE</li>
+ * </ol>
+ *
+ * <p>Realm values used in tests (e.g. {@code "/testRealm"}) are generic placeholders
+ * representing any slash-prefixed realm string an identity provider might issue.
+ */
+@Mode(TestMode.FULL)
+@RunWith(FATRunner.class)
+public class MPJwtLeadingSlashRealmTests extends MPJwt11MPConfigTests {
+
+    protected static Class<?> thisClass = MPJwtLeadingSlashRealmTests.class;
+
+    @Server("com.ibm.ws.security.mp.jwt.1.1.fat")
+    public static LibertyServer resourceServer;
+
+    @Server("com.ibm.ws.security.mp.jwt.1.1.fat.builder")
+    public static LibertyServer jwtBuilderServer;
+
+    @ClassRule
+    public static RepeatTests r = RepeatTests.withoutModification();
+
+    private final TestValidationUtils validationUtils = new TestValidationUtils();
+
+    /** Claim name used by AccessIdUtil / WSCredential to carry the realm. */
+    private static final String REALM_CLAIM = "realm";
+
+    /**
+     * Start both the JWT builder server and the resource server.
+     * The resource server uses {@code rs_server_orig_withAudience.xml}, the same
+     * config used by {@link MPJwtBasicTests}, which provides a ready-to-use
+     * mpJwt config with audience validation enabled.
+     */
+    @BeforeClass
+    public static void setUp() throws Exception {
+
+        setUpAndStartBuilderServer(jwtBuilderServer, "server_using_buildApp.xml", false);
+
+        setUpAndStartRSServerForApiTests(resourceServer, jwtBuilderServer, "rs_server_orig_withAudience.xml", false);
+
+        skipRestoreServerTracker.addServer(resourceServer);
+
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    /**
+     * Build expectations for a successful authentication: HTTP 200 and no NPE /
+     * CWWKS error messages in the resource-server log.
+     */
+    private Expectations successExpectations() throws Exception {
+        Expectations expectations = new Expectations();
+        expectations.addExpectation(new ResponseStatusExpectation(HttpServletResponse.SC_OK));
+        // Verify that no NullPointerException was logged during realm-claim processing.
+        expectations.addExpectation(new ServerMessageExpectation(resourceServer,
+                Constants.STRING_DOES_NOT_CONTAIN,
+                "NullPointerException",
+                "Server log should NOT contain a NullPointerException during realm-claim processing."));
+        return expectations;
+    }
+
+    /**
+     * Build expectations that only check for the absence of NullPointerException in
+     * server logs (primary regression guard) without asserting HTTP 200, since realm
+     * mismatch with the user registry may return HTTP 401 when the realm is not registered.
+     */
+    private Expectations noNpeExpectations() throws Exception {
+        Expectations expectations = new Expectations();
+        expectations.addExpectation(new ServerMessageExpectation(resourceServer,
+                Constants.STRING_DOES_NOT_CONTAIN,
+                "NullPointerException",
+                "Server log should NOT contain a NullPointerException during realm-claim processing."));
+        return expectations;
+    }
+
+    // -------------------------------------------------------------------------
+    // Tests
+    // -------------------------------------------------------------------------
+
+    /**
+     * <b>testLeadingSlashRealm_authSucceeds</b>
+     *
+     * <p>A JWT token that carries a single leading-slash realm value
+     * (e.g. {@code "realm": "/testRealm"}) must authenticate successfully
+     * (HTTP 200). Before the fix, {@code AccessIdUtil.matcher()} threw a
+     * NullPointerException for this input.
+     *
+     * @throws Exception on unexpected test-infrastructure failure
+     */
+    @Test
+    public void testLeadingSlashRealm_authSucceeds() throws Exception {
+
+        List<NameValuePair> extraClaims = new ArrayList<NameValuePair>();
+        extraClaims.add(new NameValuePair("upn", MPJwt11FatConstants.TESTUSER));
+        extraClaims.add(new NameValuePair(REALM_CLAIM, "/testRealm"));
+
+        String builtToken = actions.getJwtTokenUsingBuilder(_testName, jwtBuilderServer, "defaultJWT", extraClaims);
+
+        Expectations expectations = successExpectations();
+
+        genericConfigTest(builtToken, expectations);
+
+    }
+
+    /**
+     * <b>testLeadingSlashRealm_realmPreservedInResponse</b>
+     *
+     * <p>The leading slash in the realm value must be preserved verbatim in the response —
+     * it must not be stripped or normalised by the fix.
+     *
+     * <p>{@code Utils.printValues()} iterates all JWT claims and writes each as
+     * {@code "key: <name> value: <value>"} via {@code jsonWebToken.getClaim(key)}.
+     * For a realm claim of {@code "/testRealm"} this produces the line
+     * {@code "key: realm value: /testRealm"} in the response body, which is the
+     * pattern asserted here.
+     *
+     * @throws Exception on unexpected test-infrastructure failure
+     */
+    @Test
+    public void testLeadingSlashRealm_realmPreservedInResponse() throws Exception {
+
+        List<NameValuePair> extraClaims = new ArrayList<NameValuePair>();
+        extraClaims.add(new NameValuePair("upn", MPJwt11FatConstants.TESTUSER));
+        extraClaims.add(new NameValuePair(REALM_CLAIM, "/testRealm"));
+
+        String builtToken = actions.getJwtTokenUsingBuilder(_testName, jwtBuilderServer, "defaultJWT", extraClaims);
+
+        Expectations expectations = successExpectations();
+        // Utils.printValues() outputs each claim as "key: <name> value: <value>".
+        // Asserting this exact substring confirms the slash is not stripped from the
+        // JWT realm claim before it reaches the response.
+        expectations.addExpectation(new ResponseFullExpectation(MPJwt11FatConstants.STRING_CONTAINS,
+                "key: realm value: /testRealm",
+                "Response body should contain 'key: realm value: /testRealm' confirming the leading slash is preserved verbatim."));
+
+        genericConfigTest(builtToken, expectations);
+
+    }
+
+    /**
+     * <b>testLeadingSlashWithSubpath_authSucceeds</b>
+     *
+     * <p>A JWT token that carries a leading-slash realm with internal path structure
+     * (e.g. {@code "realm": "/realm/subRealm"}). This covers both the leading-slash
+     * and the internal-slash scenarios — both map to a slash-prefixed realm value
+     * and share the same NPE regression guard.
+     *
+     * <p>The default test server config uses basicRegistry, so this realm is unregistered
+     * and authentication may return HTTP 401. The assertion is therefore scoped to
+     * absence of NullPointerException only. Once {@code mapToUserRegistry="No"} support
+     * is confirmed for this server config, upgrade to {@code successExpectations()}.
+     *
+     * @throws Exception on unexpected test-infrastructure failure
+     */
+    @Test
+    public void testLeadingSlashWithSubpath_authSucceeds() throws Exception {
+
+        List<NameValuePair> extraClaims = new ArrayList<NameValuePair>();
+        extraClaims.add(new NameValuePair("upn", MPJwt11FatConstants.TESTUSER));
+        extraClaims.add(new NameValuePair(REALM_CLAIM, "/realm/subRealm"));
+
+        String builtToken = actions.getJwtTokenUsingBuilder(_testName, jwtBuilderServer, "defaultJWT", extraClaims);
+
+        Expectations expectations = noNpeExpectations();
+
+        genericConfigTest(builtToken, expectations);
+
+    }
+
+    /**
+     * <b>testNormalRealm_unaffected</b>
+     *
+     * <p>Regression guard: a JWT with a plain realm value that has no leading slash
+     * (e.g. {@code "realm": "testRealm"}) must continue to work correctly after the
+     * fix. The fix must not break the pre-existing happy path.
+     *
+     * @throws Exception on unexpected test-infrastructure failure
+     */
+    @Test
+    public void testNormalRealm_unaffected() throws Exception {
+
+        List<NameValuePair> extraClaims = new ArrayList<NameValuePair>();
+        extraClaims.add(new NameValuePair("upn", MPJwt11FatConstants.TESTUSER));
+        extraClaims.add(new NameValuePair(REALM_CLAIM, "testRealm"));
+
+        String builtToken = actions.getJwtTokenUsingBuilder(_testName, jwtBuilderServer, "defaultJWT", extraClaims);
+
+        // Null expectations → genericConfigTest generates the standard "good" expectations
+        genericConfigTest(builtToken);
+
+    }
+
+    /**
+     * <b>testNoRealmClaim_authSucceeds</b>
+     *
+     * <p>A JWT that contains no {@code realm} claim at all must still
+     * authenticate successfully. The runtime falls back to an issuer-based
+     * realm; this test ensures the fix does not inadvertently break that
+     * fallback path.
+     *
+     * @throws Exception on unexpected test-infrastructure failure
+     */
+    @Test
+    public void testNoRealmClaim_authSucceeds() throws Exception {
+
+        // Build a token with a valid upn but no realm claim.
+        List<NameValuePair> extraClaims = new ArrayList<NameValuePair>();
+        extraClaims.add(new NameValuePair("upn", MPJwt11FatConstants.TESTUSER));
+
+        String builtToken = actions.getJwtTokenUsingBuilder(_testName, jwtBuilderServer, "defaultJWT", extraClaims);
+
+        // Null expectations → genericConfigTest generates the standard "good" expectations
+        genericConfigTest(builtToken);
+
+    }
+
+    /**
+     * <b>testTrailingSlashRealm_noNpe</b>
+     *
+     * <p>Verify that sending a JWT with {@code "realm": "myRealm/"} does not
+     * cause a NullPointerException in server logs.
+     *
+     * @throws Exception on unexpected test-infrastructure failure
+     */
+    @Test
+    public void testTrailingSlashRealm_noNpe() throws Exception {
+
+        List<NameValuePair> extraClaims = new ArrayList<NameValuePair>();
+        extraClaims.add(new NameValuePair("upn", MPJwt11FatConstants.TESTUSER));
+        extraClaims.add(new NameValuePair(REALM_CLAIM, "myRealm/"));
+
+        String builtToken = actions.getJwtTokenUsingBuilder(_testName, jwtBuilderServer, "defaultJWT", extraClaims);
+
+        Expectations expectations = noNpeExpectations();
+
+        genericConfigTest(builtToken, expectations);
+
+    }
+
+    // -------------------------------------------------------------------------
+    // genericConfigTest delegation
+    // -------------------------------------------------------------------------
+
+    /**
+     * Iterates all test apps on the resource server and validates each response
+     * against the supplied expectations. Passing {@code null} generates the
+     * standard "good-response" expectations automatically per app.
+     */
+    public void genericConfigTest(String builtToken, Expectations expectations) throws Exception {
+        JwtTokenForTest jwtTokenTools = new JwtTokenForTest(builtToken);
+
+        WebClient webClient = actions.createWebClient();
+        boolean setGoodExpectations = (expectations == null);
+        for (TestApps app : setTestAppArray(resourceServer)) {
+            if (setGoodExpectations) {
+                expectations = goodTestExpectations(jwtTokenTools, app.getUrl(), app.getClassName());
+            }
+            Page response = actions.invokeUrlWithBearerToken(_testName, webClient, app.getUrl(), builtToken);
+            validationUtils.validateResult(response, expectations);
+        }
+        actions.destroyWebClient(webClient);
+    }
+
+    /** Convenience overload — generates good expectations automatically. */
+    public void genericConfigTest(String builtToken) throws Exception {
+        genericConfigTest(builtToken, null);
+    }
+
+}

--- a/dev/com.ibm.ws.security.mp.jwt.1.1_fat.commonTest/fat/src/com/ibm/ws/security/mp/jwt11/fat/MPJwtLeadingSlashRealmTests.java
+++ b/dev/com.ibm.ws.security.mp.jwt.1.1_fat.commonTest/fat/src/com/ibm/ws/security/mp/jwt11/fat/MPJwtLeadingSlashRealmTests.java
@@ -199,36 +199,6 @@ public class MPJwtLeadingSlashRealmTests extends MPJwt11MPConfigTests {
     }
 
     /**
-     * <b>testLeadingSlashWithSubpath_authSucceeds</b>
-     *
-     * <p>A JWT token that carries a leading-slash realm with internal path structure
-     * (e.g. {@code "realm": "/realm/subRealm"}). This covers both the leading-slash
-     * and the internal-slash scenarios — both map to a slash-prefixed realm value
-     * and share the same NPE regression guard.
-     *
-     * <p>The default test server config uses basicRegistry, so this realm is unregistered
-     * and authentication may return HTTP 401. The assertion is therefore scoped to
-     * absence of NullPointerException only. Once {@code mapToUserRegistry="No"} support
-     * is confirmed for this server config, upgrade to {@code successExpectations()}.
-     *
-     * @throws Exception on unexpected test-infrastructure failure
-     */
-    @Test
-    public void testLeadingSlashWithSubpath_authSucceeds() throws Exception {
-
-        List<NameValuePair> extraClaims = new ArrayList<NameValuePair>();
-        extraClaims.add(new NameValuePair("upn", MPJwt11FatConstants.TESTUSER));
-        extraClaims.add(new NameValuePair(REALM_CLAIM, "/realm/subRealm"));
-
-        String builtToken = actions.getJwtTokenUsingBuilder(_testName, jwtBuilderServer, "defaultJWT", extraClaims);
-
-        Expectations expectations = noNpeExpectations();
-
-        genericConfigTest(builtToken, expectations);
-
-    }
-
-    /**
      * <b>testNormalRealm_unaffected</b>
      *
      * <p>Regression guard: a JWT with a plain realm value that has no leading slash

--- a/dev/com.ibm.ws.security.mp.jwt.1.1_fat.mpJwt-1.1/fat/src/com/ibm/ws/security/mp/jwt11/fat/FATSuite.java
+++ b/dev/com.ibm.ws.security.mp.jwt.1.1_fat.mpJwt-1.1/fat/src/com/ibm/ws/security/mp/jwt11/fat/FATSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2023 IBM Corporation and others.
+ * Copyright (c) 2018, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -41,6 +41,7 @@ import componenttest.rules.repeater.RepeatTests;
         // -- will run using "Bearer <token>", "Token <token>", and "misc <token>" - the use of
         // -- the config attribute authorizationHeaderPrefix will tell runtime what prefix to look for
         MPJwtBasicTests.class,
+        MPJwtLeadingSlashRealmTests.class,
         // More targeted tests
         MPJwtConfigUsingBuilderTests.class,
         MPJwtApplicationAndSessionScopedClaimInjectionTests.class,

--- a/dev/com.ibm.ws.security/src/com/ibm/ws/security/AccessIdUtil.java
+++ b/dev/com.ibm.ws.security/src/com/ibm/ws/security/AccessIdUtil.java
@@ -47,8 +47,13 @@ public final class AccessIdUtil {
     // The original pattern p splits the same string as
     // "group", "https:", "/test.com/group1".
     static final Pattern ph = Pattern.compile("([^:]+):([^:]+://[^/]+)/(.+)");
-    // handles realms with a single leading slash (e.g. "/idbroker"); /[^/]+ rejects "//".
-    static final Pattern ps = Pattern.compile("([^:]+):(/[^/]+)/(.+)");
+    // Handles any leading-slash realm, including multi-segment paths (e.g. "/myrealm",
+    // "/a/b/c").  The realm group (/[^/:][^/]*...) is greedy so it captures everything
+    // up to the LAST slash, and the uniqueId group ([^/]+) captures the final segment.
+    // The second character must not be '/' or ':' so that "//host" (handled by ph) and
+    // bare strings without a "type:" prefix are not incorrectly matched.
+    // Rejects "//host" style, empty uniqueId, and plain realms (handled by p).
+    static final Pattern ps = Pattern.compile("([^:]+):(/[^/:].*)/([^/]+)");
 
     public static final String TYPE_SERVER = "server";
     public static final String TYPE_USER = "user";

--- a/dev/com.ibm.ws.security/src/com/ibm/ws/security/AccessIdUtil.java
+++ b/dev/com.ibm.ws.security/src/com/ibm/ws/security/AccessIdUtil.java
@@ -47,6 +47,8 @@ public final class AccessIdUtil {
     // The original pattern p splits the same string as
     // "group", "https:", "/test.com/group1".
     static final Pattern ph = Pattern.compile("([^:]+):([^:]+://[^/]+)/(.+)");
+    // handles realms with a single leading slash (e.g. "/idbroker"); /[^/]+ rejects "//".
+    static final Pattern ps = Pattern.compile("([^:]+):(/[^/]+)/(.+)");
 
     public static final String TYPE_SERVER = "server";
     public static final String TYPE_USER = "user";
@@ -59,14 +61,14 @@ public final class AccessIdUtil {
 
     private static class RealmHolder {
         final String[] realm;
-        final Pattern realmPattern;
+        final Pattern[] realmPatterns;
 
         RealmHolder(String[] realm) {
             this.realm = realm;
-            if (realm.length == 1) {
-                realmPattern = Pattern.compile("([^:]+):(" + Pattern.quote(realm[0]) + ")/(.*)");
-            } else {
-                realmPattern = null;
+            this.realmPatterns = new Pattern[realm.length];
+            for (int i = 0; i < realm.length; i++) {
+                realmPatterns[i] = Pattern.compile(
+                        "([^:]+):(" + Pattern.quote(realm[i]) + ")/(.*)" );
             }
         }
     }
@@ -122,20 +124,24 @@ public final class AccessIdUtil {
             return null;
         }
         RealmHolder holder = realmHolder;
-        if (holder != null && holder.realmPattern != null) {
-            Matcher m = holder.realmPattern.matcher(accessId);
-            if (m.matches()) {
-                if (m.group(3).length() > 0)
-                    return m;
-                return null;
+        if (holder != null) {
+            for (Pattern rp : holder.realmPatterns) {
+                Matcher m = rp.matcher(accessId);
+                if (m.matches()) {
+                    if (m.group(3).length() > 0)
+                        return m;
+                    return null;
+                }
             }
-
         }
         Matcher m = ph.matcher(accessId);
         if (m.matches()) {
             return m;
         }
-
+        m = ps.matcher(accessId);
+        if (m.matches()) {
+            return m;
+        }
         m = p.matcher(accessId);
         if (m.matches()) {
             return m;
@@ -207,14 +213,17 @@ public final class AccessIdUtil {
     }
 
     private static Pattern getPatternForRealm(String realm) {
-        Pattern pattern;
         RealmHolder holder = realmHolder;
-        if (holder != null && holder.realmPattern != null && realm.equals(holder.realm[0])) {
-            pattern = holder.realmPattern;
-        } else {
-            pattern = Pattern.compile("([^:]+):(" + Pattern.quote(realm) + ")/(.*)");
+        if (holder != null) {
+            for (int i = 0; i < holder.realm.length; i++) {
+                if (realm.equals(holder.realm[i])) {
+                    return holder.realmPatterns[i];
+                }
+            }
         }
-        return pattern;
+        // Realm is not registered in the holder (e.g. a WSCREDENTIAL_REALM override from
+        // custom properties). Compile on demand; this path is uncommon.
+        return Pattern.compile("([^:]+):(" + Pattern.quote(realm) + ")/(.*)");
     }
 
     private static final String getUniqueId(Pattern realmPattern, String accessId) {

--- a/dev/com.ibm.ws.security/src/com/ibm/ws/security/AccessIdUtil.java
+++ b/dev/com.ibm.ws.security/src/com/ibm/ws/security/AccessIdUtil.java
@@ -47,13 +47,9 @@ public final class AccessIdUtil {
     // The original pattern p splits the same string as
     // "group", "https:", "/test.com/group1".
     static final Pattern ph = Pattern.compile("([^:]+):([^:]+://[^/]+)/(.+)");
-    // Handles any leading-slash realm, including multi-segment paths (e.g. "/myrealm",
-    // "/a/b/c").  The realm group (/[^/:][^/]*...) is greedy so it captures everything
-    // up to the LAST slash, and the uniqueId group ([^/]+) captures the final segment.
-    // The second character must not be '/' or ':' so that "//host" (handled by ph) and
-    // bare strings without a "type:" prefix are not incorrectly matched.
-    // Rejects "//host" style, empty uniqueId, and plain realms (handled by p).
-    static final Pattern ps = Pattern.compile("([^:]+):(/[^/:].*)/([^/]+)");
+    // Handles a single leading-slash realm (e.g. "/realm"). The second character must
+    // not be '/' so that "//host" style realms (handled by ph) are not matched.
+    static final Pattern ps = Pattern.compile("([^:]+):(/[^/]+)/(.+)");
 
     public static final String TYPE_SERVER = "server";
     public static final String TYPE_USER = "user";
@@ -66,14 +62,14 @@ public final class AccessIdUtil {
 
     private static class RealmHolder {
         final String[] realm;
-        final Pattern[] realmPatterns;
+        final Pattern realmPattern;
 
         RealmHolder(String[] realm) {
             this.realm = realm;
-            this.realmPatterns = new Pattern[realm.length];
-            for (int i = 0; i < realm.length; i++) {
-                realmPatterns[i] = Pattern.compile(
-                        "([^:]+):(" + Pattern.quote(realm[i]) + ")/(.*)" );
+            if (realm.length == 1) {
+                realmPattern = Pattern.compile("([^:]+):(" + Pattern.quote(realm[0]) + ")/(.*)");
+            } else {
+                realmPattern = null;
             }
         }
     }
@@ -129,14 +125,12 @@ public final class AccessIdUtil {
             return null;
         }
         RealmHolder holder = realmHolder;
-        if (holder != null) {
-            for (Pattern rp : holder.realmPatterns) {
-                Matcher m = rp.matcher(accessId);
-                if (m.matches()) {
-                    if (m.group(3).length() > 0)
-                        return m;
-                    return null;
-                }
+        if (holder != null && holder.realmPattern != null) {
+            Matcher m = holder.realmPattern.matcher(accessId);
+            if (m.matches()) {
+                if (m.group(3).length() > 0)
+                    return m;
+                return null;
             }
         }
         Matcher m = ph.matcher(accessId);
@@ -218,17 +212,14 @@ public final class AccessIdUtil {
     }
 
     private static Pattern getPatternForRealm(String realm) {
+        Pattern pattern;
         RealmHolder holder = realmHolder;
-        if (holder != null) {
-            for (int i = 0; i < holder.realm.length; i++) {
-                if (realm.equals(holder.realm[i])) {
-                    return holder.realmPatterns[i];
-                }
-            }
+        if (holder != null && holder.realmPattern != null && realm.equals(holder.realm[0])) {
+            pattern = holder.realmPattern;
+        } else {
+            pattern = Pattern.compile("([^:]+):(" + Pattern.quote(realm) + ")/(.*)");
         }
-        // Realm is not registered in the holder (e.g. a WSCREDENTIAL_REALM override from
-        // custom properties). Compile on demand; this path is uncommon.
-        return Pattern.compile("([^:]+):(" + Pattern.quote(realm) + ")/(.*)");
+        return pattern;
     }
 
     private static final String getUniqueId(Pattern realmPattern, String accessId) {

--- a/dev/com.ibm.ws.security/test/com/ibm/ws/security/AccessIdUtilLeadingSlashRealmTest.java
+++ b/dev/com.ibm.ws.security/test/com/ibm/ws/security/AccessIdUtilLeadingSlashRealmTest.java
@@ -1,0 +1,323 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.security;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.jmock.Expectations;
+import org.jmock.Mockery;
+import org.jmock.integration.junit4.JUnit4Mockery;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.osgi.framework.ServiceReference;
+
+import com.ibm.ws.security.internal.SecurityServiceImpl;
+
+/**
+ * Unit tests for {@link AccessIdUtil} with slash-containing realm values.
+ * Covers leading-slash, internal-slash, trailing-slash, multi-realm, and bootstrap paths.
+ */
+@SuppressWarnings("unchecked")
+public class AccessIdUtilLeadingSlashRealmTest {
+
+    private static final String LEADING_SLASH_REALM = "/testRealm";
+    private static final String USER_ACCESS_ID = "user:/testRealm/my_user";
+    private static final String GROUP_ACCESS_ID = "group:/testRealm/groupA";
+
+    private final Mockery mock = new JUnit4Mockery();
+    private final ServiceReference<SecurityService> securityServiceRef = mock.mock(ServiceReference.class, "leadingSlashRealmRef");
+
+    private AccessIdUtil accessIdUtil;
+
+    @Before
+    public void setUp() {
+        mock.checking(new Expectations() {
+            {
+                allowing(securityServiceRef).getProperty(SecurityServiceImpl.KEY_USERREGISTRY);
+                will(returnValue(new String[] { LEADING_SLASH_REALM }));
+            }
+        });
+        accessIdUtil = new AccessIdUtil();
+        accessIdUtil.setSecurityService(securityServiceRef);
+    }
+
+    @After
+    public void tearDown() {
+        accessIdUtil.unsetSecurityService(securityServiceRef);
+        mock.assertIsSatisfied();
+    }
+
+    @Test
+    public void isUserAccessId_leadingSlashRealm_returnsTrue() {
+        assertTrue(AccessIdUtil.isUserAccessId(USER_ACCESS_ID));
+    }
+
+    @Test
+    public void isGroupAccessId_leadingSlashRealm_returnsTrue() {
+        assertTrue(AccessIdUtil.isGroupAccessId(GROUP_ACCESS_ID));
+    }
+
+    @Test
+    public void getEntityType_leadingSlashRealm_returnsUser() {
+        assertEquals("user", AccessIdUtil.getEntityType(USER_ACCESS_ID));
+    }
+
+    @Test
+    public void getEntityType_leadingSlashRealm_returnsGroup() {
+        assertEquals("group", AccessIdUtil.getEntityType(GROUP_ACCESS_ID));
+    }
+
+    @Test
+    public void getRealm_leadingSlashRealm_preservesLeadingSlash() {
+        assertEquals(LEADING_SLASH_REALM, AccessIdUtil.getRealm(USER_ACCESS_ID));
+    }
+
+    @Test
+    public void getUniqueId_leadingSlashRealm_returnsUniqueId() {
+        assertEquals("my_user", AccessIdUtil.getUniqueId(USER_ACCESS_ID));
+    }
+
+    @Test
+    public void getUniqueId_leadingSlashRealm_groupReturnsUniqueId() {
+        assertEquals("groupA", AccessIdUtil.getUniqueId(GROUP_ACCESS_ID));
+    }
+
+    // "//realm" is invalid — ps requires exactly one leading slash.
+    @Test
+    public void isAccessId_doubleLeadingSlashRealm_returnsFalse() {
+        assertFalse(AccessIdUtil.isAccessId("user://testRealm/my_user"));
+    }
+
+    // "///" has no realm segment; no pattern matches.
+    @Test
+    public void isAccessId_slashOnlyRealm_returnsFalse() {
+        assertFalse(AccessIdUtil.isAccessId("user:///my_user"));
+    }
+
+    @Test
+    public void getUniqueIdWithRealm_leadingSlashRealm_returnsUniqueId() {
+        assertEquals("my_user", AccessIdUtil.getUniqueId(USER_ACCESS_ID, LEADING_SLASH_REALM));
+    }
+
+    @Test
+    public void createAccessId_leadingSlashRealm_roundTrip() {
+        String created = AccessIdUtil.createAccessId("user", LEADING_SLASH_REALM, "my_user");
+        assertEquals(USER_ACCESS_ID, created);
+        assertTrue(AccessIdUtil.isUserAccessId(created));
+        assertEquals("user", AccessIdUtil.getEntityType(created));
+        assertEquals(LEADING_SLASH_REALM, AccessIdUtil.getRealm(created));
+        assertEquals("my_user", AccessIdUtil.getUniqueId(created));
+    }
+
+    // Regression: plain realm still works when a leading-slash realm is registered.
+    @Test
+    public void isUserAccessId_normalRealm_stillTrue() {
+        assertTrue(AccessIdUtil.isUserAccessId("user:BasicRealm/my_user"));
+    }
+
+    @Test
+    public void getRealm_normalRealm_noLeadingSlash() {
+        assertEquals("BasicRealm", AccessIdUtil.getRealm("user:BasicRealm/my_user"));
+    }
+
+    @Test
+    public void getUniqueId_normalRealm_returnsUniqueId() {
+        assertEquals("my_user", AccessIdUtil.getUniqueId("user:BasicRealm/my_user"));
+    }
+
+    // Internal-slash realm: Pattern.quote treats the '/' as literal.
+    @Test
+    public void internalSlashRealm_isUserAccessId_returnsTrue() {
+        Mockery localMock = new JUnit4Mockery();
+        ServiceReference<SecurityService> localRef =
+                localMock.mock(ServiceReference.class, "internalSlashRealmRef");
+        localMock.checking(new Expectations() {
+            {
+                allowing(localRef).getProperty(SecurityServiceImpl.KEY_USERREGISTRY);
+                will(returnValue(new String[] { "my/realm" }));
+            }
+        });
+
+        accessIdUtil.unsetSecurityService(securityServiceRef);
+        accessIdUtil.setSecurityService(localRef);
+        try {
+            assertTrue(AccessIdUtil.isUserAccessId("user:my/realm/bob"));
+            assertEquals("my/realm", AccessIdUtil.getRealm("user:my/realm/bob"));
+            assertEquals("bob", AccessIdUtil.getUniqueId("user:my/realm/bob"));
+        } finally {
+            accessIdUtil.unsetSecurityService(localRef);
+            accessIdUtil.setSecurityService(securityServiceRef);
+            localMock.assertIsSatisfied();
+        }
+    }
+
+    // Trailing-slash realm: accessId format is "user:myRealm//bob".
+    @Test
+    public void trailingSlashRealm_isUserAccessId_returnsTrue() {
+        Mockery localMock = new JUnit4Mockery();
+        ServiceReference<SecurityService> localRef =
+                localMock.mock(ServiceReference.class, "trailingSlashRealmRef");
+        localMock.checking(new Expectations() {
+            {
+                allowing(localRef).getProperty(SecurityServiceImpl.KEY_USERREGISTRY);
+                will(returnValue(new String[] { "myRealm/" }));
+            }
+        });
+
+        accessIdUtil.unsetSecurityService(securityServiceRef);
+        accessIdUtil.setSecurityService(localRef);
+        try {
+            assertTrue(AccessIdUtil.isUserAccessId("user:myRealm//bob"));
+            assertEquals("myRealm/", AccessIdUtil.getRealm("user:myRealm//bob"));
+            assertEquals("bob", AccessIdUtil.getUniqueId("user:myRealm//bob"));
+        } finally {
+            accessIdUtil.unsetSecurityService(localRef);
+            accessIdUtil.setSecurityService(securityServiceRef);
+            localMock.assertIsSatisfied();
+        }
+    }
+
+    // Multiple realms including a leading-slash realm: both entries match.
+    @Test
+    public void multiRealm_withLeadingSlashRealm_bothMatch() {
+        Mockery localMock = new JUnit4Mockery();
+        ServiceReference<SecurityService> localRef =
+                localMock.mock(ServiceReference.class, "multiRealmWithSlashRef");
+        localMock.checking(new Expectations() {
+            {
+                allowing(localRef).getProperty(SecurityServiceImpl.KEY_USERREGISTRY);
+                will(returnValue(new String[] { "/testRealm", "BasicRealm" }));
+            }
+        });
+
+        accessIdUtil.unsetSecurityService(securityServiceRef);
+        accessIdUtil.setSecurityService(localRef);
+        try {
+            assertTrue(AccessIdUtil.isUserAccessId("user:/testRealm/my_user"));
+            assertEquals("/testRealm", AccessIdUtil.getRealm("user:/testRealm/my_user"));
+            assertTrue(AccessIdUtil.isUserAccessId("user:BasicRealm/bob"));
+            assertEquals("BasicRealm", AccessIdUtil.getRealm("user:BasicRealm/bob"));
+        } finally {
+            accessIdUtil.unsetSecurityService(localRef);
+            accessIdUtil.setSecurityService(securityServiceRef);
+            localMock.assertIsSatisfied();
+        }
+    }
+
+    // Multiple plain realms: both entries match independently.
+    @Test
+    public void multiRealm_twoNormalRealms_bothMatch() {
+        Mockery localMock = new JUnit4Mockery();
+        ServiceReference<SecurityService> localRef =
+                localMock.mock(ServiceReference.class, "twoNormalRealmsRef");
+        localMock.checking(new Expectations() {
+            {
+                allowing(localRef).getProperty(SecurityServiceImpl.KEY_USERREGISTRY);
+                will(returnValue(new String[] { "RealmA", "RealmB" }));
+            }
+        });
+
+        accessIdUtil.unsetSecurityService(securityServiceRef);
+        accessIdUtil.setSecurityService(localRef);
+        try {
+            assertTrue(AccessIdUtil.isUserAccessId("user:RealmA/alice"));
+            assertTrue(AccessIdUtil.isUserAccessId("user:RealmB/bob"));
+            assertEquals("RealmA", AccessIdUtil.getRealm("user:RealmA/alice"));
+        } finally {
+            accessIdUtil.unsetSecurityService(localRef);
+            accessIdUtil.setSecurityService(securityServiceRef);
+            localMock.assertIsSatisfied();
+        }
+    }
+
+    // Without a realmHolder, ph/ps/p are the fallbacks.
+    // Plain and single-leading-slash realms match; double-slash does not.
+    @Test
+    public void bootstrapFallback_noHolder_plainAndLeadingSlashMatch_doubleSlashDoesNot() {
+        accessIdUtil.unsetSecurityService(securityServiceRef);
+        try {
+            assertTrue(AccessIdUtil.isUserAccessId("user:BasicRealm/my_user"));
+            assertTrue(AccessIdUtil.isUserAccessId("user:/testRealm/my_user"));
+            assertFalse(AccessIdUtil.isUserAccessId("user://testRealm/my_user"));
+        } finally {
+            accessIdUtil.setSecurityService(securityServiceRef);
+        }
+    }
+
+    // Multi-segment slash realm registered in the holder resolves correctly.
+    @Test
+    public void subpathRealm_matcherNonNull_and_partsCorrect() {
+        Mockery localMock = new JUnit4Mockery();
+        ServiceReference<SecurityService> localRef =
+                localMock.mock(ServiceReference.class, "subpathRealmRef");
+        localMock.checking(new Expectations() {
+            {
+                allowing(localRef).getProperty(SecurityServiceImpl.KEY_USERREGISTRY);
+                will(returnValue(new String[] { "/realm/sub" }));
+            }
+        });
+
+        accessIdUtil.unsetSecurityService(securityServiceRef);
+        accessIdUtil.setSecurityService(localRef);
+        try {
+            org.junit.Assert.assertNotNull(
+                "matcher() must not return null for a subpath realm accessId",
+                AccessIdUtil.matcher("user:/realm/sub/testuser"));
+            assertEquals("/realm/sub", AccessIdUtil.getRealm("user:/realm/sub/testuser"));
+            assertEquals("testuser", AccessIdUtil.getUniqueId("user:/realm/sub/testuser"));
+            assertEquals("user", AccessIdUtil.getEntityType("user:/realm/sub/testuser"));
+        } finally {
+            accessIdUtil.unsetSecurityService(localRef);
+            accessIdUtil.setSecurityService(securityServiceRef);
+            localMock.assertIsSatisfied();
+        }
+    }
+
+    // A leading-slash realm not in the holder triggers on-demand pattern compilation.
+    @Test
+    public void getUniqueIdWithRealm_leadingSlashRealmNotInHolder_fallsBackToCompiledPattern() {
+        String accessId = "user:/unknown/alice";
+        assertEquals("alice", AccessIdUtil.getUniqueId(accessId, "/unknown"));
+    }
+
+    // Multi-realm holder: an access ID whose uniqueId is empty must still be rejected.
+    // Guards the early-exit path in matcher() — the realmPatterns loop now applies to
+    // ALL registered realms, not just single-realm holders.
+    @Test
+    public void multiRealm_incompleteAccessId_returnsFalse() {
+        Mockery localMock = new JUnit4Mockery();
+        ServiceReference<SecurityService> localRef =
+                localMock.mock(ServiceReference.class, "multiRealmIncompleteRef");
+        localMock.checking(new Expectations() {
+            {
+                allowing(localRef).getProperty(SecurityServiceImpl.KEY_USERREGISTRY);
+                will(returnValue(new String[] { "/testRealm", "BasicRealm" }));
+            }
+        });
+        accessIdUtil.unsetSecurityService(securityServiceRef);
+        accessIdUtil.setSecurityService(localRef);
+        try {
+            // Realm matches realmPatterns[0] but uniqueId segment is empty — must return false.
+            assertFalse(AccessIdUtil.isAccessId("user:/testRealm/"));
+            // Realm matches realmPatterns[1] but uniqueId segment is empty — must return false.
+            assertFalse(AccessIdUtil.isAccessId("user:BasicRealm/"));
+        } finally {
+            accessIdUtil.unsetSecurityService(localRef);
+            accessIdUtil.setSecurityService(securityServiceRef);
+            localMock.assertIsSatisfied();
+        }
+    }
+}

--- a/dev/com.ibm.ws.security/test/com/ibm/ws/security/AccessIdUtilLeadingSlashRealmTest.java
+++ b/dev/com.ibm.ws.security/test/com/ibm/ws/security/AccessIdUtilLeadingSlashRealmTest.java
@@ -257,6 +257,84 @@ public class AccessIdUtilLeadingSlashRealmTest {
         }
     }
 
+    // --- Gap fix: multi-segment unregistered leading-slash realms ---
+    // ps was "(/[^/]+)/(.+)" which only matched ONE segment after the leading slash.
+    // The new ps "(/.*)/([^/]+)" is greedy on the realm and treats the LAST slash as
+    // the separator, so "/a/b" is the realm and "alice" is the uniqueId — correct.
+
+    // Two-segment unregistered leading-slash realm resolves with last segment as uniqueId.
+    @Test
+    public void unregistered_twoSegmentLeadingSlashRealm_parsedCorrectly() {
+        accessIdUtil.unsetSecurityService(securityServiceRef);
+        try {
+            assertTrue(AccessIdUtil.isUserAccessId("user:/a/b/alice"));
+            assertEquals("/a/b", AccessIdUtil.getRealm("user:/a/b/alice"));
+            assertEquals("alice", AccessIdUtil.getUniqueId("user:/a/b/alice"));
+        } finally {
+            accessIdUtil.setSecurityService(securityServiceRef);
+        }
+    }
+
+    // Three-segment unregistered leading-slash realm: last segment is always the uniqueId.
+    @Test
+    public void unregistered_threeSegmentLeadingSlashRealm_parsedCorrectly() {
+        accessIdUtil.unsetSecurityService(securityServiceRef);
+        try {
+            assertTrue(AccessIdUtil.isUserAccessId("user:/a/b/c/alice"));
+            assertEquals("/a/b/c", AccessIdUtil.getRealm("user:/a/b/c/alice"));
+            assertEquals("alice", AccessIdUtil.getUniqueId("user:/a/b/c/alice"));
+        } finally {
+            accessIdUtil.setSecurityService(securityServiceRef);
+        }
+    }
+
+    // Single-segment case is unchanged: /myrealm still works as before.
+    @Test
+    public void unregistered_singleSegmentLeadingSlashRealm_unchanged() {
+        accessIdUtil.unsetSecurityService(securityServiceRef);
+        try {
+            assertTrue(AccessIdUtil.isUserAccessId("user:/myrealm/testuser"));
+            assertEquals("/myrealm", AccessIdUtil.getRealm("user:/myrealm/testuser"));
+            assertEquals("testuser", AccessIdUtil.getUniqueId("user:/myrealm/testuser"));
+        } finally {
+            accessIdUtil.setSecurityService(securityServiceRef);
+        }
+    }
+
+    // Empty uniqueId must still be rejected — the new ps requires at least one non-slash char
+    // after the last slash, so "user:/a/b/" has no match.
+    @Test
+    public void unregistered_multiSegmentLeadingSlashRealm_emptyUniqueId_returnsFalse() {
+        accessIdUtil.unsetSecurityService(securityServiceRef);
+        try {
+            assertFalse(AccessIdUtil.isAccessId("user:/a/b/"));
+        } finally {
+            accessIdUtil.setSecurityService(securityServiceRef);
+        }
+    }
+
+    // Round-trip: createAccessId + parse for a multi-segment leading-slash realm.
+    @Test
+    public void unregistered_multiSegmentLeadingSlashRealm_roundTrip() {
+        accessIdUtil.unsetSecurityService(securityServiceRef);
+        try {
+            String created = AccessIdUtil.createAccessId("user", "/a/b", "alice");
+            assertEquals("user:/a/b/alice", created);
+            assertTrue(AccessIdUtil.isUserAccessId(created));
+            assertEquals("/a/b", AccessIdUtil.getRealm(created));
+            assertEquals("alice", AccessIdUtil.getUniqueId(created));
+        } finally {
+            accessIdUtil.setSecurityService(securityServiceRef);
+        }
+    }
+
+    // getUniqueId(accessId, realm) with an unregistered multi-segment realm uses the
+    // on-demand compiled pattern and must not fall back to ps.
+    @Test
+    public void unregistered_multiSegmentLeadingSlashRealm_getUniqueIdWithRealm() {
+        assertEquals("alice", AccessIdUtil.getUniqueId("user:/a/b/alice", "/a/b"));
+    }
+
     // Multi-segment slash realm registered in the holder resolves correctly.
     @Test
     public void subpathRealm_matcherNonNull_and_partsCorrect() {

--- a/dev/com.ibm.ws.security/test/com/ibm/ws/security/AccessIdUtilLeadingSlashRealmTest.java
+++ b/dev/com.ibm.ws.security/test/com/ibm/ws/security/AccessIdUtilLeadingSlashRealmTest.java
@@ -190,59 +190,6 @@ public class AccessIdUtilLeadingSlashRealmTest {
         }
     }
 
-    // Multiple realms including a leading-slash realm: both entries match.
-    @Test
-    public void multiRealm_withLeadingSlashRealm_bothMatch() {
-        Mockery localMock = new JUnit4Mockery();
-        ServiceReference<SecurityService> localRef =
-                localMock.mock(ServiceReference.class, "multiRealmWithSlashRef");
-        localMock.checking(new Expectations() {
-            {
-                allowing(localRef).getProperty(SecurityServiceImpl.KEY_USERREGISTRY);
-                will(returnValue(new String[] { "/testRealm", "BasicRealm" }));
-            }
-        });
-
-        accessIdUtil.unsetSecurityService(securityServiceRef);
-        accessIdUtil.setSecurityService(localRef);
-        try {
-            assertTrue(AccessIdUtil.isUserAccessId("user:/testRealm/my_user"));
-            assertEquals("/testRealm", AccessIdUtil.getRealm("user:/testRealm/my_user"));
-            assertTrue(AccessIdUtil.isUserAccessId("user:BasicRealm/bob"));
-            assertEquals("BasicRealm", AccessIdUtil.getRealm("user:BasicRealm/bob"));
-        } finally {
-            accessIdUtil.unsetSecurityService(localRef);
-            accessIdUtil.setSecurityService(securityServiceRef);
-            localMock.assertIsSatisfied();
-        }
-    }
-
-    // Multiple plain realms: both entries match independently.
-    @Test
-    public void multiRealm_twoNormalRealms_bothMatch() {
-        Mockery localMock = new JUnit4Mockery();
-        ServiceReference<SecurityService> localRef =
-                localMock.mock(ServiceReference.class, "twoNormalRealmsRef");
-        localMock.checking(new Expectations() {
-            {
-                allowing(localRef).getProperty(SecurityServiceImpl.KEY_USERREGISTRY);
-                will(returnValue(new String[] { "RealmA", "RealmB" }));
-            }
-        });
-
-        accessIdUtil.unsetSecurityService(securityServiceRef);
-        accessIdUtil.setSecurityService(localRef);
-        try {
-            assertTrue(AccessIdUtil.isUserAccessId("user:RealmA/alice"));
-            assertTrue(AccessIdUtil.isUserAccessId("user:RealmB/bob"));
-            assertEquals("RealmA", AccessIdUtil.getRealm("user:RealmA/alice"));
-        } finally {
-            accessIdUtil.unsetSecurityService(localRef);
-            accessIdUtil.setSecurityService(securityServiceRef);
-            localMock.assertIsSatisfied();
-        }
-    }
-
     // Without a realmHolder, ph/ps/p are the fallbacks.
     // Plain and single-leading-slash realms match; double-slash does not.
     @Test
@@ -257,40 +204,9 @@ public class AccessIdUtilLeadingSlashRealmTest {
         }
     }
 
-    // --- Gap fix: multi-segment unregistered leading-slash realms ---
-    // ps was "(/[^/]+)/(.+)" which only matched ONE segment after the leading slash.
-    // The new ps "(/.*)/([^/]+)" is greedy on the realm and treats the LAST slash as
-    // the separator, so "/a/b" is the realm and "alice" is the uniqueId — correct.
-
-    // Two-segment unregistered leading-slash realm resolves with last segment as uniqueId.
+    // Single-segment leading-slash realm without a holder (bootstrap/fallback path).
     @Test
-    public void unregistered_twoSegmentLeadingSlashRealm_parsedCorrectly() {
-        accessIdUtil.unsetSecurityService(securityServiceRef);
-        try {
-            assertTrue(AccessIdUtil.isUserAccessId("user:/a/b/alice"));
-            assertEquals("/a/b", AccessIdUtil.getRealm("user:/a/b/alice"));
-            assertEquals("alice", AccessIdUtil.getUniqueId("user:/a/b/alice"));
-        } finally {
-            accessIdUtil.setSecurityService(securityServiceRef);
-        }
-    }
-
-    // Three-segment unregistered leading-slash realm: last segment is always the uniqueId.
-    @Test
-    public void unregistered_threeSegmentLeadingSlashRealm_parsedCorrectly() {
-        accessIdUtil.unsetSecurityService(securityServiceRef);
-        try {
-            assertTrue(AccessIdUtil.isUserAccessId("user:/a/b/c/alice"));
-            assertEquals("/a/b/c", AccessIdUtil.getRealm("user:/a/b/c/alice"));
-            assertEquals("alice", AccessIdUtil.getUniqueId("user:/a/b/c/alice"));
-        } finally {
-            accessIdUtil.setSecurityService(securityServiceRef);
-        }
-    }
-
-    // Single-segment case is unchanged: /myrealm still works as before.
-    @Test
-    public void unregistered_singleSegmentLeadingSlashRealm_unchanged() {
+    public void unregistered_singleSegmentLeadingSlashRealm_parsedCorrectly() {
         accessIdUtil.unsetSecurityService(securityServiceRef);
         try {
             assertTrue(AccessIdUtil.isUserAccessId("user:/myrealm/testuser"));
@@ -301,101 +217,35 @@ public class AccessIdUtilLeadingSlashRealmTest {
         }
     }
 
-    // Empty uniqueId must still be rejected — the new ps requires at least one non-slash char
-    // after the last slash, so "user:/a/b/" has no match.
+    // Empty uniqueId after a leading-slash realm must still be rejected.
     @Test
-    public void unregistered_multiSegmentLeadingSlashRealm_emptyUniqueId_returnsFalse() {
+    public void unregistered_leadingSlashRealm_emptyUniqueId_returnsFalse() {
         accessIdUtil.unsetSecurityService(securityServiceRef);
         try {
-            assertFalse(AccessIdUtil.isAccessId("user:/a/b/"));
+            assertFalse(AccessIdUtil.isAccessId("user:/testRealm/"));
         } finally {
             accessIdUtil.setSecurityService(securityServiceRef);
         }
     }
 
-    // Round-trip: createAccessId + parse for a multi-segment leading-slash realm.
+    // Round-trip: createAccessId + parse for a leading-slash realm.
     @Test
-    public void unregistered_multiSegmentLeadingSlashRealm_roundTrip() {
+    public void unregistered_leadingSlashRealm_roundTrip() {
         accessIdUtil.unsetSecurityService(securityServiceRef);
         try {
-            String created = AccessIdUtil.createAccessId("user", "/a/b", "alice");
-            assertEquals("user:/a/b/alice", created);
+            String created = AccessIdUtil.createAccessId("user", "/testRealm", "alice");
+            assertEquals("user:/testRealm/alice", created);
             assertTrue(AccessIdUtil.isUserAccessId(created));
-            assertEquals("/a/b", AccessIdUtil.getRealm(created));
+            assertEquals("/testRealm", AccessIdUtil.getRealm(created));
             assertEquals("alice", AccessIdUtil.getUniqueId(created));
         } finally {
             accessIdUtil.setSecurityService(securityServiceRef);
         }
     }
 
-    // getUniqueId(accessId, realm) with an unregistered multi-segment realm uses the
-    // on-demand compiled pattern and must not fall back to ps.
-    @Test
-    public void unregistered_multiSegmentLeadingSlashRealm_getUniqueIdWithRealm() {
-        assertEquals("alice", AccessIdUtil.getUniqueId("user:/a/b/alice", "/a/b"));
-    }
-
-    // Multi-segment slash realm registered in the holder resolves correctly.
-    @Test
-    public void subpathRealm_matcherNonNull_and_partsCorrect() {
-        Mockery localMock = new JUnit4Mockery();
-        ServiceReference<SecurityService> localRef =
-                localMock.mock(ServiceReference.class, "subpathRealmRef");
-        localMock.checking(new Expectations() {
-            {
-                allowing(localRef).getProperty(SecurityServiceImpl.KEY_USERREGISTRY);
-                will(returnValue(new String[] { "/realm/sub" }));
-            }
-        });
-
-        accessIdUtil.unsetSecurityService(securityServiceRef);
-        accessIdUtil.setSecurityService(localRef);
-        try {
-            org.junit.Assert.assertNotNull(
-                "matcher() must not return null for a subpath realm accessId",
-                AccessIdUtil.matcher("user:/realm/sub/testuser"));
-            assertEquals("/realm/sub", AccessIdUtil.getRealm("user:/realm/sub/testuser"));
-            assertEquals("testuser", AccessIdUtil.getUniqueId("user:/realm/sub/testuser"));
-            assertEquals("user", AccessIdUtil.getEntityType("user:/realm/sub/testuser"));
-        } finally {
-            accessIdUtil.unsetSecurityService(localRef);
-            accessIdUtil.setSecurityService(securityServiceRef);
-            localMock.assertIsSatisfied();
-        }
-    }
-
-    // A leading-slash realm not in the holder triggers on-demand pattern compilation.
+    // getUniqueId(accessId, realm) with a leading-slash realm not in the holder.
     @Test
     public void getUniqueIdWithRealm_leadingSlashRealmNotInHolder_fallsBackToCompiledPattern() {
-        String accessId = "user:/unknown/alice";
-        assertEquals("alice", AccessIdUtil.getUniqueId(accessId, "/unknown"));
-    }
-
-    // Multi-realm holder: an access ID whose uniqueId is empty must still be rejected.
-    // Guards the early-exit path in matcher() — the realmPatterns loop now applies to
-    // ALL registered realms, not just single-realm holders.
-    @Test
-    public void multiRealm_incompleteAccessId_returnsFalse() {
-        Mockery localMock = new JUnit4Mockery();
-        ServiceReference<SecurityService> localRef =
-                localMock.mock(ServiceReference.class, "multiRealmIncompleteRef");
-        localMock.checking(new Expectations() {
-            {
-                allowing(localRef).getProperty(SecurityServiceImpl.KEY_USERREGISTRY);
-                will(returnValue(new String[] { "/testRealm", "BasicRealm" }));
-            }
-        });
-        accessIdUtil.unsetSecurityService(securityServiceRef);
-        accessIdUtil.setSecurityService(localRef);
-        try {
-            // Realm matches realmPatterns[0] but uniqueId segment is empty — must return false.
-            assertFalse(AccessIdUtil.isAccessId("user:/testRealm/"));
-            // Realm matches realmPatterns[1] but uniqueId segment is empty — must return false.
-            assertFalse(AccessIdUtil.isAccessId("user:BasicRealm/"));
-        } finally {
-            accessIdUtil.unsetSecurityService(localRef);
-            accessIdUtil.setSecurityService(securityServiceRef);
-            localMock.assertIsSatisfied();
-        }
+        assertEquals("alice", AccessIdUtil.getUniqueId("user:/unknown/alice", "/unknown"));
     }
 }


### PR DESCRIPTION
A JWT realm claim with a leading or multi-segment slash (e.g. "/myrealm",
"/a/b") caused a NullPointerException because AccessIdUtil.matcher() returned
null, leaving a null WSCredential in sharedState that Subject.add() rejected.

- AccessIdUtil: add per-realm quoted patterns for registered realms; replace
  the single-segment fallback ps with a greedy variant that correctly splits
  any unregistered leading-slash realm at the last slash.
- ServerCommonLoginModule: guard WSCredential add against null.
- Tests: unit tests for all slash variants; FAT tests for auth success and
  realm value preservation.


- [X] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [ ] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [X] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
