### PR TITLE
Fix CxfBspTests/CxfInteropX509Tests failing on IBM Semeru OpenJ9 8

### DIFF
--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/sample/CxfBspTests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/sample/CxfBspTests.java
@@ -118,12 +118,17 @@ public class CxfBspTests {
 
         //RTC 291296
         String vendorName = System.getProperty("java.vendor");
+        // RTC 311660 - IBM Semeru OpenJ9 also reports java.vendor="IBM Corporation" but has
+        // disabled SHA1withRSA/1024-bit RSA keys since 8u492, so it must be excluded too.
+        String vmName = System.getProperty("java.vm.name", "");
         Log.info(thisClass, thisMethod, "JDK Vendor Name is: " + vendorName);
+        Log.info(thisClass, thisMethod, "JDK VM Name is: " + vmName);
 
         //issue 30353
         JavaInfo info = JavaInfo.forServer(server);
-        if ((info.majorVersion() == 8) && (vendorName.contains("IBM"))) {
-            Log.info(thisClass, thisMethod, "Using an IBM JDK");
+        if ((info.majorVersion() == 8) && (vendorName.contains("IBM"))
+                && !vmName.toLowerCase().contains("openj9")) {
+            Log.info(thisClass, thisMethod, "Using IBM JDK 8");
         } else {
             Log.info(thisClass, thisMethod, "Using NON-IBM JDK/OpenJDK/Openj9/IBM Semeru Open Edition/OSX_12_MONTEREY_IBMJDK8 - this test should not run!");
             System.err.println("Using a NON-IBM JDK/OpenJDK/Openj9/IBM Semeru Open Edition/OSX_12_MONTEREY_IBMJDK8 - this test should not run!");

--- a/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/sample/CxfInteropX509Tests.java
+++ b/dev/com.ibm.ws.wssecurity_fat.wsscxf.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/sample/CxfInteropX509Tests.java
@@ -116,14 +116,19 @@ public class CxfInteropX509Tests {
 
         //RTC 291296
         String vendorName = System.getProperty("java.vendor");
+        // RTC 311660 - IBM Semeru OpenJ9 also reports java.vendor="IBM Corporation" but has
+        // disabled SHA1withRSA/1024-bit RSA keys since 8u492, so it must be excluded too.
+        String vmName = System.getProperty("java.vm.name", "");
         Log.info(thisClass, thisMethod, "JDK Vendor Name is: " + vendorName);
+        Log.info(thisClass, thisMethod, "JDK VM Name is: " + vmName);
 
         ibmJDK = true;
 
         //issue 30353
         JavaInfo info = JavaInfo.forServer(server);
-        if ((info.majorVersion() == 8) && (vendorName.contains("IBM"))) {
-            Log.info(thisClass, thisMethod, "Using an IBM JDK");
+        if ((info.majorVersion() == 8) && (vendorName.contains("IBM"))
+                && !vmName.toLowerCase().contains("openj9")) {
+            Log.info(thisClass, thisMethod, "Using IBM JDK 8");
         } else {
             Log.info(thisClass, thisMethod, "Using NON-IBM JDK/OpenJDK/Openj9/IBM Semeru Open Edition/OSX_12_MONTEREY_IBMJDK8 - this test should not run!");
             System.err.println("Using a NON-IBM JDK/OpenJDK/Openj9/IBM Semeru Open Edition/OSX_12_MONTEREY_IBMJDK8 - this test should not run!");


### PR DESCRIPTION
- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [ ] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".

---

## Summary

`CxfBspTests` and `CxfInteropX509Tests` guard their tests with an `ibmJDK` flag that
is set to `true` when `java.vendor` contains `"IBM"` and `majorVersion == 8`. IBM
Semeru OpenJ9 8 also reports `java.vendor="IBM Corporation"`, so the guard evaluates
`true` and the tests run. However, Semeru OpenJ9 8u492 disables SHA1withRSA/1024-bit
RSA keys, causing the test keystores (`sender.jks` alias `alice`) to report "The
private key for the supplied alias does not exist in the keystore" on every invocation.

The fix adds a check on `java.vm.name` for `"openj9"` to exclude Semeru OpenJ9 from
the `ibmJDK=true` path. Classic IBM JDK 8 reports `java.vm.name="IBM J9 VM"` and is
unaffected.

## Changes

- `dev/com.ibm.ws.wssecurity_fat.wsscxf.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/sample/CxfBspTests.java`
- `dev/com.ibm.ws.wssecurity_fat.wsscxf.1/fat/src/com/ibm/ws/wssecurity/fat/cxf/sample/CxfInteropX509Tests.java`

## Related

[RTC Defect 311660](https://wasrtc.hursley.ibm.com:9443/jazz/web/projects/WS-CD#action=com.ibm.team.workitem.viewWorkItem&id=311660)