### PR TITLE
Add realmName and realmIdentifier attributes to mpJwt element

### DIFF
--- a/dev/com.ibm.ws.security.jwtsso/src/com/ibm/ws/security/jwtsso/internal/JwtSsoComponent.java
+++ b/dev/com.ibm.ws.security.jwtsso/src/com/ibm/ws/security/jwtsso/internal/JwtSsoComponent.java
@@ -355,6 +355,18 @@ public class JwtSsoComponent implements JwtSsoConfig {
 
     /** {@inheritDoc} */
     @Override
+    public String getRealmIdentifier() {
+        return null;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public String getRealmName() {
+        return null;
+    }
+
+    /** {@inheritDoc} */
+    @Override
     public boolean ignoreApplicationAuthMethod() {
         return true;
     }

--- a/dev/com.ibm.ws.security.mp.jwt.1.1_fat.commonTest/fat/src/com/ibm/ws/security/mp/jwt11/fat/MPJwtRealmConfigTests.java
+++ b/dev/com.ibm.ws.security.mp.jwt.1.1_fat.commonTest/fat/src/com/ibm/ws/security/mp/jwt11/fat/MPJwtRealmConfigTests.java
@@ -17,6 +17,8 @@ import java.util.List;
 
 import javax.servlet.http.HttpServletResponse;
 
+import com.ibm.ws.security.fat.common.jwt.JwtConstants;
+
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -136,8 +138,9 @@ public class MPJwtRealmConfigTests extends MPJwt11MPConfigTests {
         resourceServer.reconfigureServerUsingExpandedConfiguration(_testName, "rs_server_realmIdentifier_realmClaim.xml");
 
         List<NameValuePair> extraClaims = new ArrayList<NameValuePair>();
+        extraClaims.add(new NameValuePair(JwtConstants.PARAM_UPN, MPJwt11FatConstants.TESTUSER));
         extraClaims.add(new NameValuePair("realm", "TokenRealm"));
-        String builtToken = actions.getJwtTokenUsingBuilder(_testName, jwtBuilderServer, "defaultJWT", extraClaims);
+        String builtToken = actions.getJwtTokenUsingBuilder(_testName, jwtBuilderServer, "defaultJWT_withAudience", extraClaims);
 
         Expectations expectations = new Expectations();
         expectations.addExpectation(new ResponseStatusExpectation(HttpServletResponse.SC_OK));
@@ -157,8 +160,9 @@ public class MPJwtRealmConfigTests extends MPJwt11MPConfigTests {
         resourceServer.reconfigureServerUsingExpandedConfiguration(_testName, "rs_server_realmIdentifier_tenantClaim.xml");
 
         List<NameValuePair> extraClaims = new ArrayList<NameValuePair>();
+        extraClaims.add(new NameValuePair(JwtConstants.PARAM_UPN, MPJwt11FatConstants.TESTUSER));
         extraClaims.add(new NameValuePair("tenant", "TenantA"));
-        String builtToken = actions.getJwtTokenUsingBuilder(_testName, jwtBuilderServer, "defaultJWT", extraClaims);
+        String builtToken = actions.getJwtTokenUsingBuilder(_testName, jwtBuilderServer, "defaultJWT_withAudience", extraClaims);
 
         Expectations expectations = new Expectations();
         expectations.addExpectation(new ResponseStatusExpectation(HttpServletResponse.SC_OK));
@@ -178,7 +182,7 @@ public class MPJwtRealmConfigTests extends MPJwt11MPConfigTests {
         resourceServer.reconfigureServerUsingExpandedConfiguration(_testName, "rs_server_realmIdentifier_tenantClaim.xml");
 
         // No "tenant" extra claim — token will not have it
-        String builtToken = actions.getJwtTokenUsingBuilder(_testName, jwtBuilderServer, "defaultJWT");
+        String builtToken = actions.getJwtTokenUsingBuilder(_testName, jwtBuilderServer, "defaultJWT_withAudience");
         JwtTokenForTest jwtTokenTools = new JwtTokenForTest(builtToken);
         String expectedRealm = getIssuerFromToken(jwtTokenTools);
 
@@ -201,8 +205,9 @@ public class MPJwtRealmConfigTests extends MPJwt11MPConfigTests {
 
         // Add a "realm" claim in the token — realmName should win over it
         List<NameValuePair> extraClaims = new ArrayList<NameValuePair>();
+        extraClaims.add(new NameValuePair(JwtConstants.PARAM_UPN, MPJwt11FatConstants.TESTUSER));
         extraClaims.add(new NameValuePair("realm", "TokenRealm"));
-        String builtToken = actions.getJwtTokenUsingBuilder(_testName, jwtBuilderServer, "defaultJWT", extraClaims);
+        String builtToken = actions.getJwtTokenUsingBuilder(_testName, jwtBuilderServer, "defaultJWT_withAudience", extraClaims);
 
         Expectations expectations = new Expectations();
         expectations.addExpectation(new ResponseStatusExpectation(HttpServletResponse.SC_OK));
@@ -223,8 +228,9 @@ public class MPJwtRealmConfigTests extends MPJwt11MPConfigTests {
         resourceServer.reconfigureServerUsingExpandedConfiguration(_testName, "rs_server_realmName_overrides_realmIdentifier.xml");
 
         List<NameValuePair> extraClaims = new ArrayList<NameValuePair>();
+        extraClaims.add(new NameValuePair(JwtConstants.PARAM_UPN, MPJwt11FatConstants.TESTUSER));
         extraClaims.add(new NameValuePair("tenant", "TenantA"));
-        String builtToken = actions.getJwtTokenUsingBuilder(_testName, jwtBuilderServer, "defaultJWT", extraClaims);
+        String builtToken = actions.getJwtTokenUsingBuilder(_testName, jwtBuilderServer, "defaultJWT_withAudience", extraClaims);
 
         Expectations expectations = new Expectations();
         expectations.addExpectation(new ResponseStatusExpectation(HttpServletResponse.SC_OK));

--- a/dev/com.ibm.ws.security.mp.jwt.1.1_fat.commonTest/fat/src/com/ibm/ws/security/mp/jwt11/fat/MPJwtRealmConfigTests.java
+++ b/dev/com.ibm.ws.security.mp.jwt.1.1_fat.commonTest/fat/src/com/ibm/ws/security/mp/jwt11/fat/MPJwtRealmConfigTests.java
@@ -1,0 +1,237 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ * IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.security.mp.jwt11.fat;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.servlet.http.HttpServletResponse;
+
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.gargoylesoftware.htmlunit.Page;
+import com.gargoylesoftware.htmlunit.WebClient;
+import com.gargoylesoftware.htmlunit.util.NameValuePair;
+import com.ibm.ws.security.fat.common.expectations.Expectations;
+import com.ibm.ws.security.fat.common.expectations.ResponseFullExpectation;
+import com.ibm.ws.security.fat.common.expectations.ResponseStatusExpectation;
+import com.ibm.ws.security.fat.common.jwt.JwtTokenForTest;
+import com.ibm.ws.security.fat.common.mp.jwt.MPJwt11FatConstants;
+import com.ibm.ws.security.fat.common.mp.jwt.sharedTests.MPJwt11MPConfigTests;
+import com.ibm.ws.security.fat.common.validation.TestValidationUtils;
+
+import componenttest.annotation.Server;
+import componenttest.custom.junit.runner.FATRunner;
+import componenttest.custom.junit.runner.Mode;
+import componenttest.custom.junit.runner.Mode.TestMode;
+import componenttest.rules.repeater.RepeatTests;
+import componenttest.topology.impl.LibertyServer;
+
+/**
+ * FAT tests for the mpJwt realmName and realmIdentifier configuration attributes.
+ *
+ * Resolution order:
+ * 1. realmName (static override) wins if set.
+ * 2. Claim named by realmIdentifier (default "realm") provides the realm.
+ * 3. iss claim is the fallback.
+ */
+@Mode(TestMode.FULL)
+@RunWith(FATRunner.class)
+public class MPJwtRealmConfigTests extends MPJwt11MPConfigTests {
+
+    @Server("com.ibm.ws.security.mp.jwt.1.1.fat")
+    public static LibertyServer resourceServer;
+
+    @Server("com.ibm.ws.security.mp.jwt.1.1.fat.builder")
+    public static LibertyServer jwtBuilderServer;
+
+    @ClassRule
+    public static RepeatTests r = RepeatTests.withoutModification();
+
+    private final TestValidationUtils validationUtils = new TestValidationUtils();
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        setUpAndStartBuilderServer(jwtBuilderServer, "server_using_buildApp.xml", false);
+        setUpAndStartRSServerForApiTests(resourceServer, jwtBuilderServer, "rs_server_orig_withAudience.xml", false);
+        skipRestoreServerTracker.addServer(resourceServer);
+    }
+
+    // -----------------------------------------------------------------------
+    // Helper
+    // -----------------------------------------------------------------------
+
+    /**
+     * Extract the issuer string from a built token, stripping any trailing slash.
+     */
+    private String getIssuerFromToken(JwtTokenForTest jwtTokenTools) {
+        String issuer = jwtTokenTools.getJsonPayload().getString("iss");
+        if (issuer != null && issuer.endsWith("/")) {
+            issuer = issuer.substring(0, issuer.length() - 1);
+        }
+        return issuer;
+    }
+
+    /**
+     * Invoke all test apps with the given bearer token and validate against the supplied expectations.
+     */
+    private void invokeAppsAndValidate(String builtToken, Expectations expectations) throws Exception {
+        WebClient webClient = actions.createWebClient();
+        try {
+            for (TestApps app : setTestAppArray(resourceServer)) {
+                Page response = actions.invokeUrlWithBearerToken(_testName, webClient, app.getUrl(), builtToken);
+                validationUtils.validateResult(response, expectations);
+            }
+        } finally {
+            actions.destroyWebClient(webClient);
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Tests
+    // -----------------------------------------------------------------------
+
+    /**
+     * Default config: no realmIdentifier or realmName override.
+     * The default realmIdentifier is "realm". The token has no "realm" claim.
+     * Expect realm to fall back to the iss claim value.
+     */
+    @Test
+    public void MPJwtRealmConfig_default_noRealmClaim_fallsBackToIss() throws Exception {
+        // Use the base config — no realm-specific attributes set
+        resourceServer.restoreServerConfigurationAndWaitForApps();
+
+        String builtToken = actions.getJwtTokenUsingBuilder(_testName, jwtBuilderServer);
+        JwtTokenForTest jwtTokenTools = new JwtTokenForTest(builtToken);
+        String expectedRealm = getIssuerFromToken(jwtTokenTools);
+
+        Expectations expectations = new Expectations();
+        expectations.addExpectation(new ResponseStatusExpectation(HttpServletResponse.SC_OK));
+        expectations.addExpectation(new ResponseFullExpectation(MPJwt11FatConstants.STRING_CONTAINS,
+                "com.ibm.wsspi.security.cred.uniqueId=user:" + expectedRealm + "/",
+                "Response did NOT contain uniqueId with realm equal to the iss value [" + expectedRealm + "]"));
+
+        invokeAppsAndValidate(builtToken, expectations);
+    }
+
+    /**
+     * realmIdentifier="realm" (the default) and the token contains a "realm" claim.
+     * Expect the realm claim value to be used as the realm.
+     */
+    @Test
+    public void MPJwtRealmConfig_realmIdentifier_default_realmClaimPresent() throws Exception {
+        resourceServer.reconfigureServerUsingExpandedConfiguration(_testName, "rs_server_realmIdentifier_realmClaim.xml");
+
+        List<NameValuePair> extraClaims = new ArrayList<NameValuePair>();
+        extraClaims.add(new NameValuePair("realm", "TokenRealm"));
+        String builtToken = actions.getJwtTokenUsingBuilder(_testName, jwtBuilderServer, "defaultJWT", extraClaims);
+
+        Expectations expectations = new Expectations();
+        expectations.addExpectation(new ResponseStatusExpectation(HttpServletResponse.SC_OK));
+        expectations.addExpectation(new ResponseFullExpectation(MPJwt11FatConstants.STRING_CONTAINS,
+                "com.ibm.wsspi.security.cred.uniqueId=user:TokenRealm/",
+                "Response did NOT contain uniqueId with realm equal to the 'realm' claim value 'TokenRealm'"));
+
+        invokeAppsAndValidate(builtToken, expectations);
+    }
+
+    /**
+     * realmIdentifier="tenant" and the token contains a "tenant" claim.
+     * Expect the tenant claim value to be used as the realm.
+     */
+    @Test
+    public void MPJwtRealmConfig_realmIdentifier_customClaim_present() throws Exception {
+        resourceServer.reconfigureServerUsingExpandedConfiguration(_testName, "rs_server_realmIdentifier_tenantClaim.xml");
+
+        List<NameValuePair> extraClaims = new ArrayList<NameValuePair>();
+        extraClaims.add(new NameValuePair("tenant", "TenantA"));
+        String builtToken = actions.getJwtTokenUsingBuilder(_testName, jwtBuilderServer, "defaultJWT", extraClaims);
+
+        Expectations expectations = new Expectations();
+        expectations.addExpectation(new ResponseStatusExpectation(HttpServletResponse.SC_OK));
+        expectations.addExpectation(new ResponseFullExpectation(MPJwt11FatConstants.STRING_CONTAINS,
+                "com.ibm.wsspi.security.cred.uniqueId=user:TenantA/",
+                "Response did NOT contain uniqueId with realm equal to the 'tenant' claim value 'TenantA'"));
+
+        invokeAppsAndValidate(builtToken, expectations);
+    }
+
+    /**
+     * realmIdentifier="tenant" but the token does NOT contain a "tenant" claim.
+     * Expect realm to fall back to the iss claim.
+     */
+    @Test
+    public void MPJwtRealmConfig_realmIdentifier_customClaim_absent_fallsBackToIss() throws Exception {
+        resourceServer.reconfigureServerUsingExpandedConfiguration(_testName, "rs_server_realmIdentifier_tenantClaim.xml");
+
+        // No "tenant" extra claim — token will not have it
+        String builtToken = actions.getJwtTokenUsingBuilder(_testName, jwtBuilderServer, "defaultJWT");
+        JwtTokenForTest jwtTokenTools = new JwtTokenForTest(builtToken);
+        String expectedRealm = getIssuerFromToken(jwtTokenTools);
+
+        Expectations expectations = new Expectations();
+        expectations.addExpectation(new ResponseStatusExpectation(HttpServletResponse.SC_OK));
+        expectations.addExpectation(new ResponseFullExpectation(MPJwt11FatConstants.STRING_CONTAINS,
+                "com.ibm.wsspi.security.cred.uniqueId=user:" + expectedRealm + "/",
+                "Response did NOT contain uniqueId with realm equal to iss when 'tenant' claim is absent"));
+
+        invokeAppsAndValidate(builtToken, expectations);
+    }
+
+    /**
+     * realmName="CorporateRealm" set (no realmIdentifier override).
+     * Expect the static realm name to be used regardless of token claims.
+     */
+    @Test
+    public void MPJwtRealmConfig_realmName_static_overridesToken() throws Exception {
+        resourceServer.reconfigureServerUsingExpandedConfiguration(_testName, "rs_server_realmName_static.xml");
+
+        // Add a "realm" claim in the token — realmName should win over it
+        List<NameValuePair> extraClaims = new ArrayList<NameValuePair>();
+        extraClaims.add(new NameValuePair("realm", "TokenRealm"));
+        String builtToken = actions.getJwtTokenUsingBuilder(_testName, jwtBuilderServer, "defaultJWT", extraClaims);
+
+        Expectations expectations = new Expectations();
+        expectations.addExpectation(new ResponseStatusExpectation(HttpServletResponse.SC_OK));
+        expectations.addExpectation(new ResponseFullExpectation(MPJwt11FatConstants.STRING_CONTAINS,
+                "com.ibm.wsspi.security.cred.uniqueId=user:CorporateRealm/",
+                "Response did NOT contain uniqueId with static realm 'CorporateRealm' (realmName should override token claim)"));
+
+        invokeAppsAndValidate(builtToken, expectations);
+    }
+
+    /**
+     * Both realmName="StaticRealm" and realmIdentifier="tenant" are set.
+     * The token contains a "tenant" claim.
+     * Expect realmName to take precedence — "StaticRealm" is used, not "TenantA".
+     */
+    @Test
+    public void MPJwtRealmConfig_realmName_overrides_realmIdentifier() throws Exception {
+        resourceServer.reconfigureServerUsingExpandedConfiguration(_testName, "rs_server_realmName_overrides_realmIdentifier.xml");
+
+        List<NameValuePair> extraClaims = new ArrayList<NameValuePair>();
+        extraClaims.add(new NameValuePair("tenant", "TenantA"));
+        String builtToken = actions.getJwtTokenUsingBuilder(_testName, jwtBuilderServer, "defaultJWT", extraClaims);
+
+        Expectations expectations = new Expectations();
+        expectations.addExpectation(new ResponseStatusExpectation(HttpServletResponse.SC_OK));
+        expectations.addExpectation(new ResponseFullExpectation(MPJwt11FatConstants.STRING_CONTAINS,
+                "com.ibm.wsspi.security.cred.uniqueId=user:StaticRealm/",
+                "Response did NOT contain uniqueId with 'StaticRealm' — realmName should override realmIdentifier"));
+
+        invokeAppsAndValidate(builtToken, expectations);
+    }
+}

--- a/dev/com.ibm.ws.security.mp.jwt.1.1_fat.commonTest/publish/servers/com.ibm.ws.security.mp.jwt.1.1.fat/configs/rs_server_realmIdentifier_realmClaim.xml
+++ b/dev/com.ibm.ws.security.mp.jwt.1.1_fat.commonTest/publish/servers/com.ibm.ws.security.mp.jwt.1.1.fat/configs/rs_server_realmIdentifier_realmClaim.xml
@@ -18,7 +18,7 @@
 		jwksUri="${mpJwt_jwksUri}"
 		keyName="${mpJwt_keyName}"
 		realmIdentifier="realm"
-		userNameAttribute="sub"
+		audiences="client01, client02"
 		issuer="http://${fat.server.hostname}:${bvt.prop.security_2_HTTP_default}/jwt/defaultJWT,
 						http://${fat.server.hostip}:${bvt.prop.security_2_HTTP_default}/jwt/defaultJWT,
 						https://${fat.server.hostname}:${bvt.prop.security_2_HTTP_default.secure}/jwt/defaultJWT,

--- a/dev/com.ibm.ws.security.mp.jwt.1.1_fat.commonTest/publish/servers/com.ibm.ws.security.mp.jwt.1.1.fat/configs/rs_server_realmIdentifier_realmClaim.xml
+++ b/dev/com.ibm.ws.security.mp.jwt.1.1_fat.commonTest/publish/servers/com.ibm.ws.security.mp.jwt.1.1.fat/configs/rs_server_realmIdentifier_realmClaim.xml
@@ -1,0 +1,31 @@
+
+<server>
+
+	<include location="${shared.config.dir}/rsFeatures.xml" />
+
+	<include location="${shared.config.dir}/goodBasicRegistry.xml" />
+
+	<include location="${shared.config.dir}/goodSSLSettings.xml" />
+
+	<include location="${shared.config.dir}/microProfileApplication.xml" />
+
+	<include location="${shared.config.dir}/rs_fatTestPorts.xml" />
+
+	<include location="${shared.config.dir}/microProfileAppJava2Settings.xml"/>
+
+	<mpJwt
+		id="mpJwt_1"
+		jwksUri="${mpJwt_jwksUri}"
+		keyName="${mpJwt_keyName}"
+		realmIdentifier="realm"
+		userNameAttribute="sub"
+		issuer="http://${fat.server.hostname}:${bvt.prop.security_2_HTTP_default}/jwt/defaultJWT,
+						http://${fat.server.hostip}:${bvt.prop.security_2_HTTP_default}/jwt/defaultJWT,
+						https://${fat.server.hostname}:${bvt.prop.security_2_HTTP_default.secure}/jwt/defaultJWT,
+						https://${fat.server.hostip}:${bvt.prop.security_2_HTTP_default.secure}/jwt/defaultJWT,
+						https://localhost:${bvt.prop.security_2_HTTP_default}/oidc/endpoint/OidcConfigSample,
+						https://localhost:${bvt.prop.security_2_HTTP_default.secure}/oidc/endpoint/OidcConfigSample,
+						testIssuer">
+	</mpJwt>
+
+</server>

--- a/dev/com.ibm.ws.security.mp.jwt.1.1_fat.commonTest/publish/servers/com.ibm.ws.security.mp.jwt.1.1.fat/configs/rs_server_realmIdentifier_tenantClaim.xml
+++ b/dev/com.ibm.ws.security.mp.jwt.1.1_fat.commonTest/publish/servers/com.ibm.ws.security.mp.jwt.1.1.fat/configs/rs_server_realmIdentifier_tenantClaim.xml
@@ -1,0 +1,31 @@
+
+<server>
+
+	<include location="${shared.config.dir}/rsFeatures.xml" />
+
+	<include location="${shared.config.dir}/goodBasicRegistry.xml" />
+
+	<include location="${shared.config.dir}/goodSSLSettings.xml" />
+
+	<include location="${shared.config.dir}/microProfileApplication.xml" />
+
+	<include location="${shared.config.dir}/rs_fatTestPorts.xml" />
+
+	<include location="${shared.config.dir}/microProfileAppJava2Settings.xml"/>
+
+	<mpJwt
+		id="mpJwt_1"
+		jwksUri="${mpJwt_jwksUri}"
+		keyName="${mpJwt_keyName}"
+		realmIdentifier="tenant"
+		userNameAttribute="sub"
+		issuer="http://${fat.server.hostname}:${bvt.prop.security_2_HTTP_default}/jwt/defaultJWT,
+						http://${fat.server.hostip}:${bvt.prop.security_2_HTTP_default}/jwt/defaultJWT,
+						https://${fat.server.hostname}:${bvt.prop.security_2_HTTP_default.secure}/jwt/defaultJWT,
+						https://${fat.server.hostip}:${bvt.prop.security_2_HTTP_default.secure}/jwt/defaultJWT,
+						https://localhost:${bvt.prop.security_2_HTTP_default}/oidc/endpoint/OidcConfigSample,
+						https://localhost:${bvt.prop.security_2_HTTP_default.secure}/oidc/endpoint/OidcConfigSample,
+						testIssuer">
+	</mpJwt>
+
+</server>

--- a/dev/com.ibm.ws.security.mp.jwt.1.1_fat.commonTest/publish/servers/com.ibm.ws.security.mp.jwt.1.1.fat/configs/rs_server_realmIdentifier_tenantClaim.xml
+++ b/dev/com.ibm.ws.security.mp.jwt.1.1_fat.commonTest/publish/servers/com.ibm.ws.security.mp.jwt.1.1.fat/configs/rs_server_realmIdentifier_tenantClaim.xml
@@ -18,7 +18,7 @@
 		jwksUri="${mpJwt_jwksUri}"
 		keyName="${mpJwt_keyName}"
 		realmIdentifier="tenant"
-		userNameAttribute="sub"
+		audiences="client01, client02"
 		issuer="http://${fat.server.hostname}:${bvt.prop.security_2_HTTP_default}/jwt/defaultJWT,
 						http://${fat.server.hostip}:${bvt.prop.security_2_HTTP_default}/jwt/defaultJWT,
 						https://${fat.server.hostname}:${bvt.prop.security_2_HTTP_default.secure}/jwt/defaultJWT,

--- a/dev/com.ibm.ws.security.mp.jwt.1.1_fat.commonTest/publish/servers/com.ibm.ws.security.mp.jwt.1.1.fat/configs/rs_server_realmName_overrides_realmIdentifier.xml
+++ b/dev/com.ibm.ws.security.mp.jwt.1.1_fat.commonTest/publish/servers/com.ibm.ws.security.mp.jwt.1.1.fat/configs/rs_server_realmName_overrides_realmIdentifier.xml
@@ -19,7 +19,7 @@
 		keyName="${mpJwt_keyName}"
 		realmName="StaticRealm"
 		realmIdentifier="tenant"
-		userNameAttribute="sub"
+		audiences="client01, client02"
 		issuer="http://${fat.server.hostname}:${bvt.prop.security_2_HTTP_default}/jwt/defaultJWT,
 						http://${fat.server.hostip}:${bvt.prop.security_2_HTTP_default}/jwt/defaultJWT,
 						https://${fat.server.hostname}:${bvt.prop.security_2_HTTP_default.secure}/jwt/defaultJWT,

--- a/dev/com.ibm.ws.security.mp.jwt.1.1_fat.commonTest/publish/servers/com.ibm.ws.security.mp.jwt.1.1.fat/configs/rs_server_realmName_overrides_realmIdentifier.xml
+++ b/dev/com.ibm.ws.security.mp.jwt.1.1_fat.commonTest/publish/servers/com.ibm.ws.security.mp.jwt.1.1.fat/configs/rs_server_realmName_overrides_realmIdentifier.xml
@@ -1,0 +1,32 @@
+
+<server>
+
+	<include location="${shared.config.dir}/rsFeatures.xml" />
+
+	<include location="${shared.config.dir}/goodBasicRegistry.xml" />
+
+	<include location="${shared.config.dir}/goodSSLSettings.xml" />
+
+	<include location="${shared.config.dir}/microProfileApplication.xml" />
+
+	<include location="${shared.config.dir}/rs_fatTestPorts.xml" />
+
+	<include location="${shared.config.dir}/microProfileAppJava2Settings.xml"/>
+
+	<mpJwt
+		id="mpJwt_1"
+		jwksUri="${mpJwt_jwksUri}"
+		keyName="${mpJwt_keyName}"
+		realmName="StaticRealm"
+		realmIdentifier="tenant"
+		userNameAttribute="sub"
+		issuer="http://${fat.server.hostname}:${bvt.prop.security_2_HTTP_default}/jwt/defaultJWT,
+						http://${fat.server.hostip}:${bvt.prop.security_2_HTTP_default}/jwt/defaultJWT,
+						https://${fat.server.hostname}:${bvt.prop.security_2_HTTP_default.secure}/jwt/defaultJWT,
+						https://${fat.server.hostip}:${bvt.prop.security_2_HTTP_default.secure}/jwt/defaultJWT,
+						https://localhost:${bvt.prop.security_2_HTTP_default}/oidc/endpoint/OidcConfigSample,
+						https://localhost:${bvt.prop.security_2_HTTP_default.secure}/oidc/endpoint/OidcConfigSample,
+						testIssuer">
+	</mpJwt>
+
+</server>

--- a/dev/com.ibm.ws.security.mp.jwt.1.1_fat.commonTest/publish/servers/com.ibm.ws.security.mp.jwt.1.1.fat/configs/rs_server_realmName_static.xml
+++ b/dev/com.ibm.ws.security.mp.jwt.1.1_fat.commonTest/publish/servers/com.ibm.ws.security.mp.jwt.1.1.fat/configs/rs_server_realmName_static.xml
@@ -18,7 +18,7 @@
 		jwksUri="${mpJwt_jwksUri}"
 		keyName="${mpJwt_keyName}"
 		realmName="CorporateRealm"
-		userNameAttribute="sub"
+		audiences="client01, client02"
 		issuer="http://${fat.server.hostname}:${bvt.prop.security_2_HTTP_default}/jwt/defaultJWT,
 						http://${fat.server.hostip}:${bvt.prop.security_2_HTTP_default}/jwt/defaultJWT,
 						https://${fat.server.hostname}:${bvt.prop.security_2_HTTP_default.secure}/jwt/defaultJWT,

--- a/dev/com.ibm.ws.security.mp.jwt.1.1_fat.commonTest/publish/servers/com.ibm.ws.security.mp.jwt.1.1.fat/configs/rs_server_realmName_static.xml
+++ b/dev/com.ibm.ws.security.mp.jwt.1.1_fat.commonTest/publish/servers/com.ibm.ws.security.mp.jwt.1.1.fat/configs/rs_server_realmName_static.xml
@@ -1,0 +1,31 @@
+
+<server>
+
+	<include location="${shared.config.dir}/rsFeatures.xml" />
+
+	<include location="${shared.config.dir}/goodBasicRegistry.xml" />
+
+	<include location="${shared.config.dir}/goodSSLSettings.xml" />
+
+	<include location="${shared.config.dir}/microProfileApplication.xml" />
+
+	<include location="${shared.config.dir}/rs_fatTestPorts.xml" />
+
+	<include location="${shared.config.dir}/microProfileAppJava2Settings.xml"/>
+
+	<mpJwt
+		id="mpJwt_1"
+		jwksUri="${mpJwt_jwksUri}"
+		keyName="${mpJwt_keyName}"
+		realmName="CorporateRealm"
+		userNameAttribute="sub"
+		issuer="http://${fat.server.hostname}:${bvt.prop.security_2_HTTP_default}/jwt/defaultJWT,
+						http://${fat.server.hostip}:${bvt.prop.security_2_HTTP_default}/jwt/defaultJWT,
+						https://${fat.server.hostname}:${bvt.prop.security_2_HTTP_default.secure}/jwt/defaultJWT,
+						https://${fat.server.hostip}:${bvt.prop.security_2_HTTP_default.secure}/jwt/defaultJWT,
+						https://localhost:${bvt.prop.security_2_HTTP_default}/oidc/endpoint/OidcConfigSample,
+						https://localhost:${bvt.prop.security_2_HTTP_default.secure}/oidc/endpoint/OidcConfigSample,
+						testIssuer">
+	</mpJwt>
+
+</server>

--- a/dev/com.ibm.ws.security.mp.jwt.1.1_fat.mpJwt-1.1/fat/src/com/ibm/ws/security/mp/jwt11/fat/FATSuite.java
+++ b/dev/com.ibm.ws.security.mp.jwt.1.1_fat.mpJwt-1.1/fat/src/com/ibm/ws/security/mp/jwt11/fat/FATSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2023 IBM Corporation and others.
+ * Copyright (c) 2018, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -28,6 +28,7 @@ import com.ibm.ws.security.mp.jwt11.fat.configInAppTests.MPJwtMPOtherSigAlgConfi
 import com.ibm.ws.security.mp.jwt11.fat.featureSupportTests.MPJwtNoMpJwtConfig;
 import com.ibm.ws.security.mp.jwt11.fat.propagationTests.MPJwtPropagationTests_notUsingWebTarget;
 import com.ibm.ws.security.mp.jwt11.fat.propagationTests.MPJwtPropagationTests_usingWebTarget;
+import com.ibm.ws.security.mp.jwt11.fat.MPJwtRealmConfigTests;
 
 import componenttest.custom.junit.runner.AlwaysPassesTest;
 import componenttest.rules.repeater.RepeatTests;
@@ -43,6 +44,7 @@ import componenttest.rules.repeater.RepeatTests;
         MPJwtBasicTests.class,
         // More targeted tests
         MPJwtConfigUsingBuilderTests.class,
+        MPJwtRealmConfigTests.class,
         MPJwtApplicationAndSessionScopedClaimInjectionTests.class,
         MPJwtLoginConfig_ignoreApplicationAuthMethodTrueTests.class,
         MPJwtLoginConfig_ignoreApplicationAuthMethodFalseTests.class,

--- a/dev/com.ibm.ws.security.mp.jwt/resources/OSGI-INF/l10n/metatype.properties
+++ b/dev/com.ibm.ws.security.mp.jwt/resources/OSGI-INF/l10n/metatype.properties
@@ -111,10 +111,9 @@ keyManagementKeyAlgorithm.desc=Specifies the decryption algorithm that is used t
 tokenAge=Time allowed since the JWT token was issued
 tokenAge.desc=Specifies the allowed token age in seconds when validating the JSON web token. This attribute is used only in versions 2.1 and later of the MP-JWT feature. The issued at (iat) claim must be present in the JWT token. The configured number of seconds since iat must not have elapsed. If it has elapsed, then the request is rejected with an unauthorized response. The specified token age overrides the mp.jwt.verify.token.age MicroProfile Config property if it is configured.
 
-realmIdentifier=Realm identifier claim
-realmIdentifier.desc=The name of the claim in the JWT token whose value is used as the realm. \
-  If realmName is also set, realmName takes precedence.
+realmIdentifier=Realm identifier
+realmIdentifier.desc=Specifies a JSON attribute in the JWT token that is used as the realm name.
 
+#do not translate mapToUserRegistry
 realmName=Realm name
-realmName.desc=A static realm name used to create the user subject. \
-  When set, this value takes precedence over realmIdentifier.
+realmName.desc=Specifies a realm name to be used to create the user subject when the mapToUserRegistry attribute is set to false.

--- a/dev/com.ibm.ws.security.mp.jwt/resources/OSGI-INF/l10n/metatype.properties
+++ b/dev/com.ibm.ws.security.mp.jwt/resources/OSGI-INF/l10n/metatype.properties
@@ -110,3 +110,11 @@ keyManagementKeyAlgorithm.desc=Specifies the decryption algorithm that is used t
 # Do not translate "iat", "JWT", "MP-JWT", "mp.jwt.verify.token.age", or "MicroProfile Config"
 tokenAge=Time allowed since the JWT token was issued
 tokenAge.desc=Specifies the allowed token age in seconds when validating the JSON web token. This attribute is used only in versions 2.1 and later of the MP-JWT feature. The issued at (iat) claim must be present in the JWT token. The configured number of seconds since iat must not have elapsed. If it has elapsed, then the request is rejected with an unauthorized response. The specified token age overrides the mp.jwt.verify.token.age MicroProfile Config property if it is configured.
+
+realmIdentifier=Realm identifier claim
+realmIdentifier.desc=The name of the claim in the JWT token whose value is used as the realm. \
+  If realmName is also set, realmName takes precedence.
+
+realmName=Realm name
+realmName.desc=A static realm name used to create the user subject. \
+  When set, this value takes precedence over realmIdentifier.

--- a/dev/com.ibm.ws.security.mp.jwt/resources/OSGI-INF/metatype/metatype.xml
+++ b/dev/com.ibm.ws.security.mp.jwt/resources/OSGI-INF/metatype/metatype.xml
@@ -55,6 +55,10 @@
         </AD>
         <AD id="cookieName" name="%cookieName" description="%cookieName.desc" required="false" type="String" />
         <AD id="keyManagementKeyAlias" name="%keyManagementKeyAlias" description="%keyManagementKeyAlias.desc" required="false" type="String" />
+        <AD id="realmName" name="%realmName" description="%realmName.desc"
+            required="false" type="String" />
+        <AD id="realmIdentifier" name="%realmIdentifier" description="%realmIdentifier.desc"
+            required="false" type="String" default="realm" />
 
         <AD id="signatureAlgorithm" required="false" type="String" name="%signatureAlgorithm" description="%signatureAlgorithm.desc" >
             <Option label="%tokenSignAlgorithm.RS256" value="RS256" />

--- a/dev/com.ibm.ws.security.mp.jwt/src/com/ibm/ws/security/mp/jwt/MicroProfileJwtConfig.java
+++ b/dev/com.ibm.ws.security.mp.jwt/src/com/ibm/ws/security/mp/jwt/MicroProfileJwtConfig.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2022 IBM Corporation and others.
+ * Copyright (c) 2017, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -37,5 +37,9 @@ public interface MicroProfileJwtConfig extends JwtConsumerConfig {
     public String getTokenHeader();
 
     public String getCookieName();
+
+    public String getRealmIdentifier();
+
+    public String getRealmName();
 
 }

--- a/dev/com.ibm.ws.security.mp.jwt/src/com/ibm/ws/security/mp/jwt/impl/MicroProfileJwtConfigImpl.java
+++ b/dev/com.ibm.ws.security.mp.jwt/src/com/ibm/ws/security/mp/jwt/impl/MicroProfileJwtConfigImpl.java
@@ -103,6 +103,12 @@ public class MicroProfileJwtConfigImpl implements MicroProfileJwtConfig {
     public static final String KEY_groupNameAttribute = "groupNameAttribute";
     protected String groupNameAttribute = null;
 
+    public static final String KEY_realmIdentifier = "realmIdentifier";
+    protected String realmIdentifier = null;
+
+    public static final String KEY_realmName = "realmName";
+    protected String realmName = null;
+
     public static final String KEY_authorizationHeaderScheme = "authorizationHeaderScheme";
     protected String authorizationHeaderScheme = null;
 
@@ -193,6 +199,8 @@ public class MicroProfileJwtConfigImpl implements MicroProfileJwtConfig {
 
         this.userNameAttribute = configUtils.getConfigAttribute(props, KEY_userNameAttribute);
         this.groupNameAttribute = configUtils.getConfigAttribute(props, KEY_groupNameAttribute);
+        this.realmIdentifier = configUtils.getConfigAttribute(props, KEY_realmIdentifier);
+        this.realmName = configUtils.getConfigAttribute(props, KEY_realmName);
 
         this.authorizationHeaderScheme = configUtils.getConfigAttribute(props, KEY_authorizationHeaderScheme);
         this.clockSkewMilliSeconds = configUtils.getLongConfigAttribute(props, CFG_KEY_CLOCK_SKEW, clockSkewMilliSeconds);
@@ -569,6 +577,16 @@ public class MicroProfileJwtConfigImpl implements MicroProfileJwtConfig {
     @Override
     public String getGroupNameAttribute() {
         return this.groupNameAttribute;
+    }
+
+    @Override
+    public String getRealmIdentifier() {
+        return realmIdentifier;
+    }
+
+    @Override
+    public String getRealmName() {
+        return realmName;
     }
 
     /** {@inheritDoc} */

--- a/dev/com.ibm.ws.security.mp.jwt/src/com/ibm/ws/security/mp/jwt/impl/utils/JwtPrincipalMapping.java
+++ b/dev/com.ibm.ws.security.mp.jwt/src/com/ibm/ws/security/mp/jwt/impl/utils/JwtPrincipalMapping.java
@@ -36,10 +36,6 @@ public class JwtPrincipalMapping {
     String userName = null;
     ArrayList<String> groupIds = null;
 
-    public JwtPrincipalMapping(JwtToken jwtToken, String userAttr, String groupAttr, boolean mapToUr) {
-        this(jwtToken, userAttr, groupAttr, mapToUr, null);
-    }
-
     public JwtPrincipalMapping(JwtToken jwtToken, String userAttr, String groupAttr, boolean mapToUr, String realmIdentifierAttr) {
         String methodName = "<init>";
         if (tc.isDebugEnabled()) {

--- a/dev/com.ibm.ws.security.mp.jwt/src/com/ibm/ws/security/mp/jwt/impl/utils/JwtPrincipalMapping.java
+++ b/dev/com.ibm.ws.security.mp.jwt/src/com/ibm/ws/security/mp/jwt/impl/utils/JwtPrincipalMapping.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017,2022 IBM Corporation and others.
+ * Copyright (c) 2017, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -37,9 +37,13 @@ public class JwtPrincipalMapping {
     ArrayList<String> groupIds = null;
 
     public JwtPrincipalMapping(JwtToken jwtToken, String userAttr, String groupAttr, boolean mapToUr) {
+        this(jwtToken, userAttr, groupAttr, mapToUr, null);
+    }
+
+    public JwtPrincipalMapping(JwtToken jwtToken, String userAttr, String groupAttr, boolean mapToUr, String realmIdentifierAttr) {
         String methodName = "<init>";
         if (tc.isDebugEnabled()) {
-            Tr.entry(tc, methodName, jwtToken, userAttr, groupAttr, mapToUr);
+            Tr.entry(tc, methodName, jwtToken, userAttr, groupAttr, mapToUr, realmIdentifierAttr);
         }
         userName = getUserName(userAttr, jwtToken);
         if (userName == null) {
@@ -52,7 +56,9 @@ public class JwtPrincipalMapping {
             Tr.debug(tc, "user name = ", userName);
         }
         if (!mapToUr) {
-            realm = getRealm(REALM_CLAIM, jwtToken);
+            String effectiveRealmAttr = (realmIdentifierAttr != null && !realmIdentifierAttr.isEmpty())
+                                        ? realmIdentifierAttr : REALM_CLAIM;
+            realm = getRealm(effectiveRealmAttr, jwtToken);
             populateGroupIds(jwtToken, groupAttr);
         }
         if (tc.isDebugEnabled()) {

--- a/dev/com.ibm.ws.security.mp.jwt/src/com/ibm/ws/security/mp/jwt/tai/TAIMappingHelper.java
+++ b/dev/com.ibm.ws.security.mp.jwt/src/com/ibm/ws/security/mp/jwt/tai/TAIMappingHelper.java
@@ -53,7 +53,7 @@ public class TAIMappingHelper {
         config = null;
         //addJwtPrincipalToSubject = true;
         if (jwtToken != null) {
-            claimToPrincipalMapping = new JwtPrincipalMapping(jwtToken, "upn", "groups", false);
+            claimToPrincipalMapping = new JwtPrincipalMapping(jwtToken, "upn", "groups", false, "realm");
             setUsername();
             setRealm();
         }
@@ -79,14 +79,22 @@ public class TAIMappingHelper {
      *
      */
     private void setRealm() {
+        if (getmaptoURconfig()) {
+            return;
+        }
         if (config != null) {
             String configuredRealmName = config.getRealmName();
             if (configuredRealmName != null && !configuredRealmName.isEmpty()) {
                 this.realm = configuredRealmName;
-                return;
+            } else {
+                this.realm = claimToPrincipalMapping.getMappedRealm();
             }
+        } else {
+            this.realm = claimToPrincipalMapping.getMappedRealm();
         }
-        this.realm = claimToPrincipalMapping.getMappedRealm();
+        if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+            Tr.debug(tc, "realm name = ", this.realm);
+        }
     }
 
     public void createJwtPrincipalAndPopulateCustomProperties(@Sensitive JwtToken jwtToken, boolean addJwtPrincipal) throws MpJwtProcessingException {
@@ -211,6 +219,9 @@ public class TAIMappingHelper {
             customProperties.put(AttributeNameConstants.WSCREDENTIAL_USERID, username);
         } else {
             if (realm == null && issuer != null) {
+                if (TraceComponent.isAnyTracingEnabled() && tc.isDebugEnabled()) {
+                    Tr.debug(tc, "There is no realm, using issuer as realm");
+                }
                 realm = getRealm(issuer);
             }
             String uniqueID = getUniqueId(realm);

--- a/dev/com.ibm.ws.security.mp.jwt/src/com/ibm/ws/security/mp/jwt/tai/TAIMappingHelper.java
+++ b/dev/com.ibm.ws.security.mp.jwt/src/com/ibm/ws/security/mp/jwt/tai/TAIMappingHelper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2022 IBM Corporation and others.
+ * Copyright (c) 2017, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -66,7 +66,7 @@ public class TAIMappingHelper {
         }
         config = clientConfig;
         if (jwtToken != null) {
-            claimToPrincipalMapping = new JwtPrincipalMapping(jwtToken, config.getUserNameAttribute(), config.getGroupNameAttribute(), config.getMapToUserRegistry());
+            claimToPrincipalMapping = new JwtPrincipalMapping(jwtToken, config.getUserNameAttribute(), config.getGroupNameAttribute(), config.getMapToUserRegistry(), config.getRealmIdentifier());
             setUsername();
             setRealm();
         }
@@ -79,8 +79,14 @@ public class TAIMappingHelper {
      *
      */
     private void setRealm() {
+        if (config != null) {
+            String configuredRealmName = config.getRealmName();
+            if (configuredRealmName != null && !configuredRealmName.isEmpty()) {
+                this.realm = configuredRealmName;
+                return;
+            }
+        }
         this.realm = claimToPrincipalMapping.getMappedRealm();
-
     }
 
     public void createJwtPrincipalAndPopulateCustomProperties(@Sensitive JwtToken jwtToken, boolean addJwtPrincipal) throws MpJwtProcessingException {

--- a/dev/com.ibm.ws.security.mp.jwt/test/com/ibm/ws/security/mp/jwt/impl/MicroProfileJwtConfigImplTest.java
+++ b/dev/com.ibm.ws.security.mp.jwt/test/com/ibm/ws/security/mp/jwt/impl/MicroProfileJwtConfigImplTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2020, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -12,8 +12,13 @@
  *******************************************************************************/
 package com.ibm.ws.security.mp.jwt.impl;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+
+import java.util.HashMap;
+import java.util.Map;
 
 import org.jmock.Expectations;
 import org.junit.After;
@@ -22,6 +27,7 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.osgi.framework.Version;
+import org.osgi.service.component.ComponentContext;
 
 import com.ibm.ws.security.test.common.CommonTestClass;
 
@@ -106,6 +112,74 @@ public class MicroProfileJwtConfigImplTest extends CommonTestClass {
         });
         boolean result = config.isRuntimeVersionAtLeast(minimumVersionRequired);
         assertFalse("Runtime version [" + thisRuntimeVersion + "] should NOT have been considered at or above [" + minimumVersionRequired + "].", result);
+    }
+
+    private Map<String, Object> buildMinimalProps() {
+        Map<String, Object> props = new HashMap<String, Object>();
+        // Provide the mpConfigProxy cardinality minimum that initProps expects
+        props.put("MpConfigProxy.cardinality.minimum", "0");
+        return props;
+    }
+
+    @Test
+    public void test_realmIdentifier_defaultValue() throws Exception {
+        mockery.checking(new Expectations() {
+            {
+                allowing(runtimeVersion).getVersion();
+                will(returnValue(io.openliberty.security.mp.jwt.osgi.MpJwtRuntimeVersion.VERSION_1_1));
+            }
+        });
+        Map<String, Object> props = buildMinimalProps();
+        // Simulate OSGi metatype default injection
+        props.put(MicroProfileJwtConfigImpl.KEY_realmIdentifier, "realm");
+        config.initProps(null, props);
+        assertEquals("Expected default realmIdentifier to be 'realm'",
+                     "realm", config.getRealmIdentifier());
+    }
+
+    @Test
+    public void test_realmIdentifier_customValue() throws Exception {
+        mockery.checking(new Expectations() {
+            {
+                allowing(runtimeVersion).getVersion();
+                will(returnValue(io.openliberty.security.mp.jwt.osgi.MpJwtRuntimeVersion.VERSION_1_1));
+            }
+        });
+        Map<String, Object> props = buildMinimalProps();
+        props.put(MicroProfileJwtConfigImpl.KEY_realmIdentifier, "tenant");
+        config.initProps(null, props);
+        assertEquals("Expected realmIdentifier to be 'tenant'",
+                     "tenant", config.getRealmIdentifier());
+    }
+
+    @Test
+    public void test_realmName_notSet() throws Exception {
+        mockery.checking(new Expectations() {
+            {
+                allowing(runtimeVersion).getVersion();
+                will(returnValue(io.openliberty.security.mp.jwt.osgi.MpJwtRuntimeVersion.VERSION_1_1));
+            }
+        });
+        Map<String, Object> props = buildMinimalProps();
+        // realmName intentionally absent — no default in metatype
+        config.initProps(null, props);
+        assertNull("Expected realmName to be null when not configured",
+                   config.getRealmName());
+    }
+
+    @Test
+    public void test_realmName_setValue() throws Exception {
+        mockery.checking(new Expectations() {
+            {
+                allowing(runtimeVersion).getVersion();
+                will(returnValue(io.openliberty.security.mp.jwt.osgi.MpJwtRuntimeVersion.VERSION_1_1));
+            }
+        });
+        Map<String, Object> props = buildMinimalProps();
+        props.put(MicroProfileJwtConfigImpl.KEY_realmName, "CorporateRealm");
+        config.initProps(null, props);
+        assertEquals("Expected realmName to be 'CorporateRealm'",
+                     "CorporateRealm", config.getRealmName());
     }
 
 }

--- a/dev/com.ibm.ws.security.mp.jwt/test/com/ibm/ws/security/mp/jwt/impl/utils/JwtPrincipalMappingTest.java
+++ b/dev/com.ibm.ws.security.mp.jwt/test/com/ibm/ws/security/mp/jwt/impl/utils/JwtPrincipalMappingTest.java
@@ -1,0 +1,183 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ * IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.ws.security.mp.jwt.impl.utils;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.jmock.Expectations;
+import org.jmock.Mockery;
+import org.jmock.integration.junit4.JUnit4Mockery;
+import org.jmock.lib.legacy.ClassImposteriser;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
+
+import com.ibm.websphere.security.jwt.Claims;
+import com.ibm.websphere.security.jwt.JwtToken;
+
+import test.common.SharedOutputManager;
+
+public class JwtPrincipalMappingTest {
+
+    protected final Mockery mockery = new JUnit4Mockery() {
+        {
+            setImposteriser(ClassImposteriser.INSTANCE);
+        }
+    };
+
+    private static SharedOutputManager outputMgr = SharedOutputManager.getInstance().trace("com.ibm.ws.security.mp.jwt.*=all");
+
+    @Rule
+    public final TestName testName = new TestName();
+
+    @BeforeClass
+    public static void setUpBeforeClass() throws Exception {
+        outputMgr.captureStreams();
+    }
+
+    @Before
+    public void before() {
+        System.out.println("Entering test: " + testName.getMethodName());
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        System.out.println("Exiting test: " + testName.getMethodName());
+        outputMgr.resetStreams();
+        mockery.assertIsSatisfied();
+    }
+
+    @AfterClass
+    public static void tearDownAfterClass() throws Exception {
+        outputMgr.dumpStreams();
+        outputMgr.restoreStreams();
+    }
+
+    /**
+     * Build a JwtToken whose getClaims() returns a Claims backed by the given data map.
+     * Claims extends Map<String,Object> so we use an anonymous implementation.
+     */
+    private JwtToken buildMockToken(Map<String, Object> claimsData) throws Exception {
+        // Wrap the data map in a minimal Claims implementation
+        Claims claims = new Claims() {
+            private final HashMap<String, Object> delegate = new HashMap<String, Object>(claimsData);
+
+            @Override public Object get(Object key) { return delegate.get(key); }
+            @Override public boolean containsKey(Object key) { return delegate.containsKey(key); }
+            @Override public boolean containsValue(Object value) { return delegate.containsValue(value); }
+            @Override public Set<Map.Entry<String, Object>> entrySet() { return delegate.entrySet(); }
+            @Override public boolean isEmpty() { return delegate.isEmpty(); }
+            @Override public Set<String> keySet() { return delegate.keySet(); }
+            @Override public Object put(String key, Object value) { return delegate.put(key, value); }
+            @Override public void putAll(Map<? extends String, ? extends Object> m) { delegate.putAll(m); }
+            @Override public Object remove(Object key) { return delegate.remove(key); }
+            @Override public int size() { return delegate.size(); }
+            @Override public Collection<Object> values() { return delegate.values(); }
+            @Override public void clear() { delegate.clear(); }
+            // Claims-specific methods (not exercised in these tests)
+            @Override public String getIssuer() { return (String) delegate.get("iss"); }
+            @Override public String getSubject() { return (String) delegate.get("sub"); }
+            @Override public List<String> getAudience() { return null; }
+            @Override public long getExpiration() { return 0; }
+            @Override public long getNotBefore() { return 0; }
+            @Override public long getIssuedAt() { return 0; }
+            @Override public String getJwtId() { return null; }
+            @Override public String getAuthorizedParty() { return null; }
+            @Override public <T> T getClaim(String claimName, Class<T> requiredType) { return requiredType.cast(delegate.get(claimName)); }
+            @Override public Map<String, Object> getAllClaims() { return delegate; }
+            @Override public String toJsonString() { return delegate.toString(); }
+        };
+
+        JwtToken token = mockery.mock(JwtToken.class, "jwtToken_" + testName.getMethodName());
+        mockery.checking(new Expectations() {
+            {
+                allowing(token).getClaims();
+                will(returnValue(claims));
+            }
+        });
+        return token;
+    }
+
+    @Test
+    public void testGetMappedRealm_customAttr_claimPresent() {
+        try {
+            Map<String, Object> claims = new HashMap<String, Object>();
+            claims.put("upn", "testuser");
+            claims.put("tenant", "TenantA");
+            JwtToken token = buildMockToken(claims);
+
+            JwtPrincipalMapping mapping = new JwtPrincipalMapping(token, "upn", "groups", false, "tenant");
+            assertEquals("Expected realm from 'tenant' claim", "TenantA", mapping.getMappedRealm());
+        } catch (Exception e) {
+            outputMgr.failWithThrowable(testName.getMethodName(), e);
+        }
+    }
+
+    @Test
+    public void testGetMappedRealm_defaultAttr_realmClaimPresent() {
+        try {
+            Map<String, Object> claims = new HashMap<String, Object>();
+            claims.put("upn", "testuser");
+            claims.put("realm", "DefaultRealm");
+            JwtToken token = buildMockToken(claims);
+
+            JwtPrincipalMapping mapping = new JwtPrincipalMapping(token, "upn", "groups", false, "realm");
+            assertEquals("Expected realm from 'realm' claim", "DefaultRealm", mapping.getMappedRealm());
+        } catch (Exception e) {
+            outputMgr.failWithThrowable(testName.getMethodName(), e);
+        }
+    }
+
+    @Test
+    public void testGetMappedRealm_nullAttr_fallsBackToRealmConstant() {
+        try {
+            Map<String, Object> claims = new HashMap<String, Object>();
+            claims.put("upn", "testuser");
+            claims.put("realm", "FallbackRealm");
+            JwtToken token = buildMockToken(claims);
+
+            // null realmIdentifierAttr → falls back to REALM_CLAIM="realm"
+            JwtPrincipalMapping mapping = new JwtPrincipalMapping(token, "upn", "groups", false, null);
+            assertEquals("Expected realm from default 'realm' claim when attr is null",
+                         "FallbackRealm", mapping.getMappedRealm());
+        } catch (Exception e) {
+            outputMgr.failWithThrowable(testName.getMethodName(), e);
+        }
+    }
+
+    @Test
+    public void testGetMappedRealm_claimAbsent() {
+        try {
+            Map<String, Object> claims = new HashMap<String, Object>();
+            claims.put("upn", "testuser");
+            // No "tenant" claim
+            JwtToken token = buildMockToken(claims);
+
+            JwtPrincipalMapping mapping = new JwtPrincipalMapping(token, "upn", "groups", false, "tenant");
+            assertNull("Expected null realm when claim is absent", mapping.getMappedRealm());
+        } catch (Exception e) {
+            outputMgr.failWithThrowable(testName.getMethodName(), e);
+        }
+    }
+}

--- a/dev/com.ibm.ws.security.mp.jwt/test/com/ibm/ws/security/mp/jwt/tai/TAIMappingHelperTest.java
+++ b/dev/com.ibm.ws.security.mp.jwt/test/com/ibm/ws/security/mp/jwt/tai/TAIMappingHelperTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018,2022 IBM Corporation and others.
+ * Copyright (c) 2018, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -19,6 +19,7 @@ import java.util.Map;
 import java.util.Set;
 
 import org.eclipse.microprofile.jwt.JsonWebToken;
+import org.jmock.Expectations;
 import org.jmock.Mockery;
 import org.jmock.integration.junit4.JUnit4Mockery;
 import org.jmock.lib.legacy.ClassImposteriser;
@@ -34,8 +35,10 @@ import com.ibm.websphere.security.jwt.JwtToken;
 import com.ibm.ws.security.common.jwk.utils.JsonUtils;
 import com.ibm.ws.security.jwt.internal.ConsumerUtil;
 import com.ibm.ws.security.jwt.internal.JwtConsumerConfigImpl;
+import com.ibm.ws.security.mp.jwt.MicroProfileJwtConfig;
 import com.ibm.ws.security.mp.jwt.error.MpJwtProcessingException;
 import com.ibm.ws.security.mp.jwt.impl.DefaultJsonWebTokenImpl;
+import com.ibm.wsspi.security.token.AttributeNameConstants;
 
 import test.common.SharedOutputManager;
 
@@ -160,6 +163,111 @@ public class TAIMappingHelperTest {
                     assertEquals(expectedClaim, claim);
                 }
             }
+        } catch (Exception e) {
+            outputMgr.failWithThrowable(testName.getMethodName(), e);
+        }
+    }
+
+    private MicroProfileJwtConfig buildMockConfig(String realmNameValue, String realmIdentifierValue) {
+        MicroProfileJwtConfig mockConfig = mockery.mock(MicroProfileJwtConfig.class, "config_" + realmNameValue + "_" + realmIdentifierValue);
+        mockery.checking(new Expectations() {
+            {
+                allowing(mockConfig).getRealmName();
+                will(returnValue(realmNameValue));
+                allowing(mockConfig).getRealmIdentifier();
+                will(returnValue(realmIdentifierValue));
+                allowing(mockConfig).getUserNameAttribute();
+                will(returnValue("upn"));
+                allowing(mockConfig).getGroupNameAttribute();
+                will(returnValue("groups"));
+                allowing(mockConfig).getMapToUserRegistry();
+                will(returnValue(false));
+            }
+        });
+        return mockConfig;
+    }
+
+    @Test
+    public void testSetRealm_realmNameTakesPrecedence() {
+        // When realmName is set, it should take precedence over anything else
+        // Test this via the getRealm / setRealm logic by creating a helper with null jwtToken
+        // and then calling getRealm() directly
+        try {
+            // Use the existing JWT from testClaimsProcessedTheSame which has iss "https://9.24.8.103:8947/jwt/jwkEnabled"
+            String jwt = "eyJraWQiOiJXYlVqSEN5b3V5ZEoySEFKc1dOMSIsImFsZyI6IlJTMjU2In0.eyJ0b2tlbl90eXBlIjoiQmVhcmVyIiwiYXVkIjoiYXVkMSIsInN1YiI6InRlc3R1c2VyIiwidXBuIjoidGVzdHVzZXIiLCJncm91cHMiOlsiZ3JvdXAxLWFiYyIsImdyb3VwMi1kZWYiLCJ0ZXN0dXNlci1ncm91cCJdLCJpc3MiOiJodHRwczovLzkuMjQuOC4xMDM6ODk0Ny9qd3QvandrRW5hYmxlZCIsImV4cCI6MTUwNDIxMjM5MCwiaWF0IjoxNTA0MjA1MTkwfQ.egKHKw1hfEAmZMBwI1_vPFxZIzXd9UWjLqz1MvlcvT3FHNKyV3CQ8KVSb-DrHll5J57QgJxY_vBiKgZgKkDJn6rKB4LNivV-_mcsCWawjKkmFDjesMLiSFKLfLWpfbt7qVbnRNT7ysMlXMDDJguRHRj_l1M70VAQT9gaCrPsoMvDAzOtTBS0iLnRATFCddYwQsw82Ma4rfTo5Hq-ouQWgRYerxkNswZJRnahsUKoSh4ptjYBmNySBTIF7X0WL9q0gr3SzJA59rLbQLaIhLzv8lYn7GRL05ifegQX41y11peG0_-ySN3nvaYvynwwbVvsJhRWbOc9B9LiYCX_qpxuXA";
+            ConsumerUtil consumerUtil = new ConsumerUtil(null);
+            JwtConsumerConfigImpl jwtConfig = new JwtConsumerConfigImpl() {
+                @Override
+                public boolean isValidationRequired() {
+                    return false;
+                }
+            };
+            JwtToken jwtToken = consumerUtil.parseJwt(jwt, jwtConfig);
+
+            MicroProfileJwtConfig mpJwtConfig = buildMockConfig("StaticRealm", "tenant");
+            TAIMappingHelper helper = new TAIMappingHelper(jwtToken, mpJwtConfig);
+            helper.createJwtPrincipalAndPopulateCustomProperties(jwtToken, false);
+
+            // realmName="StaticRealm" should win regardless of token claims
+            Object realm = helper.getCustomProperties().get(AttributeNameConstants.WSCREDENTIAL_REALM);
+            assertEquals("Expected realmName to take precedence", "StaticRealm", realm);
+        } catch (Exception e) {
+            outputMgr.failWithThrowable(testName.getMethodName(), e);
+        }
+    }
+
+    @Test
+    public void testSetRealm_fallbackToIss_realmIdentifierClaimAbsent() {
+        // When realmName=null and the realmIdentifier claim is absent from the token,
+        // the realm should fall back to the iss claim value (trailing slash stripped).
+        // The existing JWT has iss "https://9.24.8.103:8947/jwt/jwkEnabled" (no trailing slash).
+        try {
+            String jwt = "eyJraWQiOiJXYlVqSEN5b3V5ZEoySEFKc1dOMSIsImFsZyI6IlJTMjU2In0.eyJ0b2tlbl90eXBlIjoiQmVhcmVyIiwiYXVkIjoiYXVkMSIsInN1YiI6InRlc3R1c2VyIiwidXBuIjoidGVzdHVzZXIiLCJncm91cHMiOlsiZ3JvdXAxLWFiYyIsImdyb3VwMi1kZWYiLCJ0ZXN0dXNlci1ncm91cCJdLCJpc3MiOiJodHRwczovLzkuMjQuOC4xMDM6ODk0Ny9qd3QvandrRW5hYmxlZCIsImV4cCI6MTUwNDIxMjM5MCwiaWF0IjoxNTA0MjA1MTkwfQ.egKHKw1hfEAmZMBwI1_vPFxZIzXd9UWjLqz1MvlcvT3FHNKyV3CQ8KVSb-DrHll5J57QgJxY_vBiKgZgKkDJn6rKB4LNivV-_mcsCWawjKkmFDjesMLiSFKLfLWpfbt7qVbnRNT7ysMlXMDDJguRHRj_l1M70VAQT9gaCrPsoMvDAzOtTBS0iLnRATFCddYwQsw82Ma4rfTo5Hq-ouQWgRYerxkNswZJRnahsUKoSh4ptjYBmNySBTIF7X0WL9q0gr3SzJA59rLbQLaIhLzv8lYn7GRL05ifegQX41y11peG0_-ySN3nvaYvynwwbVvsJhRWbOc9B9LiYCX_qpxuXA";
+            ConsumerUtil consumerUtil = new ConsumerUtil(null);
+            JwtConsumerConfigImpl jwtConfig = new JwtConsumerConfigImpl() {
+                @Override
+                public boolean isValidationRequired() {
+                    return false;
+                }
+            };
+            JwtToken jwtToken = consumerUtil.parseJwt(jwt, jwtConfig);
+
+            // realmIdentifier="tenant" but there is no "tenant" claim in this JWT
+            MicroProfileJwtConfig mpJwtConfig = buildMockConfig(null, "tenant");
+            TAIMappingHelper helper = new TAIMappingHelper(jwtToken, mpJwtConfig);
+            helper.createJwtPrincipalAndPopulateCustomProperties(jwtToken, false);
+
+            // Should fall back to iss claim
+            Object realm = helper.getCustomProperties().get(AttributeNameConstants.WSCREDENTIAL_REALM);
+            assertEquals("Expected realm to fall back to iss claim",
+                         "https://9.24.8.103:8947/jwt/jwkEnabled", realm);
+        } catch (Exception e) {
+            outputMgr.failWithThrowable(testName.getMethodName(), e);
+        }
+    }
+
+    @Test
+    public void testSetRealm_noConfig_fallbackToIss() {
+        // No config (null) path: TAIMappingHelper(JwtToken) uses "upn"/"groups"/false/null
+        // so realmIdentifier defaults to REALM_CLAIM="realm", which is absent → falls back to iss
+        try {
+            String jwt = "eyJraWQiOiJXYlVqSEN5b3V5ZEoySEFKc1dOMSIsImFsZyI6IlJTMjU2In0.eyJ0b2tlbl90eXBlIjoiQmVhcmVyIiwiYXVkIjoiYXVkMSIsInN1YiI6InRlc3R1c2VyIiwidXBuIjoidGVzdHVzZXIiLCJncm91cHMiOlsiZ3JvdXAxLWFiYyIsImdyb3VwMi1kZWYiLCJ0ZXN0dXNlci1ncm91cCJdLCJpc3MiOiJodHRwczovLzkuMjQuOC4xMDM6ODk0Ny9qd3QvandrRW5hYmxlZCIsImV4cCI6MTUwNDIxMjM5MCwiaWF0IjoxNTA0MjA1MTkwfQ.egKHKw1hfEAmZMBwI1_vPFxZIzXd9UWjLqz1MvlcvT3FHNKyV3CQ8KVSb-DrHll5J57QgJxY_vBiKgZgKkDJn6rKB4LNivV-_mcsCWawjKkmFDjesMLiSFKLfLWpfbt7qVbnRNT7ysMlXMDDJguRHRj_l1M70VAQT9gaCrPsoMvDAzOtTBS0iLnRATFCddYwQsw82Ma4rfTo5Hq-ouQWgRYerxkNswZJRnahsUKoSh4ptjYBmNySBTIF7X0WL9q0gr3SzJA59rLbQLaIhLzv8lYn7GRL05ifegQX41y11peG0_-ySN3nvaYvynwwbVvsJhRWbOc9B9LiYCX_qpxuXA";
+            ConsumerUtil consumerUtil = new ConsumerUtil(null);
+            JwtConsumerConfigImpl jwtConfig = new JwtConsumerConfigImpl() {
+                @Override
+                public boolean isValidationRequired() {
+                    return false;
+                }
+            };
+            JwtToken jwtToken = consumerUtil.parseJwt(jwt, jwtConfig);
+
+            // Use the no-config constructor
+            TAIMappingHelper helper = new TAIMappingHelper(jwtToken);
+            helper.createJwtPrincipalAndPopulateCustomProperties(jwtToken, false);
+
+            Object realm = helper.getCustomProperties().get(AttributeNameConstants.WSCREDENTIAL_REALM);
+            assertEquals("Expected realm to be iss claim value when no config",
+                         "https://9.24.8.103:8947/jwt/jwkEnabled", realm);
         } catch (Exception e) {
             outputMgr.failWithThrowable(testName.getMethodName(), e);
         }


### PR DESCRIPTION
Adds two new configuration attributes to the MicroProfile JWT <mpJwt> element to give operators control over realm resolution:

  realmName       - static string; when set, always used as the realm
  realmIdentifier - JWT claim name to read the realm from (default: \"realm\")

Resolution order mirrors openidConnectClient behaviour:
  1. realmName (if non-empty)
  2. claim named by realmIdentifier
  3. iss fallback

Fixes a customer issue (TS022732550) where an IdP issues tokens with \"realm\": \"/idbroker\" (slash-prefixed). The slash caused AccessIdUtil.matcher() to return null, which broke authentication. Setting realmName=\"myapp\" in <mpJwt> bypasses the problematic claim entirely and authentication succeeds.

Components changed:
  com.ibm.ws.security.mp.jwt          - metatype, config interface/impl,
                                        JwtPrincipalMapping, TAIMappingHelper,
                                        unit tests
  com.ibm.ws.security.jwtsso          - stub getters in JwtSsoComponent
  com.ibm.ws.security.mp.jwt.1.1_fat  - MPJwtRealmConfigTests + 4 server
                                        configs + FATSuite registration"


- [X] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [ ] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [X] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
