### PR TITLE
update image; change to create dockerfile

### DIFF
--- a/dev/io.openliberty.microprofile.telemetry.2.0.logging.internal.container_fat/bnd.bnd
+++ b/dev/io.openliberty.microprofile.telemetry.2.0.logging.internal.container_fat/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2024, 2025 IBM Corporation and others.
+# Copyright (c) 2024, 2026 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
@@ -21,7 +21,8 @@ fat.project: true
 # Uncomment to use remote docker host to simulate continuous build behavior.
 #fat.test.use.remote.docker: true
 
-fat.test.container.images: otel/opentelemetry-collector-contrib:0.103.0
+fat.test.container.images: \
+  ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.154.0
 
 tested.features=mpTelemetry-2.0,\
   mpTelemetry-2.1,\

--- a/dev/io.openliberty.microprofile.telemetry.2.0.logging.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/logging/internal/container/fat/JULDuplicateTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.2.0.logging.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/logging/internal/container/fat/JULDuplicateTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024, 2025 IBM Corporation and others.
+ * Copyright (c) 2024, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -51,7 +51,6 @@ public class JULDuplicateTest {
 
     private static final String[] EXPECTED_FAILURES = { "CWMOT5005W", "SRVE0315E", "SRVE0777E" };
 
-    //TODO switch to use ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.117.0
     //TODO remove withDockerfileFromBuilder and instead create a dockerfile
     @ClassRule
     public static GenericContainer<?> container = new GenericContainer<>(new ImageFromDockerfile()
@@ -97,7 +96,7 @@ public class JULDuplicateTest {
         // Wait for the second message (SESN0176I) to arrive, to ensure all the occurrences of the first message (SRVE0250I) has arrived.
         server.waitForStringInLog("SESN0176I");
 
-        TestUtils.isContainerStarted("LogsExporter", container);
+        TestUtils.isContainerStarted("Everything is ready.", container);
 
         RemoteFile messageLogFile = server.getDefaultLogFile();
         setConfig(SERVER_XML_ALL_SOURCES, messageLogFile, server);

--- a/dev/io.openliberty.microprofile.telemetry.2.0.logging.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/logging/internal/container/fat/JULDuplicateTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.2.0.logging.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/logging/internal/container/fat/JULDuplicateTest.java
@@ -23,7 +23,7 @@ import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.testcontainers.containers.GenericContainer;
-import org.testcontainers.images.builder.ImageFromDockerfile;
+import org.testcontainers.utility.MountableFile;
 
 import com.ibm.websphere.simplicity.RemoteFile;
 import com.ibm.websphere.simplicity.ShrinkHelper;
@@ -51,12 +51,10 @@ public class JULDuplicateTest {
 
     private static final String[] EXPECTED_FAILURES = { "CWMOT5005W", "SRVE0315E", "SRVE0777E" };
 
-    //TODO remove withDockerfileFromBuilder and instead create a dockerfile
     @ClassRule
-    public static GenericContainer<?> container = new GenericContainer<>(new ImageFromDockerfile()
-                    .withDockerfileFromBuilder(builder -> builder.from(TestUtils.IMAGE_NAME)
-                                    .copy("/etc/otelcol-contrib/config.yaml", "/etc/otelcol-contrib/config.yaml"))
-                    .withFileFromFile("/etc/otelcol-contrib/config.yaml", new File(TestUtils.PATH_TO_AUTOFVT_TESTFILES + "config.yaml"), 0644))
+    public static GenericContainer<?> container = new GenericContainer<>(TestUtils.IMAGE_NAME)
+                    .withCopyFileToContainer(MountableFile.forHostPath(new File(TestUtils.PATH_TO_AUTOFVT_TESTFILES + "config.yaml").toPath()),
+                                             "/etc/otelcol-contrib/config.yaml")
                     .withLogConsumer(new SimpleLogConsumer(JULDuplicateTest.class, "opentelemetry-collector-contrib"))
                     .withExposedPorts(4317, 4318);
 

--- a/dev/io.openliberty.microprofile.telemetry.2.0.logging.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/logging/internal/container/fat/JULLogServletTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.2.0.logging.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/logging/internal/container/fat/JULLogServletTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024, 2025 IBM Corporation and others.
+ * Copyright (c) 2024, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -49,7 +49,6 @@ public class JULLogServletTest {
 
     private static final String[] EXPECTED_FAILURES = { "CWMOT5005W", "SRVE0315E", "SRVE0777E" };
 
-    //TODO switch to use ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.117.0
     //TODO remove withDockerfileFromBuilder and instead create a dockerfile
     @ClassRule
     public static GenericContainer<?> container = new GenericContainer<>(new ImageFromDockerfile()
@@ -91,7 +90,7 @@ public class JULLogServletTest {
     public void testMatchingJULMessageLogsWithContainerViaOpenTelemetryAgent() throws Exception {
         assertTrue("The server was not started successfully.", server.isStarted());
 
-        TestUtils.isContainerStarted("LogsExporter", container);
+        TestUtils.isContainerStarted("Everything is ready.", container);
 
         TimeUnit.SECONDS.sleep(5);
 

--- a/dev/io.openliberty.microprofile.telemetry.2.0.logging.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/logging/internal/container/fat/JULLogServletTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.2.0.logging.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/logging/internal/container/fat/JULLogServletTest.java
@@ -24,7 +24,7 @@ import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.testcontainers.containers.GenericContainer;
-import org.testcontainers.images.builder.ImageFromDockerfile;
+import org.testcontainers.utility.MountableFile;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
 import com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions;
@@ -49,12 +49,10 @@ public class JULLogServletTest {
 
     private static final String[] EXPECTED_FAILURES = { "CWMOT5005W", "SRVE0315E", "SRVE0777E" };
 
-    //TODO remove withDockerfileFromBuilder and instead create a dockerfile
     @ClassRule
-    public static GenericContainer<?> container = new GenericContainer<>(new ImageFromDockerfile()
-                    .withDockerfileFromBuilder(builder -> builder.from(TestUtils.IMAGE_NAME)
-                                    .copy("/etc/otelcol-contrib/config.yaml", "/etc/otelcol-contrib/config.yaml"))
-                    .withFileFromFile("/etc/otelcol-contrib/config.yaml", new File(TestUtils.PATH_TO_AUTOFVT_TESTFILES + "config.yaml"), 0644))
+    public static GenericContainer<?> container = new GenericContainer<>(TestUtils.IMAGE_NAME)
+                    .withCopyFileToContainer(MountableFile.forHostPath(new File(TestUtils.PATH_TO_AUTOFVT_TESTFILES + "config.yaml").toPath()),
+                                             "/etc/otelcol-contrib/config.yaml")
                     .withLogConsumer(new SimpleLogConsumer(JULLogServletTest.class, "opentelemetry-collector-contrib"))
                     .withExposedPorts(4317, 4318);
 

--- a/dev/io.openliberty.microprofile.telemetry.2.0.logging.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/logging/internal/container/fat/LoggingBridgeServletTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.2.0.logging.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/logging/internal/container/fat/LoggingBridgeServletTest.java
@@ -23,7 +23,7 @@ import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.testcontainers.containers.GenericContainer;
-import org.testcontainers.images.builder.ImageFromDockerfile;
+import org.testcontainers.utility.MountableFile;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
 import com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions;
@@ -43,12 +43,10 @@ public class LoggingBridgeServletTest {
 
     private static final String[] EXPECTED_FAILURES = { "CWMOT5005W", "SRVE0315E", "SRVE0777E" };
 
-    //TODO remove withDockerfileFromBuilder and instead create a dockerfile
     @ClassRule
-    public static GenericContainer<?> container = new GenericContainer<>(new ImageFromDockerfile()
-                    .withDockerfileFromBuilder(builder -> builder.from(TestUtils.IMAGE_NAME)
-                                    .copy("/etc/otelcol-contrib/config.yaml", "/etc/otelcol-contrib/config.yaml"))
-                    .withFileFromFile("/etc/otelcol-contrib/config.yaml", new File(TestUtils.PATH_TO_AUTOFVT_TESTFILES + "config.yaml"), 0644))
+    public static GenericContainer<?> container = new GenericContainer<>(TestUtils.IMAGE_NAME)
+                    .withCopyFileToContainer(MountableFile.forHostPath(new File(TestUtils.PATH_TO_AUTOFVT_TESTFILES + "config.yaml").toPath()),
+                                             "/etc/otelcol-contrib/config.yaml")
                     .withLogConsumer(new SimpleLogConsumer(LoggingBridgeServletTest.class, "opentelemetry-collector-contrib"))
                     .withExposedPorts(4317, 4318);
 

--- a/dev/io.openliberty.microprofile.telemetry.2.0.logging.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/logging/internal/container/fat/LoggingBridgeServletTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.2.0.logging.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/logging/internal/container/fat/LoggingBridgeServletTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 IBM Corporation and others.
+ * Copyright (c) 2024, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -43,7 +43,6 @@ public class LoggingBridgeServletTest {
 
     private static final String[] EXPECTED_FAILURES = { "CWMOT5005W", "SRVE0315E", "SRVE0777E" };
 
-    //TODO switch to use ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.117.0
     //TODO remove withDockerfileFromBuilder and instead create a dockerfile
     @ClassRule
     public static GenericContainer<?> container = new GenericContainer<>(new ImageFromDockerfile()
@@ -83,7 +82,7 @@ public class LoggingBridgeServletTest {
     public void testBridgedLogs() throws Exception {
         assertTrue("The server was not started successfully.", server.isStarted());
 
-        TestUtils.isContainerStarted("LogsExporter", container);
+        TestUtils.isContainerStarted("Everything is ready.", container);
 
         TestUtils.runApp(server, "logs");
 

--- a/dev/io.openliberty.microprofile.telemetry.2.0.logging.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/logging/internal/container/fat/LoggingServletTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.2.0.logging.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/logging/internal/container/fat/LoggingServletTest.java
@@ -24,7 +24,7 @@ import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.testcontainers.containers.GenericContainer;
-import org.testcontainers.images.builder.ImageFromDockerfile;
+import org.testcontainers.utility.MountableFile;
 
 import com.ibm.websphere.simplicity.RemoteFile;
 import com.ibm.websphere.simplicity.ShrinkHelper;
@@ -58,12 +58,10 @@ public class LoggingServletTest {
 
     public static final int WAIT_TIMEOUT = 5; // 5 seconds
 
-    //TODO remove withDockerfileFromBuilder and instead create a dockerfile
     @ClassRule
-    public static GenericContainer<?> container = new GenericContainer<>(new ImageFromDockerfile()
-                    .withDockerfileFromBuilder(builder -> builder.from(TestUtils.IMAGE_NAME)
-                                    .copy("/etc/otelcol-contrib/config.yaml", "/etc/otelcol-contrib/config.yaml"))
-                    .withFileFromFile("/etc/otelcol-contrib/config.yaml", new File(TestUtils.PATH_TO_AUTOFVT_TESTFILES + "config.yaml"), 0644))
+    public static GenericContainer<?> container = new GenericContainer<>(TestUtils.IMAGE_NAME)
+                    .withCopyFileToContainer(MountableFile.forHostPath(new File(TestUtils.PATH_TO_AUTOFVT_TESTFILES + "config.yaml").toPath()),
+                                             "/etc/otelcol-contrib/config.yaml")
                     .withLogConsumer(new SimpleLogConsumer(LoggingServletTest.class, "opentelemetry-collector-contrib"))
                     .withExposedPorts(4317, 4318);
 

--- a/dev/io.openliberty.microprofile.telemetry.2.0.logging.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/logging/internal/container/fat/LoggingServletTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.2.0.logging.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/logging/internal/container/fat/LoggingServletTest.java
@@ -58,7 +58,6 @@ public class LoggingServletTest {
 
     public static final int WAIT_TIMEOUT = 5; // 5 seconds
 
-    //TODO switch to use ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.117.0
     //TODO remove withDockerfileFromBuilder and instead create a dockerfile
     @ClassRule
     public static GenericContainer<?> container = new GenericContainer<>(new ImageFromDockerfile()
@@ -98,7 +97,7 @@ public class LoggingServletTest {
     public void testMessageLogs() throws Exception {
         assertTrue("The server was not started successfully.", server.isStarted());
 
-        TestUtils.isContainerStarted("LogsExporter", container);
+        TestUtils.isContainerStarted("Everything is ready.", container);
 
         RemoteFile messageLogFile = server.getDefaultLogFile();
         setConfig(SERVER_XML_MSG_SOURCES, messageLogFile, server);
@@ -135,7 +134,7 @@ public class LoggingServletTest {
 
         assertTrue("The server was not started successfully.", server.isStarted());
 
-        TestUtils.isContainerStarted("LogsExporter", container);
+        TestUtils.isContainerStarted("Everything is ready.", container);
 
         RemoteFile messageLogFile = server.getDefaultLogFile();
         setConfig(SERVER_XML_TRACE_SOURCE, messageLogFile, server);
@@ -175,7 +174,7 @@ public class LoggingServletTest {
 
         assertTrue("The server was not started successfully.", server.isStarted());
 
-        TestUtils.isContainerStarted("LogsExporter", container);
+        TestUtils.isContainerStarted("Everything is ready.", container);
 
         RemoteFile messageLogFile = server.getDefaultLogFile();
         setConfig(SERVER_XML_FFDC_SOURCE, messageLogFile, server);
@@ -224,7 +223,7 @@ public class LoggingServletTest {
     public void testAuditEventLogs() throws Exception {
         assertTrue("The server was not started successfully.", server.isStarted());
 
-        TestUtils.isContainerStarted("LogsExporter", container);
+        TestUtils.isContainerStarted("Everything is ready.", container);
 
         RemoteFile messageLogFile = server.getDefaultLogFile();
         setConfig(SERVER_XML_AUDIT_SOURCE, messageLogFile, server);
@@ -277,7 +276,7 @@ public class LoggingServletTest {
 
         assertTrue("The server was not started successfully.", server.isStarted());
 
-        TestUtils.isContainerStarted("LogsExporter", container);
+        TestUtils.isContainerStarted("Everything is ready.", container);
 
         RemoteFile messageLogFile = server.getDefaultLogFile();
         setConfig(SERVER_XML_ACCESS_SOURCE, messageLogFile, server);

--- a/dev/io.openliberty.microprofile.telemetry.2.0.logging.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/logging/internal/container/fat/TestUtils.java
+++ b/dev/io.openliberty.microprofile.telemetry.2.0.logging.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/logging/internal/container/fat/TestUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 IBM Corporation and others.
+ * Copyright (c) 2024, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -40,7 +40,7 @@ public class TestUtils {
     protected static final String PATH_TO_AUTOFVT_TESTFILES = "lib/LibertyFATTestFiles/";
 
     protected static final String IMAGE_NAME = ImageNameSubstitutor.instance() //
-                    .apply(DockerImageName.parse("otel/opentelemetry-collector-contrib:0.103.0")).asCanonicalNameString();
+                    .apply(DockerImageName.parse("ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.154.0")).asCanonicalNameString();
 
     public static void runApp(LibertyServer server, String type) throws Exception {
         String url = "http://" + server.getHostname() + ":" + server.getHttpDefaultPort() + "/MpTelemetryLogApp";

--- a/dev/io.openliberty.microprofile.telemetry.2.0.logging.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/logging/internal/container/fat/TestUtils.java
+++ b/dev/io.openliberty.microprofile.telemetry.2.0.logging.internal.container_fat/fat/src/io/openliberty/microprofile/telemetry/logging/internal/container/fat/TestUtils.java
@@ -28,7 +28,6 @@ import javax.net.ssl.X509TrustManager;
 
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.utility.DockerImageName;
-import org.testcontainers.utility.ImageNameSubstitutor;
 
 import com.ibm.websphere.simplicity.log.Log;
 
@@ -39,8 +38,7 @@ public class TestUtils {
     private static Class<?> c = TestUtils.class;
     protected static final String PATH_TO_AUTOFVT_TESTFILES = "lib/LibertyFATTestFiles/";
 
-    protected static final String IMAGE_NAME = ImageNameSubstitutor.instance() //
-                    .apply(DockerImageName.parse("ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.154.0")).asCanonicalNameString();
+    protected static final DockerImageName IMAGE_NAME = DockerImageName.parse("ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.154.0");
 
     public static void runApp(LibertyServer server, String type) throws Exception {
         String url = "http://" + server.getHostname() + ":" + server.getHttpDefaultPort() + "/MpTelemetryLogApp";

--- a/dev/io.openliberty.microprofile.telemetry.internal.monitor_fat/bnd.bnd
+++ b/dev/io.openliberty.microprofile.telemetry.internal.monitor_fat/bnd.bnd
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2024, 2025 IBM Corporation and others.
+# Copyright (c) 2024, 2026 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at

--- a/dev/io.openliberty.microprofile.telemetry.internal.monitor_fat/bnd.bnd
+++ b/dev/io.openliberty.microprofile.telemetry.internal.monitor_fat/bnd.bnd
@@ -53,7 +53,8 @@ tested.features:\
 # Uncomment to use remote docker host to simulate continuous build behavior.
 #fat.test.use.remote.docker: true
 
-fat.test.container.images: otel/opentelemetry-collector-contrib:0.103.0
+fat.test.container.images: \
+  ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.154.0
 	
 # To define a global minimum java level for the FAT, use the following property.
 # If unspecified, the default value is ${javac.source}

--- a/dev/io.openliberty.microprofile.telemetry.internal.monitor_fat/fat/src/io/openliberty/microprofile/telemetry/internal/monitor_fat/BaseTestClass.java
+++ b/dev/io.openliberty.microprofile.telemetry.internal.monitor_fat/fat/src/io/openliberty/microprofile/telemetry/internal/monitor_fat/BaseTestClass.java
@@ -22,7 +22,6 @@ import java.util.function.Supplier;
 import org.junit.Assert;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.utility.DockerImageName;
-import org.testcontainers.utility.ImageNameSubstitutor;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
 import com.ibm.websphere.simplicity.log.Log;
@@ -39,8 +38,7 @@ public abstract class BaseTestClass {
 
     protected static final String PATH_TO_AUTOFVT_TESTFILES = "lib/LibertyFATTestFiles/";
 
-    protected static final String IMAGE_NAME = ImageNameSubstitutor.instance() //
-                    .apply(DockerImageName.parse("otel/opentelemetry-collector-contrib:0.103.0")).asCanonicalNameString();
+    protected static final DockerImageName IMAGE_NAME = DockerImageName.parse("ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.154.0");
 
     
     protected String requestContainerHttpServlet(String servletPath, String host, int port, String requestMethod, String query) {

--- a/dev/io.openliberty.microprofile.telemetry.internal.monitor_fat/fat/src/io/openliberty/microprofile/telemetry/internal/monitor_fat/ConnectionPoolMetricsTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.internal.monitor_fat/fat/src/io/openliberty/microprofile/telemetry/internal/monitor_fat/ConnectionPoolMetricsTest.java
@@ -22,7 +22,7 @@ import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.testcontainers.containers.GenericContainer;
-import org.testcontainers.images.builder.ImageFromDockerfile;
+import org.testcontainers.utility.MountableFile;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
 import com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions;
@@ -49,15 +49,12 @@ public class ConnectionPoolMetricsTest extends BaseTestClass {
     @ClassRule
     public static RepeatTests rt = FATSuite.testRepeatMPTel20(SERVER_NAME);
 	
-    //TODO switch to use ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.117.0
-    //TODO remove withDockerfileFromBuilder and instead create a dockerfile
-	@ClassRule
-	public static GenericContainer<?> container = new GenericContainer<>(new ImageFromDockerfile()
-			.withDockerfileFromBuilder(builder -> builder.from(IMAGE_NAME).copy("/etc/otelcol-contrib/config.yaml",
-					"/etc/otelcol-contrib/config.yaml"))
-			.withFileFromFile("/etc/otelcol-contrib/config.yaml", new File(PATH_TO_AUTOFVT_TESTFILES + "config.yaml")))
-			.withLogConsumer(new SimpleLogConsumer(ConnectionPoolMetricsTest.class, "opentelemetry-collector-contrib"))
-			.withExposedPorts(8888, 8889, 4317);
+ @ClassRule
+ public static GenericContainer<?> container = new GenericContainer<>(IMAGE_NAME)
+   .withCopyFileToContainer(MountableFile.forHostPath(new File(PATH_TO_AUTOFVT_TESTFILES + "config.yaml").toPath()),
+    	"/etc/otelcol-contrib/config.yaml")
+   .withLogConsumer(new SimpleLogConsumer(ConnectionPoolMetricsTest.class, "opentelemetry-collector-contrib"))
+   .withExposedPorts(8888, 8889, 4317);
 
 	@BeforeClass
 	public static void beforeClass() throws Exception {

--- a/dev/io.openliberty.microprofile.telemetry.internal.monitor_fat/fat/src/io/openliberty/microprofile/telemetry/internal/monitor_fat/LibertyMetricsTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.internal.monitor_fat/fat/src/io/openliberty/microprofile/telemetry/internal/monitor_fat/LibertyMetricsTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024, 2025 IBM Corporation and others.
+ * Copyright (c) 2024, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/dev/io.openliberty.microprofile.telemetry.internal.monitor_fat/fat/src/io/openliberty/microprofile/telemetry/internal/monitor_fat/LibertyMetricsTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.internal.monitor_fat/fat/src/io/openliberty/microprofile/telemetry/internal/monitor_fat/LibertyMetricsTest.java
@@ -20,7 +20,7 @@ import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.testcontainers.containers.GenericContainer;
-import org.testcontainers.images.builder.ImageFromDockerfile;
+import org.testcontainers.utility.MountableFile;
 
 import com.ibm.websphere.simplicity.log.Log;
 
@@ -44,15 +44,12 @@ public class LibertyMetricsTest extends BaseTestClass {
     @ClassRule
     public static RepeatTests rt = FATSuite.testRepeatMPTel20(SERVER_NAME);
 	
-    //TODO switch to use ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.117.0
-    //TODO remove withDockerfileFromBuilder and instead create a dockerfile
-	@ClassRule
-	public static GenericContainer<?> container = new GenericContainer<>(new ImageFromDockerfile()
-			.withDockerfileFromBuilder(builder -> builder.from(IMAGE_NAME).copy("/etc/otelcol-contrib/config.yaml",
-					"/etc/otelcol-contrib/config.yaml"))
-			.withFileFromFile("/etc/otelcol-contrib/config.yaml", new File(PATH_TO_AUTOFVT_TESTFILES + "config.yaml")))
-			.withLogConsumer(new SimpleLogConsumer(LibertyMetricsTest.class, "opentelemetry-collector-contrib"))
-			.withExposedPorts(8888, 8889, 4317);
+ @ClassRule
+ public static GenericContainer<?> container = new GenericContainer<>(IMAGE_NAME)
+   .withCopyFileToContainer(MountableFile.forHostPath(new File(PATH_TO_AUTOFVT_TESTFILES + "config.yaml").toPath()),
+    	"/etc/otelcol-contrib/config.yaml")
+   .withLogConsumer(new SimpleLogConsumer(LibertyMetricsTest.class, "opentelemetry-collector-contrib"))
+   .withExposedPorts(8888, 8889, 4317);
 
 	@BeforeClass
 	public static void beforeClass() throws Exception {

--- a/dev/io.openliberty.microprofile.telemetry.internal.monitor_fat/fat/src/io/openliberty/microprofile/telemetry/internal/monitor_fat/SessionMetricsTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.internal.monitor_fat/fat/src/io/openliberty/microprofile/telemetry/internal/monitor_fat/SessionMetricsTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024, 2025 IBM Corporation and others.
+ * Copyright (c) 2024, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/dev/io.openliberty.microprofile.telemetry.internal.monitor_fat/fat/src/io/openliberty/microprofile/telemetry/internal/monitor_fat/SessionMetricsTest.java
+++ b/dev/io.openliberty.microprofile.telemetry.internal.monitor_fat/fat/src/io/openliberty/microprofile/telemetry/internal/monitor_fat/SessionMetricsTest.java
@@ -22,7 +22,7 @@ import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.testcontainers.containers.GenericContainer;
-import org.testcontainers.images.builder.ImageFromDockerfile;
+import org.testcontainers.utility.MountableFile;
 
 import com.ibm.websphere.simplicity.ShrinkHelper;
 import com.ibm.websphere.simplicity.ShrinkHelper.DeployOptions;
@@ -47,15 +47,12 @@ public class SessionMetricsTest extends BaseTestClass {
     @ClassRule
     public static RepeatTests rt = FATSuite.testRepeatMPTel20(SERVER_NAME);
 	
-    //TODO switch to use ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.117.0
-    //TODO remove withDockerfileFromBuilder and instead create a dockerfile
-	@ClassRule
-	public static GenericContainer<?> container = new GenericContainer<>(new ImageFromDockerfile()
-			.withDockerfileFromBuilder(builder -> builder.from(IMAGE_NAME).copy("/etc/otelcol-contrib/config.yaml",
-					"/etc/otelcol-contrib/config.yaml"))
-			.withFileFromFile("/etc/otelcol-contrib/config.yaml", new File(PATH_TO_AUTOFVT_TESTFILES + "config.yaml")))
-			.withLogConsumer(new SimpleLogConsumer(SessionMetricsTest.class, "opentelemetry-collector-contrib"))
-			.withExposedPorts(8888, 8889, 4317);
+ @ClassRule
+ public static GenericContainer<?> container = new GenericContainer<>(IMAGE_NAME)
+   .withCopyFileToContainer(MountableFile.forHostPath(new File(PATH_TO_AUTOFVT_TESTFILES + "config.yaml").toPath()),
+    	"/etc/otelcol-contrib/config.yaml")
+   .withLogConsumer(new SimpleLogConsumer(SessionMetricsTest.class, "opentelemetry-collector-contrib"))
+   .withExposedPorts(8888, 8889, 4317);
 
 	@BeforeClass
 	public static void beforeClass() throws Exception {
@@ -109,11 +106,11 @@ public class SessionMetricsTest extends BaseTestClass {
 
 		// Allow time for the collector to receive and expose metrics
 		matchStringsWithRetries(() -> getContainerCollectorMetrics(container),
-                new String[] { "io_openliberty_session_created_total\\{instance=\"[a-zA-Z0-9-]*\",io_openliberty_app_name=\"default_host/testSessionApp\",job=\"unknown_service\"\\}.*",
-                        "io_openliberty_session_live\\{instance=\"[a-zA-Z0-9-]*\",io_openliberty_app_name=\"default_host/testSessionApp\",job=\"unknown_service\"\\}.*",
-                        "io_openliberty_session_active\\{instance=\"[a-zA-Z0-9-]*\",io_openliberty_app_name=\"default_host/testSessionApp\",job=\"unknown_service\"\\}.*",
-                        "io_openliberty_session_invalidated_total\\{instance=\"[a-zA-Z0-9-]*\",io_openliberty_app_name=\"default_host/testSessionApp\",job=\"unknown_service\"\\}.*",
-                        "io_openliberty_session_invalidated_by_timeout_total\\{instance=\"[a-zA-Z0-9-]*\",io_openliberty_app_name=\"default_host/testSessionApp\",job=\"unknown_service\"\\}.*" });
+		              new String[] { "io_openliberty_session_created_total\\{.*io_openliberty_app_name=\"default_host/testSessionApp\".*\\}.*",
+		                      "io_openliberty_session_live\\{.*io_openliberty_app_name=\"default_host/testSessionApp\".*\\}.*",
+		                      "io_openliberty_session_active\\{.*io_openliberty_app_name=\"default_host/testSessionApp\".*\\}.*",
+		                      "io_openliberty_session_invalidated_total\\{.*io_openliberty_app_name=\"default_host/testSessionApp\".*\\}.*",
+		                      "io_openliberty_session_invalidated_by_timeout_total\\{.*io_openliberty_app_name=\"default_host/testSessionApp\".*\\}.*" });
 	}
 	
 

--- a/dev/io.openliberty.microprofile.telemetry.internal.monitor_fat/publish/files/config.yaml
+++ b/dev/io.openliberty.microprofile.telemetry.internal.monitor_fat/publish/files/config.yaml
@@ -2,6 +2,7 @@ receivers:
   otlp:
     protocols:
         grpc:
+          endpoint: "0.0.0.0:4317"
 
 exporters:
   prometheus:

--- a/dev/io.openliberty.org.testcontainers/cache/externals
+++ b/dev/io.openliberty.org.testcontainers/cache/externals
@@ -5,6 +5,7 @@ fbicodex/spnego-kdc-server:1.0
 ghcr.io/gvenzl/oracle-free:23.26.2-full-faststart
 ghcr.io/gvenzl/oracle-free:23.9-full-faststart
 ghcr.io/gvenzl/oracle-free:23.9-slim-faststart
+ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.154.0
 ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:0.127.0
 ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:0.150.1
 ghcr.io/openzipkin/zipkin-slim:3.6
@@ -40,7 +41,6 @@ localhost/openliberty/testcontainers/spnego-kdc-server:1.0.0.1
 localhost/openliberty/testcontainers/sqlserver-ssl:2022.0.0.1-latest
 mariadb:10.3
 mcr.microsoft.com/mssql/server:2022-latest
-otel/opentelemetry-collector-contrib:0.103.0
 public.ecr.aws/docker/library/alpine:3
 public.ecr.aws/docker/library/alpine:3.17
 public.ecr.aws/docker/library/couchdb:3

--- a/dev/io.openliberty.org.testcontainers/cache/images
+++ b/dev/io.openliberty.org.testcontainers/cache/images
@@ -12,6 +12,7 @@ wasliberty-aws-docker-remote/elastic/logstash:9.3.3
 wasliberty-ghcr-docker-remote/gvenzl/oracle-free:23.26.2-full-faststart
 wasliberty-ghcr-docker-remote/gvenzl/oracle-free:23.9-full-faststart
 wasliberty-ghcr-docker-remote/gvenzl/oracle-free:23.9-slim-faststart
+wasliberty-ghcr-docker-remote/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.154.0
 wasliberty-ghcr-docker-remote/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:0.127.0
 wasliberty-ghcr-docker-remote/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:0.150.1
 wasliberty-ghcr-docker-remote/openzipkin/zipkin-slim:3.6
@@ -32,7 +33,6 @@ wasliberty-infrastructure-docker/jiwoo/squid-proxy:1.0
 wasliberty-infrastructure-docker/letsencrypt/pebble-challtestsrv:v2.3.1
 wasliberty-infrastructure-docker/letsencrypt/pebble:v2.3.1
 wasliberty-infrastructure-docker/mariadb:10.3
-wasliberty-infrastructure-docker/otel/opentelemetry-collector-contrib:0.103.0
 wasliberty-infrastructure-docker/ryanesch/acme-boulder:1.2
 wasliberty-infrastructure-docker/seleniarm/standalone-chromium:4.8.3
 wasliberty-infrastructure-docker/selenium/standalone-chrome:4.8.3


### PR DESCRIPTION
Update container images for io.openliberty.microprofile.telemetry.2.0.logging.internal.container_fat, and create dockerfile instead of using withDockerfileFromBuilder

- [ ] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [ ] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [ ] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".