### PR TITLE
Scopes for Scheduled Methods

### DIFF
--- a/dev/com.ibm.ws.concurrent_fat_jakarta_12/fat/src/test/jakarta/concurrency32/Concurrency32WithCDITest.java
+++ b/dev/com.ibm.ws.concurrent_fat_jakarta_12/fat/src/test/jakarta/concurrency32/Concurrency32WithCDITest.java
@@ -13,6 +13,7 @@
 package test.jakarta.concurrency32;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 import java.util.List;
 
@@ -123,10 +124,18 @@ public class Concurrency32WithCDITest extends FATServletClient {
                      false,
                      testRan);
 
-        // EJB container should have rejected the @Schedule annotation
-        // Also wait for FFDC so it doen't interfere with subsequent tests
-        server.waitForStringsInLogUsingMark(List.of("CNTR0344E",
-                                                    "CNTR4006E",
-                                                    "FFDC1015I.*WELD-000079"));
+        // An error will either be raised by EJB or Concurrency depending on timing
+        // TODO the Concurrency error still needs an NLS message
+        String searchFor = "CNTR0344E" + // EJB
+                           "|" + // or
+                           "ScheduleMethodBean.*scope"; // Concurrency
+        String line = server.waitForStringInLogUsingMark(searchFor);
+        assertNotNull("Container or Concurrency error message not found in log",
+                      line);
+
+        if (line.contains("CNTR0344E"))
+            // Also wait for FFDC so it doen't interfere with subsequent tests
+            server.waitForStringsInLogUsingMark(List.of("CNTR4006E",
+                                                        "FFDC1015I.*WELD-000079"));
     }
 }

--- a/dev/com.ibm.ws.concurrent_fat_jakarta_12/test-applications/Concurrency32CDITestApp/src/test/jakarta/concurrency32cdi/ejb/AsyncWithSchedule.java
+++ b/dev/com.ibm.ws.concurrent_fat_jakarta_12/test-applications/Concurrency32CDITestApp/src/test/jakarta/concurrency32cdi/ejb/AsyncWithSchedule.java
@@ -18,14 +18,14 @@ import java.time.Year;
 
 import jakarta.enterprise.concurrent.Asynchronous;
 import jakarta.enterprise.concurrent.Schedule;
-import jakarta.enterprise.context.SessionScoped;
+import jakarta.enterprise.context.Dependent;
 
 /**
  * Bean with Asynchronous that also has Schedule on a bean method.
  * This must be rejected with UnsupportedOperationException.
  */
 @Asynchronous
-@SessionScoped
+@Dependent
 public class AsyncWithSchedule implements Serializable {
     private static final long serialVersionUID = 7391058645294L;
 

--- a/dev/com.ibm.ws.concurrent_fat_jakarta_12/test-applications/Concurrency32CDITestApp/src/test/jakarta/concurrency32cdi/web/Concurrency32CDITestServlet.java
+++ b/dev/com.ibm.ws.concurrent_fat_jakarta_12/test-applications/Concurrency32CDITestApp/src/test/jakarta/concurrency32cdi/web/Concurrency32CDITestServlet.java
@@ -457,6 +457,39 @@ public class Concurrency32CDITestServlet extends FATServlet {
     }
 
     /**
+     * A RequestScoped bean method annotated Schedule runs automatically and
+     * provides a fresh bean instance on each execution. Because RequestScoped
+     * beans are normal-scoped, the CDI proxy is always resolvable, and the
+     * container must activate a request context for each scheduled invocation
+     * so that the underlying bean instance can be created. This test verifies
+     * that the method fires at least twice and that each invocation receives a
+     * distinct bean instance (i.e. a fresh request-scoped instance per run).
+     */
+    @Test
+    public void testRequestScopedBeanWithScheduledMethod() //
+                    throws InterruptedException {
+
+        Integer firstHash = RequestScopedConcurrency32Bean //
+                        .onThirdSecondsFrom1Queue.poll(TIMEOUT_NS,
+                                                       TimeUnit.NANOSECONDS);
+        assertNotNull("Timed out waiting for first execution of" +
+                      " RequestScopedConcurrency32Bean.onThirdSecondsFrom1",
+                      firstHash);
+
+        Integer secondHash = RequestScopedConcurrency32Bean //
+                        .onThirdSecondsFrom1Queue.poll(TIMEOUT_NS,
+                                                       TimeUnit.NANOSECONDS);
+        assertNotNull("Timed out waiting for second execution of " +
+                      " RequestScopedConcurrency32Bean.onThirdSecondsFrom1",
+                      secondHash);
+
+        assertEquals("Each Schedule invocation of a RequestScoped bean must" +
+                     " use a distinct bean instance",
+                     false,
+                     firstHash.equals(secondHash));
+    }
+
+    /**
      * A bean method that is scheduled to automatically run every 4 seconds,
      * but completes itself the first time it runs must run exactly once.
      */
@@ -735,4 +768,5 @@ public class Concurrency32CDITestServlet extends FATServlet {
         assertEquals(92,
                      writeLockBean.blockingReadNumber());
     }
+
 }

--- a/dev/com.ibm.ws.concurrent_fat_jakarta_12/test-applications/Concurrency32CDITestApp/src/test/jakarta/concurrency32cdi/web/RequestScopedConcurrency32Bean.java
+++ b/dev/com.ibm.ws.concurrent_fat_jakarta_12/test-applications/Concurrency32CDITestApp/src/test/jakarta/concurrency32cdi/web/RequestScopedConcurrency32Bean.java
@@ -1,0 +1,43 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package test.jakarta.concurrency32cdi.web;
+
+import java.util.concurrent.LinkedBlockingQueue;
+
+import jakarta.enterprise.concurrent.Schedule;
+import jakarta.enterprise.context.RequestScoped;
+
+/**
+ * A RequestScoped CDI managed bean.
+ */
+@RequestScoped
+public class RequestScopedConcurrency32Bean {
+
+    /**
+     * Receives the identity hash code of the RequestScopedConcurrency32Bean
+     * instance each time onThirdSecondsFrom1() fires.
+     */
+    static final LinkedBlockingQueue<Integer> onThirdSecondsFrom1Queue = //
+                    new LinkedBlockingQueue<>();
+
+    /**
+     * Fires every 3 seconds (at seconds 1, 4, 7, 10, ...). Each invocation
+     * records this instance's identity hash code so the test can verify that
+     * a fresh bean instance is obtained on each execution (as a @RequestScoped
+     * bean should provide), and so the test can confirm the method ran.
+     */
+    @Schedule(cron = "1/3 * * * * *")
+    public void onThirdSecondsFrom1() {
+        onThirdSecondsFrom1Queue.add(System.identityHashCode(this));
+    }
+}

--- a/dev/io.openliberty.concurrent.internal.cdi/src/io/openliberty/concurrent/internal/cdi/ConcurrencyExtensionMetadata.java
+++ b/dev/io.openliberty.concurrent.internal.cdi/src/io/openliberty/concurrent/internal/cdi/ConcurrencyExtensionMetadata.java
@@ -64,10 +64,16 @@ import jakarta.enterprise.concurrent.ManagedExecutorService;
 import jakarta.enterprise.concurrent.ManagedScheduledExecutorService;
 import jakarta.enterprise.concurrent.ManagedThreadFactory;
 import jakarta.enterprise.concurrent.Schedule;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.context.NormalScope;
+import jakarta.enterprise.context.RequestScoped;
 import jakarta.enterprise.inject.spi.AnnotatedMethod;
 import jakarta.enterprise.inject.spi.AnnotatedType;
 import jakarta.enterprise.inject.spi.Extension;
 import jakarta.inject.Qualifier;
+import jakarta.inject.Scope;
+import jakarta.inject.Singleton;
 
 @Component(configurationPolicy = ConfigurationPolicy.IGNORE,
            service = { ApplicationStateListener.class,
@@ -89,6 +95,16 @@ public class ConcurrencyExtensionMetadata implements //
 
     private static final String DEFAULT_MSES_FILTER = //
                     "(&(id=DefaultManagedScheduledExecutorService)(component.name=com.ibm.ws.concurrent.internal.ManagedScheduledExecutorServiceImpl))";
+
+    /**
+     * Scope annotations that are supported on CDI managed beans that have
+     * methods annotated Schedule.
+     */
+    private static final Set<Class<? extends Annotation>> SCHEDULED_METHOD_BEAN_SCOPES = //
+                    Set.of(Singleton.class,
+                           ApplicationScoped.class,
+                           Dependent.class,
+                           RequestScoped.class);
 
     /**
      * For obtaining the JEE name of the application artifact that provides each
@@ -401,30 +417,54 @@ public class ConcurrencyExtensionMetadata implements //
             }
 
             // Schedule each method that is annotated @Schedule
-            for (AnnotatedType<?> beanType : beanTypes)
+            for (AnnotatedType<?> beanType : beanTypes) {
+                Class<?> beanClass = beanType.getJavaClass();
+                Class<? extends Annotation> scopeClass = null;
+                ArrayList<Annotation> beanAnnoList = new ArrayList<>();
+                for (Annotation beanAnno : beanType.getAnnotations()) {
+                    Class<? extends Annotation> annoType = //
+                                    beanAnno.annotationType();
+                    if (annoType.isAnnotationPresent(Qualifier.class))
+                        beanAnnoList.add(beanAnno);
+                    else if (annoType.isAnnotationPresent(Scope.class) ||
+                             annoType.isAnnotationPresent(NormalScope.class))
+                        scopeClass = annoType;
+                }
+
+                if (scopeClass == null ||
+                    !SCHEDULED_METHOD_BEAN_SCOPES.contains(scopeClass)) {
+                    // TODO NLS
+                    System.out.println("Methods of the " + beanClass.getName() +
+                                       " CDI managed bean that are annotated Schedule" +
+                                       " are not automatically scheduled because the" +
+                                       " CDI managed bean has a " +
+                                       (scopeClass == null ? null : scopeClass.getName()) +
+                                       " scope annotation. Scheduled methods must have" +
+                                       " one of the following scope annotations: " +
+                                       SCHEDULED_METHOD_BEAN_SCOPES);
+                    continue;
+                }
+
+                Annotation[] beanAnnos = beanAnnoList //
+                                .toArray(new Annotation[beanAnnoList.size()]);
+
                 for (AnnotatedMethod<?> method : beanType.getMethods()) {
-                    Class<?> beanClass = beanType.getJavaClass();
                     Schedule schedule = method.getAnnotation(Schedule.class);
                     if (schedule != null &&
                         !beanClass.isAnnotationPresent(Asynchronous.class) &&
                         !method.isAnnotationPresent(Asynchronous.class)) {
 
-                        ArrayList<Annotation> beanAnnoList = new ArrayList<>();
-                        for (Annotation beanAnno : beanType.getAnnotations())
-                            if (beanAnno.annotationType() //
-                                            .isAnnotationPresent(Qualifier.class))
-                                beanAnnoList.add(beanAnno);
-                        Annotation[] beanAnnos = beanAnnoList //
-                                        .toArray(new Annotation[beanAnnoList.size()]);
                         new ScheduledMethod<>( //
                                         method.getJavaMember(), //
                                         schedule, //
                                         threadContext, //
                                         execSvc, //
+                                        scopeClass, //
                                         beanClass, //
                                         beanAnnos);
                     }
                 } // let Asynchronous handle the invalid combination of annos
+            }
         }
     }
 

--- a/dev/io.openliberty.concurrent.internal.cdi/src/io/openliberty/concurrent/internal/cdi/ScheduledMethod.java
+++ b/dev/io.openliberty.concurrent.internal.cdi/src/io/openliberty/concurrent/internal/cdi/ScheduledMethod.java
@@ -25,6 +25,9 @@ import com.ibm.wsspi.threadcontext.ThreadContextDescriptor;
 
 import jakarta.enterprise.concurrent.Schedule;
 import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.enterprise.context.control.RequestContextController;
+import jakarta.enterprise.inject.Instance;
 import jakarta.enterprise.inject.Instance.Handle;
 import jakarta.enterprise.inject.spi.CDI;
 
@@ -35,6 +38,7 @@ import jakarta.enterprise.inject.spi.CDI;
 public class ScheduledMethod<T> extends ScheduledMethodAbstract {
     private final Class<T> beanClass;
     private final Annotation[] beanQualifierAnnos;
+    private final Class<? extends Annotation> beanScopeClass;
 
     /**
      * Constructor for Schedule directly annotating a bean method.
@@ -44,12 +48,15 @@ public class ScheduledMethod<T> extends ScheduledMethodAbstract {
      * @param schedule          the Schedule annotation
      * @param contextDescriptor captured thread context
      * @param managedExecutor   managed executor or managed scheduled executor
+     * @param beanScopeClass    class of the bean's scope (such as ApplicationScoped)
+     * @param beanClass         class of the bean that has the scheduled method
      * @param beanAnnos         qualifier annotations on the bean class (if any)
      */
     ScheduledMethod(Method method,
                     Schedule schedule,
                     ThreadContextDescriptor contextDescriptor,
                     WSManagedExecutorService managedExecutor,
+                    Class<? extends Annotation> beanScopeClass,
                     Class<T> beanClass,
                     Annotation... beanQualifierAnnos) {
         super(method, //
@@ -60,6 +67,7 @@ public class ScheduledMethod<T> extends ScheduledMethodAbstract {
 
         this.beanClass = beanClass;
         this.beanQualifierAnnos = beanQualifierAnnos;
+        this.beanScopeClass = beanScopeClass;
 
         // Intentionally placed as last line of constructuor to ensure
         // intialization is complete before the first task execution runs
@@ -85,17 +93,37 @@ public class ScheduledMethod<T> extends ScheduledMethodAbstract {
     protected CompletionStage<?> invokeMethod() //
                     throws InvocationTargetException, Exception {
 
-        Handle<T> handle = CDI.current() //
-                        .select(beanClass, beanQualifierAnnos) //
-                        .getHandle();
-        boolean isDependent = Dependent.class.equals(handle.getBean().getScope());
+        // Activate a request context for the duration of this invocation
+        // when the bean is @RequestScoped, so that the CDI proxy can
+        // resolve a contextual instance on the timer thread where no
+        // request context would otherwise be active.
+        RequestContextController requestContext = null;
+        if (RequestScoped.class.equals(beanScopeClass)) {
+            requestContext = CDI.current() //
+                            .select(RequestContextController.class) //
+                            .get();
+            if (!requestContext.activate())
+                requestContext = null;
+        }
 
+        Handle<T> handle = null;
         Object result;
         try {
-            result = method.invoke(handle.get());
+            Instance<T> instance = CDI.current().select(beanClass,
+                                                        beanQualifierAnnos);
+
+            // invoke the bean method
+            if (Dependent.class.equals(beanScopeClass)) {
+                handle = instance.getHandle();
+                result = method.invoke(handle.get());
+            } else {
+                result = method.invoke(instance.get());
+            }
         } finally {
-            if (isDependent)
+            if (handle != null)
                 handle.destroy();
+            if (requestContext != null)
+                requestContext.deactivate();
         }
 
         if (result instanceof CompletionStage<?> cs)

--- a/dev/io.openliberty.concurrent.internal.cdi/src/io/openliberty/concurrent/internal/cdi/ScheduledMethodAbstract.java
+++ b/dev/io.openliberty.concurrent.internal.cdi/src/io/openliberty/concurrent/internal/cdi/ScheduledMethodAbstract.java
@@ -162,6 +162,9 @@ public abstract class ScheduledMethodAbstract implements //
             // TODO application can also raise types of RuntimeException
             if (!appException)
                 FFDCFilter.processException(x, getClass().getName(), "183", this);
+
+            if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled())
+                Tr.debug(this, tc, "exception from scheduled method", x);
         } finally {
             try {
                 if (contextApplied != null)
@@ -169,8 +172,16 @@ public abstract class ScheduledMethodAbstract implements //
             } catch (RuntimeException x) {
                 failure = x;
             } finally {
-                if (failure != null)
+                if (failure != null) {
                     future.completeExceptionally(failure);
+                    // TODO NLS
+                    System.out.println("The " + method.getName() +
+                                       " scheduled method of the " +
+                                       method.getDeclaringClass().getName() +
+                                       " CDI managed bean failed due to an error" +
+                                       " and will not run again. The error is: " +
+                                       failure);
+                }
             }
         }
 


### PR DESCRIPTION
Implement remaining scope support for Scheduled Methods and determine which scopes are not possible and explicitly disallow them.  RequestScoped is added by this PR, and the implementation for ApplicationScoped, Dependent, and Singleton is updated/finished to behave correctly.  Other scopes do not make sense for Scheduled Methods and are explicitly rejected.  A test is added for RequestScoped and a test for a different error path is updated to avoid SessionScoped because that would now preempt the expected error that the test wants to see.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
