### PR TITLE
Updating the connection parameter in GET req

### DIFF
--- a/dev/io.openliberty.transport.http_fat/fat/src/io/openliberty/transport/http_fat/TraceRequestBodyTests.java
+++ b/dev/io.openliberty.transport.http_fat/fat/src/io/openliberty/transport/http_fat/TraceRequestBodyTests.java
@@ -275,10 +275,13 @@ public class TraceRequestBodyTests {
                 "\r\n" +
                 postBody;
 
+        // Use keep-alive so Netty's HttpServerKeepAliveHandler does not close
+        // the channel after writing the POST response, which on servlet-4.0+
+        // would race with the server writing the pipelined GET response.
         String getRequest =
                 "GET " + TRACE_SERVLET + " HTTP/1.1\r\n" +
                 "Host: " + hostHeader() + "\r\n" +
-                "Connection: close\r\n" +
+                "Connection: keep-alive\r\n" +
                 "\r\n";
 
         String response = sendRawRequest(postRequest + getRequest);


### PR DESCRIPTION
testLegitimatePostGetPipelineReturnsTwoResponses fails in the io.openliberty.transport.http_fat FAT suite. The test sends a pipelined POST+GET on a single raw TCP socket and expects two HTTP 200 responses, but only receives one (the POST response).

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
