### PR TITLE
fix(fat): change autoFVT task ordering from shouldRunAfter to mustRunAfter

### DIFF
--- a/dev/wlp-gradle/subprojects/fat.gradle
+++ b/dev/wlp-gradle/subprojects/fat.gradle
@@ -273,7 +273,7 @@ if (!bnd.get('-sub', '').empty) {
 publishedArtifacts.add(project.name)
 
 task autoFVT {
-  shouldRunAfter cleanFat
+  mustRunAfter cleanFat
   dependsOn jar
   dependsOn ':cnf:copyMavenLibs'
   dependsOn addRequiredLibraries


### PR DESCRIPTION
## Summary

The `autoFVT` task used `shouldRunAfter cleanFat`, which only enforces ordering when both tasks happen to be scheduled in the same build invocation. This meant that `cleanFat` could run concurrently with or after `autoFVT` in certain execution plans, leaving the autoFVT output directory in an inconsistent state.

Changing to `mustRunAfter` guarantees that `cleanFat` always completes before `autoFVT` begins whenever both are present in the task graph, preventing stale output from a previous run contaminating the current FAT assembly.
