### PR TITLE
Offset pagination for NativeQuery

### DIFF
--- a/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/Fail.java
+++ b/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/Fail.java
@@ -11,6 +11,7 @@ package io.openliberty.data.internal;
 
 import static io.openliberty.data.internal.QueryType.FIND;
 import static io.openliberty.data.internal.QueryType.FIND_AND_DELETE;
+import static io.openliberty.data.internal.QueryType.NATIVE;
 import static io.openliberty.data.internal.cdi.DataExtension.exc;
 
 import java.lang.annotation.Annotation;
@@ -34,6 +35,7 @@ import jakarta.data.exceptions.OptimisticLockingFailureException;
 import jakarta.data.page.CursoredPage;
 import jakarta.data.page.Page;
 import jakarta.data.page.PageRequest;
+import jakarta.data.repository.NativeQuery;
 import jakarta.data.repository.OrderBy;
 import jakarta.data.repository.Param;
 
@@ -1107,6 +1109,34 @@ public class Fail {
                   info.repositoryInterface.getName(),
                   paramType.getSimpleName(),
                   info.type.operationName);
+    }
+
+    /**
+     * Raise a new UnsupportedOperationException for the errors where a count of
+     * total elements or pages is not possible due to the query being a NativeQuery
+     * or having a keyword that is incompatible with automatically generating a
+     * count query.
+     *
+     * @param info query information for the repository method.
+     * @throws UnsupportedOperationException.
+     */
+    static UnsupportedOperationException totalsNotSupported(QueryInfo info) {
+        if (info.type == NATIVE) // TODO NLS
+            throw new UnsupportedOperationException //
+            ("A count of total elements or total pages cannot be automatically" +
+             " obtained for the " + info.method.getName() + " method of the " +
+             info.repositoryInterface.getName() +
+             " repository because the repository method has the " +
+             NativeQuery.class.getSimpleName() +
+             " annotation. Write a separate repository method annotated " +
+             NativeQuery.class.getSimpleName() + " to compute the count.");
+        else
+            throw exc(UnsupportedOperationException.class,
+                      "CWWKD1119.keyword.prevents.count",
+                      info.method.getName(),
+                      info.repositoryInterface.getName(),
+                      info.jpqlCount,
+                      info.ql);
     }
 
     /**

--- a/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/PageImpl.java
+++ b/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/PageImpl.java
@@ -209,13 +209,9 @@ public class PageImpl<T> implements Page<T> {
             pageRequest.size() < Integer.MAX_VALUE)
             return results.size();
 
-        if (queryInfo.jpqlCount.length() < Util.MIN_COUNT_QUERY_LENGTH)
-            throw exc(UnsupportedOperationException.class,
-                      "CWWKD1119.keyword.prevents.count",
-                      queryInfo.method.getName(),
-                      queryInfo.repositoryInterface.getName(),
-                      queryInfo.jpqlCount,
-                      queryInfo.ql);
+        if (queryInfo.type == QueryType.NATIVE ||
+            queryInfo.jpqlCount.length() < Util.MIN_COUNT_QUERY_LENGTH)
+            Fail.totalsNotSupported(queryInfo);
 
         boolean stateful = queryInfo.producer.stateful();
         EntityHandlerFactory factory = queryInfo.entityInfo.factory;

--- a/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/PageImpl.java
+++ b/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/PageImpl.java
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package io.openliberty.data.internal;
 
+import static io.openliberty.data.internal.QueryType.NATIVE;
 import static io.openliberty.data.internal.cdi.DataExtension.exc;
 
 import java.util.AbstractList;
@@ -31,6 +32,7 @@ import jakarta.data.page.CursoredPage;
 import jakarta.data.page.Page;
 import jakarta.data.page.PageRequest;
 import jakarta.data.page.PageRequest.Mode;
+import jakarta.persistence.Query;
 import jakarta.persistence.TypedQuery;
 
 /**
@@ -125,9 +127,14 @@ public class PageImpl<T> implements Page<T> {
                       queryInfo.method.getGenericReturnType().getTypeName(),
                       CursoredPage.class.getName());
 
-        TypedQuery<T> query = queryInfo.ehCreateTypedQuery(entityHandler,
-                                                           queryInfo.ql,
-                                                           Object.class);
+        Query query;
+        if (queryInfo.type == NATIVE)
+            query = queryInfo.ehCreateNativeQuery(entityHandler);
+        else
+            query = queryInfo.ehCreateTypedQuery(entityHandler,
+                                                 queryInfo.ql,
+                                                 Object.class);
+
         queryInfo.setParameters(query,
                                 args,
                                 deferredConstraints,
@@ -140,7 +147,9 @@ public class PageImpl<T> implements Page<T> {
                         ? Integer.MAX_VALUE //
                         : (maxPageSize + 1)); // extra result indicates if next page exists
 
-        results = query.getResultList();
+        @SuppressWarnings("unchecked")
+        List<T> resultList = query.getResultList();
+        results = resultList;
 
         if (trace && tc.isEntryEnabled())
             Tr.exit(this, tc, "<init>");

--- a/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/QueryInfo.java
+++ b/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/QueryInfo.java
@@ -1487,6 +1487,8 @@ public abstract class QueryInfo {
      * @param entityHandler EntityAgent or EntityManager
      * @return the query
      */
+    // TODO once we have persistence providers that support Persistence 4.0,
+    // see if we can have this method return TypedQuery<T> like ehCreateTypedQuery
     protected abstract jakarta.persistence.Query //
                     ehCreateNativeQuery(AutoCloseable entityHandler);
 

--- a/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/QueryInfo.java
+++ b/dev/io.openliberty.data.internal/src/io/openliberty/data/internal/QueryInfo.java
@@ -211,7 +211,8 @@ public abstract class QueryInfo {
      * For counting the total number of results across all pages.
      * If less than Util.MIN_COUNT_QUERY_LENGTH characters long, indicates a
      * query keyword that prevents computation of a count.
-     * Null if pagination is not used or if pagination without totals is used.
+     * Null if pagination is not used or if pagination without totals is used
+     * or the query is a NativeQuery.
      */
     String jpqlCount;
 
@@ -3839,7 +3840,8 @@ public abstract class QueryInfo {
                     specialParamsStartAt = i;
                 // Reject all special parameters on native queries until we
                 // TODO determine which, if any, can be supported
-                if (!Limit.class.equals(paramType))
+                if (!Limit.class.equals(paramType) &&
+                    !PageRequest.class.equals(paramType))
                     throw new UnsupportedOperationException //
                     ("The " + method.getName() + " method of the " +
                      repositoryInterface.getName() + " repository cannot have a " +
@@ -3877,7 +3879,6 @@ public abstract class QueryInfo {
             throw Fail.mixedQLParamTypes(this, namedParamCount);
 
         qlParamCount = specialParamsStartAt;
-
         ql = sql;
     }
 
@@ -4754,13 +4755,22 @@ public abstract class QueryInfo {
             Tr.entry(this, tc, "nativeQuery");
 
         QueryCustomization qc = QueryCustomization.from(this, args);
+        Limit limit = qc.limit();
         PageRequest pageReq = qc.pageRequest();
         Object returnValue;
 
         if (CursoredPage.class.equals(multiType)) {
             throw new UnsupportedOperationException(); // TODO
         } else if (Page.class.equals(multiType)) {
-            throw new UnsupportedOperationException(); // TODO
+            PageRequest req = limit == null ? pageReq : toPageRequest(limit);
+            returnValue = new PageImpl<>(//
+                            this, //
+                            entityHandler, //
+                            req, //
+                            args, //
+                            Map.of(), // no deferred constraints
+                            null, // no added query parameters
+                            null); // Sort/Order not supported for native query
         } else if (pageReq != null &&
                    !PageRequest.Mode.OFFSET.equals(pageReq.mode())) {
             throw Fail.pageModeIncompatible(this, pageReq);
@@ -4791,7 +4801,6 @@ public abstract class QueryInfo {
             } else {
                 query = ehCreateNativeQuery(entityHandler);
 
-                Limit limit = qc.limit();
                 int startAt = limit != null //
                                 ? computeOffset(limit) //
                                 : pageReq != null //

--- a/dev/io.openliberty.data.internal_fat_1_1/test-applications/Data_1_1_App/src/test/jakarta/data/v1_1/web/Data_1_1_Servlet.java
+++ b/dev/io.openliberty.data.internal_fat_1_1/test-applications/Data_1_1_App/src/test/jakarta/data/v1_1/web/Data_1_1_Servlet.java
@@ -2058,6 +2058,119 @@ public class Data_1_1_Servlet extends FATServlet {
     }
 
     /**
+     * Use a NativeQuery method that returns a page of results. Retrieve the
+     * second page, then the next (third) page, then the next (fourth) page.
+     * Finally, retrieve the previous page from the second page, which is page 1.
+     */
+    @Test
+    public void testNativeQueryRetrievesPages() {
+        // Fractions n/d where 2^n < d^2, ordered by denominator ASC, numerator ASC.
+        // With page size 8: page 1 = items 1-8, page 2 = items 9-16, etc.
+
+        PageRequest page2Req = PageRequest.ofSize(8).pageNumber(2);
+
+        Page<Fraction> page2 = fractions //
+                        .pageOfNumSquaredLessThanDenomPowerOf(2,
+                                                              page2Req);
+
+        assertEquals(List.of("3/5",
+                             "4/5",
+                             "1/6",
+                             "2/6",
+                             "3/6",
+                             "4/6",
+                             "5/6",
+                             "1/7"),
+                     page2.stream()
+                                     .map(f -> f.numerator + "/" + f.denominator)
+                                     .collect(Collectors.toList()));
+
+        assertEquals(2L,
+                     page2.pageRequest().pageNumber());
+        assertEquals(8,
+                     page2.numberOfElements());
+        assertEquals(true,
+                     page2.hasPrevious());
+        assertEquals(true,
+                     page2.hasNext());
+
+        Page<Fraction> page3 = fractions //
+                        .pageOfNumSquaredLessThanDenomPowerOf(2,
+                                                              page2.nextPageRequest());
+
+        assertEquals(List.of("2/7",
+                             "3/7",
+                             "4/7",
+                             "5/7",
+                             "1/8",
+                             "2/8",
+                             "3/8",
+                             "4/8"),
+                     page3.stream()
+                                     .map(f -> f.numerator + "/" + f.denominator)
+                                     .collect(Collectors.toList()));
+
+        assertEquals(3L,
+                     page3.pageRequest().pageNumber());
+        assertEquals(8,
+                     page3.numberOfElements());
+        assertEquals(true,
+                     page3.hasPrevious());
+        assertEquals(true,
+                     page3.hasNext());
+
+        Page<Fraction> page4 = fractions //
+                        .pageOfNumSquaredLessThanDenomPowerOf(2,
+                                                              page3.nextPageRequest());
+
+        assertEquals(List.of("5/8",
+                             "1/9",
+                             "2/9",
+                             "3/9",
+                             "4/9",
+                             "5/9",
+                             "6/9",
+                             "1/10"),
+                     page4.stream()
+                                     .map(f -> f.numerator + "/" + f.denominator)
+                                     .collect(Collectors.toList()));
+
+        assertEquals(4L,
+                     page4.pageRequest().pageNumber());
+        assertEquals(8,
+                     page4.numberOfElements());
+        assertEquals(true,
+                     page4.hasPrevious());
+        assertEquals(true,
+                     page4.hasNext());
+
+        Page<Fraction> page1 = fractions //
+                        .pageOfNumSquaredLessThanDenomPowerOf(2,
+                                                              page2.previousPageRequest());
+
+        assertEquals(List.of("1/2",
+                             "1/3",
+                             "2/3",
+                             "1/4",
+                             "2/4",
+                             "3/4",
+                             "1/5",
+                             "2/5"),
+                     page1.stream()
+                                     .map(f -> f.numerator + "/" + f.denominator)
+                                     .collect(Collectors.toList()));
+
+        assertEquals(1L,
+                     page1.pageRequest().page());
+        assertEquals(8,
+                     page1.numberOfElements());
+        assertEquals(false,
+                     page1.hasPrevious());
+        assertEquals(true,
+                     page1.hasNext());
+    }
+
+    /**
      * Use a NativeQuery method that returns subsets of entity attributes
      * as an array of Java records
      */

--- a/dev/io.openliberty.data.internal_fat_1_1/test-applications/Data_1_1_App/src/test/jakarta/data/v1_1/web/Fractions.java
+++ b/dev/io.openliberty.data.internal_fat_1_1/test-applications/Data_1_1_App/src/test/jakarta/data/v1_1/web/Fractions.java
@@ -233,6 +233,15 @@ public interface Fractions {
     @QueryOptions(entityGraph = "EagerlyLoadRoundedValues")
     Optional<Fraction> of(int numerator, int denominator);
 
+    @NativeQuery("""
+                    SELECT *
+                      FROM Fraction
+                     WHERE POWER(2, numerator) < POWER(denominator, ?)
+                     ORDER BY denominator ASC, numerator ASC
+                    """)
+    Page<Fraction> pageOfNumSquaredLessThanDenomPowerOf(int denominatorExponent,
+                                                        PageRequest PageReq);
+
     @Query("SELECT numerator, denominator - numerator" +
            " ORDER BY denominator - numerator DESC, numerator ASC")
     Page<Ratio> pageOfRatios(PageRequest pageReq);

--- a/dev/io.openliberty.data.internal_fat_errorpaths/.classpath
+++ b/dev/io.openliberty.data.internal_fat_errorpaths/.classpath
@@ -2,6 +2,7 @@
 <classpath>
 	<classpathentry kind="src" path="fat/src"/>
 	<classpathentry kind="src" path="test-applications/DataErrPathsTestApp/src"/>
+	<classpathentry kind="src" path="test-applications/DataErrPaths_1_1_App/src"/>
 	<classpathentry kind="con" path="aQute.bnd.classpath.container"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17">
 		<attributes>

--- a/dev/io.openliberty.data.internal_fat_errorpaths/bnd.bnd
+++ b/dev/io.openliberty.data.internal_fat_errorpaths/bnd.bnd
@@ -15,7 +15,8 @@ bVersion=1.0
 
 src: \
   fat/src,\
-  test-applications/DataErrPathsTestApp/src
+  test-applications/DataErrPathsTestApp/src,\
+  test-applications/DataErrPaths_1_1_App/src
 
 javac.source: 17
 javac.target: 17
@@ -30,7 +31,7 @@ fat.project: true
   com.ibm.ws.org.osgi.annotation.versioning;version=latest,\
   io.openliberty.jakarta.annotation.2.1,\
   io.openliberty.jakarta.cdi.4.1,\
-  io.openliberty.jakarta.data.1.0,\
+  io.openliberty.jakarta.data.1.1,\
   io.openliberty.jakarta.persistence.3.2,\
   io.openliberty.jakarta.validation.3.1,\
   io.openliberty.jakarta.servlet.6.1;version=latest,\

--- a/dev/io.openliberty.data.internal_fat_errorpaths/fat/src/test/jakarta/data/errpaths/DataErrPaths_1_1_Test.java
+++ b/dev/io.openliberty.data.internal_fat_errorpaths/fat/src/test/jakarta/data/errpaths/DataErrPaths_1_1_Test.java
@@ -1,0 +1,62 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package test.jakarta.data.errpaths;
+
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.runner.RunWith;
+
+import com.ibm.websphere.simplicity.ShrinkHelper;
+
+import componenttest.annotation.MaximumJavaLevel;
+import componenttest.annotation.MinimumJavaLevel;
+import componenttest.annotation.Server;
+import componenttest.annotation.TestServlet;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.topology.impl.LibertyServer;
+import componenttest.topology.utils.FATServletClient;
+import test.jakarta.data.errpaths.v1_1.web.DataErrPaths_1_1_Servlet;
+
+@RunWith(FATRunner.class)
+@MinimumJavaLevel(javaLevel = 21)
+@MaximumJavaLevel(javaLevel = 25) // TODO remove once RTC 309096 updates Byte Buddy to a version that supports java 26+
+public class DataErrPaths_1_1_Test extends FATServletClient {
+
+    private static final String APP_NAME = "DataErrPaths_1_1_App";
+
+    /**
+     * Error messages that are intentionally caused by tests to cover error paths.
+     * These are ignored when checking the messages.log file for errors.
+     */
+    private static final String[] EXPECTED_ERROR_MESSAGES = //
+                    new String[] {
+                    };
+
+    @Server("io.openliberty.data.internal.fat.errpaths.1.1")
+    @TestServlet(servlet = DataErrPaths_1_1_Servlet.class, contextRoot = APP_NAME)
+    public static LibertyServer server;
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        WebArchive war = ShrinkHelper.buildDefaultApp("DataErrPaths_1_1_App",
+                                                      "test.jakarta.data.errpaths.v1_1.web");
+        ShrinkHelper.exportAppToServer(server, war);
+        server.startServer();
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        server.stopServer(EXPECTED_ERROR_MESSAGES);
+    }
+}

--- a/dev/io.openliberty.data.internal_fat_errorpaths/fat/src/test/jakarta/data/errpaths/FATSuite.java
+++ b/dev/io.openliberty.data.internal_fat_errorpaths/fat/src/test/jakarta/data/errpaths/FATSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024,2025 IBM Corporation and others.
+ * Copyright (c) 2024,2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -21,6 +21,7 @@ import componenttest.custom.junit.runner.AlwaysPassesTest;
 @RunWith(Suite.class)
 @SuiteClasses({
                 AlwaysPassesTest.class,
+                DataErrPaths_1_1_Test.class,
                 DataErrPathsTest.class,
                 DataIntrospectorTest.class
 })

--- a/dev/io.openliberty.data.internal_fat_errorpaths/publish/servers/io.openliberty.data.internal.fat.errpaths.1.1/bootstrap.properties
+++ b/dev/io.openliberty.data.internal_fat_errorpaths/publish/servers/io.openliberty.data.internal.fat.errpaths.1.1/bootstrap.properties
@@ -1,0 +1,14 @@
+###############################################################################
+# Copyright (c) 2026 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-2.0/
+# 
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+###############################################################################
+bootstrap.include=../testports.properties
+com.ibm.ws.logging.trace.specification=*=info:data=all:persistenceService=all

--- a/dev/io.openliberty.data.internal_fat_errorpaths/publish/servers/io.openliberty.data.internal.fat.errpaths.1.1/server.xml
+++ b/dev/io.openliberty.data.internal_fat_errorpaths/publish/servers/io.openliberty.data.internal.fat.errpaths.1.1/server.xml
@@ -1,0 +1,36 @@
+<!--
+    Copyright (c) 2026 IBM Corporation and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License 2.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-2.0/
+    
+    SPDX-License-Identifier: EPL-2.0
+   
+    Contributors:
+        IBM Corporation - initial API and implementation
+ -->
+<server>
+
+  <featureManager>
+    <feature>componenttest-2.0</feature>
+    <feature>data-1.1</feature>
+    <feature>persistence-3.2</feature>
+    <feature>servlet-6.1</feature>
+  </featureManager>
+
+  <include location="../fatTestPorts.xml"/>
+
+  <data>
+    <logValues>test.jakarta.data.errpaths.v1_1.web</logValues>
+  </data>
+
+  <application location="DataErrPaths_1_1_App.war">
+    <classloader commonLibraryRef="H2Lib"/>
+  </application>
+
+  <library id="H2Lib">
+    <file name="${shared.resource.dir}/h2/h2.jar"/>
+  </library>
+
+</server>

--- a/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPaths_1_1_App/resources/WEB-INF/classes/META-INF/persistence.xml
+++ b/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPaths_1_1_App/resources/WEB-INF/classes/META-INF/persistence.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- 
+/*******************************************************************************
+ * Copyright (c) 2024,2026 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+-->
+<persistence 
+    xmlns="http://java.sun.com/xml/ns/persistence"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://java.sun.com/xml/ns/persistence http://java.sun.com/xml/ns/persistence/persistence_1_0.xsd"
+    version="1.0">
+
+    <!-- A valid persistence unit -->
+    <persistence-unit name="OpsPersistenceUnit">
+        <jta-data-source>java:comp/jdbc/H2</jta-data-source>
+        <class>test.jakarta.data.errpaths.v1_1.web.Operation</class>
+        <exclude-unlisted-classes>true</exclude-unlisted-classes>
+        <properties>
+            <property name="jakarta.persistence.schema-generation.database.action"
+                      value="create"/>
+        </properties>
+    </persistence-unit>
+
+</persistence>

--- a/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPaths_1_1_App/src/test/jakarta/data/errpaths/v1_1/web/DataErrPaths_1_1_Servlet.java
+++ b/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPaths_1_1_App/src/test/jakarta/data/errpaths/v1_1/web/DataErrPaths_1_1_Servlet.java
@@ -1,0 +1,111 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package test.jakarta.data.errpaths.v1_1.web;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import java.util.List;
+
+import jakarta.annotation.Resource;
+import jakarta.annotation.sql.DataSourceDefinition;
+import jakarta.data.exceptions.MappingException;
+import jakarta.data.page.Page;
+import jakarta.data.page.PageRequest;
+import jakarta.inject.Inject;
+import jakarta.servlet.ServletConfig;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.transaction.UserTransaction;
+
+import org.junit.Test;
+
+import componenttest.app.FATServlet;
+
+@DataSourceDefinition(name = "java:comp/jdbc/H2",
+                      className = "org.h2.jdbcx.JdbcDataSource",
+                      url = "jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1",
+                      user = "dbuser1",
+                      password = "dbpwd1")
+@SuppressWarnings("serial")
+@WebServlet("/*")
+public class DataErrPaths_1_1_Servlet extends FATServlet {
+
+    @Inject
+    Operations ops;
+
+    @Resource
+    UserTransaction tx;
+
+    /**
+     * Initialize the database with some data that other tests can try to read.
+     */
+    @Override
+    public void init(ServletConfig config) throws ServletException {
+        ops.define(Operation.of("addition", 2, Character.valueOf('+')));
+        ops.define(Operation.of("subtraction", 2, Character.valueOf('-')));
+        ops.define(Operation.of("multiplication", 2, Character.valueOf('⨉')));
+        ops.define(Operation.of("division", 2, Character.valueOf('÷')));
+        ops.define(Operation.of("square", 1, Character.valueOf('²')));
+        ops.define(Operation.of("square root", 1, Character.valueOf('√')));
+        ops.define(Operation.of("cube", 1, Character.valueOf('³')));
+        ops.define(Operation.of("cube root", 1, Character.valueOf('∛')));
+        ops.define(Operation.of("pi", 0, Character.valueOf('π')));
+        ops.define(Operation.of("equal", 2, Character.valueOf('=')));
+        ops.define(Operation.of("greater than", 2, Character.valueOf('>')));
+        ops.define(Operation.of("greater than or equal", 2, Character.valueOf('≥')));
+        ops.define(Operation.of("less than", 2, Character.valueOf('<')));
+        ops.define(Operation.of("less than or equal", 2, Character.valueOf('≤')));
+        ops.define(Operation.of("not equal", 2, Character.valueOf('≠')));
+        ops.define(Operation.of("element of", 2, Character.valueOf('∈')));
+        ops.define(Operation.of("intersection", 2, Character.valueOf('⋂')));
+        ops.define(Operation.of("subset of", 2, Character.valueOf('⊂')));
+        ops.define(Operation.of("union", 2, Character.valueOf('⋃')));
+    }
+
+    /**
+     * Verify an error is raised when a total count of elements is requested of
+     * a Page that was obtained via a NativeQuery.
+     */
+    @Test
+    public void nativeQueryCountElements() {
+        Page<Character> page = ops.binaryOps(PageRequest.ofSize(5));
+        assertEquals(true,
+                     page.hasContent());
+        assertEquals(5L,
+                     page.numberOfElements());
+        assertEquals(List.of('+', '-', '<', '=', '>'),
+                     page.content());
+        try {
+            long total = page.totalElements();
+            fail("Should not be able to count totalElements from a NativeQuery." +
+                 " Found " + total);
+        } catch (UnsupportedOperationException x) {
+            if (x.getMessage() == null ||
+                //TODO once NLS is added: !x.getMessage().startsWith("CWWKD????E:") ||
+                !x.getMessage().contains("NativeQuery"))
+                throw x;
+        }
+
+        try {
+            long total = page.totalPages();
+            fail("Should not be able to count totalPages from a NativeQuery." +
+                 " Found " + total);
+        } catch (UnsupportedOperationException x) {
+            if (x.getMessage() == null ||
+                //TODO once NLS is added: !x.getMessage().startsWith("CWWKD????E:") ||
+                !x.getMessage().contains("NativeQuery"))
+                throw x;
+        }
+    }
+}

--- a/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPaths_1_1_App/src/test/jakarta/data/errpaths/v1_1/web/DataErrPaths_1_1_Servlet.java
+++ b/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPaths_1_1_App/src/test/jakarta/data/errpaths/v1_1/web/DataErrPaths_1_1_Servlet.java
@@ -19,7 +19,6 @@ import java.util.List;
 
 import jakarta.annotation.Resource;
 import jakarta.annotation.sql.DataSourceDefinition;
-import jakarta.data.exceptions.MappingException;
 import jakarta.data.page.Page;
 import jakarta.data.page.PageRequest;
 import jakarta.inject.Inject;
@@ -79,12 +78,12 @@ public class DataErrPaths_1_1_Servlet extends FATServlet {
      */
     @Test
     public void nativeQueryCountElements() {
-        Page<Character> page = ops.binaryOps(PageRequest.ofSize(5));
+        Page<String> page = ops.binaryOps(PageRequest.ofSize(5));
         assertEquals(true,
                      page.hasContent());
         assertEquals(5L,
                      page.numberOfElements());
-        assertEquals(List.of('+', '-', '<', '=', '>'),
+        assertEquals(List.of("+", "-", "<", "=", ">"),
                      page.content());
         try {
             long total = page.totalElements();
@@ -92,7 +91,7 @@ public class DataErrPaths_1_1_Servlet extends FATServlet {
                  " Found " + total);
         } catch (UnsupportedOperationException x) {
             if (x.getMessage() == null ||
-                //TODO once NLS is added: !x.getMessage().startsWith("CWWKD????E:") ||
+            //TODO once NLS is added: !x.getMessage().startsWith("CWWKD????E:") ||
                 !x.getMessage().contains("NativeQuery"))
                 throw x;
         }
@@ -103,7 +102,7 @@ public class DataErrPaths_1_1_Servlet extends FATServlet {
                  " Found " + total);
         } catch (UnsupportedOperationException x) {
             if (x.getMessage() == null ||
-                //TODO once NLS is added: !x.getMessage().startsWith("CWWKD????E:") ||
+            //TODO once NLS is added: !x.getMessage().startsWith("CWWKD????E:") ||
                 !x.getMessage().contains("NativeQuery"))
                 throw x;
         }

--- a/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPaths_1_1_App/src/test/jakarta/data/errpaths/v1_1/web/Operation.java
+++ b/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPaths_1_1_App/src/test/jakarta/data/errpaths/v1_1/web/Operation.java
@@ -1,0 +1,51 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package test.jakarta.data.errpaths.v1_1.web;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+
+/**
+ * A valid entity. Represents an arithmetic operation such as +
+ */
+@Entity
+public class Operation {
+
+    @Id
+    @Column(nullable = false)
+    public String name;
+
+    @Column(nullable = false)
+    public int numArgs;
+
+    public Character symbol;
+
+    public Operation() {
+    }
+
+    public static Operation of(String name,
+                               int numArgs,
+                               Character symbol) {
+        Operation op = new Operation();
+        op.name = name;
+        op.numArgs = numArgs;
+        op.symbol = symbol;
+        return op;
+    }
+
+    @Override
+    public String toString() {
+        return "Operation:" + name + " " + numArgs + " args " + symbol;
+    }
+}

--- a/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPaths_1_1_App/src/test/jakarta/data/errpaths/v1_1/web/Operations.java
+++ b/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPaths_1_1_App/src/test/jakarta/data/errpaths/v1_1/web/Operations.java
@@ -40,7 +40,7 @@ public interface Operations extends DataRepository<Operation, String> {
                      WHERE COALESCE (numArgs, 0) = 2
                      ORDER BY symbol ASC
                     """)
-    Page<Character> binaryOps(PageRequest req);
+    Page<String> binaryOps(PageRequest req);
 
     @Insert
     void define(Operation op);

--- a/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPaths_1_1_App/src/test/jakarta/data/errpaths/v1_1/web/Operations.java
+++ b/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPaths_1_1_App/src/test/jakarta/data/errpaths/v1_1/web/Operations.java
@@ -1,0 +1,48 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package test.jakarta.data.errpaths.v1_1.web;
+
+import jakarta.data.page.Page;
+import jakarta.data.page.PageRequest;
+import jakarta.data.repository.DataRepository;
+import jakarta.data.repository.Insert;
+import jakarta.data.repository.NativeQuery;
+import jakarta.data.repository.Repository;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.persistence.PersistenceUnit;
+
+/**
+ * Repository with a valid entity.
+ * Some methods are valid.
+ * Others have errors, as indicated.
+ */
+// TODO Remove the PersistenceUnit annotation once Liberty's Jakarta
+// Persistence container integration code implements the requirement to
+// automatically bind the EntityManagerFactory into JNDI
+@PersistenceUnit(name = "java:module/persistence/OpsPersistenceUnit/EntityManagerFactory",
+                 unitName = "OpsPersistenceUnit")
+@Repository(dataStore = "OpsPersistenceUnit")
+public interface Operations extends DataRepository<Operation, String> {
+
+    @NativeQuery("""
+                    SELECT symbol
+                      FROM Operation
+                     WHERE COALESCE (numArgs, 0) = 2
+                     ORDER BY symbol ASC
+                    """)
+    Page<Character> binaryOps(PageRequest req);
+
+    @Insert
+    void define(Operation op);
+
+}

--- a/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPaths_1_1_App/src/test/jakarta/data/errpaths/v1_1/web/_Operation.java
+++ b/dev/io.openliberty.data.internal_fat_errorpaths/test-applications/DataErrPaths_1_1_App/src/test/jakarta/data/errpaths/v1_1/web/_Operation.java
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package test.jakarta.data.errpaths.v1_1.web;
+
+import jakarta.data.metamodel.ComparableAttribute;
+import jakarta.data.metamodel.NumericAttribute;
+import jakarta.data.metamodel.StaticMetamodel;
+import jakarta.data.metamodel.TextAttribute;
+
+/**
+ * Static metamodel for the Operation entity.
+ */
+@StaticMetamodel(Operation.class)
+public interface _Operation {
+
+    String NAME = "name";
+    String NUM_ARGS = "numArgs";
+    String SYMBOL = "symbol";
+
+    TextAttribute<Operation> name = //
+                    TextAttribute.of(Operation.class, NAME);
+
+    NumericAttribute<Operation, Integer> numArgs = //
+                    NumericAttribute.of(Operation.class, NUM_ARGS, int.class);
+
+    ComparableAttribute<Operation, Character> symbol = //
+                    ComparableAttribute.of(Operation.class, SYMBOL, Character.class);
+}

--- a/dev/io.openliberty.jakarta.data.1.1/src/jakarta/data/page/PageRequest.java
+++ b/dev/io.openliberty.jakarta.data.1.1/src/jakarta/data/page/PageRequest.java
@@ -12,11 +12,11 @@
  *******************************************************************************/
 package jakarta.data.page;
 
-import jakarta.annotation.Nonnull;
-import jakarta.annotation.Nullable;
 import java.util.List;
 import java.util.Optional;
 
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 import jakarta.data.messages.Messages;
 
 /**
@@ -90,6 +90,10 @@ public interface PageRequest {
 
     @Nonnull
     public PageRequest pageNumber(long pageNum);
+
+    default long pageOffset() {
+        return pageNumber() - 1;
+    }
 
     @Nonnull
     public default PageRequest pageOffset(long offset) {


### PR DESCRIPTION
Adds offset pagination for NativeQuery methods.  Pages can be requested and obtained for a fixed offset and relative to the offsets bounding a current page.  Totals are not supported for a NativeQuery and must raise UnsupportedOperationException.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
