### PR TITLE
Improvements to tests relating to when FIPS140-3 is enabled

### DIFF
--- a/dev/com.ibm.ws.security.saml.sso_fat.2/fat/src/com/ibm/ws/security/saml/fat/common/BasicEncryptionTests.java
+++ b/dev/com.ibm.ws.security.saml.sso_fat.2/fat/src/com/ibm/ws/security/saml/fat/common/BasicEncryptionTests.java
@@ -14,6 +14,7 @@ package com.ibm.ws.security.saml.fat.common;
 
 import java.util.List;
 
+import com.ibm.websphere.simplicity.OperatingSystem;
 import org.junit.Test;
 
 import com.gargoylesoftware.htmlunit.WebClient;
@@ -238,7 +239,7 @@ public class BasicEncryptionTests extends SAMLCommonTest {
         
         String failureMessage = null;
         // IBM Java 8
-        if (testSAMLServer.getServer().isIbmJdk8FIPS140_3EnabledAndSupported()) {
+        if (testSAMLServer.getServer().isIbmJdk8FIPS140_3EnabledAndSupported() || (testSAMLServer.getServer().isSemeruFIPS140_3EnabledAndSupported() && testSAMLServer.getServer().getMachine().getOperatingSystem().equals(OperatingSystem.ZOS))) {
             failureMessage = SAMLMessageConstants.CWWKS5007E_INTERNAL_SERVER_ERROR + ".+server is configured with FIPS 140-3 enabled mode, but the received SAML assertion is signed with RSA-SHA1.*";
         } else if (testSAMLServer.getServer().isSemeruFIPS140_3EnabledAndSupported()) {
             // failureMessage = ".+The requested algorithm http://www.w3.org/2000/09/xmldsig#rsa-sha1 does not exist.*";

--- a/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyClient.java
+++ b/dev/fattest.simplicity/src/componenttest/topology/impl/LibertyClient.java
@@ -689,7 +689,7 @@ public class LibertyClient {
                 Properties clientEnv = getClientEnv();
                 Properties defaultEnv = getDefaultEnv();
                 Map<String, String> opts = getJvmOptionsAsMap();
-                if (clientEnv.containsKey("ENABLE_FIPS140_3") || defaultEnv.containsKey("ENABLE_FIPS140_3") || opts.containsKey("-Xenablefips140-3")
+                if (clientEnv.containsKey("ENABLE_FIPS140_3") || defaultEnv.containsKey("ENABLE_FIPS140_3") || useEnvVars.containsKey("ENABLE_FIPS140_3") || opts.containsKey("-Xenablefips140-3")
                     || opts.containsKey("-Dsemeru.fips")) {
                     Log.info(c, method, "Test has defined its own settings for FIPS140-3");
                 } else {

--- a/dev/io.openliberty.security.fips.internal_fat/fat/src/io/openliberty/security/fips/fat/tests/fips1403/client/FIPS1403ClientTest.java
+++ b/dev/io.openliberty.security.fips.internal_fat/fat/src/io/openliberty/security/fips/fat/tests/fips1403/client/FIPS1403ClientTest.java
@@ -75,6 +75,7 @@ public class FIPS1403ClientTest {
 
     @Test
     public void clientJFIPS140_3JVMArgsTest() throws Exception {
+        // If GLOBAL_CLIENT_FIPS is set, it will set the equivilant JVM Args for us
         if (!GLOBAL_CLIENT_FIPS) {
             Log.info(FIPS1403ClientTest.class,"setup","Setting FIPS140-3 JVM Options");
             HashMap<String, String> opts = new HashMap<>();
@@ -101,11 +102,9 @@ public class FIPS1403ClientTest {
     
     @Test
     public void clientFIPS140_3EnvTest() throws Exception {
-        assumeThat(GLOBAL_CLIENT_FIPS, is(false));
-        if(!GLOBAL_CLIENT_FIPS) {
-            client.copyFileToLibertyClientRoot("publish/resources", "resources" , STANDALONE_FIPS_PROFILE_FILENAME);
-            client.addEnvVar(ENABLE_FIPS140_3_ENV_VAR, client.getClientRoot()+"/resources/" + STANDALONE_FIPS_PROFILE_FILENAME);
-        }
+        client.copyFileToLibertyClientRoot("publish/resources", "resources" , STANDALONE_FIPS_PROFILE_FILENAME);
+        client.addEnvVar(ENABLE_FIPS140_3_ENV_VAR, client.getClientRoot()+"/resources/" + STANDALONE_FIPS_PROFILE_FILENAME);
+        // if global.client.fips_140-3=true is specified, the client will still use the envVar setting instead of applying the default args
         client.startClient();
         checkClientLogForFipsEnablementMessage(client, expectedProvider);
     }

--- a/dev/io.openliberty.security.fips.internal_fat/fat/src/io/openliberty/security/fips/fat/tests/fips1403/server/FIPS1403ServerTest.java
+++ b/dev/io.openliberty.security.fips.internal_fat/fat/src/io/openliberty/security/fips/fat/tests/fips1403/server/FIPS1403ServerTest.java
@@ -14,6 +14,7 @@ import com.ibm.websphere.simplicity.Machine;
 import com.ibm.websphere.simplicity.OperatingSystem;
 import com.ibm.websphere.simplicity.ProgramOutput;
 import com.ibm.websphere.simplicity.log.Log;
+import componenttest.annotation.MinimumJavaLevel;
 import componenttest.annotation.Server;
 import componenttest.annotation.SkipIfSysProp;
 import componenttest.custom.junit.runner.FATRunner;
@@ -122,6 +123,7 @@ public class FIPS1403ServerTest {
     }
 
     @Test
+    @MinimumJavaLevel(javaLevel=11)
     public void serverFIPS140_3DirectoryQuotedTest() throws Exception {
         server.copyFileToLibertyServerRoot("publish/resources", "resources" , LIBERTY_APPLICATION_FIPS_PROFILE_FILENAME);
         Path path = Paths.get(server.getServerRoot() + "/"+ SERVER_ENV_FILE);
@@ -137,6 +139,7 @@ public class FIPS1403ServerTest {
      * @throws Exception
      */
     @Test
+    @MinimumJavaLevel(javaLevel=11)
     public void serverFIPS140_3DirectorySpaceNoQuotesTest() throws Exception {
         assumeThat(server.getMachine().getOperatingSystem(), is(OperatingSystem.WINDOWS));
         String testDir = "resources/test dir";
@@ -148,6 +151,7 @@ public class FIPS1403ServerTest {
     }
 
     @Test
+    @MinimumJavaLevel(javaLevel=11)
     public void serverFIPS140_3DirectorySpaceQuotesTest() throws Exception {
         assumeThat(server.getMachine().getOperatingSystem(), not(OperatingSystem.WINDOWS));
         String testDir = "resources/test dir";
@@ -160,6 +164,7 @@ public class FIPS1403ServerTest {
     }
 
     @Test
+    @MinimumJavaLevel(javaLevel=11)
     public void serverFIPS140_3DirectorySpaceSlashTest() throws Exception {
         assumeThat(server.getMachine().getOperatingSystem(), not(OperatingSystem.WINDOWS));
         String testDir = "resources/test\\ dir";


### PR DESCRIPTION
Covers a known z/OS test that have different characteristics to distributed

skip some tests that should not be run on Java 8 anyway

Expand sources that FIPS enablement in Liberty Client checks to include envvars.


- [ ] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [ ] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
