### PR TITLE
Scheduled method with arg

### DIFF
--- a/dev/com.ibm.ws.concurrent_fat_jakarta_12/fat/src/test/jakarta/concurrency32/Concurrency32WithCDITest.java
+++ b/dev/com.ibm.ws.concurrent_fat_jakarta_12/fat/src/test/jakarta/concurrency32/Concurrency32WithCDITest.java
@@ -85,9 +85,19 @@ public class Concurrency32WithCDITest extends FATServletClient {
     @AfterClass
     public static void tearDown() throws Exception {
         if (server.isStarted())
-            server.stopServer("CNTR0344E", // @Schedule on EJB method
-                              "CNTR4006E" // @Schedule on EJB method
-            );
+            server.stopServer(// @Schedule on EJB method
+                              "CNTR0344E",
+                              // @Schedule on EJB method
+                              "CNTR4006E",
+                              // Scheduled method with args
+                              "CWWKC1413E.*neverDueToMethodParameter");
+    }
+
+    @Test
+    public void testScheduledMethodCannotHaveParameters() throws Exception {
+        String searchPattern = "CWWKC1413E.*neverDueToMethodParameter";
+        assertEquals(1,
+                     server.findStringsInLogs(searchPattern).size());
     }
 
     @Test

--- a/dev/com.ibm.ws.concurrent_fat_jakarta_12/test-applications/Concurrency32CDITestApp/src/test/jakarta/concurrency32cdi/web/Concurrency32CDITestServlet.java
+++ b/dev/com.ibm.ws.concurrent_fat_jakarta_12/test-applications/Concurrency32CDITestApp/src/test/jakarta/concurrency32cdi/web/Concurrency32CDITestServlet.java
@@ -490,7 +490,7 @@ public class Concurrency32CDITestServlet extends FATServlet {
     }
 
     /**
-     * A bean method with Schedule annotation and a method parameter must run
+     * A bean method with Schedule annotation and a method parameter must not run
      * automatically because method parameters are not allowed on scheduled methods.
      */
     @Test

--- a/dev/com.ibm.ws.concurrent_fat_jakarta_12/test-applications/Concurrency32CDITestApp/src/test/jakarta/concurrency32cdi/web/Concurrency32CDITestServlet.java
+++ b/dev/com.ibm.ws.concurrent_fat_jakarta_12/test-applications/Concurrency32CDITestApp/src/test/jakarta/concurrency32cdi/web/Concurrency32CDITestServlet.java
@@ -490,6 +490,27 @@ public class Concurrency32CDITestServlet extends FATServlet {
     }
 
     /**
+     * A bean method with Schedule annotation and a method parameter must run
+     * automatically because method parameters are not allowed on scheduled methods.
+     */
+    @Test
+    public void testScheduledMethodCannotHaveParametersSoItMustNotRun() //
+                    throws InterruptedException {
+        CountDownLatch methodStarts = //
+                        schedulingBean.trackerOfNeverDueToMethodParameter();
+
+        // wait up to 10 seconds past initialization to see if it runs
+        long elapsedNS = System.nanoTime() - initTimeNS.get();
+        long remainingNS = TimeUnit.SECONDS.toNanos(10) - elapsedNS;
+        if (remainingNS > 0)
+            assertEquals(false,
+                         methodStarts.await(remainingNS, TimeUnit.NANOSECONDS));
+        else
+            assertEquals(1, // countDown was never invoked
+                         methodStarts.getCount());
+    }
+
+    /**
      * A bean method that is scheduled to automatically run every 4 seconds,
      * but completes itself the first time it runs must run exactly once.
      */

--- a/dev/com.ibm.ws.concurrent_fat_jakarta_12/test-applications/Concurrency32CDITestApp/src/test/jakarta/concurrency32cdi/web/SchedulingBean.java
+++ b/dev/com.ibm.ws.concurrent_fat_jakarta_12/test-applications/Concurrency32CDITestApp/src/test/jakarta/concurrency32cdi/web/SchedulingBean.java
@@ -81,6 +81,12 @@ public class SchedulingBean {
     /**
      * Tracks the non-execution of the notScheduled method.
      */
+    private final CountDownLatch neverDueToMethodParameterLatch = //
+                    new CountDownLatch(1);
+
+    /**
+     * Tracks the non-execution of the notScheduled method.
+     */
     private final CountDownLatch notScheduledLatch = //
                     new CountDownLatch(1);
 
@@ -169,6 +175,19 @@ public class SchedulingBean {
         }
     }
 
+    /**
+     * This should never schedule or run because scheduled methods cannot have
+     * parameters.
+     */
+    @Schedule(cron = "* * * * * *")
+    public void neverDueToMethodParameter(String message) {
+        System.out.println("Running a scheduled method that has a parameter: " +
+                           message);
+    }
+
+    /**
+     * This should never schedule or run because it has no Schedule annotation.
+     */
     public void notScheduled() {
         System.out.println("Running a method that is NOT SCHEDULED!");
         notScheduledLatch.countDown();
@@ -218,6 +237,16 @@ public class SchedulingBean {
      */
     public LinkedBlockingQueue<Object> trackerOfLookUp3Times() {
         return lookUp3TimesQueue;
+    }
+
+    /**
+     * Returns a latch tracking the non-execution of the neverDueToMethodParameter
+     * method.
+     *
+     * @return a latch tracking non-execution of the neverDueToMethodParameter method
+     */
+    public CountDownLatch trackerOfNeverDueToMethodParameter() {
+        return neverDueToMethodParameterLatch;
     }
 
     /**

--- a/dev/io.openliberty.concurrent.internal.cdi/resources/io/openliberty/concurrent/internal/cdi/resources/CWWKCMessages.nlsprops
+++ b/dev/io.openliberty.concurrent.internal.cdi/resources/io/openliberty/concurrent/internal/cdi/resources/CWWKCMessages.nlsprops
@@ -55,3 +55,11 @@ CWWKC1412.qualifier.conflict.explanation=Each resource definition of the \
  same type that has a qualifier must have a different qualifier.
 CWWKC1412.qualifier.conflict.useraction=Ensure that each resource definition \
  of the same type has a different qualifier or does not have any qualifiers.
+
+CWWKC1413.sched.method.args=CWWKC1413E: The {0} method of the {1} CDI managed \
+ bean is annotated Schedule but is not automatically scheduled because \
+ methods annotated Schedule are are not permitted to have parameters.
+CWWKC1413.sched.method.args.explanation=Methods that are annotated Schedule \
+ must have no parameters.
+CWWKC1413.sched.method.args.useraction=Remove the method's parameters, or \
+ remove the Schedule annotation from the method.

--- a/dev/io.openliberty.concurrent.internal.cdi/resources/io/openliberty/concurrent/internal/cdi/resources/CWWKCMessages.nlsprops
+++ b/dev/io.openliberty.concurrent.internal.cdi/resources/io/openliberty/concurrent/internal/cdi/resources/CWWKCMessages.nlsprops
@@ -58,8 +58,8 @@ CWWKC1412.qualifier.conflict.useraction=Ensure that each resource definition \
 
 CWWKC1413.sched.method.args=CWWKC1413E: The {0} method of the {1} CDI managed \
  bean is annotated Schedule but is not automatically scheduled because \
- methods annotated Schedule are are not permitted to have parameters.
+ methods annotated Schedule are not permitted to have parameters.
 CWWKC1413.sched.method.args.explanation=Methods that are annotated Schedule \
  must have no parameters.
-CWWKC1413.sched.method.args.useraction=Remove the method's parameters, or \
- remove the Schedule annotation from the method.
+CWWKC1413.sched.method.args.useraction=Remove the parameters from the method, \
+ or remove the Schedule annotation from the method.

--- a/dev/io.openliberty.concurrent.internal.cdi/src/io/openliberty/concurrent/internal/cdi/ConcurrencyExtensionMetadata.java
+++ b/dev/io.openliberty.concurrent.internal.cdi/src/io/openliberty/concurrent/internal/cdi/ConcurrencyExtensionMetadata.java
@@ -454,14 +454,19 @@ public class ConcurrencyExtensionMetadata implements //
                         !beanClass.isAnnotationPresent(Asynchronous.class) &&
                         !method.isAnnotationPresent(Asynchronous.class)) {
 
-                        new ScheduledMethod<>( //
-                                        method.getJavaMember(), //
-                                        schedule, //
-                                        threadContext, //
-                                        execSvc, //
-                                        scopeClass, //
-                                        beanClass, //
-                                        beanAnnos);
+                        if (method.getJavaMember().getParameterCount() == 0)
+                            new ScheduledMethod<>( //
+                                            method.getJavaMember(), //
+                                            schedule, //
+                                            threadContext, //
+                                            execSvc, //
+                                            scopeClass, //
+                                            beanClass, //
+                                            beanAnnos);
+                        else // Scheduled methods cannot have parameters
+                            Tr.error(tc, "CWWKC1413.sched.method.args",
+                                     method.getJavaMember().getName(),
+                                     beanClass.getName());
                     }
                 } // let Asynchronous handle the invalid combination of annos
             }

--- a/dev/io.openliberty.concurrent.internal.cdi/src/io/openliberty/concurrent/internal/cdi/ConcurrencyExtensionMetadata.java
+++ b/dev/io.openliberty.concurrent.internal.cdi/src/io/openliberty/concurrent/internal/cdi/ConcurrencyExtensionMetadata.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021,2024 IBM Corporation and others.
+ * Copyright (c) 2021,2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at


### PR DESCRIPTION
Scheduled methods are not allowed to have any method parameters. If we don't do anything to enforce this, a method with parameters would fail at method.invoke(handle.get()) with a runtime IllegalArgumentException rather than a clean deployment-time error. Add detection and a useful message to users along with testing.

- [x] I have considered the risk of behavior change or other zero migration impact (https://github.com/OpenLiberty/open-liberty/wiki/Behavior-Changes).
- [x] If this PR fixes an Issue, the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN" (verify `release bug` label if applicable: https://github.com/OpenLiberty/open-liberty/wiki/Open-Liberty-Conventions).
- [x] If this PR resolves an external Known Issue (including APARS), the description includes "Fixes #FILLMEIN" or "Resolves #FILLMEIN".
