### PR TITLE
Require jar to run before compileTestJava

### DIFF
--- a/dev/wlp-gradle/subprojects/tasks.gradle
+++ b/dev/wlp-gradle/subprojects/tasks.gradle
@@ -171,6 +171,10 @@ compileJava {
   }
 }
 
+// Ensure all jar tasks complete before compileTestJava runs to avoid a parallel-build
+// race in bnd where concurrent jar tasks corrupt shared Project state (versionMap).
+compileTestJava.mustRunAfter jar
+
 tasks.withType(Test) configureEach {
     int javaVersionNumVal = Integer.parseInt(JavaVersion.current().getMajorVersion())
     if (javaVersionNumVal < 21 && '21'.equals(bnd.get('javac.source'))) {


### PR DESCRIPTION
- When I undid the changes in tasks.gradle for compileTestJava for the bug in bnd, it removed an implicit dependency between compileTestJava and jar which exposed another intermittent concurrency problem in bnd that needs to be fixed.  This change puts in a requirement that jar be complete before doing compileTestJava to avoid the problem.

Co-authored-by-AI: IBM Bob 2.0.1

- [ ] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [ ] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
