### PR TITLE
Fix CPU limits not working on CpuInfo.java with cgroupsv2 support #24588

### DIFF
--- a/dev/com.ibm.ws.kernel.boot_fat/publish/servers/com.ibm.ws.kernel.service/server.xml
+++ b/dev/com.ibm.ws.kernel.boot_fat/publish/servers/com.ibm.ws.kernel.service/server.xml
@@ -13,6 +13,9 @@
 <server>
 <!-- Note fatTestPort is not included because we control creation of all ports in fats  -->
 	<include location="../fatTestCommon.xml"/>
+
+    <!-- Temporary: enable CpuInfo trace for cgroups v2 fix verification - remove before merge -->
+    <logging traceSpecification="com.ibm.ws.kernel.service.util.CpuInfo=all" traceFileName="trace.log"/>
 	
     <featureManager>
         <feature>localConnector-1.0</feature>

--- a/dev/com.ibm.ws.kernel.service/src/com/ibm/ws/kernel/service/util/CpuInfo.java
+++ b/dev/com.ibm.ws.kernel.service/src/com/ibm/ws/kernel/service/util/CpuInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2022 IBM Corporation and others.
+ * Copyright (c) 2018, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -200,46 +200,110 @@ public class CpuInfo {
         return cpuUsage;
     }
 
-    // utility below parses cpu limits info from Docker files
+    // cgroups v1 file paths
+    static final String CGROUP_V1_PERIOD_FILE = "/sys/fs/cgroup/cpu/cpu.cfs_period_us";
+    static final String CGROUP_V1_QUOTA_FILE = "/sys/fs/cgroup/cpu/cpu.cfs_quota_us";
+
+    // cgroups v2 file paths
+    // /sys/fs/cgroup/cgroup.controllers is the canonical marker for a v2 hierarchy.
+    // /sys/fs/cgroup/cpu.max contains "quota period" on one line, or "max period" when unlimited.
+    static final String CGROUP_V2_MARKER_FILE = "/sys/fs/cgroup/cgroup.controllers";
+    static final String CGROUP_V2_CPU_MAX_FILE = "/sys/fs/cgroup/cpu.max";
+
+    // Sentinel value in cpu.max meaning "no quota limit"
+    private static final String CGROUP_V2_CPU_MAX_UNLIMITED = "max";
+
+    // utility below parses cpu limits info from cgroup files (v1 and v2)
     private static float getAvailableProcessorsFromFilesystemFloat() {
+        return getAvailableProcessorsFromFilesystemFloat(CGROUP_V1_PERIOD_FILE, CGROUP_V1_QUOTA_FILE, CGROUP_V2_CPU_MAX_FILE);
+    }
+
+    // Package-private overload to allow unit tests to supply custom file paths
+    static float getAvailableProcessorsFromFilesystemFloat(String v1PeriodPath, String v1QuotaPath, String v2CpuMaxPath) {
         boolean isTraceOn = TraceComponent.isAnyTracingEnabled();
 
         float availableProcessorsFloat = -1;
 
-        //Check for docker files
-        String periodFileLocation = File.separator + "sys" + File.separator + "fs" + File.separator + "cgroup" + File.separator + "cpu" + File.separator + "cpu.cfs_period_us";
-        String quotaFileLocation = File.separator + "sys" + File.separator + "fs" + File.separator + "cgroup" + File.separator + "cpu" + File.separator + "cpu.cfs_quota_us";
-        File cfsPeriod = new File(periodFileLocation);
-        File cfsQuota = new File(quotaFileLocation);
-        if (cfsPeriod.exists() && cfsQuota.exists()) { //Found docker files
-            //Read quota
+        // --- cgroups v1: /sys/fs/cgroup/cpu/cpu.cfs_period_us + cpu.cfs_quota_us ---
+        // Try v1 first. This also covers hybrid environments (e.g. AKS 1.25) where
+        // both v1 and v2 structures are present, since v1 files will still exist.
+        File cfsPeriod = new File(v1PeriodPath);
+        File cfsQuota = new File(v1QuotaPath);
+        if (cfsPeriod.exists() && cfsQuota.exists()) {
+            if (isTraceOn && tc.isDebugEnabled())
+                Tr.debug(tc, "Found cgroups v1 cpu files");
             try {
                 String quotaContents = readFile(cfsQuota);
-                float quotaFloat = Float.parseFloat(quotaContents);
+                float quotaFloat = Float.parseFloat(quotaContents.trim());
                 if (isTraceOn && tc.isDebugEnabled())
                     Tr.debug(tc, "quotaFloat = " + quotaFloat);
                 if (quotaFloat >= 0) {
-                    //Read period
                     String periodContents = readFile(cfsPeriod);
-                    float periodFloat = Float.parseFloat(periodContents);
+                    float periodFloat = Float.parseFloat(periodContents.trim());
                     if (isTraceOn && tc.isDebugEnabled())
                         Tr.debug(tc, "periodFloat = " + periodFloat);
                     if (periodFloat != 0) {
                         availableProcessorsFloat = quotaFloat / periodFloat;
                         availableProcessorsFloat = roundToTwoDecimalPlaces(availableProcessorsFloat);
                         if (isTraceOn && tc.isDebugEnabled())
-                            Tr.debug(tc, "Calculated availableProcessors: " + availableProcessorsFloat + ". period=" + periodFloat + ", quota=" + quotaFloat);
+                            Tr.debug(tc, "Calculated availableProcessors (v1): " + availableProcessorsFloat + ". period=" + periodFloat + ", quota=" + quotaFloat);
                     }
                 }
             } catch (Throwable e) {
                 if (isTraceOn && tc.isDebugEnabled())
-                    Tr.debug(tc, "Caught exception: " + e.getMessage() + ". Using number of processors reported by java");
+                    Tr.debug(tc, "Caught exception reading cgroups v1 cpu files: " + e.getMessage() + ". Trying cgroups v2.");
                 availableProcessorsFloat = -1;
             }
         } else {
             if (isTraceOn && tc.isDebugEnabled()) {
-                Tr.debug(tc, "Files " + quotaFileLocation + " : " + cfsQuota.exists());
-                Tr.debug(tc, "Files " + periodFileLocation + " : " + cfsPeriod.exists());
+                Tr.debug(tc, "cgroups v1 cpu files not found: " + CGROUP_V1_QUOTA_FILE + " exists=" + cfsQuota.exists()
+                             + ", " + CGROUP_V1_PERIOD_FILE + " exists=" + cfsPeriod.exists());
+            }
+        }
+
+        // --- cgroups v2: /sys/fs/cgroup/cpu.max ---
+        // Only attempt if v1 did not yield a result.
+        // Format: "<quota> <period>" or "max <period>" (unlimited).
+        if (availableProcessorsFloat <= 0) {
+            File cpuMax = new File(v2CpuMaxPath);
+            if (cpuMax.exists()) {
+                if (isTraceOn && tc.isDebugEnabled())
+                    Tr.debug(tc, "Found cgroups v2 cpu.max file");
+                try {
+                    String cpuMaxContents = readFile(cpuMax).trim();
+                    String[] parts = cpuMaxContents.split("\\s+");
+                    if (parts.length == 2) {
+                        String quotaPart = parts[0];
+                        String periodPart = parts[1];
+                        if (CGROUP_V2_CPU_MAX_UNLIMITED.equals(quotaPart)) {
+                            // "max" means no quota is set — leave availableProcessorsFloat as -1
+                            // so the caller falls back to Runtime.getRuntime().availableProcessors()
+                            if (isTraceOn && tc.isDebugEnabled())
+                                Tr.debug(tc, "cgroups v2 cpu.max quota is unlimited, using JVM reported processors");
+                        } else {
+                            float quotaFloat = Float.parseFloat(quotaPart);
+                            float periodFloat = Float.parseFloat(periodPart);
+                            if (isTraceOn && tc.isDebugEnabled())
+                                Tr.debug(tc, "cgroups v2 quotaFloat=" + quotaFloat + ", periodFloat=" + periodFloat);
+                            if (quotaFloat >= 0 && periodFloat != 0) {
+                                availableProcessorsFloat = quotaFloat / periodFloat;
+                                availableProcessorsFloat = roundToTwoDecimalPlaces(availableProcessorsFloat);
+                                if (isTraceOn && tc.isDebugEnabled())
+                                    Tr.debug(tc, "Calculated availableProcessors (v2): " + availableProcessorsFloat + ". period=" + periodFloat + ", quota=" + quotaFloat);
+                            }
+                        }
+                    } else {
+                        if (isTraceOn && tc.isDebugEnabled())
+                            Tr.debug(tc, "Unexpected cgroups v2 cpu.max format: " + cpuMaxContents + ". Using number of processors reported by java");
+                    }
+                } catch (Throwable e) {
+                    if (isTraceOn && tc.isDebugEnabled())
+                        Tr.debug(tc, "Caught exception reading cgroups v2 cpu.max: " + e.getMessage() + ". Using number of processors reported by java");
+                    availableProcessorsFloat = -1;
+                }
+            } else {
+                if (isTraceOn && tc.isDebugEnabled())
+                    Tr.debug(tc, "cgroups v2 cpu.max file not found: " + CGROUP_V2_CPU_MAX_FILE);
             }
         }
 

--- a/dev/com.ibm.ws.kernel.service/test/com/ibm/ws/kernel/service/util/CpuInfoFilesystemTest.java
+++ b/dev/com.ibm.ws.kernel.service/test/com/ibm/ws/kernel/service/util/CpuInfoFilesystemTest.java
@@ -1,0 +1,191 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.kernel.service.util;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.file.Files;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import com.ibm.ws.kernel.service.util.CpuInfo;
+
+/**
+ * Unit tests for the cgroup filesystem parsing logic in CpuInfo.
+ * Tests cgroups v1, v2, hybrid, and no-cgroup scenarios by writing
+ * temporary files and supplying their paths to the package-private overload.
+ */
+public class CpuInfoFilesystemTest {
+
+    @Rule
+    public final TemporaryFolder tmpFolder = new TemporaryFolder();
+
+    // Paths supplied to the method under test; set per test case
+    private String v1PeriodPath;
+    private String v1QuotaPath;
+    private String v2CpuMaxPath;
+
+    // Non-existent sentinel path used when a file should be absent
+    private String absentPath;
+
+    @Before
+    public void setUp() throws IOException {
+        absentPath = new File(tmpFolder.getRoot(), "does-not-exist").getAbsolutePath();
+        // Default: no files present (all absent)
+        v1PeriodPath = absentPath;
+        v1QuotaPath = absentPath;
+        v2CpuMaxPath = absentPath;
+    }
+
+    @After
+    public void tearDown() {
+        // TemporaryFolder cleans up automatically
+    }
+
+    // -----------------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------------
+
+    private File writeFile(String name, String content) throws IOException {
+        File f = tmpFolder.newFile(name);
+        try (FileWriter fw = new FileWriter(f)) {
+            fw.write(content);
+        }
+        return f;
+    }
+
+    private static void assertNearlyEqual(float expected, float actual) {
+        assertTrue("Expected ~" + expected + " but got " + actual,
+                   Math.abs(expected - actual) < 0.01f);
+    }
+
+    // -----------------------------------------------------------------------
+    // cgroups v1 tests
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testV1_halfCpu() throws IOException {
+        // quota=50000, period=100000 → 0.50 CPUs
+        v1QuotaPath = writeFile("cpu.cfs_quota_us", "50000\n").getAbsolutePath();
+        v1PeriodPath = writeFile("cpu.cfs_period_us", "100000\n").getAbsolutePath();
+
+        float result = CpuInfo.getAvailableProcessorsFromFilesystemFloat(v1PeriodPath, v1QuotaPath, v2CpuMaxPath);
+        assertNearlyEqual(0.50f, result);
+    }
+
+    @Test
+    public void testV1_twoCpus() throws IOException {
+        // quota=200000, period=100000 → 2.00 CPUs
+        v1QuotaPath = writeFile("cpu.cfs_quota_us_2", "200000\n").getAbsolutePath();
+        v1PeriodPath = writeFile("cpu.cfs_period_us_2", "100000\n").getAbsolutePath();
+
+        float result = CpuInfo.getAvailableProcessorsFromFilesystemFloat(v1PeriodPath, v1QuotaPath, v2CpuMaxPath);
+        assertNearlyEqual(2.00f, result);
+    }
+
+    @Test
+    public void testV1_negativeQuotaMeansUnlimited() throws IOException {
+        // quota=-1 means no limit in v1; should return -1 so caller falls back to Runtime
+        v1QuotaPath = writeFile("cpu.cfs_quota_us_neg", "-1\n").getAbsolutePath();
+        v1PeriodPath = writeFile("cpu.cfs_period_us_neg", "100000\n").getAbsolutePath();
+
+        float result = CpuInfo.getAvailableProcessorsFromFilesystemFloat(v1PeriodPath, v1QuotaPath, v2CpuMaxPath);
+        assertTrue("Expected -1 for unlimited v1 quota, got: " + result, result <= 0);
+    }
+
+    // -----------------------------------------------------------------------
+    // cgroups v2 tests
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testV2_halfCpu() throws IOException {
+        // cpu.max: "50000 100000" → 0.50 CPUs
+        v2CpuMaxPath = writeFile("cpu.max", "50000 100000\n").getAbsolutePath();
+
+        float result = CpuInfo.getAvailableProcessorsFromFilesystemFloat(v1PeriodPath, v1QuotaPath, v2CpuMaxPath);
+        assertNearlyEqual(0.50f, result);
+    }
+
+    @Test
+    public void testV2_twoCpus() throws IOException {
+        // cpu.max: "200000 100000" → 2.00 CPUs
+        v2CpuMaxPath = writeFile("cpu.max_2", "200000 100000\n").getAbsolutePath();
+
+        float result = CpuInfo.getAvailableProcessorsFromFilesystemFloat(v1PeriodPath, v1QuotaPath, v2CpuMaxPath);
+        assertNearlyEqual(2.00f, result);
+    }
+
+    @Test
+    public void testV2_unlimitedQuota() throws IOException {
+        // cpu.max: "max 100000" → no limit; should return -1
+        v2CpuMaxPath = writeFile("cpu.max_unlimited", "max 100000\n").getAbsolutePath();
+
+        float result = CpuInfo.getAvailableProcessorsFromFilesystemFloat(v1PeriodPath, v1QuotaPath, v2CpuMaxPath);
+        assertTrue("Expected -1 for unlimited v2 quota, got: " + result, result <= 0);
+    }
+
+    @Test
+    public void testV2_malformedFile() throws IOException {
+        // cpu.max with unexpected content should not throw; should return -1
+        v2CpuMaxPath = writeFile("cpu.max_bad", "not-a-number garbage extra\n").getAbsolutePath();
+
+        float result = CpuInfo.getAvailableProcessorsFromFilesystemFloat(v1PeriodPath, v1QuotaPath, v2CpuMaxPath);
+        assertTrue("Expected -1 for malformed v2 cpu.max, got: " + result, result <= 0);
+    }
+
+    // -----------------------------------------------------------------------
+    // No cgroup files present
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testNoCgroupFiles_returnsNegative() {
+        // Neither v1 nor v2 files exist → -1 so caller uses Runtime
+        float result = CpuInfo.getAvailableProcessorsFromFilesystemFloat(v1PeriodPath, v1QuotaPath, v2CpuMaxPath);
+        assertTrue("Expected -1 when no cgroup files present, got: " + result, result <= 0);
+    }
+
+    // -----------------------------------------------------------------------
+    // Hybrid: both v1 and v2 files present (e.g. AKS 1.25)
+    // v1 should take priority
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testHybrid_v1TakesPriority() throws IOException {
+        // v1 says 0.5 CPU, v2 says 2.0 CPU — v1 must win
+        v1QuotaPath = writeFile("cpu.cfs_quota_us_h", "50000\n").getAbsolutePath();
+        v1PeriodPath = writeFile("cpu.cfs_period_us_h", "100000\n").getAbsolutePath();
+        v2CpuMaxPath = writeFile("cpu.max_h", "200000 100000\n").getAbsolutePath();
+
+        float result = CpuInfo.getAvailableProcessorsFromFilesystemFloat(v1PeriodPath, v1QuotaPath, v2CpuMaxPath);
+        assertNearlyEqual(0.50f, result);
+    }
+
+    @Test
+    public void testHybrid_v1UnlimitedFallsBackToV2() throws IOException {
+        // v1 quota=-1 (unlimited), v2 says 1.5 CPUs — should fall back to v2
+        v1QuotaPath = writeFile("cpu.cfs_quota_us_fb", "-1\n").getAbsolutePath();
+        v1PeriodPath = writeFile("cpu.cfs_period_us_fb", "100000\n").getAbsolutePath();
+        v2CpuMaxPath = writeFile("cpu.max_fb", "150000 100000\n").getAbsolutePath();
+
+        float result = CpuInfo.getAvailableProcessorsFromFilesystemFloat(v1PeriodPath, v1QuotaPath, v2CpuMaxPath);
+        assertNearlyEqual(1.50f, result);
+    }
+}


### PR DESCRIPTION
Issue Link: [24588](https://github.com/OpenLiberty/open-liberty/issues/24588)

### The Issue

Liberty was blind to CPU limits in modern Linux containers due to cgroupsv1 no longer existing on Linux kernel 4.5+ systems. When this happened it defaulted back to ``availableProcessors()`` which looks at the JDK. Modern JDKs could read cgroupv2 correctly but the JVM would return a rounded integer instead of a float which could cause incorrect logic based on if the actual value. Ex: ``--cpus=0.5`` would be reported as ``1`` through ``availableProcessors()`` . Because of this, CPU usage was off by up to 2x for fractional allocations. i.e. ``1 * 100=100`` would be reported as opposed to ``0.5*100=50``.

Older JDKs that can't report cgroupv2 would default back to the full host CPU count ignoring container limits.

In the context of cgroups and cpu limits, v1 and v2 differ here:

v1 - two separate files, each containing a single number:
```
/sys/fs/cgroup/cpu/cpu.cfs_quota_us   → 50000
/sys/fs/cgroup/cpu/cpu.cfs_period_us  → 100000
```
v2 - one line, both values on one line:
```
/sys/fs/cgroup/cpu.max   → 50000 100000
```
### Updates

#### CpuInfo.java
+ Changed initial strings into named constants.
+ ``private static float getAvailableProcessorsFromFilesystemFloat()`` - parses for cpu limits from both cgroupsv1 and cgroupsv2 files
+ cgroupsv2 block + logic to handle hybrid where both cgroupsv1 and v2 are reported

+ CpuInfoFilesystemTest.java - Unit Tests

### Verification
Testing in Progress, will update further