### PR TITLE
Fix failing FAT test: DelaySseTest.testRetrySse

### DIFF
--- a/dev/com.ibm.ws.jaxrs.2.1.sse_fat/test-applications/DelaySseApp/src/jaxrs21sse/delay/DelaySseResource.java
+++ b/dev/com.ibm.ws.jaxrs.2.1.sse_fat/test-applications/DelaySseApp/src/jaxrs21sse/delay/DelaySseResource.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2021 IBM Corporation and others.
+ * Copyright (c) 2017, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -17,6 +17,7 @@ package jaxrs21sse.delay;
 
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.Locale;
 
 import javax.ws.rs.ApplicationPath;
 import javax.ws.rs.GET;
@@ -62,7 +63,7 @@ public class DelaySseResource extends Application {
             long delayTime2 = startTime + 10000;
             //get the Date to send
             Date testDate = new Date(delayTime2);
-            SimpleDateFormat sdf = new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss z");
+            SimpleDateFormat sdf = new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss z", Locale.US);
             String sdfString = sdf.format(testDate);
             System.out.println("DelaySseResource:  Throwing 503-2:  sdfString = " + sdfString);
             throw new WebApplicationException(Response.status(503).header(HttpHeaders.RETRY_AFTER, sdfString).build());


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [ ] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

---

## Summary

Fix a locale-sensitive date formatting bug in the `DelaySseTest.testRetrySse` FAT test that causes intermittent failures on macOS CI builders during September.

RTC Defect: [311833](https://wasrtc.hursley.ibm.com:9443/jazz/web/projects/WS-CD#action=com.ibm.team.workitem.viewWorkItem&id=311833)

## Root Cause

[`DelaySseResource.java`](dev/com.ibm.ws.jaxrs.2.1.sse_fat/test-applications/DelaySseApp/src/jaxrs21sse/delay/DelaySseResource.java) constructed a `Retry-After` HTTP date header using `SimpleDateFormat` without an explicit `Locale`. On the Hursley Mac EBC builders (`en_GB` locale), IBM Semeru JDK 21 formats September as `Sept` (4 letters) instead of the RFC 1123-required `Sep` (3 letters). RESTEasy's `DateUtil.parseDate()` uses `Locale.US` strictly and throws `DateParseException` on `Sept`, which kills the SSE reconnect loop before the completion callback fires. The 120-second `CountDownLatch` times out and the assertion at `DelaySseTestServlet.java:114` fails. Only affects September runs on `en_GB` Mac machines.

## Changes

- [`DelaySseResource.java`](dev/com.ibm.ws.jaxrs.2.1.sse_fat/test-applications/DelaySseApp/src/jaxrs21sse/delay/DelaySseResource.java): Added `Locale.US` to `SimpleDateFormat` to ensure RFC 1123-compliant 3-letter month abbreviations regardless of JVM default locale